### PR TITLE
fix(cli): allow subcommand options to override global options

### DIFF
--- a/v3/@claude-flow/cli/src/index.ts
+++ b/v3/@claude-flow/cli/src/index.ts
@@ -207,6 +207,10 @@ export class CLI {
         }
       }
 
+      // Apply command-specific defaults before validation
+      // This ensures subcommand options properly override global options
+      this.parser.applyDefaults(flags, targetCommand);
+
       // Validate flags
       const validationErrors = this.parser.validateFlags(flags, targetCommand);
       if (validationErrors.length > 0) {


### PR DESCRIPTION
## Summary

- Fixes bug where subcommand `--format` option was being validated against global option choices
- Example: `claude-flow process monitor` failed with "Invalid value for --format: text. Must be one of: dashboard, compact, json"

## Root Cause

The parser applied global option defaults (`--format` defaulting to `'text'`) before command resolution. When validating, the subcommand's `--format` choices (`['dashboard', 'compact', 'json']`) were checked against the global default value (`'text'`), causing validation to fail.

## Changes

1. **parser.ts**: Defer `applyDefaults()` - no longer called during `parse()`, moved to CLI after command resolution
2. **parser.ts**: Updated `applyDefaults()` to accept command parameter and skip global defaults when command defines same option
3. **parser.ts**: Updated `validateFlags()` to filter out global options when command overrides them
4. **index.ts**: Call `applyDefaults(flags, targetCommand)` after subcommand resolution

## Test Plan

- [x] `claude-flow process monitor` now works (uses dashboard format by default)
- [x] `claude-flow process monitor --format json` works
- [x] `claude-flow process monitor --format compact` works
- [x] `claude-flow --version` still works
- [x] Other commands unaffected

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)