### PR TITLE
fix: change const to let for variables that get reassigned

### DIFF
--- a/src/cli/simple-commands/coordination.js
+++ b/src/cli/simple-commands/coordination.js
@@ -55,7 +55,7 @@ async function swarmInitCommand(subArgs, flags) {
   console.log(`🤖 Max agents: ${maxAgents}`);
 
   // Check if ruv-swarm is available
-  const isAvailable = await checkRuvSwarmAvailable();
+  let isAvailable = await checkRuvSwarmAvailable();
   
   if (isAvailable) {
     try {

--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -2006,7 +2006,7 @@ async function spawnClaudeCodeInstances(swarmId, swarmName, objective, workers, 
   try {
     // Generate comprehensive Hive Mind prompt
     const workerGroups = groupWorkersByType(workers);
-    const hiveMindPrompt = generateHiveMindPrompt(
+    let hiveMindPrompt = generateHiveMindPrompt(
       swarmId,
       swarmName,
       objective,

--- a/src/cli/simple-commands/swarm.js
+++ b/src/cli/simple-commands/swarm.js
@@ -378,7 +378,7 @@ export async function swarmCommand(args, flags) {
         flags.sparc !== false && (strategy === 'development' || strategy === 'auto');
 
       // Build the complete swarm prompt before checking for claude
-      const swarmPrompt = `You are orchestrating a Claude Flow Swarm using Claude Code's Task tool for agent execution.
+      let swarmPrompt = `You are orchestrating a Claude Flow Swarm using Claude Code's Task tool for agent execution.
 
 🚨 CRITICAL INSTRUCTION: Use Claude Code's Task Tool for ALL Agent Spawning!
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
  ## Problem

  The package fails to run with Bun due to const reassignment violations. Bun properly enforces const semantics, causing runtime errors when const-declared variables are reassigned.

  **Error example:**
```
803 |           swarmPrompt = enhanceSwarmPrompt(swarmPrompt, maxAgents);
                ^
error: This assignment will throw because "swarmPrompt" is a constant
    at /tmp/bunx-1000-claude-flow@alpha/node_modules/claude-flow/src/cli/simple-commands/swarm.js:803:11

381 |       const swarmPrompt = `You are orchestrating a Claude Flow Swarm using Claude Code's Tas
                  ^
note: The symbol "swarmPrompt" was declared a constant here:
   at /tmp/bunx-1000-claude-flow@alpha/node_modules/claude-flow/src/cli/simple-commands/swarm.js:381:13
```
  ## Solution

  Changed `const` to `let` for three variables that get reassigned later in the code:

  1. **`swarmPrompt`** (swarm.js:381) - reassigned when memory protocol enhancement is enabled via `--claude` flag
  2. **`isAvailable`** (coordination.js:58) - reassigned in error catch block during ruv-swarm fallback
  3. **`hiveMindPrompt`** (hive-mind.js:2009) - reassigned when memory protocol enhancement is enabled via `--claude` flag

  ## Testing

  ✅ Verified with both package runners:
  - `npx "dspearson/claude-flow#fix/bun-const-reassignment" --help` ✅ Works
  - `bunx "dspearson/claude-flow#fix/bun-const-reassignment" --help` ✅ Works (previously failed)

  ## Impact

  - **Compatibility**: Fixes runtime errors in Bun
  - **Scope**: Minimal - only changes variable declarations, no logic changes
  - **Risk**: Very low - `let` is functionally identical to `const` when variables are reassigned
