### PR TITLE
feat: update default model to Claude Opus 4.6

### DIFF
--- a/.claude/helpers/auto-commit.sh
+++ b/.claude/helpers/auto-commit.sh
@@ -90,7 +90,7 @@ Automatic checkpoint created by Claude Code
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>" --quiet 2>/dev/null; then
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>" --quiet 2>/dev/null; then
         log "Created commit: $message"
 
         # Push if enabled

--- a/.claude/settings copy.json
+++ b/.claude/settings copy.json
@@ -1,6 +1,6 @@
 {
-  "model": "claude-opus-4-5-20251101",
-  "customInstructions": "Follow the project's CLAUDE.md guidelines. Use concurrent execution for all operations. Prioritize v3 implementation with security-first development, 15-agent swarm coordination, phased performance optimization, and cross-platform helper automation. Leverage Opus 4.5's advanced reasoning for complex architectural decisions and system optimization. CRITICAL: When spawning swarms, ALWAYS use MCP tools AND Task tool in the SAME message. V3 CLI hooks enabled at /workspaces/claude-flow/v3/@claude-flow/cli/bin/cli.js with SONA, MoE, and HNSW intelligence features.",
+  "model": "claude-opus-4-6",
+  "customInstructions": "Follow the project's CLAUDE.md guidelines. Use concurrent execution for all operations. Prioritize v3 implementation with security-first development, 15-agent swarm coordination, phased performance optimization, and cross-platform helper automation. Leverage Opus 4.6's advanced reasoning for complex architectural decisions and system optimization. CRITICAL: When spawning swarms, ALWAYS use MCP tools AND Task tool in the SAME message. V3 CLI hooks enabled at /workspaces/claude-flow/v3/@claude-flow/cli/bin/cli.js with SONA, MoE, and HNSW intelligence features.",
   "env": {
     "AGENTIC_FLOW_INTELLIGENCE": "true",
     "AGENTIC_FLOW_LEARNING_RATE": "0.05",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
-  "model": "claude-opus-4-5-20251101",
-  "customInstructions": "Follow the project's CLAUDE.md guidelines. Use concurrent execution for all operations. Prioritize v3 implementation with security-first development, 15-agent swarm coordination, phased performance optimization, and cross-platform helper automation. Leverage Opus 4.5's advanced reasoning for complex architectural decisions and system optimization. CRITICAL: When spawning swarms, ALWAYS use MCP tools AND Task tool in the SAME message. V3 CLI hooks enabled at /workspaces/claude-flow/v3/@claude-flow/cli/bin/cli.js with SONA, MoE, and HNSW intelligence features.",
+  "model": "claude-opus-4-6",
+  "customInstructions": "Follow the project's CLAUDE.md guidelines. Use concurrent execution for all operations. Prioritize v3 implementation with security-first development, 15-agent swarm coordination, phased performance optimization, and cross-platform helper automation. Leverage Opus 4.6's advanced reasoning for complex architectural decisions and system optimization. CRITICAL: When spawning swarms, ALWAYS use MCP tools AND Task tool in the SAME message. V3 CLI hooks enabled at /workspaces/claude-flow/v3/@claude-flow/cli/bin/cli.js with SONA, MoE, and HNSW intelligence features.",
   "env": {
     "AGENTIC_FLOW_INTELLIGENCE": "true",
     "AGENTIC_FLOW_LEARNING_RATE": "0.05",

--- a/README.md
+++ b/README.md
@@ -1714,7 +1714,7 @@ npx claude-flow@v3alpha worker status
 
 | Provider | Models (2025-2026) | Features | Cost |
 |----------|--------|----------|------|
-| **Anthropic** | Claude Opus 4.5, Claude Sonnet 4.5, Claude Haiku 4.5 | Native, streaming, tool calling, extended thinking | $1-25/1M tokens |
+| **Anthropic** | Claude Opus 4.6, Claude Sonnet 4.5, Claude Haiku 4.5 | Native, streaming, tool calling, extended thinking | $1-25/1M tokens |
 | **OpenAI** | GPT-5.2, o3, o3-pro, o4-mini | 400K context, reasoning chains, 100% AIME 2025 | $0.15-60/1M tokens |
 | **Google** | Gemini 3 Pro, Gemini 3 Flash, Gemini 3 Deep Think | 1M+ context, multimodal, Deep Think reasoning | $0.075-7/1M tokens |
 | **xAI** | Grok 4.1, Grok 3 | Truth-seeking, real-time data, 200K H100 training | $2-10/1M tokens |
@@ -2146,7 +2146,7 @@ Real-time development status display for Claude Code integration showing DDD pro
 
 **Output Format:**
 ```
-▊ Claude Flow V3 ● ruvnet  │  ⎇ v3  │  Opus 4.5
+▊ Claude Flow V3 ● ruvnet  │  ⎇ v3  │  Opus 4.6
 ─────────────────────────────────────────────────────
 🏗️  DDD Domains    [●●●●●]  5/5    ⚡ 1.0x → 2.49x-7.47x
 🤖 Swarm  ◉ [58/15]  👥 0    🟢 CVE 3/3    💾 22282MB    📂  47%    🧠  10%
@@ -2158,7 +2158,7 @@ Real-time development status display for Claude Code integration showing DDD pro
 | `▊ Claude Flow V3` | Project header | Always shown |
 | `● ruvnet` | GitHub user (via `gh` CLI) | Dynamic |
 | `⎇ v3` | Current git branch | Dynamic |
-| `Opus 4.5` | Claude model name | From Claude Code |
+| `Opus 4.6` | Claude model name | From Claude Code |
 | `[●●●●●]` | DDD domain progress bar | 0-5 domains |
 | `⚡ 1.0x → 2.49x-7.47x` | Performance speedup target | Current → Target |
 | `◉/○` | Swarm coordination status | Active/Inactive |

--- a/v3/@claude-flow/cli/.claude/helpers/auto-commit.sh
+++ b/v3/@claude-flow/cli/.claude/helpers/auto-commit.sh
@@ -90,7 +90,7 @@ Automatic checkpoint created by Claude Code
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>" --quiet 2>/dev/null; then
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>" --quiet 2>/dev/null; then
         log "Created commit: $message"
 
         # Push if enabled

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.js
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.js
@@ -47,7 +47,7 @@ const c = {
 function getUserInfo() {
   let name = 'user';
   let gitBranch = '';
-  let modelName = 'Opus 4.5';
+  let modelName = 'Opus 4.6';
 
   try {
     name = execSync('git config user.name 2>/dev/null || echo "user"', { encoding: 'utf-8' }).trim();

--- a/v3/@claude-flow/cli/.claude/settings.json
+++ b/v3/@claude-flow/cli/.claude/settings.json
@@ -142,7 +142,7 @@
     "version": "3.0.0",
     "enabled": true,
     "modelPreferences": {
-      "default": "claude-opus-4-5-20251101",
+      "default": "claude-opus-4-6",
       "routing": "claude-3-5-haiku-20241022"
     },
     "swarm": {

--- a/v3/@claude-flow/cli/README.md
+++ b/v3/@claude-flow/cli/README.md
@@ -1714,7 +1714,7 @@ npx claude-flow@v3alpha worker status
 
 | Provider | Models (2025-2026) | Features | Cost |
 |----------|--------|----------|------|
-| **Anthropic** | Claude Opus 4.5, Claude Sonnet 4.5, Claude Haiku 4.5 | Native, streaming, tool calling, extended thinking | $1-25/1M tokens |
+| **Anthropic** | Claude Opus 4.6, Claude Sonnet 4.5, Claude Haiku 4.5 | Native, streaming, tool calling, extended thinking | $1-25/1M tokens |
 | **OpenAI** | GPT-5.2, o3, o3-pro, o4-mini | 400K context, reasoning chains, 100% AIME 2025 | $0.15-60/1M tokens |
 | **Google** | Gemini 3 Pro, Gemini 3 Flash, Gemini 3 Deep Think | 1M+ context, multimodal, Deep Think reasoning | $0.075-7/1M tokens |
 | **xAI** | Grok 4.1, Grok 3 | Truth-seeking, real-time data, 200K H100 training | $2-10/1M tokens |
@@ -2146,7 +2146,7 @@ Real-time development status display for Claude Code integration showing DDD pro
 
 **Output Format:**
 ```
-▊ Claude Flow V3 ● ruvnet  │  ⎇ v3  │  Opus 4.5
+▊ Claude Flow V3 ● ruvnet  │  ⎇ v3  │  Opus 4.6
 ─────────────────────────────────────────────────────
 🏗️  DDD Domains    [●●●●●]  5/5    ⚡ 1.0x → 2.49x-7.47x
 🤖 Swarm  ◉ [58/15]  👥 0    🟢 CVE 3/3    💾 22282MB    📂  47%    🧠  10%
@@ -2158,7 +2158,7 @@ Real-time development status display for Claude Code integration showing DDD pro
 | `▊ Claude Flow V3` | Project header | Always shown |
 | `● ruvnet` | GitHub user (via `gh` CLI) | Dynamic |
 | `⎇ v3` | Current git branch | Dynamic |
-| `Opus 4.5` | Claude model name | From Claude Code |
+| `Opus 4.6` | Claude model name | From Claude Code |
 | `[●●●●●]` | DDD domain progress bar | 0-5 domains |
 | `⚡ 1.0x → 2.49x-7.47x` | Performance speedup target | Current → Target |
 | `◉/○` | Swarm coordination status | Active/Inactive |

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -3473,7 +3473,7 @@ const statuslineCommand: Command = {
     function getUserInfo() {
       let name = 'user';
       let gitBranch = '';
-      const modelName = 'Opus 4.5';
+      const modelName = 'Opus 4.6';
       const isWindows = process.platform === 'win32';
 
       try {

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -49,7 +49,7 @@ export function generateSettings(options: InitOptions): object {
     version: '3.0.0',
     enabled: true,
     modelPreferences: {
-      default: 'claude-opus-4-5-20251101',
+      default: 'claude-opus-4-6',
       routing: 'claude-3-5-haiku-20241022',
     },
     swarm: {

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -8,7 +8,7 @@ import type { InitOptions, StatuslineConfig } from './types.js';
 /**
  * Generate statusline configuration script
  * Matches the advanced format:
- * ▊ Claude Flow V3 ● user  │  ⎇ v3  │  Opus 4.5
+ * ▊ Claude Flow V3 ● user  │  ⎇ v3  │  Opus 4.6
  * ─────────────────────────────────────────────────────
  * 🏗️  DDD Domains    [●●●●●]  5/5    ⚡ HNSW 12500x (or 📚 22.9k patterns)
  * 🤖 Swarm  ◉ [12/15]  👥 0    🟢 CVE 3/3    💾 5177MB    📂  56%    🧠  30%
@@ -119,7 +119,7 @@ function getUserInfo() {
           }
 
           // Parse model ID to human-readable name
-          if (modelId.includes('opus')) modelName = 'Opus 4.5';
+          if (modelId.includes('opus')) modelName = 'Opus 4.6';
           else if (modelId.includes('sonnet')) modelName = 'Sonnet 4';
           else if (modelId.includes('haiku')) modelName = 'Haiku 4.5';
           else modelName = modelId.split('-').slice(1, 3).join(' ');
@@ -137,7 +137,7 @@ function getUserInfo() {
       if (fs.existsSync(settingsPath)) {
         const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
         if (settings.model) {
-          if (settings.model.includes('opus')) modelName = 'Opus 4.5';
+          if (settings.model.includes('opus')) modelName = 'Opus 4.6';
           else if (settings.model.includes('sonnet')) modelName = 'Sonnet 4';
           else if (settings.model.includes('haiku')) modelName = 'Haiku 4.5';
           else modelName = settings.model.split('-').slice(1, 3).join(' ');

--- a/v3/@claude-flow/hooks/src/statusline/index.ts
+++ b/v3/@claude-flow/hooks/src/statusline/index.ts
@@ -5,7 +5,7 @@
  * Provides real-time progress, metrics, and status information.
  *
  * Format matches the working .claude/statusline.sh output:
- * ▊ Claude Flow V3 ● ruvnet  │  ⎇ v3  │  Opus 4.5
+ * ▊ Claude Flow V3 ● ruvnet  │  ⎇ v3  │  Opus 4.6
  * ─────────────────────────────────────────────────────
  * 🏗️  DDD Domains    [●●●●●]  5/5    ⚡ 1.0x → 2.49x-7.47x
  * 🤖 Swarm  ◉ [58/15]  👥 0    🟢 CVE 3/3    💾 22282MB    📂  47%    🧠  10%

--- a/v3/@claude-flow/mcp/.claude/helpers/auto-commit.sh
+++ b/v3/@claude-flow/mcp/.claude/helpers/auto-commit.sh
@@ -90,7 +90,7 @@ Automatic checkpoint created by Claude Code
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>" --quiet 2>/dev/null; then
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>" --quiet 2>/dev/null; then
         log "Created commit: $message"
 
         # Push if enabled

--- a/v3/@claude-flow/mcp/.claude/helpers/statusline.js
+++ b/v3/@claude-flow/mcp/.claude/helpers/statusline.js
@@ -47,7 +47,7 @@ const c = {
 function getUserInfo() {
   let name = 'user';
   let gitBranch = '';
-  let modelName = 'Opus 4.5';
+  let modelName = 'Opus 4.6';
 
   try {
     name = execSync('git config user.name 2>/dev/null || echo "user"', { encoding: 'utf-8' }).trim();

--- a/v3/@claude-flow/mcp/.claude/settings.json
+++ b/v3/@claude-flow/mcp/.claude/settings.json
@@ -142,7 +142,7 @@
     "version": "3.0.0",
     "enabled": true,
     "modelPreferences": {
-      "default": "claude-opus-4-5-20251101",
+      "default": "claude-opus-4-6",
       "routing": "claude-3-5-haiku-20241022"
     },
     "swarm": {

--- a/v3/@claude-flow/plugins/src/providers/index.ts
+++ b/v3/@claude-flow/plugins/src/providers/index.ts
@@ -533,7 +533,7 @@ export class ProviderFactory {
       name: 'anthropic',
       displayName: options?.displayName ?? 'Anthropic Claude',
       models: options?.models ?? [
-        'claude-opus-4-5-20251101',
+        'claude-opus-4-6',
         'claude-sonnet-4-20250514',
         'claude-3-5-haiku-20241022',
       ],

--- a/v3/@claude-flow/shared/src/hooks/safety/git-commit.ts
+++ b/v3/@claude-flow/shared/src/hooks/safety/git-commit.ts
@@ -170,7 +170,7 @@ interface CoAuthor {
 }
 
 const DEFAULT_CO_AUTHOR: CoAuthor = {
-  name: 'Claude Opus 4.5',
+  name: 'Claude Opus 4.6',
   email: 'noreply@anthropic.com',
 };
 


### PR DESCRIPTION
## Summary

Updates the default Claude model across the codebase from `claude-opus-4-5-20251101` to `claude-opus-4-6`.

Relates to #1082

## What changed (17 files, 25 lines)

| Category | Files | Changes |
|----------|-------|---------|
| **Settings** | `.claude/settings.json`, `.claude/settings copy.json` | Default model → `claude-opus-4-6`, customInstructions text |
| **CLI settings** | `v3/@claude-flow/cli/.claude/settings.json`, `v3/@claude-flow/mcp/.claude/settings.json` | Default model config |
| **Settings generator** | `v3/@claude-flow/cli/src/init/settings-generator.ts` | Generated model string |
| **Provider registry** | `v3/@claude-flow/plugins/src/providers/index.ts` | Model ID in provider list |
| **Statusline** | `v3/@claude-flow/cli/src/init/statusline-generator.ts`, `v3/@claude-flow/cli/.claude/helpers/statusline.js`, `v3/@claude-flow/mcp/.claude/helpers/statusline.js` | Display name → `Opus 4.6` |
| **Hooks** | `v3/@claude-flow/cli/src/commands/hooks.ts`, `v3/@claude-flow/hooks/src/statusline/index.ts` | Hardcoded model display name |
| **Git helpers** | `.claude/helpers/auto-commit.sh`, `v3/@claude-flow/cli/.claude/helpers/auto-commit.sh`, `v3/@claude-flow/mcp/.claude/helpers/auto-commit.sh` | Co-author tag |
| **Safety hooks** | `v3/@claude-flow/shared/src/hooks/safety/git-commit.ts` | Model name string |
| **Documentation** | `README.md`, `v3/@claude-flow/cli/README.md` | Banner, provider table, statusline example |

## Why

Claude Opus 4.6 shipped Feb 5, 2026 with:
- **Effort levels** (low/medium/high/max) — GA, no beta header needed
- **Adaptive thinking** — replaces `budget_tokens` (deprecated)
- **128K max output** (doubled from 64K)
- **1M context window** (beta)
- **Compaction API** (beta) — server-side context summarization
- **Simplified model ID** — `claude-opus-4-6` (no date suffix)
- **Same pricing** — $5/$25 per MTok

## Breaking change awareness

- Assistant message **prefilling is not supported** on Opus 4.6 (returns 400)
- `budget_tokens` in thinking config is deprecated (still works for now)
- `interleaved-thinking` beta header is deprecated (safely ignored)

## Verification

```bash
# No remaining opus-4-5 references outside CHANGELOG
grep -rn "claude-opus-4-5" --include="*.ts" --include="*.js" --include="*.json" --include="*.md" . | grep -v node_modules | grep -v CHANGELOG
# → 0 results

# No remaining "Opus 4.5" display names
grep -rn "Opus 4\.5" --include="*.ts" --include="*.js" --include="*.json" --include="*.md" . | grep -v node_modules | grep -v CHANGELOG
# → 0 results
```

## Testing checklist

- [ ] `npx @claude-flow/cli@latest init --wizard` generates `claude-opus-4-6` in settings
- [ ] Statusline displays `Opus 4.6`
- [ ] `hooks model-route` returns updated model name
- [ ] No remaining references to `claude-opus-4-5` outside CHANGELOG
- [ ] Build passes with no regressions