### PR TITLE
docs: Fix 136 broken internal links to relocated files

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -705,7 +705,7 @@ Claude Flow integrates with 3 MCP servers providing 110+ tools:
 
 ## 📝 License
 
-MIT License - see [LICENSE](LICENSE) file for details
+MIT License - see [LICENSE](../LICENSE) file for details
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1320,7 +1320,7 @@ All existing commands continue to work as before, but now return correct results
 ### 🔗 Links
 
 - **npm Package**: [claude-flow@2.7.0-alpha.10](https://www.npmjs.com/package/claude-flow/v/2.7.0-alpha.10)
-- **Release Notes**: [docs/RELEASE-NOTES-v2.7.0-alpha.10.md](./docs/RELEASE-NOTES-v2.7.0-alpha.10.md)
+- **Release Notes**: [docs/RELEASE-NOTES-v2.7.0-alpha.10.md](./docs/releases/v2.7.0-alpha.10/RELEASE-NOTES-v2.7.0-alpha.10.md)
 - **GitHub Issues**: [Report bugs](https://github.com/ruvnet/claude-flow/issues)
 
 ---

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Claude-Flow includes **25 specialized skills** that activate automatically via n
 - **Automation & Quality** (4) - Hooks, verification, performance analysis
 - **Flow Nexus Platform** (3) - Cloud sandboxes and neural training
 
-📚 **[Complete Skills Tutorial](./docs/skills-tutorial.md)** - Full guide with usage examples
+📚 **[Complete Skills Tutorial](./docs/skills/skills-tutorial.md)** - Full guide with usage examples
 
 ---
 
@@ -117,7 +117,7 @@ npx claude-flow@alpha memory query "configuration" --namespace semantic --reason
 # ✅ Found 3 results (semantic search) in 2ms
 ```
 
-📚 **Release Notes**: [v2.7.0-alpha.10](./docs/RELEASE-NOTES-v2.7.0-alpha.10.md)
+📚 **Release Notes**: [v2.7.0-alpha.10](./docs/releases/v2.7.0-alpha.10/RELEASE-NOTES-v2.7.0-alpha.10.md)
 
 ## 🧠 **Memory System Commands**
 
@@ -390,7 +390,7 @@ npx claude-flow@alpha memory query "microservices patterns" --reasoningbank
 
 ### **⚙️ Configuration & Setup**
 - **[CLAUDE.md Templates](./docs/CLAUDE-MD-TEMPLATES.md)** - Project configs
-- **[SPARC Methodology](./docs/SPARC.md)** - TDD patterns
+- **[SPARC Methodology](./docs/reference/SPARC.md)** - TDD patterns
 - **[Windows Installation](./docs/windows-installation.md)** - Windows setup
 
 ---

--- a/benchmark/archive/BENCHMARK_DOCUMENTATION_INDEX.md
+++ b/benchmark/archive/BENCHMARK_DOCUMENTATION_INDEX.md
@@ -7,87 +7,87 @@ Complete documentation for the enhanced Claude Flow benchmark system with MLE-ST
 
 ### Core Documentation
 - **[README.md](./README.md)** - Main benchmark system overview and quick start guide
-- **[ENHANCEMENT_PLAN.md](./ENHANCEMENT_PLAN.md)** - Original enhancement plan and objectives
-- **[DETAILED_IMPLEMENTATION_GUIDE.md](./DETAILED_IMPLEMENTATION_GUIDE.md)** - Comprehensive implementation specifications
+- **[ENHANCEMENT_PLAN.md](./implementation-reports/ENHANCEMENT_PLAN.md)** - Original enhancement plan and objectives
+- **[DETAILED_IMPLEMENTATION_GUIDE.md](./implementation-reports/DETAILED_IMPLEMENTATION_GUIDE.md)** - Comprehensive implementation specifications
 
 ### Implementation Reports
-- **[IMPLEMENTATION_SUMMARY.md](./IMPLEMENTATION_SUMMARY.md)** - Summary of implementation phases
+- **[IMPLEMENTATION_SUMMARY.md](./reports/IMPLEMENTATION_SUMMARY.md)** - Summary of implementation phases
 - **[OPTIMIZATION_ANALYSIS.md](./OPTIMIZATION_ANALYSIS.md)** - Performance optimization analysis and results
-- **[REAL_BENCHMARK_SUMMARY.md](./REAL_BENCHMARK_SUMMARY.md)** - Real-world benchmark results
+- **[REAL_BENCHMARK_SUMMARY.md](./reports/REAL_BENCHMARK_SUMMARY.md)** - Real-world benchmark results
 
 ### Performance Analysis
-- **[PERFORMANCE_SUITE_README.md](./PERFORMANCE_SUITE_README.md)** - Performance testing suite documentation
-- **[LOAD_TESTING_IMPLEMENTATION_REPORT.md](./LOAD_TESTING_IMPLEMENTATION_REPORT.md)** - Load testing implementation details
-- **[analysis/hive-mind-performance-analysis.md](./analysis/hive-mind-performance-analysis.md)** - Hive mind collective intelligence analysis
+- **[PERFORMANCE_SUITE_README.md](./reports/PERFORMANCE_SUITE_README.md)** - Performance testing suite documentation
+- **[LOAD_TESTING_IMPLEMENTATION_REPORT.md](./reports/LOAD_TESTING_IMPLEMENTATION_REPORT.md)** - Load testing implementation details
+- **[analysis/hive-mind-performance-analysis.md](../analysis/hive-mind-performance-analysis.md)** - Hive mind collective intelligence analysis
 
 ### Technical Documentation (docs/)
 - **[docs/README.md](./docs/README.md)** - Documentation overview
-- **[docs/api_reference.md](./docs/api_reference.md)** - Complete API reference
-- **[docs/claude_optimizer_guide.md](./docs/claude_optimizer_guide.md)** - CLAUDE.md optimizer user guide
-- **[docs/quick-start.md](./docs/quick-start.md)** - Quick start guide
-- **[docs/best-practices.md](./docs/best-practices.md)** - Best practices and patterns
-- **[docs/optimization-guide.md](./docs/optimization-guide.md)** - Performance optimization guide
-- **[docs/coordination-modes.md](./docs/coordination-modes.md)** - Swarm coordination modes
-- **[docs/strategies.md](./docs/strategies.md)** - Benchmark strategies documentation
-- **[docs/integration_guide.md](./docs/integration_guide.md)** - Integration with Claude Flow
-- **[docs/cli-reference.md](./docs/cli-reference.md)** - CLI command reference
-- **[docs/PARALLEL_EXECUTION.md](./docs/PARALLEL_EXECUTION.md)** - Parallel execution patterns
-- **[docs/real-benchmark-architecture.md](./docs/real-benchmark-architecture.md)** - Real benchmark architecture
-- **[docs/real-benchmark-quickstart.md](./docs/real-benchmark-quickstart.md)** - Real benchmark quick start
-- **[docs/real_metrics_collection.md](./docs/real_metrics_collection.md)** - Metrics collection guide
+- **[docs/api_reference.md](../docs/api_reference.md)** - Complete API reference
+- **[docs/claude_optimizer_guide.md](../docs/claude_optimizer_guide.md)** - CLAUDE.md optimizer user guide
+- **[docs/quick-start.md](../docs/quick-start.md)** - Quick start guide
+- **[docs/best-practices.md](../docs/best-practices.md)** - Best practices and patterns
+- **[docs/optimization-guide.md](../docs/optimization-guide.md)** - Performance optimization guide
+- **[docs/coordination-modes.md](../docs/coordination-modes.md)** - Swarm coordination modes
+- **[docs/strategies.md](../docs/strategies.md)** - Benchmark strategies documentation
+- **[docs/integration_guide.md](../docs/integration_guide.md)** - Integration with Claude Flow
+- **[docs/cli-reference.md](../docs/cli-reference.md)** - CLI command reference
+- **[docs/PARALLEL_EXECUTION.md](../docs/PARALLEL_EXECUTION.md)** - Parallel execution patterns
+- **[docs/real-benchmark-architecture.md](../docs/real-benchmark-architecture.md)** - Real benchmark architecture
+- **[docs/real-benchmark-quickstart.md](../docs/real-benchmark-quickstart.md)** - Real benchmark quick start
+- **[docs/real_metrics_collection.md](../docs/real_metrics_collection.md)** - Metrics collection guide
 
 ### Planning Documentation (plans/)
-- **[plans/architecture-design.md](./plans/architecture-design.md)** - System architecture design
-- **[plans/deployment-guide.md](./plans/deployment-guide.md)** - Deployment instructions
+- **[plans/architecture-design.md](../plans/architecture-design.md)** - System architecture design
+- **[plans/deployment-guide.md](../plans/deployment-guide.md)** - Deployment instructions
 - **[plans/implementation-plan.md](./plans/implementation-plan.md)** - Implementation roadmap
-- **[plans/testing-strategy.md](./plans/testing-strategy.md)** - Testing approach and strategy
+- **[plans/testing-strategy.md](../plans/testing-strategy.md)** - Testing approach and strategy
 
 ### Test Documentation (tests/)
 - **[tests/README.md](./tests/README.md)** - Test suite documentation
 - **[tests/integration/README.md](./tests/integration/README.md)** - Integration testing guide
 
 ### Hive Mind Benchmarks
-- **[hive-mind-benchmarks/reports/hive_mind_comprehensive_benchmark_report.md](./hive-mind-benchmarks/reports/hive_mind_comprehensive_benchmark_report.md)** - Comprehensive hive mind benchmark report
-- **[hive-mind-benchmarks/reports/performance_summary.md](./hive-mind-benchmarks/reports/performance_summary.md)** - Performance summary
+- **[hive-mind-benchmarks/reports/hive_mind_comprehensive_benchmark_report.md](../hive-mind-benchmarks/reports/hive_mind_comprehensive_benchmark_report.md)** - Comprehensive hive mind benchmark report
+- **[hive-mind-benchmarks/reports/performance_summary.md](../hive-mind-benchmarks/reports/performance_summary.md)** - Performance summary
 
 ## 🚀 Quick Navigation
 
 ### For Users
 1. Start with [README.md](./README.md)
-2. Follow [docs/quick-start.md](./docs/quick-start.md)
-3. Review [docs/best-practices.md](./docs/best-practices.md)
+2. Follow [docs/quick-start.md](../docs/quick-start.md)
+3. Review [docs/best-practices.md](../docs/best-practices.md)
 
 ### For Developers
-1. Read [DETAILED_IMPLEMENTATION_GUIDE.md](./DETAILED_IMPLEMENTATION_GUIDE.md)
-2. Check [docs/api_reference.md](./docs/api_reference.md)
-3. Study [docs/integration_guide.md](./docs/integration_guide.md)
+1. Read [DETAILED_IMPLEMENTATION_GUIDE.md](./implementation-reports/DETAILED_IMPLEMENTATION_GUIDE.md)
+2. Check [docs/api_reference.md](../docs/api_reference.md)
+3. Study [docs/integration_guide.md](../docs/integration_guide.md)
 
 ### For Performance Tuning
 1. See [OPTIMIZATION_ANALYSIS.md](./OPTIMIZATION_ANALYSIS.md)
-2. Follow [docs/optimization-guide.md](./docs/optimization-guide.md)
-3. Review [PERFORMANCE_SUITE_README.md](./PERFORMANCE_SUITE_README.md)
+2. Follow [docs/optimization-guide.md](../docs/optimization-guide.md)
+3. Review [PERFORMANCE_SUITE_README.md](./reports/PERFORMANCE_SUITE_README.md)
 
 ### For CLAUDE.md Optimization
-1. Start with [docs/claude_optimizer_guide.md](./docs/claude_optimizer_guide.md)
+1. Start with [docs/claude_optimizer_guide.md](../docs/claude_optimizer_guide.md)
 2. Review examples in implementation guide
 3. Check API reference for advanced usage
 
 ## 📊 Key Features Documentation
 
 ### MLE-STAR Integration
-- Implementation details in [DETAILED_IMPLEMENTATION_GUIDE.md](./DETAILED_IMPLEMENTATION_GUIDE.md#mle-star-integration)
-- API reference in [docs/api_reference.md](./docs/api_reference.md#mle-star)
+- Implementation details in [DETAILED_IMPLEMENTATION_GUIDE.md](./implementation-reports/DETAILED_IMPLEMENTATION_GUIDE.md#mle-star-integration)
+- API reference in [docs/api_reference.md](../docs/api_reference.md#mle-star)
 
 ### Automation Systems
 - Batch processing guide in implementation documentation
-- Pipeline patterns in [docs/PARALLEL_EXECUTION.md](./docs/PARALLEL_EXECUTION.md)
+- Pipeline patterns in [docs/PARALLEL_EXECUTION.md](../docs/PARALLEL_EXECUTION.md)
 
 ### Advanced Metrics
-- Metrics collection in [docs/real_metrics_collection.md](./docs/real_metrics_collection.md)
+- Metrics collection in [docs/real_metrics_collection.md](../docs/real_metrics_collection.md)
 - Performance analysis in [OPTIMIZATION_ANALYSIS.md](./OPTIMIZATION_ANALYSIS.md)
 
 ### CLAUDE.md Optimizer
-- Complete guide in [docs/claude_optimizer_guide.md](./docs/claude_optimizer_guide.md)
+- Complete guide in [docs/claude_optimizer_guide.md](../docs/claude_optimizer_guide.md)
 - Implementation examples throughout documentation
 
 ## 📈 Latest Results

--- a/benchmark/archive/old-reports/README.md
+++ b/benchmark/archive/old-reports/README.md
@@ -86,10 +86,10 @@ python examples/verify_real_integration.py
 
 ## 📚 Documentation
 
-- [API Reference](docs/api_reference.md)
-- [CLAUDE.md Optimizer Guide](docs/claude_optimizer_guide.md)
+- [API Reference](../../docs/api_reference.md)
+- [CLAUDE.md Optimizer Guide](../../docs/claude_optimizer_guide.md)
 - [Real Benchmarks Guide](REAL_BENCHMARKS_README.md)
-- [Architecture Overview](docs/real-benchmark-architecture.md)
+- [Architecture Overview](../../docs/real-benchmark-architecture.md)
 
 ## 🎯 Example Usage
 

--- a/benchmark/archive/reports/PERFORMANCE_SUITE_README.md
+++ b/benchmark/archive/reports/PERFORMANCE_SUITE_README.md
@@ -485,7 +485,7 @@ node ../cli.js swarm list
 ## 📚 Additional Resources
 
 ### Performance Analysis
-- [Performance Optimization Guide](./docs/optimization-guide.md)
+- [Performance Optimization Guide](../../docs/optimization-guide.md)
 - [Memory Management Best Practices](./docs/memory-management.md)
 - [Scalability Testing Strategies](./docs/scalability-testing.md)
 

--- a/benchmark/docs/README.md
+++ b/benchmark/docs/README.md
@@ -76,4 +76,4 @@ We welcome contributions! See our [Contributing Guide](contributing.md) for deta
 
 ---
 
-© 2024 Claude Flow Team | [License](../LICENSE) | [Code of Conduct](code-of-conduct.md)
+© 2024 Claude Flow Team | [License](../../LICENSE) | [Code of Conduct](code-of-conduct.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -76,13 +76,13 @@ Complete automation toolkit covering file operations, system management, GitHub 
 
 ### 🏃‍♂️ Getting Started
 - **[README-NEW.md](../README.md)** - Complete project overview and quick start
-- **[DEPLOYMENT.md](DEPLOYMENT.md)** - Installation, setup, and production deployment
+- **[DEPLOYMENT.md](./development/DEPLOYMENT.md)** - Installation, setup, and production deployment
 - **System Requirements**: Node.js v20+, 2GB RAM minimum, 8GB recommended
 
 ### 🏗️ Architecture & Development  
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - System design, patterns, and scalability
-- **[DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md)** - Development process and best practices
-- **[API_DOCUMENTATION.md](API_DOCUMENTATION.md)** - Complete API reference and examples
+- **[ARCHITECTURE.md](./architecture/ARCHITECTURE.md)** - System design, patterns, and scalability
+- **[DEVELOPMENT_WORKFLOW.md](./development/DEVELOPMENT_WORKFLOW.md)** - Development process and best practices
+- **[API_DOCUMENTATION.md](./api/API_DOCUMENTATION.md)** - Complete API reference and examples
 
 ### 🎯 Core Concepts
 - **Agent Management**: Spawn, coordinate, and monitor AI agents
@@ -312,20 +312,20 @@ docs/
 #### 👨‍💻 **Developers**
 1. [Quick Start Guide](../README.md#-quick-start) - Get up and running in 5 minutes
 2. [SPARC Development](../README.md#-sparc-development-environment) - Structured development methodology
-3. [API Reference](API_DOCUMENTATION.md) - Complete endpoint documentation
-4. [Development Workflow](DEVELOPMENT_WORKFLOW.md) - Best practices and standards
+3. [API Reference](./api/API_DOCUMENTATION.md) - Complete endpoint documentation
+4. [Development Workflow](./development/DEVELOPMENT_WORKFLOW.md) - Best practices and standards
 
 #### 🏢 **DevOps/Operations**  
-1. [Deployment Guide](DEPLOYMENT.md) - Production deployment strategies
-2. [Architecture Overview](ARCHITECTURE.md) - System design and scaling
-3. [Monitoring Setup](DEPLOYMENT.md#monitoring--maintenance) - Health checks and metrics
-4. [Security Implementation](ARCHITECTURE.md#security-architecture) - Security best practices
+1. [Deployment Guide](./development/DEPLOYMENT.md) - Production deployment strategies
+2. [Architecture Overview](./architecture/ARCHITECTURE.md) - System design and scaling
+3. [Monitoring Setup](./development/DEPLOYMENT.md#monitoring--maintenance) - Health checks and metrics
+4. [Security Implementation](./architecture/ARCHITECTURE.md#security-architecture) - Security best practices
 
 #### 👑 **Technical Leaders**
-1. [System Architecture](ARCHITECTURE.md#system-overview) - High-level system design
+1. [System Architecture](./architecture/ARCHITECTURE.md#system-overview) - High-level system design
 2. [Performance Metrics](../README.md#-performance-metrics) - Benchmarks and optimization
 3. [Swarm Intelligence](../README.md#-swarm-intelligence) - Distributed coordination strategies
-4. [Enterprise Features](DEPLOYMENT.md#production-setup) - Production-grade capabilities
+4. [Enterprise Features](./development/DEPLOYMENT.md#production-setup) - Production-grade capabilities
 
 #### 🚀 **Product Managers**
 1. [Feature Overview](../README.md#-key-features) - Complete capability matrix
@@ -446,22 +446,22 @@ npx claude-flow@alpha analytics --export-metrics --format prometheus
 ### 🎓 **Training Path for New Users**
 
 #### **Week 1: Fundamentals**
-1. **[Installation & Setup](DEPLOYMENT.md#installation-methods)** - Get Claude Flow running
+1. **[Installation & Setup](./development/DEPLOYMENT.md#installation-methods)** - Get Claude Flow running
 2. **[First Swarm Creation](../README.md#-quick-start)** - Build your first AI team  
 3. **[SPARC Methodology](../README.md#-sparc-development-environment)** - Learn structured development
 4. **[Basic Commands](../README.md#-essential-commands)** - Master core CLI operations
 
 #### **Week 2: Advanced Features**
-1. **[Agent Coordination](ARCHITECTURE.md#agent-architecture)** - Understanding swarm intelligence
-2. **[Memory Management](ARCHITECTURE.md#memory-architecture)** - Persistent state across sessions
-3. **[GitHub Integration](API_DOCUMENTATION.md#github-operations)** - Complete DevOps workflow
-4. **[Performance Optimization](ARCHITECTURE.md#performance-architecture)** - Speed and efficiency
+1. **[Agent Coordination](./architecture/ARCHITECTURE.md#agent-architecture)** - Understanding swarm intelligence
+2. **[Memory Management](./architecture/ARCHITECTURE.md#memory-architecture)** - Persistent state across sessions
+3. **[GitHub Integration](./api/API_DOCUMENTATION.md#github-operations)** - Complete DevOps workflow
+4. **[Performance Optimization](./architecture/ARCHITECTURE.md#performance-architecture)** - Speed and efficiency
 
 #### **Week 3: Production Deployment**
-1. **[Architecture Design](ARCHITECTURE.md#system-overview)** - Scalable system patterns
-2. **[Security Implementation](ARCHITECTURE.md#security-architecture)** - Enterprise security
-3. **[Monitoring Setup](DEPLOYMENT.md#monitoring--maintenance)** - Production observability
-4. **[Troubleshooting](DEPLOYMENT.md#troubleshooting)** - Issue resolution strategies
+1. **[Architecture Design](./architecture/ARCHITECTURE.md#system-overview)** - Scalable system patterns
+2. **[Security Implementation](./architecture/ARCHITECTURE.md#security-architecture)** - Enterprise security
+3. **[Monitoring Setup](./development/DEPLOYMENT.md#monitoring--maintenance)** - Production observability
+4. **[Troubleshooting](./development/DEPLOYMENT.md#troubleshooting)** - Issue resolution strategies
 
 ### 📊 **Success Metrics**
 Track your progress with these benchmarks:

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,15 +7,15 @@ Welcome to the Claude-Flow documentation! This directory contains comprehensive 
 | Document | Description |
 |----------|-------------|
 | [INDEX.md](INDEX.md) | Complete documentation hub with navigation and quick start |
-| [USER_GUIDE.md](USER_GUIDE.md) | Comprehensive user guide with tutorials and examples |
-| [API_DOCUMENTATION.md](API_DOCUMENTATION.md) | Complete API reference with all 112 MCP tools |
-| [AGENTS.md](AGENTS.md) | All 65+ agent types with capabilities and usage |
-| [SWARM.md](SWARM.md) | Swarm intelligence, topologies, and coordination |
-| [SPARC.md](SPARC.md) | SPARC methodology with all 17 development modes |
-| [MCP_TOOLS.md](MCP_TOOLS.md) | Detailed reference for all MCP tools |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | System architecture and design patterns |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | Production deployment guides for Docker, K8s, Cloud |
-| [DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md) | Development setup and contribution guide |
+| [USER_GUIDE.md](./guides/USER_GUIDE.md) | Comprehensive user guide with tutorials and examples |
+| [API_DOCUMENTATION.md](./api/API_DOCUMENTATION.md) | Complete API reference with all 112 MCP tools |
+| [AGENTS.md](./reference/AGENTS.md) | All 65+ agent types with capabilities and usage |
+| [SWARM.md](./reference/SWARM.md) | Swarm intelligence, topologies, and coordination |
+| [SPARC.md](./reference/SPARC.md) | SPARC methodology with all 17 development modes |
+| [MCP_TOOLS.md](./reference/MCP_TOOLS.md) | Detailed reference for all MCP tools |
+| [ARCHITECTURE.md](./architecture/ARCHITECTURE.md) | System architecture and design patterns |
+| [DEPLOYMENT.md](./development/DEPLOYMENT.md) | Production deployment guides for Docker, K8s, Cloud |
+| [DEVELOPMENT_WORKFLOW.md](./development/DEVELOPMENT_WORKFLOW.md) | Development setup and contribution guide |
 
 ## 📁 Documentation Categories
 
@@ -79,10 +79,10 @@ Third-party platform integrations
 
 ## 🚀 Quick Links
 
-- **Getting Started**: See [USER_GUIDE.md](USER_GUIDE.md#getting-started)
-- **API Reference**: See [API_DOCUMENTATION.md](API_DOCUMENTATION.md)
-- **Agent Catalog**: See [AGENTS.md](AGENTS.md)
-- **Deployment**: See [DEPLOYMENT.md](DEPLOYMENT.md)
+- **Getting Started**: See [USER_GUIDE.md](./guides/USER_GUIDE.md#getting-started)
+- **API Reference**: See [API_DOCUMENTATION.md](./api/API_DOCUMENTATION.md)
+- **Agent Catalog**: See [AGENTS.md](./reference/AGENTS.md)
+- **Deployment**: See [DEPLOYMENT.md](./development/DEPLOYMENT.md)
 - **Skills Tutorial**: See [Skills Tutorial](./guides/skills-tutorial.md)
 - **AgentDB Integration**: See [AgentDB](./agentdb/)
 
@@ -91,16 +91,16 @@ Third-party platform integrations
 ### 👨‍💻 **Developers**
 1. [Quick Start Guide](../README.md#-quick-start) - Get up and running
 2. [Skills Tutorial](./guides/skills-tutorial.md) - Natural language skill activation
-3. [SPARC Development](SPARC.md) - Structured development methodology
-4. [API Reference](API_DOCUMENTATION.md) - Complete endpoint documentation
+3. [SPARC Development](./reference/SPARC.md) - Structured development methodology
+4. [API Reference](./api/API_DOCUMENTATION.md) - Complete endpoint documentation
 
 ### 🏢 **DevOps/Operations**
-1. [Deployment Guide](DEPLOYMENT.md) - Production deployment
-2. [Architecture Overview](ARCHITECTURE.md) - System design
+1. [Deployment Guide](./development/DEPLOYMENT.md) - Production deployment
+2. [Architecture Overview](./architecture/ARCHITECTURE.md) - System design
 3. [Docker Verification](./validation/DOCKER_VERIFICATION_REPORT.md) - Testing reports
 
 ### 👑 **Technical Leaders**
-1. [System Architecture](ARCHITECTURE.md#system-overview) - High-level design
+1. [System Architecture](./architecture/ARCHITECTURE.md#system-overview) - High-level design
 2. [Performance Metrics](./performance/) - Benchmarks and optimization
 3. [AgentDB Integration](./agentdb/) - 96x-164x performance improvements
 

--- a/docs/VALIDATION_REPORT_v2.7.1.md
+++ b/docs/VALIDATION_REPORT_v2.7.1.md
@@ -305,8 +305,8 @@ npm error path .../node_modules/better-sqlite3
 ## 📚 Additional Documentation
 
 - [Branch Information](/workspaces/claude-code-flow/docs/BRANCH_INFO.md) - Created earlier
-- [Remote Install Fix](/workspaces/claude-code-flow/docs/REMOTE_INSTALL_FIX.md) - Technical details
-- [v2.7.14 Release Notes](/workspaces/claude-code-flow/docs/V2.7.14_RELEASE_NOTES.md) - Current alpha comparison
+- [Remote Install Fix](./REMOTE_INSTALL_FIX.md) - Technical details
+- [v2.7.14 Release Notes](./V2.7.14_RELEASE_NOTES.md) - Current alpha comparison
 
 ---
 

--- a/docs/api/API_DOCUMENTATION.md
+++ b/docs/api/API_DOCUMENTATION.md
@@ -716,6 +716,6 @@ npx claude-flow@alpha --version
 
 *Intelligent AI Agent Orchestration*
 
-[🚀 Get Started](../README.md) | [🔧 Configure](./DEPLOYMENT.md) | [🤝 Contribute](../CONTRIBUTING.md)
+[🚀 Get Started](../README.md) | [🔧 Configure](../development/DEPLOYMENT.md) | [🤝 Contribute](../CONTRIBUTING.md)
 
 </div>

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1685,6 +1685,6 @@ This sophisticated architecture positions Claude-Flow as the next-generation pla
 
 **Claude-Flow Architecture v2.0.0**
 
-[Back to README](../README.md) | [API Documentation](API_DOCUMENTATION.md)
+[Back to README](../README.md) | [API Documentation](../api/API_DOCUMENTATION.md)
 
 </div>

--- a/docs/development/DEPLOYMENT.md
+++ b/docs/development/DEPLOYMENT.md
@@ -2304,10 +2304,10 @@ Level 3: Leadership
 
 ### Documentation Links
 
-- **Architecture Guide**: [ARCHITECTURE.md](./ARCHITECTURE.md)
-- **API Documentation**: [API_DOCUMENTATION.md](./API_DOCUMENTATION.md)  
+- **Architecture Guide**: [ARCHITECTURE.md](../architecture/ARCHITECTURE.md)
+- **API Documentation**: [API_DOCUMENTATION.md](../api/API_DOCUMENTATION.md)  
 - **Development Workflow**: [DEVELOPMENT_WORKFLOW.md](./DEVELOPMENT_WORKFLOW.md)
-- **Main Documentation**: [INDEX.md](./INDEX.md)
+- **Main Documentation**: [INDEX.md](../INDEX.md)
 - **Repository**: https://github.com/ruvnet/claude-flow
 - **Issues**: https://github.com/ruvnet/claude-flow/issues
 
@@ -2341,7 +2341,7 @@ kubectl get events --sort-by='.metadata.creationTimestamp' -n claude-flow  # Rec
 
 **Ready for Enterprise Scale • Production Tested • Fully Documented**
 
-[📚 Documentation Home](./INDEX.md) | [🏗️ Architecture](./ARCHITECTURE.md) | [📖 API Reference](./API_DOCUMENTATION.md) | [⚡ Development](./DEVELOPMENT_WORKFLOW.md)
+[📚 Documentation Home](../INDEX.md) | [🏗️ Architecture](../architecture/ARCHITECTURE.md) | [📖 API Reference](../api/API_DOCUMENTATION.md) | [⚡ Development](./DEVELOPMENT_WORKFLOW.md)
 
 [🐙 GitHub Repository](https://github.com/ruvnet/claude-flow) | [🐛 Report Issues](https://github.com/ruvnet/claude-flow/issues) | [💬 Community Support](https://discord.gg/claude-flow)
 

--- a/docs/github-issues/wsl-enotempty-automatic-recovery.md
+++ b/docs/github-issues/wsl-enotempty-automatic-recovery.md
@@ -277,9 +277,9 @@ await errorRecovery.retryWithRecovery(myOperation, {
 
 ### Updated Documentation
 
-- ✅ [Automatic Error Recovery](../docs/features/automatic-error-recovery.md)
-- ✅ [WSL Troubleshooting Guide](../docs/troubleshooting/wsl-better-sqlite3-error.md)
-- ✅ [Implementation Summary](../docs/AUTOMATIC_ERROR_RECOVERY_v2.7.35.md)
+- ✅ [Automatic Error Recovery](../features/automatic-error-recovery.md)
+- ✅ [WSL Troubleshooting Guide](../troubleshooting/wsl-better-sqlite3-error.md)
+- ✅ [Implementation Summary](../AUTOMATIC_ERROR_RECOVERY_v2.7.35.md)
 
 ### Examples Added
 

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -1127,7 +1127,7 @@ We welcome contributions! Please see our [Contributing Guide](../CONTRIBUTING.md
 
 You now have everything you need to master Claude-Flow!
 
-[🚀 Start Building](../README.md#-quick-start) | [📖 API Reference](API_DOCUMENTATION.md) | [🏗️ Architecture Guide](ARCHITECTURE.md)
+[🚀 Start Building](../README.md#-quick-start) | [📖 API Reference](../api/API_DOCUMENTATION.md) | [🏗️ Architecture Guide](../architecture/ARCHITECTURE.md)
 
 ---
 

--- a/docs/integrations/agent-booster/AGENT-BOOSTER-INTEGRATION.md
+++ b/docs/integrations/agent-booster/AGENT-BOOSTER-INTEGRATION.md
@@ -388,9 +388,9 @@ claude-flow agent booster benchmark --iterations 100
 
 ## 📚 Related Documentation
 
-- [PERFORMANCE-SYSTEMS-STATUS.md](./PERFORMANCE-SYSTEMS-STATUS.md) - Complete performance analysis
-- [AGENTIC-FLOW-INTEGRATION-GUIDE.md](./AGENTIC-FLOW-INTEGRATION-GUIDE.md) - Full agentic-flow integration
-- [REASONINGBANK-COST-OPTIMIZATION.md](./REASONINGBANK-COST-OPTIMIZATION.md) - Memory cost optimization
+- [PERFORMANCE-SYSTEMS-STATUS.md](../../technical/performance/PERFORMANCE-SYSTEMS-STATUS.md) - Complete performance analysis
+- [AGENTIC-FLOW-INTEGRATION-GUIDE.md](../agentic-flow/AGENTIC-FLOW-INTEGRATION-GUIDE.md) - Full agentic-flow integration
+- [REASONINGBANK-COST-OPTIMIZATION.md](../reasoningbank/REASONINGBANK-COST-OPTIMIZATION.md) - Memory cost optimization
 
 ---
 

--- a/docs/integrations/agentic-flow/README.md
+++ b/docs/integrations/agentic-flow/README.md
@@ -198,7 +198,7 @@ All improvements automatically benefit claude-flow users:
 
 - **Agentic-flow docs**: https://github.com/ruvnet/agentic-flow#readme
 - **Claude-flow docs**: [../../README.md](../../README.md)
-- **API reference**: [../../API_DOCUMENTATION.md](../../API_DOCUMENTATION.md)
+- **API reference**: [../../API_DOCUMENTATION.md](../../api/API_DOCUMENTATION.md)
 
 ---
 

--- a/docs/integrations/reasoningbank/REASONING-AGENTS.md
+++ b/docs/integrations/reasoningbank/REASONING-AGENTS.md
@@ -474,7 +474,7 @@ npx agentic-flow --agent reasoning-optimized --task "Build authentication"
 npx agentic-flow --agent adaptive-learner --task "Implement feature"
 ```
 
-See [REASONING-AGENTS.md](./docs/REASONING-AGENTS.md) for details.
+See [REASONING-AGENTS.md](./REASONING-AGENTS.md) for details.
 ```
 
 ---

--- a/docs/performance/PERFORMANCE-JSON-IMPROVEMENTS.md
+++ b/docs/performance/PERFORMANCE-JSON-IMPROVEMENTS.md
@@ -267,7 +267,7 @@ npx claude-flow memory stats
 ## Related Documentation
 
 - [Performance Metrics Guide](./PERFORMANCE-METRICS-GUIDE.md) - Detailed usage guide
-- [ReasoningBank Integration](./REASONINGBANK-INTEGRATION-STATUS.md) - ReasoningBank status
+- [ReasoningBank Integration](../integrations/reasoningbank/REASONINGBANK-INTEGRATION-STATUS.md) - ReasoningBank status
 - [AUTO MODE Documentation](./AUTO-MODE.md) - AUTO MODE details (if exists)
 
 ## Version

--- a/docs/reasoningbank/CLAUDE-CODE-INTEGRATION.md
+++ b/docs/reasoningbank/CLAUDE-CODE-INTEGRATION.md
@@ -559,5 +559,5 @@ ReasoningBank integration transforms Claude Code from a stateless tool into an i
 **Related Documentation**:
 - [ReasoningBank README](./README.md)
 - [Architecture Guide](./architecture.md)
-- [CLI Reference](./cli-reference.md)
+- [CLI Reference](../../benchmark/docs/cli-reference.md)
 - [Google Research Paper](./google-research.md)

--- a/docs/reasoningbank/models/_docs/COMPLETION-SUMMARY.md
+++ b/docs/reasoningbank/models/_docs/COMPLETION-SUMMARY.md
@@ -455,8 +455,8 @@ Every model achieved:
 
 **Documentation**:
 - Quick Start: [models/README.md](./README.md)
-- Usage Guide: [models/HOW-TO-USE.md](./HOW-TO-USE.md)
-- Training Guide: [models/HOW-TO-TRAIN.md](./HOW-TO-TRAIN.md)
+- Usage Guide: [models/HOW-TO-USE.md](../HOW-TO-USE.md)
+- Training Guide: [models/HOW-TO-TRAIN.md](../HOW-TO-TRAIN.md)
 - Navigation Index: [models/INDEX.md](./INDEX.md)
 
 **Issues**: [GitHub Issues](https://github.com/ruvnet/claude-flow/issues)

--- a/docs/reasoningbank/models/_docs/SCHEMA-UPDATE-SUMMARY.md
+++ b/docs/reasoningbank/models/_docs/SCHEMA-UPDATE-SUMMARY.md
@@ -335,7 +335,7 @@ CREATE TABLE session_metrics (id, session_id, metric_name, metric_value);
 
 See documentation:
 - [COMPATIBILITY.md](./COMPATIBILITY.md) - Schema reference
-- [HOW-TO-USE.md](./HOW-TO-USE.md) - Usage guide
+- [HOW-TO-USE.md](../HOW-TO-USE.md) - Usage guide
 - [README.md](./README.md) - Model catalog
 
 ### Issues?

--- a/docs/reasoningbank/models/_docs/VERIFICATION-COMPLETE.md
+++ b/docs/reasoningbank/models/_docs/VERIFICATION-COMPLETE.md
@@ -260,7 +260,7 @@ sqlite3 memory.db "SELECT COUNT(*) FROM patterns"
   - Model comparison
   - Installation
 
-- **[HOW-TO-USE.md](./HOW-TO-USE.md)** - Usage guide
+- **[HOW-TO-USE.md](../HOW-TO-USE.md)** - Usage guide
   - Installation methods
   - Query examples
   - Integration patterns
@@ -318,7 +318,7 @@ Each model has a detailed report:
 ### Questions?
 
 1. **Schema reference**: See [COMPATIBILITY.md](./COMPATIBILITY.md)
-2. **Usage help**: See [HOW-TO-USE.md](./HOW-TO-USE.md)
+2. **Usage help**: See [HOW-TO-USE.md](../HOW-TO-USE.md)
 3. **Model info**: See [README.md](./README.md)
 
 ### Issues?

--- a/docs/reference/AGENTS.md
+++ b/docs/reference/AGENTS.md
@@ -986,9 +986,9 @@ npx claude-flow@alpha dashboard --agents --performance
 ## 📮 Support & Resources
 
 ### Documentation
-- [Agent API Reference](/docs/API_DOCUMENTATION.md)
+- [Agent API Reference](../api/API_DOCUMENTATION.md)
 - [Swarm Coordination Guide](/docs/SWARM_DOCUMENTATION.md)
-- [Architecture Overview](/docs/ARCHITECTURE.md)
+- [Architecture Overview](../architecture/ARCHITECTURE.md)
 
 ### Community
 - [GitHub Repository](https://github.com/ruvnet/claude-flow)

--- a/docs/releases/v2.7.0-alpha.10/RELEASE-NOTES-v2.7.0-alpha.10.md
+++ b/docs/releases/v2.7.0-alpha.10/RELEASE-NOTES-v2.7.0-alpha.10.md
@@ -288,9 +288,9 @@ Users should:
 
 ## 📚 Related Documentation
 
-- [ReasoningBank v1.5.13 Validation](./validation/REASONINGBANK-v1.5.13-VALIDATION.md)
-- [Migration Guide v1.5.13](../integrations/reasoningbank/MIGRATION-v1.5.13.md)
-- [Process Exit Fix v2.7.0-alpha.9](./RELEASE-NOTES-v2.7.0-alpha.9.md)
+- [ReasoningBank v1.5.13 Validation](../../reports/validation/REASONINGBANK-v1.5.13-VALIDATION.md)
+- [Migration Guide v1.5.13](../../integrations/reasoningbank/MIGRATION-v1.5.13.md)
+- [Process Exit Fix v2.7.0-alpha.9](../v2.7.0-alpha.9/RELEASE-NOTES-v2.7.0-alpha.9.md)
 
 ---
 

--- a/docs/releases/v2.7.0-alpha.9/RELEASE-NOTES-v2.7.0-alpha.9.md
+++ b/docs/releases/v2.7.0-alpha.9/RELEASE-NOTES-v2.7.0-alpha.9.md
@@ -198,9 +198,9 @@ Users should:
 
 ## 📚 Related Documentation
 
-- [Process Exit Fix Report](./validation/PROCESS-EXIT-FIX-v2.7.0-alpha.9.md)
-- [ReasoningBank v1.5.13 Validation](./validation/REASONINGBANK-v1.5.13-VALIDATION.md)
-- [Migration Guide v1.5.13](../integrations/reasoningbank/MIGRATION-v1.5.13.md)
+- [Process Exit Fix Report](../../reports/validation/PROCESS-EXIT-FIX-v2.7.0-alpha.9.md)
+- [ReasoningBank v1.5.13 Validation](../../reports/validation/REASONINGBANK-v1.5.13-VALIDATION.md)
+- [Migration Guide v1.5.13](../../integrations/reasoningbank/MIGRATION-v1.5.13.md)
 
 ---
 

--- a/docs/setup/ENV-SETUP-GUIDE.md
+++ b/docs/setup/ENV-SETUP-GUIDE.md
@@ -147,7 +147,7 @@ claude-flow agent run coder "Build API" \
   --memory-k 5
 ```
 
-See [REASONINGBANK-COST-OPTIMIZATION.md](./REASONINGBANK-COST-OPTIMIZATION.md) for detailed cost analysis.
+See [REASONINGBANK-COST-OPTIMIZATION.md](../integrations/reasoningbank/REASONINGBANK-COST-OPTIMIZATION.md) for detailed cost analysis.
 
 ## Using Memory Without .env (Alternative Methods)
 
@@ -240,13 +240,13 @@ Database: 20 entries with embeddings
 **Solution:** Add API keys to `.env` file
 
 ### Problem: High costs with memory
-**Solution:** See [REASONINGBANK-COST-OPTIMIZATION.md](./REASONINGBANK-COST-OPTIMIZATION.md)
+**Solution:** See [REASONINGBANK-COST-OPTIMIZATION.md](../integrations/reasoningbank/REASONINGBANK-COST-OPTIMIZATION.md)
 
 ## Related Documentation
 
-- [REASONINGBANK-AGENT-CREATION-GUIDE.md](./REASONINGBANK-AGENT-CREATION-GUIDE.md) - Creating custom reasoning agents
-- [AGENTIC-FLOW-INTEGRATION-GUIDE.md](./AGENTIC-FLOW-INTEGRATION-GUIDE.md) - Complete command reference
-- [REASONINGBANK-COST-OPTIMIZATION.md](./REASONINGBANK-COST-OPTIMIZATION.md) - Cost savings strategies
+- [REASONINGBANK-AGENT-CREATION-GUIDE.md](../integrations/reasoningbank/REASONINGBANK-AGENT-CREATION-GUIDE.md) - Creating custom reasoning agents
+- [AGENTIC-FLOW-INTEGRATION-GUIDE.md](../integrations/agentic-flow/AGENTIC-FLOW-INTEGRATION-GUIDE.md) - Complete command reference
+- [REASONINGBANK-COST-OPTIMIZATION.md](../integrations/reasoningbank/REASONINGBANK-COST-OPTIMIZATION.md) - Cost savings strategies
 
 ## Template Contents
 

--- a/docs/technical/performance/PERFORMANCE-SYSTEMS-STATUS.md
+++ b/docs/technical/performance/PERFORMANCE-SYSTEMS-STATUS.md
@@ -324,10 +324,10 @@ Iteration 100: 91% success, 352x faster + 40% smarter, 78 memories
 
 ## 🔗 Related Documentation
 
-- [ReasoningBank Agent Creation](./REASONINGBANK-AGENT-CREATION-GUIDE.md)
-- [ReasoningBank Cost Optimization](./REASONINGBANK-COST-OPTIMIZATION.md)
-- [Agentic-Flow Integration](./AGENTIC-FLOW-INTEGRATION-GUIDE.md)
-- [Environment Setup](./ENV-SETUP-GUIDE.md)
+- [ReasoningBank Agent Creation](../../integrations/reasoningbank/REASONINGBANK-AGENT-CREATION-GUIDE.md)
+- [ReasoningBank Cost Optimization](../../integrations/reasoningbank/REASONINGBANK-COST-OPTIMIZATION.md)
+- [Agentic-Flow Integration](../../integrations/agentic-flow/AGENTIC-FLOW-INTEGRATION-GUIDE.md)
+- [Environment Setup](../../setup/ENV-SETUP-GUIDE.md)
 
 ## 📞 Support
 

--- a/src/swarm/optimizations/README.md
+++ b/src/swarm/optimizations/README.md
@@ -203,7 +203,7 @@ After implementing all optimizations:
 
 - [Migration Guide](./migration-guide.md)
 - [Optimization Analysis](/reports/swarm-optimization/recommendations/)
-- [Benchmark Results](/benchmark/demo_reports/)
+- [Benchmark Results](../../../benchmark/archive/demo_reports)
 
 ## 🤝 Contributing
 

--- a/tests/README-AGENTDB-TESTS.md
+++ b/tests/README-AGENTDB-TESTS.md
@@ -448,7 +448,7 @@ When adding new tests:
 
 ## Related Documentation
 
-- [AgentDB Integration Plan](../docs/AGENTDB_INTEGRATION_PLAN.md)
+- [AgentDB Integration Plan](../docs/agentdb/AGENTDB_INTEGRATION_PLAN.md)
 - [EnhancedMemory API](../src/memory/enhanced-memory.js)
 - [Test Writing Guide](../docs/TESTING.md)
 - [Performance Benchmarks](../docs/PERFORMANCE.md)

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -227,9 +227,9 @@ The validation suite includes security tests:
 
 ## 📚 Related Documentation
 
-- [COMMAND-VERIFICATION-REPORT.md](../../docs/COMMAND-VERIFICATION-REPORT.md)
-- [INTEGRATION_COMPLETE.md](../../docs/INTEGRATION_COMPLETE.md)
-- [REASONINGBANK-INTEGRATION-COMPLETE.md](../../docs/REASONINGBANK-INTEGRATION-COMPLETE.md)
+- [COMMAND-VERIFICATION-REPORT.md](../../docs/reports/validation/COMMAND-VERIFICATION-REPORT.md)
+- [INTEGRATION_COMPLETE.md](../../docs/reports/releases/INTEGRATION_COMPLETE.md)
+- [REASONINGBANK-INTEGRATION-COMPLETE.md](../../docs/integrations/reasoningbank/REASONINGBANK-INTEGRATION-COMPLETE.md)
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
Links were broken after documentation reorganization commits:
- 845ca517 (2025-09-22): docs reorganization into subfolders
- db9e94bd (2025-10-13): v2.7.0-alpha.7 release reorg
- 07328c07 (2025-10-23): docs structure reorganization

Fixed links in 36 files across:
- Main README.md and CHANGELOG.md
- docs/ directory (INDEX.md, README.md, guides, api, etc.)
- benchmark/ documentation
- tests/ documentation