### PR TITLE
Add async hooks support for non-blocking operations (Claude Code 2.1.0+)

### DIFF
--- a/v3/@claude-flow/cli/src/init/types.ts
+++ b/v3/@claude-flow/cli/src/init/types.ts
@@ -52,6 +52,22 @@ export interface HooksConfig {
   timeout: number;
   /** Continue on hook error */
   continueOnError: boolean;
+  /**
+   * Enable async execution for non-blocking hooks (Claude Code 2.1.0+)
+   * When true, hooks run in background without blocking execution
+   * Great for logging, notifications, or any side-effect that shouldn't slow things down
+   */
+  enableAsync: boolean;
+  /**
+   * Default async mode for PostToolUse hooks
+   * PostToolUse hooks typically don't need to block since they run after the tool completes
+   */
+  postToolUseAsync: boolean;
+  /**
+   * Default async mode for Notification hooks
+   * Notifications are pure side-effects and shouldn't block execution
+   */
+  notificationAsync: boolean;
 }
 
 /**
@@ -314,6 +330,9 @@ export const DEFAULT_INIT_OPTIONS: InitOptions = {
     notification: true,
     timeout: 5000,
     continueOnError: true,
+    enableAsync: true,           // Enable async hooks (Claude Code 2.1.0+)
+    postToolUseAsync: true,      // PostToolUse runs async (non-blocking)
+    notificationAsync: true,     // Notifications run async (non-blocking)
   },
   skills: {
     core: true,
@@ -403,6 +422,9 @@ export const MINIMAL_INIT_OPTIONS: InitOptions = {
     userPromptSubmit: false,
     stop: false,
     notification: false,
+    enableAsync: true,           // Enable async hooks (Claude Code 2.1.0+)
+    postToolUseAsync: true,      // PostToolUse runs async (non-blocking)
+    notificationAsync: true,     // Notifications run async (non-blocking)
   },
   skills: {
     core: true,

--- a/v3/@claude-flow/cli/src/types.ts
+++ b/v3/@claude-flow/cli/src/types.ts
@@ -144,6 +144,23 @@ export interface HookDefinition {
   handler: string;
   priority: number;
   enabled: boolean;
+  /**
+   * Run hook asynchronously without blocking Claude Code's execution (Claude Code 2.1.0+)
+   * Great for logging, notifications, or any side-effect that shouldn't slow things down
+   * @default false
+   */
+  async?: boolean;
+  /**
+   * Maximum execution time in milliseconds
+   * @default 5000
+   */
+  timeout?: number;
+  /**
+   * Execute only once per session (Claude Code 2.1.0+)
+   * Useful for initialization hooks
+   * @default false
+   */
+  once?: boolean;
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for asynchronous hooks in Claude Code 2.1.0+, allowing hooks to run in the background without blocking execution. This is particularly useful for logging, notifications, metrics, and other side-effects that shouldn't impact performance.

## Key Changes

- **Documentation**: Added extensive "Async Hooks" section to SKILL.md with:
  - Decision table for when to use async hooks by type
  - Configuration examples for non-blocking logging and daemon startup
  - Benefits and use cases
  - Updated performance tips to reference the new `async: true` option

- **Type Definitions**: Extended `HookDefinition` interface in `src/types.ts` with:
  - `async?: boolean` - Enable asynchronous execution
  - `timeout?: number` - Maximum execution time in milliseconds
  - `once?: boolean` - Execute only once per session (Claude Code 2.1.0+)

- **Configuration**: Updated `HooksConfig` in `src/init/types.ts` with:
  - `enableAsync: boolean` - Master flag for async hook support
  - `postToolUseAsync: boolean` - Default async mode for PostToolUse hooks
  - `notificationAsync: boolean` - Default async mode for Notification hooks

- **Settings Generator**: Modified `src/init/settings-generator.ts` to:
  - Set `async: true` by default for PostToolUse hooks (logging/metrics don't need to block)
  - Set `async: true` by default for Notification hooks (pure side-effects)
  - Keep daemon start async while session-restore runs synchronously (context must load first)
  - Added inline comments explaining async behavior for each hook type

- **Defaults**: Updated both `DEFAULT_INIT_OPTIONS` and `MINIMAL_INIT_OPTIONS` to enable async hooks by default

## Implementation Details

The async hooks feature follows a sensible default strategy:
- **PostToolUse hooks**: Async by default (run after tool completes, don't need to block)
- **Notification hooks**: Async by default (pure side-effects, shouldn't block)
- **SessionStart hooks**: Mixed approach (daemon start is async, session-restore is sync to ensure context loads)
- **Stop/PreToolUse hooks**: Remain synchronous by default (may need to block for validation/cleanup)

All changes are backward compatible - the `async` property is optional and defaults to `false` for existing hook definitions.