### PR TITLE
fix(statusline): resolve character bleeding in Claude Code status line

### DIFF
--- a/v3/@claude-flow/hooks/__tests__/statusline/statusline-collision.test.ts
+++ b/v3/@claude-flow/hooks/__tests__/statusline/statusline-collision.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for statusline collision zone avoidance
+ * Tests for statusline collision zone avoidance and display width utilities
  *
  * @see https://github.com/ruvnet/claude-flow/issues/985
  *
@@ -7,17 +7,12 @@
  * Claude Code writes its internal status (e.g., "7s • 1p") at these absolute
  * terminal coordinates, causing character bleeding if our statusline has
  * content there.
+ *
+ * Additionally tests display width calculation for proper terminal rendering
+ * with emojis, ANSI codes, and wide characters.
  */
 
 import { describe, it, expect } from 'vitest';
-
-/**
- * Strip ANSI escape codes from a string
- */
-function stripAnsi(str: string): string {
-  // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, '');
-}
 
 /**
  * Get the character at a specific column (0-indexed)
@@ -168,5 +163,147 @@ describe('Statusline Output Modes', () => {
     // Compact JSON
     const compact = generator.generateCompactJSON();
     expect(JSON.parse(compact)).toBeDefined();
+  });
+});
+
+describe('Display Width Utilities', () => {
+  it('should strip ANSI codes correctly', async () => {
+    const { stripAnsi } = await import('../../src/statusline/index.js');
+
+    expect(stripAnsi('\x1b[1;31mRed Bold\x1b[0m')).toBe('Red Bold');
+    expect(stripAnsi('\x1b[0;32mGreen\x1b[0m normal')).toBe('Green normal');
+    expect(stripAnsi('No codes here')).toBe('No codes here');
+    expect(stripAnsi('')).toBe('');
+  });
+
+  it('should calculate display width for ASCII strings', async () => {
+    const { getDisplayWidth } = await import('../../src/statusline/index.js');
+
+    expect(getDisplayWidth('hello')).toBe(5);
+    expect(getDisplayWidth('hello world')).toBe(11);
+    expect(getDisplayWidth('')).toBe(0);
+  });
+
+  it('should calculate display width ignoring ANSI codes', async () => {
+    const { getDisplayWidth } = await import('../../src/statusline/index.js');
+
+    // ANSI codes should have 0 display width
+    expect(getDisplayWidth('\x1b[1;31mRed\x1b[0m')).toBe(3);
+    expect(getDisplayWidth('\x1b[0;32mGreen\x1b[0m normal')).toBe(12);
+  });
+
+  it('should calculate display width for emojis as 2 columns', async () => {
+    const { getDisplayWidth } = await import('../../src/statusline/index.js');
+
+    // Emojis typically take 2 columns in terminal
+    expect(getDisplayWidth('🤖')).toBe(2);
+    expect(getDisplayWidth('Hello 🤖')).toBe(8); // 6 + 2
+    expect(getDisplayWidth('🤖🧠')).toBe(4); // 2 + 2
+  });
+
+  it('should pad strings to target width', async () => {
+    const { padToWidth, getDisplayWidth } = await import('../../src/statusline/index.js');
+
+    const padded = padToWidth('Hi', 10);
+    expect(getDisplayWidth(padded)).toBe(10);
+    expect(padded).toBe('Hi        '); // 8 spaces
+
+    // Right align
+    const rightPadded = padToWidth('Hi', 10, ' ', 'right');
+    expect(rightPadded).toBe('        Hi');
+
+    // Center align
+    const centerPadded = padToWidth('Hi', 10, ' ', 'center');
+    expect(centerPadded).toBe('    Hi    ');
+  });
+
+  it('should truncate strings to max width', async () => {
+    const { truncateToWidth, getDisplayWidth } = await import('../../src/statusline/index.js');
+
+    const truncated = truncateToWidth('Hello World', 8);
+    expect(getDisplayWidth(truncated)).toBeLessThanOrEqual(8);
+    expect(truncated).toContain('…');
+
+    // Should not truncate if under max
+    const notTruncated = truncateToWidth('Hi', 10);
+    expect(notTruncated).toBe('Hi');
+  });
+});
+
+describe('Single Line Output - Character Bleeding Fix', () => {
+  it('should produce ASCII-only output by default', async () => {
+    const { StatuslineGenerator, stripAnsi } = await import('../../src/statusline/index.js');
+
+    const generator = new StatuslineGenerator();
+    const output = generator.generateSingleLine();
+
+    if (!output) return;
+
+    // Strip ANSI and check for emoji characters
+    const stripped = stripAnsi(output);
+
+    // Should NOT contain common problematic emojis
+    expect(stripped).not.toContain('🤖');
+    expect(stripped).not.toContain('🧠');
+    expect(stripped).not.toContain('●'); // Unicode bullet can cause issues
+
+    // Should contain ASCII-safe indicators
+    expect(stripped).toContain('CF-V3');
+    expect(stripped).toContain('D:');
+    expect(stripped).toContain('S:');
+    expect(stripped).toContain('CVE:');
+    expect(stripped).toContain('Int:');
+  });
+
+  it('should have no newlines in single-line output', async () => {
+    const { StatuslineGenerator } = await import('../../src/statusline/index.js');
+
+    const generator = new StatuslineGenerator();
+
+    // Test default single-line
+    const single = generator.generateSingleLine();
+    if (single) {
+      expect(single.includes('\n')).toBe(false);
+    }
+
+    // Test with emoji
+    const singleEmoji = generator.generateSingleLineWithEmoji();
+    if (singleEmoji) {
+      expect(singleEmoji.includes('\n')).toBe(false);
+    }
+
+    // Test ASCII-only
+    const singleAscii = generator.generateSingleLineAscii();
+    if (singleAscii) {
+      expect(singleAscii.includes('\n')).toBe(false);
+    }
+  });
+
+  it('should support no-color mode', async () => {
+    const { StatuslineGenerator } = await import('../../src/statusline/index.js');
+
+    const generator = new StatuslineGenerator();
+    const output = generator.generateSingleLine(false); // useColor = false
+
+    if (!output) return;
+
+    // Should not contain ANSI escape sequences
+    expect(output).not.toContain('\x1b[');
+  });
+
+  it('should produce predictable display width for ASCII output', async () => {
+    const { StatuslineGenerator, getDisplayWidth } = await import('../../src/statusline/index.js');
+
+    const generator = new StatuslineGenerator();
+    const output = generator.generateSingleLineAscii();
+
+    if (!output) return;
+
+    const width = getDisplayWidth(output);
+
+    // ASCII-only output should have predictable width
+    // The width should match the string length (since no ANSI codes and no wide chars)
+    expect(width).toBe(output.length);
+    expect(width).toBeLessThan(100); // Reasonable single-line length
   });
 });

--- a/v3/@claude-flow/hooks/src/index.ts
+++ b/v3/@claude-flow/hooks/src/index.ts
@@ -64,6 +64,11 @@ export {
   createShellStatusline,
   parseStatuslineData,
   defaultStatuslineGenerator,
+  // Display width utilities for proper terminal rendering
+  stripAnsi,
+  getDisplayWidth,
+  padToWidth,
+  truncateToWidth,
 } from './statusline/index.js';
 
 // MCP Tools


### PR DESCRIPTION
## Summary

Fixes character bleeding issue in Claude Code's statusLine where emojis and multi-line output cause terminal cursor positioning problems.

**Problem:**
- Multi-line statusline output confused terminal cursor positioning
- Emojis have inconsistent display widths (1-2 columns) across terminals
- ANSI escape codes contribute to string length but not visual width
- This caused "character bleeding" where text would overlap incorrectly

## Changes

### 1. Display Width Utilities (`statusline/index.ts`)
- `stripAnsi()`: Remove ANSI escape codes from strings
- `getDisplayWidth()`: Calculate visual width accounting for emojis (2 cols) and ANSI codes (0 cols)
- `padToWidth()`: Pad strings to target display width with alignment options
- `truncateToWidth()`: Truncate with proper width calculation

### 2. Improved Single-Line Output
- `generateSingleLine(useColor)`: Uses ASCII-only symbols by default for maximum compatibility
- `generateSingleLineWithEmoji(useColor)`: Optional emoji variant for terminals that handle them well
- `generateSingleLineAscii()`: Pure ASCII, no colors, maximum compatibility

### 3. New CLI Flags (`hooks statusline`)
- `--single-line`: ASCII-safe single-line output (recommended for Claude Code)
- `--safe`: Multi-line output with collision zone avoidance
- `--emoji`: Include emojis in single-line output (may cause display issues)

### 4. Comprehensive Tests
- Tests for display width calculation with ASCII, ANSI codes, and emojis
- Tests for single-line output format
- Tests for no-color mode

## Recommended Usage

For Claude Code's `statusLine` config in `.claude/settings.json`:

```json
{
  "statusLine": {
    "type": "command",
    "command": "npx @claude-flow/cli@latest hooks statusline --single-line",
    "refreshMs": 5000,
    "enabled": true
  }
}
```

## Test plan

- [ ] Verify `--single-line` produces no newlines and ASCII-only output
- [ ] Verify `--single-line --emoji` includes emojis correctly
- [ ] Verify `--single-line --no-color` produces no ANSI codes
- [ ] Verify `--safe` multi-line output avoids collision zone (cols 15-25)
- [ ] Test in Claude Code with statusLine enabled to confirm no bleeding

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)