### PR TITLE
fix mcp server improper handling of top-level await

### DIFF
--- a/src/cli/simple-cli.js
+++ b/src/cli/simple-cli.js
@@ -3425,5 +3425,12 @@ For more information about SPARC methodology, see: https://github.com/ruvnet/cla
 }
 
 if (isMainModule(import.meta.url)) {
-  await main();
+	(async () => {
+		try {
+			await main();
+		} catch (error) {
+			console.error('Error running claude-flow:', error);
+			process.exit(1);
+		}
+	})();
 }


### PR DESCRIPTION
The problem was caused by improper use of top-level await in the simple-cli.js file at line 3428. I wrapped the await main() call in an async IIFE (Immediately Invoked Function Expression) with proper error handling.

The fix:

- Changed `await main();`
to:
```
if (isMainModule(import.meta.url)) {
	(async () => {
		try {
			await main();
		} catch (error) {
			console.error('Error running claude-flow:', error);
			process.exit(1);
		}
	})();
}
```
This ensures the async operation is properly contained within an async function context

- Added error handling to gracefully manage any startup errors