### PR TITLE
fix: Add null validation for MCP tool handlers

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -199,6 +199,15 @@ export const agentTools: MCPTool[] = [
       const store = loadAgentStore();
       const agentId = (input.agentId as string) || `agent-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const agentType = input.agentType as string;
+
+      // Validate required parameter
+      if (!agentType || typeof agentType !== 'string') {
+        return {
+          success: false,
+          error: 'agentType parameter is required and must be a string',
+        };
+      }
+
       const config = (input.config as Record<string, unknown>) || {};
 
       // Add explicit model to config if provided
@@ -272,6 +281,14 @@ export const agentTools: MCPTool[] = [
       const store = loadAgentStore();
       const agentId = input.agentId as string;
 
+      // Validate required parameter
+      if (!agentId || typeof agentId !== 'string') {
+        return {
+          success: false,
+          error: 'agentId parameter is required and must be a string',
+        };
+      }
+
       if (store.agents[agentId]) {
         store.agents[agentId].status = 'terminated';
         saveAgentStore(store);
@@ -304,6 +321,16 @@ export const agentTools: MCPTool[] = [
     handler: async (input) => {
       const store = loadAgentStore();
       const agentId = input.agentId as string;
+
+      // Validate required parameter
+      if (!agentId || typeof agentId !== 'string') {
+        return {
+          agentId: null,
+          status: 'error',
+          error: 'agentId parameter is required and must be a string',
+        };
+      }
+
       const agent = store.agents[agentId];
 
       if (agent) {
@@ -584,6 +611,15 @@ export const agentTools: MCPTool[] = [
     handler: async (input) => {
       const store = loadAgentStore();
       const agentId = input.agentId as string;
+
+      // Validate required parameter
+      if (!agentId || typeof agentId !== 'string') {
+        return {
+          success: false,
+          error: 'agentId parameter is required and must be a string',
+        };
+      }
+
       const agent = store.agents[agentId];
 
       if (agent) {

--- a/v3/@claude-flow/cli/src/mcp-tools/claims-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/claims-tools.ts
@@ -120,6 +120,14 @@ export const claimsTools: MCPTool[] = [
       const claimantStr = input.claimant as string;
       const context = input.context as string | undefined;
 
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!claimantStr || typeof claimantStr !== 'string') {
+        return { success: false, error: 'claimant parameter is required and must be a string' };
+      }
+
       const claimant = parseClaimant(claimantStr);
       if (!claimant) {
         return { success: false, error: 'Invalid claimant format. Use "human:userId:name" or "agent:agentId:agentType"' };
@@ -185,6 +193,14 @@ export const claimsTools: MCPTool[] = [
       const issueId = input.issueId as string;
       const claimantStr = input.claimant as string;
       const reason = input.reason as string | undefined;
+
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!claimantStr || typeof claimantStr !== 'string') {
+        return { success: false, error: 'claimant parameter is required and must be a string' };
+      }
 
       const claimant = parseClaimant(claimantStr);
       if (!claimant) {
@@ -253,6 +269,17 @@ export const claimsTools: MCPTool[] = [
       const reason = input.reason as string | undefined;
       const progress = (input.progress as number) || 0;
 
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!fromStr || typeof fromStr !== 'string') {
+        return { success: false, error: 'from parameter is required and must be a string' };
+      }
+      if (!toStr || typeof toStr !== 'string') {
+        return { success: false, error: 'to parameter is required and must be a string' };
+      }
+
       const from = parseClaimant(fromStr);
       const to = parseClaimant(toStr);
 
@@ -310,6 +337,14 @@ export const claimsTools: MCPTool[] = [
     handler: async (input) => {
       const issueId = input.issueId as string;
       const claimantStr = input.claimant as string;
+
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!claimantStr || typeof claimantStr !== 'string') {
+        return { success: false, error: 'claimant parameter is required and must be a string' };
+      }
 
       const claimant = parseClaimant(claimantStr);
       if (!claimant) {
@@ -384,6 +419,14 @@ export const claimsTools: MCPTool[] = [
       const status = input.status as ClaimStatus;
       const note = input.note as string | undefined;
       const progress = input.progress as number | undefined;
+
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!status || typeof status !== 'string') {
+        return { success: false, error: 'status parameter is required and must be a string' };
+      }
 
       const store = loadClaims();
       const claim = store.claims[issueId];
@@ -500,6 +543,14 @@ export const claimsTools: MCPTool[] = [
       const preferredTypes = input.preferredTypes as string[] | undefined;
       const context = input.context as string | undefined;
 
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!reason || typeof reason !== 'string') {
+        return { success: false, error: 'reason parameter is required and must be a string' };
+      }
+
       const store = loadClaims();
       const claim = store.claims[issueId];
 
@@ -552,6 +603,14 @@ export const claimsTools: MCPTool[] = [
     handler: async (input) => {
       const issueId = input.issueId as string;
       const stealerStr = input.stealer as string;
+
+      // Validate required parameters
+      if (!issueId || typeof issueId !== 'string') {
+        return { success: false, error: 'issueId parameter is required and must be a string' };
+      }
+      if (!stealerStr || typeof stealerStr !== 'string') {
+        return { success: false, error: 'stealer parameter is required and must be a string' };
+      }
 
       const stealer = parseClaimant(stealerStr);
       if (!stealer) {

--- a/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
@@ -498,6 +498,12 @@ export const coordinationTools: MCPTool[] = [
     handler: async (input) => {
       const store = loadCoordStore();
       const task = input.task as string;
+
+      // Validate required parameter
+      if (!task || typeof task !== 'string') {
+        return { success: false, error: 'task parameter is required and must be a string' };
+      }
+
       const agents = (input.agents as string[]) || Object.keys(store.nodes);
       const strategy = (input.strategy as string) || 'parallel';
 

--- a/v3/@claude-flow/cli/src/mcp-tools/daa-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/daa-tools.ts
@@ -106,6 +106,11 @@ export const daaTools: MCPTool[] = [
       const store = loadDAAStore();
       const id = input.id as string;
 
+      // Validate required parameter
+      if (!id || typeof id !== 'string') {
+        return { success: false, error: 'id parameter is required and must be a string' };
+      }
+
       const agent: DAAAgent = {
         id,
         name: (input.name as string) || `DAA-${id}`,
@@ -158,6 +163,12 @@ export const daaTools: MCPTool[] = [
     handler: async (input) => {
       const store = loadDAAStore();
       const agentId = input.agentId as string;
+
+      // Validate required parameter
+      if (!agentId || typeof agentId !== 'string') {
+        return { success: false, error: 'agentId parameter is required and must be a string' };
+      }
+
       const agent = store.agents[agentId];
 
       if (!agent) {

--- a/v3/@claude-flow/cli/src/mcp-tools/embeddings-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/embeddings-tools.ts
@@ -289,6 +289,15 @@ export const embeddingsTools: MCPTool[] = [
       }
 
       const text = input.text as string;
+
+      // Validate required parameter
+      if (!text || typeof text !== 'string') {
+        return {
+          success: false,
+          error: 'text parameter is required and must be a string',
+        };
+      }
+
       const useHyperbolic = input.hyperbolic === true && config.hyperbolic.enabled;
 
       // Generate real ONNX embedding
@@ -355,6 +364,21 @@ export const embeddingsTools: MCPTool[] = [
 
       const text1 = input.text1 as string;
       const text2 = input.text2 as string;
+
+      // Validate required parameters
+      if (!text1 || typeof text1 !== 'string') {
+        return {
+          success: false,
+          error: 'text1 parameter is required and must be a string',
+        };
+      }
+      if (!text2 || typeof text2 !== 'string') {
+        return {
+          success: false,
+          error: 'text2 parameter is required and must be a string',
+        };
+      }
+
       const metric = (input.metric as string) || 'cosine';
 
       // Generate real ONNX embeddings for both texts
@@ -445,6 +469,15 @@ export const embeddingsTools: MCPTool[] = [
       }
 
       const query = input.query as string;
+
+      // Validate required parameter
+      if (!query || typeof query !== 'string') {
+        return {
+          success: false,
+          error: 'query parameter is required and must be a string',
+        };
+      }
+
       const topK = (input.topK as number) || 5;
       const threshold = (input.threshold as number) || 0.5;
       const namespace = input.namespace as string;

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -400,6 +400,16 @@ export const hooksPreEdit: MCPTool = {
   },
   handler: async (params: Record<string, unknown>) => {
     const filePath = params.filePath as string;
+
+    // Validate required parameter
+    if (!filePath || typeof filePath !== 'string') {
+      return {
+        error: 'filePath parameter is required and must be a string',
+        filePath: null,
+        context: null,
+      };
+    }
+
     const operation = (params.operation as string) || 'update';
 
     const suggestedAgents = suggestAgentsForFile(filePath);
@@ -464,6 +474,17 @@ export const hooksPreCommand: MCPTool = {
   },
   handler: async (params: Record<string, unknown>) => {
     const command = params.command as string;
+
+    // Validate required parameter
+    if (!command || typeof command !== 'string') {
+      return {
+        error: 'command parameter is required and must be a string',
+        command: null,
+        riskLevel: 'unknown',
+        risks: [],
+      };
+    }
+
     const assessment = assessCommandRisk(command);
 
     const riskLevel = assessment.level >= 0.8 ? 'critical'
@@ -526,6 +547,17 @@ export const hooksRoute: MCPTool = {
   },
   handler: async (params: Record<string, unknown>) => {
     const task = params.task as string;
+
+    // Validate required parameter
+    if (!task || typeof task !== 'string') {
+      return {
+        error: 'task parameter is required and must be a string',
+        task: null,
+        primaryAgent: null,
+        alternativeAgents: [],
+      };
+    }
+
     const suggestion = suggestAgentsForTask(task);
 
     // Determine complexity based on task length and keywords
@@ -669,6 +701,23 @@ export const hooksPreTask: MCPTool = {
     const taskId = params.taskId as string;
     const description = params.description as string;
     const filePath = params.filePath as string | undefined;
+
+    // Validate required parameters
+    if (!taskId || typeof taskId !== 'string') {
+      return {
+        error: 'taskId parameter is required and must be a string',
+        taskId: null,
+        suggestedAgents: [],
+      };
+    }
+    if (!description || typeof description !== 'string') {
+      return {
+        error: 'description parameter is required and must be a string',
+        taskId,
+        suggestedAgents: [],
+      };
+    }
+
     const suggestion = suggestAgentsForTask(description);
 
     // Determine complexity
@@ -2579,6 +2628,17 @@ export const hooksWorkerDetect: MCPTool = {
   },
   handler: async (params: Record<string, unknown>) => {
     const prompt = params.prompt as string;
+
+    // Validate required parameter
+    if (!prompt || typeof prompt !== 'string') {
+      return {
+        error: 'prompt parameter is required and must be a string',
+        triggersFound: 0,
+        detected: false,
+        triggers: [],
+      };
+    }
+
     const autoDispatch = params.autoDispatch as boolean;
     const minConfidence = (params.minConfidence as number) || 0.5;
 

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -146,6 +146,16 @@ export const memoryTools: MCPTool[] = [
       required: ['query'],
     },
     handler: async (input) => {
+      // Validate required parameter
+      if (!input.query || typeof input.query !== 'string') {
+        return {
+          error: 'query parameter is required and must be a string',
+          query: null,
+          results: [],
+          total: 0,
+        };
+      }
+
       const store = loadMemoryStore();
       const query = (input.query as string).toLowerCase();
       const limit = (input.limit as number) || 10;

--- a/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
@@ -237,6 +237,14 @@ export const neuralTools: MCPTool[] = [
       const inputText = input.input as string;
       const topK = (input.topK as number) || 3;
 
+      // Validate required parameter
+      if (!inputText || typeof inputText !== 'string') {
+        return {
+          success: false,
+          error: 'input parameter is required and must be a string',
+        };
+      }
+
       // Find model or use default
       const model = modelId ? store.models[modelId] : Object.values(store.models).find(m => m.status === 'ready');
 

--- a/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
@@ -84,6 +84,15 @@ export const taskTools: MCPTool[] = [
     },
     handler: async (input) => {
       const store = loadTaskStore();
+
+      // Validate required parameters
+      if (!input.type || typeof input.type !== 'string') {
+        return { error: 'type parameter is required and must be a string' };
+      }
+      if (!input.description || typeof input.description !== 'string') {
+        return { error: 'description parameter is required and must be a string' };
+      }
+
       const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
       const task: TaskRecord = {


### PR DESCRIPTION
## Summary

Adds defensive null/type checks before calling string methods on parameters in MCP tool handlers. This prevents `TypeError: Cannot read properties of undefined` crashes when tools are called with missing or invalid parameters.

**Total: 25 handlers fixed across 9 files (+232 lines of validation code)**

## Bug Fixes by File

### hooks-tools.ts (5 handlers)
| Tool | Bug | Fix |
|------|-----|-----|
| `hooks/pre-edit` | `filePath.match()` crash | Validate `filePath` is string |
| `hooks/pre-command` | `command.includes()` crash | Validate `command` is string |
| `hooks/route` | `task.toLowerCase()` crash | Validate `task` is string |
| `hooks/pre-task` | `description.toLowerCase()` crash | Validate `taskId` and `description` |
| `hooks/worker-detect` | `prompt.slice()` crash | Validate `prompt` is string |

### memory-tools.ts (1 handler)
| Tool | Bug | Fix |
|------|-----|-----|
| `memory/search` | `query.toLowerCase()` crash | Validate `query` is string |

### embeddings-tools.ts (3 handlers)
| Tool | Bug | Fix |
|------|-----|-----|
| `embeddings/embed` | `text.length` crash | Validate `text` is string |
| `embeddings/compare` | `text1.slice()`, `text2.slice()` crash | Validate `text1` and `text2` |
| `embeddings/search` | `generateRealEmbedding(query)` crash | Validate `query` is string |

### claims-tools.ts (7 handlers)
| Tool | Bug | Fix |
|------|-----|-----|
| `claims/claim` | `parseClaimant(claimantStr)` crash | Validate `issueId` and `claimant` |
| `claims/release` | `parseClaimant(claimantStr)` crash | Validate `issueId` and `claimant` |
| `claims/transfer` | `parseClaimant()` crash | Validate `issueId`, `from`, `to` |
| `claims/accept-handoff` | `parseClaimant(claimantStr)` crash | Validate `issueId` and `claimant` |
| `claims/status` | undefined key access | Validate `issueId` and `status` |
| `claims/mark-stealable` | undefined key access | Validate `issueId` and `reason` |
| `claims/steal` | `parseClaimant(stealerStr)` crash | Validate `issueId` and `stealer` |

### agent-tools.ts (4 handlers)
| Tool | Bug | Fix |
|------|-----|-----|
| `agent/spawn` | `agentType` undefined in object | Validate `agentType` is string |
| `agent/terminate` | `agentId` undefined key | Validate `agentId` is string |
| `agent/status` | `agentId` undefined key | Validate `agentId` is string |
| `agent/update` | `agentId` undefined key | Validate `agentId` is string |

### neural-tools.ts (1 handler)
| Tool | Bug | Fix |
|------|-----|-----|
| `neural/predict` | `generateEmbedding(inputText)` crash | Validate `input` is string |

### task-tools.ts (1 handler)
| Tool | Bug | Fix |
|------|-----|-----|
| `task/create` | `type`, `description` undefined | Validate `type` and `description` |

### daa-tools.ts (2 handlers)
| Tool | Bug | Fix |
|------|-----|-----|
| `daa/agent_create` | `id` undefined key | Validate `id` is string |
| `daa/agent_adapt` | `agentId` undefined key | Validate `agentId` is string |

### coordination-tools.ts (1 handler)
| Tool | Bug | Fix |
|------|-----|-----|
| `coordination/orchestrate` | `task` undefined | Validate `task` is string |

## Root Cause

All bugs follow the same unsafe pattern:
```typescript
// BEFORE: Unsafe - crashes if params.x is undefined
const x = params.x as string;
x.someStringMethod(); // TypeError!

// AFTER: Safe - validates before use
const x = params.x as string;
if (!x || typeof x !== 'string') {
  return { error: 'x parameter is required and must be a string', ... };
}
x.someStringMethod(); // Safe
```

## Test Plan

- [x] Verified each fix locally by calling MCP tools without required parameters
- [x] Confirmed error responses are returned instead of crashes
- [x] TypeScript compilation passes for modified files

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)