### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🌊 Claude-Flow v2.7.0: Enterprise AI Orchestration Platform
 
+[![Run in Smithery](https://smithery.ai/badge/skills/ruvnet)](https://smithery.ai/skills?ns=ruvnet&utm_source=github&utm_medium=badge)
+
+
 <div align="center">
 
 [![🌟 Star on GitHub](https://img.shields.io/github/stars/ruvnet/claude-flow?style=for-the-badge&logo=github&color=gold)](https://github.com/ruvnet/claude-flow)


### PR DESCRIPTION
## Add skill discoverability badge

Your 27 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/ruvnet)](https://smithery.ai/skills?ns=ruvnet&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.