### PR TITLE
fix: MCP server fails to start on Windows due to path comparison bug

### DIFF
--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -7,7 +7,7 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { EnhancedMemory } from '../memory/enhanced-memory.js';
 // Use the same memory system that npx commands use - singleton instance
 import { memoryStore } from '../memory/fallback-store.js';
@@ -2634,7 +2634,7 @@ async function startMCPServer() {
 }
 
 // Start the server if this file is run directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   startMCPServer().catch(console.error);
 }
 


### PR DESCRIPTION
## Summary

- Fixes the MCP server silently failing to start on Windows
- Uses `pathToFileURL()` for proper cross-platform file URL comparison

## Problem

The entry point check in `src/mcp/mcp-server.js` used:
```javascript
if (import.meta.url === `file://${process.argv[1]}`) {
```

This fails on Windows because:
- `import.meta.url` returns `file:///C:/path/to/file.js` (proper URL format)
- `` `file://${process.argv[1]}` `` creates `file://C:\path\to\file.js` (invalid)

Key differences:
- File URLs need **3 slashes** (`file:///`) not 2
- Windows paths use **backslashes** but URLs use **forward slashes**
- Backslashes in template literals are escape sequences (`\t` → tab)

## Solution

Use Node's `pathToFileURL()` for proper cross-platform path-to-URL conversion:
```javascript
if (import.meta.url === pathToFileURL(process.argv[1]).href) {
```

## Test plan

- [x] Verified MCP server starts correctly on Windows after fix
- [x] `pathToFileURL()` is already available in Node.js `url` module

Fixes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)