### PR TITLE
Fix ADR links

### DIFF
--- a/v3/plugins/gastown-bridge/README.md
+++ b/v3/plugins/gastown-bridge/README.md
@@ -633,8 +633,8 @@ See [MCP Tools Documentation](./docs/mcp-tools.md) for complete API reference.
 - [Gas Town GitHub](https://github.com/steveyegge/gastown)
 - [Beads GitHub](https://github.com/steveyegge/beads)
 - [Welcome to Gas Town (Steve Yegge)](https://steve-yegge.medium.com/welcome-to-gas-town-4f25ee16dd04)
-- [ADR-043: Gas Town Bridge Plugin](../implementation/adrs/ADR-043-gastown-bridge-plugin.md)
-- [ADR-042: Gas Town Analysis](../implementation/adrs/ADR-042-gas-town-analysis.md)
+- [ADR-043: Gas Town Bridge Plugin](../../implementation/adrs/ADR-043-gastown-bridge-plugin.md)
+- [ADR-042: Gas Town Analysis](../../implementation/adrs/ADR-042-gas-town-analysis.md)
 
 ## Contributing
 


### PR DESCRIPTION
This pull request updates documentation links in the `gastown-bridge` plugin's `README.md` to ensure they point to the correct locations. The changes are minor and focus on fixing relative paths to ADR documents. 

- Updated the relative paths for the ADR links in `README.md` to correctly reference the ADR documentation in the `implementation/adrs` directory.