### PR TITLE
fix: daemon resource thresholds incompatible with macOS

### DIFF
--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -214,7 +214,7 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean): Promi
   // This prevents command injection via paths
   const child = spawn(process.execPath, [
     cliPath,
-    'daemon', 'start', '--foreground', '--quiet'
+    'daemon', 'start', '--foreground'
   ], {
     cwd: resolvedRoot,
     detached: true,


### PR DESCRIPTION
## Summary

Fixes #1077 — Daemon workers never execute on macOS due to unrealistic resource thresholds in `canRunWorker()`.

**Three issues fixed:**

1. **`maxCpuLoad: 2.0` too low for multi-core systems** — `os.loadavg()` returns system-wide load (not per-core). An 8-core Mac under normal workload reports ~8-16, far exceeding 2.0. Changed to dynamic core-aware threshold (`os.cpus().length * 3`).

2. **`minFreeMemoryPercent: 20` incompatible with macOS** — `os.freemem()` on macOS only reports truly unused RAM, excluding reclaimable cached/purgeable memory. A typical Mac shows 1-5% "free" even with plenty available. Changed default to 1%.

3. **`--quiet` flag hardcoded in background daemon spawn** — `daemon.ts` line 217 hardcoded `--quiet`, suppressing all worker event logging to the daemon log file, making diagnosis impossible.

## Changes

- `worker-daemon.ts`: Changed `maxCpuLoad` default from `2.0` to `0` (signals dynamic threshold). Updated `canRunWorker()` to compute core-aware threshold when config is 0.
- `worker-daemon.ts`: Changed `minFreeMemoryPercent` default from `20` to `1`.
- `daemon.ts`: Removed hardcoded `--quiet` flag from background process spawn.

## Test plan

- [x] Verified `map` worker executes immediately on macOS (was permanently deferred before)
- [x] Verified `audit` worker starts after 120s offset
- [x] Verified `codebase-map.json` metrics file is written
- [x] Verified daemon state file updates with `runCount > 0`
- [ ] Test on Linux to confirm behavior unchanged (load avg reporting is similar)

## Context

The combination of low thresholds + the deadlock in `processPendingWorkers()` (addressed separately in #1052) means zero workers ever execute on macOS. This PR fixes the root cause while #1052 fixes the amplification.