### PR TITLE
fix: Add windowsHide to prevent phantom console windows on Windows

### DIFF
--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -633,6 +633,7 @@ export class HeadlessWorkerExecutor extends EventEmitter {
         encoding: 'utf-8',
         stdio: 'pipe',
         timeout: 5000,
+        windowsHide: true, // Prevent phantom console windows on Windows
       });
       this.claudeCodeAvailable = true;
       this.claudeCodeVersion = output.trim();
@@ -1125,6 +1126,7 @@ Analyze the above codebase context and provide your response following the forma
         cwd: this.projectRoot,
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true, // Prevent phantom console windows on Windows
       });
 
       // Setup timeout


### PR DESCRIPTION
## Summary

On Windows, `spawn` and `execSync` calls without `windowsHide: true` cause phantom console windows to open on screen, disrupting user experience.

This PR adds `windowsHide: true` to:
- `execSync` call in `isAvailable()` method (claude --version check)
- `spawn` call in `executeClaudeCode()` method (claude CLI execution)

## Changes

- `v3/@claude-flow/cli/src/services/headless-worker-executor.ts`: Added `windowsHide: true` to both `execSync` and `spawn` calls

## Testing

Tested on Windows 10/11 - no more phantom console windows appear when running headless workers.

Fixes #997