### PR TITLE
fix: respect user's model selection instead of forcing overrides

### DIFF
--- a/v3/@claude-flow/cli/src/runtime/headless.ts
+++ b/v3/@claude-flow/cli/src/runtime/headless.ts
@@ -142,7 +142,6 @@ async function runWorker(workerType: HeadlessWorkerType, timeout: number): Promi
   try {
     const result = await executor.execute(workerType, {
       timeoutMs: timeout,
-      model: 'sonnet',
       sandbox: 'permissive'
     });
 

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -272,7 +272,7 @@ export const LOCAL_WORKER_TYPES: LocalWorkerType[] = [
  */
 const MODEL_IDS: Record<ModelType, string> = {
   sonnet: 'claude-sonnet-4-20250514',
-  opus: 'claude-opus-4-20250514',
+  opus: 'claude-opus-4-5-20251101',
   haiku: 'claude-haiku-4-20250514',
 };
 
@@ -1118,8 +1118,10 @@ Analyze the above codebase context and provide your response following the forma
         CLAUDE_CODE_SANDBOX_MODE: options.sandbox,
       };
 
-      // Set model
-      env.ANTHROPIC_MODEL = MODEL_IDS[options.model];
+      // Set model — only override if not already set by user
+      if (!env.ANTHROPIC_MODEL) {
+        env.ANTHROPIC_MODEL = MODEL_IDS[options.model];
+      }
 
       // Spawn claude CLI process
       const child = spawn('claude', ['--print', prompt], {


### PR DESCRIPTION
## Summary

Fixes #1044 — user configures Sonnet 4.5 in Claude Code but claude-flow forces Opus 4.5.

**Three root causes found and fixed:**

- **Wrong Opus model ID**: `claude-opus-4-20250514` → `claude-opus-4-5-20251101` (the old ID doesn't exist)
- **Env var stomping**: `ANTHROPIC_MODEL` was unconditionally overwritten in `executeClaudeCode()`, ignoring any user-set value. Now respects existing env var.
- **Hardcoded sonnet override**: `headless.ts` runtime passed `model: 'sonnet'` as a config override, stomping each worker's own model preference. Removed so workers use their configured model.

## Changes

| File | Change |
|------|--------|
| `v3/.../headless-worker-executor.ts` | Fix Opus model ID, respect existing `ANTHROPIC_MODEL` env var |
| `v3/.../headless.ts` | Remove hardcoded `model: 'sonnet'` override |

## Test plan

- [ ] Set `ANTHROPIC_MODEL=claude-sonnet-4-20250514` in env, run a headless worker — should use Sonnet, not Opus
- [ ] Without env var set, workers should use their configured default model
- [ ] `ultralearn` and `deepdive` workers should correctly resolve to Opus 4.5 (new model ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)