### PR TITLE
fix: memory list --namespace filter not being applied

### DIFF
--- a/src/cli/simple-commands/memory.js
+++ b/src/cli/simple-commands/memory.js
@@ -786,8 +786,9 @@ async function handleReasoningBankList(subArgs, flags, listMemories) {
   try {
     const sort = flags?.sort || getArgValue(subArgs, '--sort') || 'created_at';
     const limit = parseInt(flags?.limit || getArgValue(subArgs, '--limit') || '10');
+    const namespace = flags?.namespace || flags?.ns || getArgValue(subArgs, '--namespace') || getArgValue(subArgs, '--ns');
 
-    const results = await listMemories({ sort, limit });
+    const results = await listMemories({ sort, limit, namespace });
 
     if (results.length === 0) {
       printWarning('No memories found');

--- a/src/reasoningbank/reasoningbank-adapter.js
+++ b/src/reasoningbank/reasoningbank-adapter.js
@@ -269,14 +269,14 @@ export async function listMemories(options = {}) {
   try {
     let memories;
 
-    if (namespace && namespace !== 'default') {
-      // Filter by namespace/domain
+    if (namespace) {
+      // Filter by namespace/domain (supports explicit 'default' namespace filtering)
       const allMemories = ReasoningBank.db.getAllActiveMemories();
       memories = allMemories
-        .filter(m => m.pattern_data?.domain === namespace)
+        .filter(m => (m.pattern_data?.domain || m.pattern_data?.namespace || 'default') === namespace)
         .slice(0, limit);
     } else {
-      // Get all active memories
+      // Get all active memories (no namespace filter)
       memories = ReasoningBank.db.getAllActiveMemories().slice(0, limit);
     }
 


### PR DESCRIPTION
## Summary
- Fixed `handleReasoningBankList()` to extract and pass namespace parameter to `listMemories()`
- Fixed `listMemories()` logic to properly filter when any namespace (including 'default') is specified

## Problem
Running `npx claude-flow@alpha memory list --namespace learning` returns ALL memories instead of filtering to the specified namespace.

## Root Cause
1. `handleReasoningBankList()` in `src/cli/simple-commands/memory.js` was not extracting the `--namespace` flag or passing it to `listMemories()`
2. `listMemories()` in `src/reasoningbank/reasoningbank-adapter.js` had faulty logic: `if (namespace && namespace !== 'default')` would skip filtering when explicitly requesting the 'default' namespace

## Solution
1. Added namespace extraction in `handleReasoningBankList()`:
   ```javascript
   const namespace = flags?.namespace || flags?.ns || getArgValue(subArgs, '--namespace') || getArgValue(subArgs, '--ns');
   const results = await listMemories({ sort, limit, namespace });
   ```

2. Fixed filter logic in adapter:
   ```javascript
   if (namespace) {
     // Filter by namespace/domain (supports explicit 'default' namespace filtering)
     memories = allMemories
       .filter(m => (m.pattern_data?.domain || m.pattern_data?.namespace || 'default') === namespace)
       .slice(0, limit);
   }
   ```

## Test plan
- [x] `memory list --namespace learning` returns only learning namespace entries
- [x] `memory list --namespace default` returns only default namespace entries
- [x] `memory list` (no namespace) returns all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)