### PR TITLE
Fixing the Skills Tutorial path on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Claude-Flow includes **25 specialized skills** that activate automatically via n
 - **Automation & Quality** (4) - Hooks, verification, performance analysis
 - **Flow Nexus Platform** (3) - Cloud sandboxes and neural training
 
-📚 **[Complete Skills Tutorial](./docs/skills-tutorial.md)** - Full guide with usage examples
+📚 **[Complete Skills Tutorial](./docs/skills/skills-tutorial.md)** - Full guide with usage examples
 
 ---
 


### PR DESCRIPTION
This pull request makes a minor documentation fix by updating a link in the `README.md` file to point to the correct location of the skills tutorial.

Fixes issues: https://github.com/ruvnet/claude-flow/issues/904 and https://github.com/ruvnet/claude-flow/issues/889

- Documentation:
  * Updated the link to the skills tutorial in `README.md` to reference `docs/skills/skills-tutorial.md` instead of the previous incorrect path.