### PR TITLE
docs(community): add fork governance and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,120 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned with this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers of this fork via this repository's issue tracker.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this Code
+of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community maintainers,
+providing clarity around the nature of the violation and an explanation of why
+the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+Community Impact Guidelines were inspired by
+https://github.com/mozilla/diversity
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to This Fork
+
+Thanks for helping improve this project.
+
+This repository is a community-maintained fork of [ruvnet/claude-flow](https://github.com/ruvnet/claude-flow). We keep this fork active to match our own maintenance and release cadence.
+
+Please follow our [Code of Conduct](./CODE_OF_CONDUCT.md) in all project spaces.
+
+## Community Principles
+
+- Respect upstream maintainers and contributors
+- Preserve attribution, license, and project history
+- Focus discussion on code and outcomes, never on people
+- Prefer transparent decisions in issues and pull requests
+
+## Contribution Workflow
+
+1. Open an issue first for non-trivial changes.
+2. Keep pull requests focused and reasonably small.
+3. Include tests or validation steps for behavior changes.
+4. Update docs when behavior, flags, or commands change.
+5. Add clear context in the PR description:
+   - What changed
+   - Why it changed
+   - How it was validated
+   - Whether it should be proposed upstream
+
+## Upstream Relationship
+
+- We regularly sync from upstream.
+- If a fix is generally useful, mark it as an upstream candidate in the PR.
+- Fork-specific behavior should be documented explicitly.
+
+## License
+
+By contributing, you agree that your contributions are released under the same license as this repository (`MIT`).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@
 
 Claude-Flow is a comprehensive AI agent orchestration framework that transforms Claude Code into a powerful multi-agent development platform. It enables teams to deploy, coordinate, and optimize specialized AI agents working together on complex software engineering tasks.
 
+## Fork Stewardship
+
+This repository is maintained as a community fork of [ruvnet/claude-flow](https://github.com/ruvnet/claude-flow).
+
+We forked because we need a different maintenance and release cadence for our roadmap, including faster turnaround when upstream pull-request review queues grow for extended periods. This choice is about delivery pace and scope, not criticism of upstream maintainers.
+
+Our open-source commitments:
+
+- Keep original attribution, license, and git history intact
+- Credit upstream maintainers for foundational work
+- Upstream generally useful fixes whenever possible
+- Sync with upstream regularly and document intentional divergence
+- Keep collaboration respectful and focused on code, not people
+
+If you want to contribute, start with [CONTRIBUTING.md](./CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
+
 ### Self-Learning/Self-Optimizing Agent Architecture
 
 ```


### PR DESCRIPTION
### What Changed
- add  section to README with clear, respectful fork rationale
- add  for fork contribution workflow and upstream relationship
- add  (Contributor Covenant 2.1)

### Why
- set transparent community expectations for maintenance cadence and collaboration
- provide standard open-source governance docs for contributors

### Notes
- documentation-only change; no runtime behavior changes

### References
- N/A