### PR TITLE
fix: Database is not a constructor error in hive-mind spawn (#893)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "2.7.41",
+  "version": "2.7.42",
   "description": "Enterprise-grade AI agent orchestration with WASM-powered ReasoningBank memory and AgentDB vector database (always uses latest agentic-flow)",
   "mcpName": "io.github.ruvnet/claude-flow",
   "main": "cli.mjs",


### PR DESCRIPTION
## Summary

Fixes the `Database is not a constructor` error when running `claude-flow hive-mind spawn` command.

### Root Cause
Two issues in `src/cli/simple-commands/hive-mind.js`:
1. **ESM/CommonJS import mismatch**: `loadSqlite()` used `sqlite.default` which doesn't work reliably with CommonJS modules in ESM context
2. **Missing `loadSqlite()` call**: `spawnSwarm()` used `new Database()` without first calling `loadSqlite()` to initialize the Database variable

### Changes
- Updated `loadSqlite()` to use `createRequire` for proper CommonJS module loading
- Added fallback to dynamic import if `createRequire` fails
- Added `loadSqlite()` call at the start of:
  - `spawnSwarm()` 
  - `showConsensus()`
  - `showMetrics()`
  - `listMemories()`
  - `searchMemories()`
- Bumped version to 2.7.42

### Test Plan
- [x] Verified fix works locally with better-sqlite3
- [x] Confirmed `createRequire` approach properly loads CommonJS module
- [ ] Test with `npx claude-flow@alpha hive-mind spawn "test"` after npm publish

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)