### PR TITLE
feat: Add mobile-responsive design to browser dashboard

### DIFF
--- a/examples/browser-dashboard/index-chat.html
+++ b/examples/browser-dashboard/index-chat.html
@@ -476,6 +476,257 @@
             transform: translateY(-2px);
             box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
         }
+
+        /* Mobile Responsive Styles */
+        @media screen and (max-width: 1024px) {
+            .right-panel {
+                width: 400px;
+            }
+
+            .sidebar {
+                width: 240px;
+            }
+        }
+
+        @media screen and (max-width: 768px) {
+            .container {
+                flex-direction: column;
+            }
+
+            .sidebar {
+                width: 100%;
+                max-height: 200px;
+                border-right: none;
+                border-bottom: 1px solid #e0e0e0;
+                overflow-y: auto;
+            }
+
+            .sidebar-section {
+                padding: 12px;
+            }
+
+            .agent-grid {
+                display: flex;
+                gap: 8px;
+                overflow-x: auto;
+                padding-bottom: 8px;
+            }
+
+            .agent-card {
+                min-width: 140px;
+                flex-shrink: 0;
+            }
+
+            .main-content {
+                height: calc(100vh - 200px);
+            }
+
+            .chat-header {
+                padding: 12px 16px;
+            }
+
+            .chat-title {
+                font-size: 14px;
+            }
+
+            .chat-messages {
+                padding: 16px;
+                gap: 16px;
+            }
+
+            .message-avatar {
+                width: 28px;
+                height: 28px;
+                font-size: 16px;
+            }
+
+            .message-text {
+                font-size: 13px;
+            }
+
+            .code-body pre {
+                font-size: 12px;
+            }
+
+            .chat-input-container {
+                padding: 12px 16px;
+            }
+
+            .chat-input {
+                font-size: 13px;
+                padding: 10px 14px;
+            }
+
+            .send-btn {
+                width: 40px;
+                height: 40px;
+                font-size: 16px;
+            }
+
+            .right-panel {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                width: 100%;
+                z-index: 1000;
+            }
+
+            .toggle-editor-btn {
+                right: 16px;
+                bottom: 70px;
+                width: 44px;
+                height: 44px;
+            }
+        }
+
+        @media screen and (max-width: 480px) {
+            .sidebar {
+                max-height: 150px;
+            }
+
+            .sidebar-header {
+                padding: 12px;
+            }
+
+            .sidebar-title {
+                font-size: 11px;
+                margin-bottom: 8px;
+            }
+
+            .status-badge {
+                font-size: 11px;
+                padding: 4px 10px;
+            }
+
+            .main-content {
+                height: calc(100vh - 150px);
+            }
+
+            .chat-header {
+                padding: 10px 12px;
+            }
+
+            .chat-title {
+                font-size: 13px;
+            }
+
+            .logo {
+                width: 20px;
+                height: 20px;
+            }
+
+            .chat-messages {
+                padding: 12px;
+                gap: 12px;
+            }
+
+            .message-avatar {
+                width: 24px;
+                height: 24px;
+                font-size: 14px;
+            }
+
+            .message-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 2px;
+            }
+
+            .message-author {
+                font-size: 13px;
+            }
+
+            .message-time {
+                font-size: 11px;
+            }
+
+            .message-text {
+                font-size: 12px;
+            }
+
+            .code-header {
+                padding: 6px 10px;
+            }
+
+            .code-language {
+                font-size: 11px;
+            }
+
+            .code-action-btn {
+                padding: 3px 8px;
+                font-size: 11px;
+            }
+
+            .code-body {
+                padding: 12px;
+            }
+
+            .code-body pre {
+                font-size: 11px;
+            }
+
+            .chat-input-container {
+                padding: 10px 12px;
+            }
+
+            .chat-input {
+                min-height: 40px;
+                font-size: 12px;
+                padding: 8px 12px;
+            }
+
+            .send-btn {
+                width: 36px;
+                height: 36px;
+                font-size: 14px;
+            }
+
+            .btn {
+                padding: 8px;
+                font-size: 12px;
+            }
+
+            .toggle-editor-btn {
+                right: 12px;
+                bottom: 60px;
+                width: 40px;
+                height: 40px;
+                font-size: 18px;
+            }
+
+            .consensus-mini {
+                padding: 10px;
+            }
+
+            .consensus-bar {
+                height: 16px;
+            }
+
+            .consensus-fill {
+                font-size: 10px;
+            }
+
+            .consensus-text {
+                font-size: 10px;
+            }
+        }
+
+        /* Touch-friendly adjustments */
+        @media (hover: none) and (pointer: coarse) {
+            .btn, .send-btn, .code-action-btn, .toggle-editor-btn {
+                min-height: 44px;
+            }
+
+            .agent-card {
+                padding: 12px;
+            }
+
+            .file-item, .agent-item {
+                padding: 12px;
+            }
+        }
     </style>
 </head>
 <body>

--- a/examples/browser-dashboard/index-code.html
+++ b/examples/browser-dashboard/index-code.html
@@ -326,6 +326,306 @@
             height: 120px;
             border-radius: 4px;
         }
+
+        /* Mobile Responsive Styles */
+        @media screen and (max-width: 1024px) {
+            .sidebar {
+                width: 220px;
+            }
+
+            .bottom-panel {
+                height: 200px;
+            }
+        }
+
+        @media screen and (max-width: 768px) {
+            body {
+                overflow: auto;
+            }
+
+            .header {
+                padding: 10px 16px;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .header-title {
+                font-size: 13px;
+            }
+
+            .logo {
+                width: 20px;
+                height: 20px;
+            }
+
+            .connection-status {
+                font-size: 11px;
+            }
+
+            .main-container {
+                flex-direction: column;
+                height: auto;
+                min-height: calc(100vh - 100px);
+            }
+
+            .sidebar {
+                width: 100%;
+                max-height: none;
+                border-right: none;
+                border-bottom: 1px solid #3e3e42;
+            }
+
+            .sidebar-section {
+                padding: 10px;
+            }
+
+            .agent-list {
+                max-height: none;
+                display: flex;
+                gap: 8px;
+                overflow-x: auto;
+                padding-bottom: 8px;
+            }
+
+            .agent-item {
+                min-width: 140px;
+                flex-shrink: 0;
+            }
+
+            .swarm-canvas-container {
+                display: none;
+            }
+
+            .editor-container {
+                min-height: 400px;
+            }
+
+            .toolbar {
+                padding: 6px 10px;
+                flex-wrap: wrap;
+            }
+
+            .btn {
+                padding: 8px 12px;
+                font-size: 11px;
+            }
+
+            .editor-tabs {
+                overflow-x: auto;
+                padding: 0 6px;
+            }
+
+            .editor-tab {
+                padding: 6px 12px;
+                font-size: 12px;
+                white-space: nowrap;
+            }
+
+            #editor {
+                min-height: 300px;
+            }
+
+            .bottom-panel {
+                height: 180px;
+                position: relative;
+            }
+
+            .panel-tabs {
+                overflow-x: auto;
+                padding: 0 6px;
+            }
+
+            .panel-tab {
+                padding: 6px 12px;
+                font-size: 11px;
+                white-space: nowrap;
+            }
+
+            .panel-content {
+                padding: 10px;
+                font-size: 12px;
+            }
+
+            .consensus-tracker {
+                padding: 10px;
+            }
+
+            .consensus-bar {
+                height: 20px;
+            }
+
+            .consensus-fill {
+                font-size: 10px;
+            }
+
+            .consensus-info {
+                font-size: 10px;
+            }
+        }
+
+        @media screen and (max-width: 480px) {
+            .header {
+                padding: 8px 12px;
+            }
+
+            .header-title {
+                font-size: 12px;
+                flex-wrap: wrap;
+            }
+
+            .header-title span:last-child {
+                flex-basis: 100%;
+                margin-top: 4px;
+            }
+
+            .logo {
+                width: 18px;
+                height: 18px;
+            }
+
+            .connection-status {
+                font-size: 10px;
+            }
+
+            .status-dot {
+                width: 6px;
+                height: 6px;
+            }
+
+            .sidebar-section {
+                padding: 8px;
+            }
+
+            .sidebar-title {
+                font-size: 10px;
+            }
+
+            .agent-item {
+                min-width: 120px;
+                padding: 6px;
+                font-size: 11px;
+            }
+
+            .agent-status {
+                font-size: 9px;
+                padding: 2px 4px;
+            }
+
+            .btn {
+                padding: 8px 10px;
+                font-size: 10px;
+            }
+
+            .toolbar {
+                padding: 6px 8px;
+                gap: 6px;
+            }
+
+            .editor-tabs {
+                padding: 0 4px;
+            }
+
+            .editor-tab {
+                padding: 6px 10px;
+                font-size: 11px;
+            }
+
+            .bottom-panel {
+                height: 150px;
+            }
+
+            .panel-tabs {
+                padding: 0 4px;
+            }
+
+            .panel-tab {
+                padding: 6px 10px;
+                font-size: 10px;
+            }
+
+            .panel-content {
+                padding: 8px;
+                font-size: 11px;
+            }
+
+            .consensus-tracker {
+                padding: 8px;
+            }
+
+            .consensus-bar {
+                height: 18px;
+            }
+
+            .consensus-fill {
+                font-size: 9px;
+            }
+
+            .consensus-info {
+                font-size: 9px;
+            }
+
+            .log-timestamp {
+                font-size: 10px;
+            }
+        }
+
+        /* Landscape mobile optimization */
+        @media screen and (max-width: 768px) and (orientation: landscape) {
+            .main-container {
+                flex-direction: row;
+            }
+
+            .sidebar {
+                width: 200px;
+                max-height: none;
+                border-right: 1px solid #3e3e42;
+                border-bottom: none;
+            }
+
+            .sidebar-section {
+                padding: 8px;
+            }
+
+            .sidebar-title {
+                font-size: 10px;
+            }
+
+            .agent-list {
+                flex-direction: column;
+            }
+
+            .agent-item {
+                min-width: auto;
+            }
+
+            .swarm-canvas-container {
+                display: block;
+            }
+
+            #swarmCanvas {
+                height: 80px;
+            }
+
+            .bottom-panel {
+                height: 150px;
+            }
+        }
+
+        /* Touch-friendly adjustments */
+        @media (hover: none) and (pointer: coarse) {
+            .btn, .editor-tab, .panel-tab {
+                min-height: 44px;
+                min-width: 44px;
+            }
+
+            .toolbar {
+                gap: 10px;
+            }
+
+            .file-item, .agent-item {
+                padding: 10px;
+            }
+        }
     </style>
 </head>
 <body>

--- a/examples/browser-dashboard/index.html
+++ b/examples/browser-dashboard/index.html
@@ -273,6 +273,140 @@
             width: 100%;
             height: 100%;
         }
+
+        /* Mobile Responsive Styles */
+        @media screen and (max-width: 768px) {
+            body {
+                padding: 10px;
+            }
+
+            .header h1 {
+                font-size: 1.8em;
+            }
+
+            .header p {
+                font-size: 0.95em;
+            }
+
+            .status-bar {
+                flex-wrap: wrap;
+                gap: 15px;
+                padding: 15px;
+            }
+
+            .stat {
+                flex: 1 1 45%;
+                min-width: 120px;
+            }
+
+            .stat-value {
+                font-size: 2em;
+            }
+
+            .stat-label {
+                font-size: 0.8em;
+            }
+
+            .grid {
+                grid-template-columns: 1fr;
+                gap: 15px;
+            }
+
+            .card {
+                padding: 20px;
+            }
+
+            .card h2 {
+                font-size: 1.3em;
+            }
+
+            .controls {
+                flex-direction: column;
+            }
+
+            .btn {
+                padding: 14px 20px;
+                font-size: 14px;
+            }
+
+            .visualization {
+                height: 250px;
+            }
+
+            .log-container {
+                max-height: 200px;
+                font-size: 0.8em;
+            }
+        }
+
+        @media screen and (max-width: 480px) {
+            body {
+                padding: 5px;
+            }
+
+            .header {
+                margin-bottom: 20px;
+            }
+
+            .header h1 {
+                font-size: 1.5em;
+            }
+
+            .header p {
+                font-size: 0.85em;
+            }
+
+            .status-bar {
+                padding: 12px;
+                gap: 10px;
+            }
+
+            .stat {
+                flex: 1 1 100%;
+            }
+
+            .stat-value {
+                font-size: 1.8em;
+            }
+
+            .card {
+                padding: 15px;
+            }
+
+            .card h2 {
+                font-size: 1.2em;
+                margin-bottom: 15px;
+            }
+
+            .agent-item {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .agent-status {
+                align-self: flex-start;
+            }
+
+            .consensus-info {
+                flex-direction: column;
+                gap: 5px;
+            }
+
+            .visualization {
+                height: 200px;
+            }
+
+            .log-container {
+                max-height: 150px;
+                font-size: 0.75em;
+            }
+
+            .btn {
+                padding: 12px 16px;
+                font-size: 13px;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
- Add comprehensive mobile CSS to all three dashboard HTML files
- Implement responsive breakpoints (1024px, 768px, 480px)
- Convert fixed-width layouts to flexible mobile-friendly layouts
- Add touch-friendly minimum sizes (44px) for all interactive elements
- Implement horizontal scrolling for agent lists on mobile
- Add landscape orientation support for mobile devices
- Scale typography appropriately for smaller screens
- Convert right panel to full-screen overlay on mobile
- Optimize spacing and padding for compact mobile displays

Fixes visualization problems on mobile devices across:
- examples/browser-dashboard/index.html
- examples/browser-dashboard/index-chat.html
- examples/browser-dashboard/index-code.html