### PR TITLE
Fix: preserve user working directory when spawning Claude instances

### DIFF
--- a/bin/claude-flow
+++ b/bin/claude-flow
@@ -40,7 +40,11 @@ const cliPath = path.join(__dirname, '..', 'src', 'cli', 'simple-cli.js');
 // Run the CLI with Deno
 const deno = spawn(denoPath, ['run', '--allow-all', '--no-check', cliPath, ...process.argv.slice(2)], {
   stdio: 'inherit',
-  cwd: path.join(__dirname, '..')
+  cwd: path.join(__dirname, '..'),
+  env: {
+    ...process.env,
+    CLAUDE_FLOW_ORIGINAL_CWD: process.cwd()
+  }
 });
 
 deno.on('error', (err) => {

--- a/src/cli/simple-cli.js
+++ b/src/cli/simple-cli.js
@@ -591,6 +591,7 @@ You are running within the Claude-Flow orchestration system, which provides powe
 - Mode: ${flags.mode || 'full'}
 - Coverage Target: ${flags.coverage || 80}%
 - Commit Strategy: ${flags.commit || 'phase'}
+- Working Directory: ${Deno.env.get('CLAUDE_FLOW_ORIGINAL_CWD') || Deno.cwd()}
 ${flags.config ? `- MCP Config: ${flags.config}` : ''}
 
 ### Available Features
@@ -738,6 +739,14 @@ ${flags.commit === 'feature' ? `- **Feature Commits**: Commit after each feature
 ${flags.commit === 'manual' ? `- **Manual Commits**: Only commit when explicitly requested by the user` : ''}
 ${!flags.commit ? `- **Default (Phase)**: Commit after completing major phases` : ''}
 
+## Important Working Directory Information
+
+IMPORTANT: You are working in the directory: ${Deno.env.get('CLAUDE_FLOW_ORIGINAL_CWD') || Deno.cwd()}
+
+This is your correct working directory. All file operations, commands, and path references should be relative to this directory, not to any claude-flow installation directory.
+
+If you see any references to "/usr/local/share/npm-global/lib/node_modules/claude-flow" in your environment, that is the claude-flow installation directory and should be ignored for your work context. Your actual working directory is the one specified above.
+
 Now, please proceed with the task: ${task}`;
             
             const claudeArgs = [enhancedTask];
@@ -771,6 +780,7 @@ Now, please proceed with the task: ${task}`;
               
               const command = new Deno.Command('claude', {
                 args: claudeArgs,
+                cwd: Deno.env.get('CLAUDE_FLOW_ORIGINAL_CWD') || Deno.cwd(),
                 env: {
                   ...Deno.env.toObject(),
                   CLAUDE_INSTANCE_ID: instanceId,
@@ -782,6 +792,8 @@ Now, please proceed with the task: ${task}`;
                   CLAUDE_FLOW_MEMORY_NAMESPACE: 'default',
                   CLAUDE_FLOW_COORDINATION_ENABLED: flags.parallel ? 'true' : 'false',
                   CLAUDE_FLOW_FEATURES: 'memory,coordination,swarm',
+                  // Pass the original working directory to Claude
+                  CLAUDE_FLOW_CWD: Deno.env.get('CLAUDE_FLOW_ORIGINAL_CWD') || Deno.cwd(),
                 },
                 stdin: 'inherit',
                 stdout: 'inherit',


### PR DESCRIPTION
## Problem
When running `claude-flow claude spawn` from a specific directory, Claude was incorrectly started with the claude-flow installation directory (`/usr/local/share/npm-global/lib/node_modules/claude-flow`) as its working directory instead of the user's current working directory.

## Root Cause
The issue occurred because:
1. `bin/claude-flow` sets `cwd: path.join(__dirname, '..')` when spawning the Deno process
2. `src/cli/simple-cli.js` did not specify a working directory when spawning Claude, inheriting the claude-flow installation directory

## Solution
Implemented a comprehensive fix that preserves the user's original working directory:

### Changes Made

1. **bin/claude-flow** - Added `CLAUDE_FLOW_ORIGINAL_CWD` environment variable to capture user's original working directory

2. **src/cli/simple-cli.js** - Multiple improvements:
   - Set `cwd` parameter to use original working directory when spawning Claude process
   - Added `CLAUDE_FLOW_CWD` environment variable passed to Claude
   - Added working directory to configuration display in enhanced task
   - Added explicit instructions to Claude about correct working directory

## How It Works
1. **Capture**: `bin/claude-flow` captures `process.cwd()` in `CLAUDE_FLOW_ORIGINAL_CWD`
2. **Process CWD**: Claude subprocess spawns with original directory as working directory
3. **Environment**: Claude receives `CLAUDE_FLOW_CWD` environment variable
4. **Instructions**: Claude gets explicit guidance about correct working directory
5. **Configuration**: Working directory is displayed in task configuration

## Testing
- Tested with dry-run mode to verify correct working directory is used
- Verified environment variables are properly set and passed

## Result
After this fix, when users run `claude-flow claude spawn` from their project directory, Claude will:
- Start with the correct working directory as its process CWD
- Receive explicit instructions about the working directory
- Show the correct directory in its welcome message
- Perform all file operations relative to the user's project directory

Fixes issue where Claude was working in claude-flow installation directory instead of user's project directory.