### PR TITLE
fix: remove non-existent labels from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "ruvnet"
-    labels:
-      - "dependencies"
-      - "npm"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -27,9 +24,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "ruvnet"
-    labels:
-      - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -44,9 +38,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "ruvnet"
-    labels:
-      - "dependencies"
-      - "deno"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Fixes #722

## Problem
Dependabot configuration referenced labels that don't exist in the repository ('dependencies', 'npm', 'github-actions', 'deno'), causing PR creation failures.

## Solution
Removed all non-existent label references from `.github/dependabot.yml`.

## Changes
- Removed `labels` sections from all three package ecosystems (npm, github-actions, gomod)
- Dependabot will now create PRs successfully without label assignment errors

## Testing
- Verified configuration syntax is valid
- Removed labels match those reported in issue #722

🤖 Generated with Claude Code (Sonnet 4.5), checked by me

Co-Authored-By: Claude <noreply@anthropic.com>