### PR TITLE
Fixes unused import alias

### DIFF
--- a/src/cli/simple-commands/init/index.js
+++ b/src/cli/simple-commands/init/index.js
@@ -2,7 +2,7 @@
 import { printSuccess, printError, printWarning, exit } from '../../utils.js';
 import { existsSync } from 'fs';
 import process from 'process';
-import { spawn, execSync as execSyncOriginal } from 'child_process';
+import { spawn, execSync } from 'child_process';
 import { promisify } from 'util';
 
 // Helper to replace Deno.Command


### PR DESCRIPTION
Fixes #534 

The file refers to `execSync` extensively, but it's actually not available as it got imported under the alias `execSyncOriginal`

Btw, `execSyncOriginal` is never used in the file.