### PR TITLE
fix(status): show RUNNING when daemon is active

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
@@ -344,4 +344,24 @@ export const taskTools: MCPTool[] = [
       };
     },
   },
+  {
+    name: 'task_summary',
+    description: 'Get task summary counts by status',
+    category: 'task',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      const store = loadTaskStore();
+      const tasks = Object.values(store.tasks);
+      return {
+        total: tasks.length,
+        pending: tasks.filter(t => t.status === 'pending').length,
+        running: tasks.filter(t => t.status === 'in_progress').length,
+        completed: tasks.filter(t => t.status === 'completed').length,
+        failed: tasks.filter(t => t.status === 'failed').length,
+      };
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- Add missing `task_summary` MCP tool to task-tools.ts
- Replace monolithic try-catch with granular error handling per service
- Use `anyServiceRunning` boolean to determine overall status
- Add fallback to `task_list` if `task_summary` fails

## Test plan

- [ ] Start daemon with `npx . daemon start`
- [ ] Verify `npx . status` shows `[RUNNING]`
- [ ] Stop daemon with `npx . daemon stop`
- [ ] Verify `npx . status` shows `[STOPPED]`

Fixes #984

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)