### PR TITLE
fix: remove broken Windows installation doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
 
 - **Node.js 18+** (LTS recommended)
 - **npm 9+** or equivalent package manager
-- **Windows users**: See [Windows Installation Guide](./docs/windows-installation.md) for special instructions
 
 ⚠️ **IMPORTANT**: Claude Code must be installed first:
 
@@ -306,7 +305,6 @@ npx claude-flow@alpha memory query "microservices patterns" --reasoningbank
 ### **Configuration**
 - **[CLAUDE.md Templates](./docs/CLAUDE-MD-TEMPLATES.md)** - Project configs
 - **[SPARC Methodology](./docs/SPARC.md)** - TDD patterns
-- **[Windows Installation](./docs/windows-installation.md)** - Windows setup
 
 ---
 


### PR DESCRIPTION
Fixes #764

## Summary

Removes broken link to `docs/windows-installation.md` which doesn't exist, causing 404 errors for users.

## Changes

Removed two references to the non-existent Windows installation documentation:
1. **Line 41**: Removed "Windows users" note from Prerequisites section
2. **Line 309**: Removed Windows Installation link from Configuration section

## Related Work

- Related to Issue #803 and PR #804 (other broken documentation links)
- Part of ongoing documentation cleanup

Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.5), checked by rhowardstone