### PR TITLE
Fix: Add missing await statements in hive-mind resume functionality

### DIFF
--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -2420,7 +2420,7 @@ function getWorkerTypeInstructions(workerType) {
 async function showSessions(flags) {
   try {
     const sessionManager = new HiveMindSessionManager();
-    const sessions = sessionManager.getActiveSessions();
+    const sessions = await sessionManager.getActiveSessions();
 
     if (sessions.length === 0) {
       console.log(chalk.gray('No active or paused sessions found'));


### PR DESCRIPTION
## Description

This PR fixes critical bugs in the hive-mind resume functionality that were preventing sessions from being resumed.

## Changes

1. **Fixed missing await in hive-mind.js**:
   - Added `await` to `sessionManager.getSession(sessionId)` in `resumeSession()` function (line 2496)
   - Added `await` to `sessionManager.getSession(sessionId)` in `stopSession()` function (line 2600)
   - Added `await` to `sessionManager.getActiveSessions()` in `showSessions()` function (line 2423)

2. **Fixed missing await in session-manager.js**:
   - Added `await` to `this.getSession(sessionId)` in `resumeSession()` method (line 505)

3. **Fixed SQLite availability on macOS**:
   - Reordered module loading to try CommonJS `require` first (more reliable on macOS)
   - Changed initial `sqliteAvailable` from `false` to `null` to allow re-checking

## Issues Fixed

- Fixes 'Cannot read properties of null (reading 'prepare')' error when resuming sessions
- Fixes 'sessions.forEach is not a function' error when listing sessions
- Fixes SQLite not being detected on macOS systems

## Testing

- ✅ Tested session creation
- ✅ Tested session resume functionality 
- ✅ Tested sessions list command
- ✅ Verified SQLite persistence works correctly

## Before/After

**Before**: 
```
Error: Cannot read properties of null (reading 'prepare')
```

**After**:
```
✔ Session resumed successfully\!
```