### PR TITLE
fix(windows): resolve CLI detection and process spawning on Windows

### DIFF
--- a/v3/@claude-flow/cli/src/resolve-command.ts
+++ b/v3/@claude-flow/cli/src/resolve-command.ts
@@ -13,7 +13,8 @@
  */
 
 import { existsSync } from 'fs';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
+import { execSync } from 'child_process';
 
 /** Extensions to try when resolving commands on Windows. */
 const WIN_EXTENSIONS = ['.cmd', '.bat', '.exe', '.ps1', ''];
@@ -71,7 +72,6 @@ export function isCommandAvailable(cmd: string): boolean {
 
   // On Unix, try to resolve via which
   try {
-    const { execSync } = require('child_process');
     execSync(`which ${cmd}`, { stdio: 'ignore' });
     return true;
   } catch {


### PR DESCRIPTION
## Summary

Fixes Windows compatibility issues where claude-flow fails to detect Claude Code CLI and fails to spawn processes correctly on Windows.

**Root cause:** On Windows, the `which` command doesn't exist (it's `where`), and `spawn`/`spawnSync`/`execSync` calls need `shell: true` to resolve executables from PATH.

### Changes

| File | Fix |
|------|-----|
| `hive-mind.ts` | Use `where` instead of `which` on win32 for Claude CLI detection |
| `hive-mind.ts` | Enable `shell: process.platform === 'win32'` for claude process spawn |
| `auto-install.ts` | Enable shell for npm spawnSync on Windows for PATH resolution |
| `headless-worker-executor.ts` | Enable shell for `claude --version` check and claude spawn |
| `doctor.ts` | Enable shell for `npm install` in `installClaudeCode()` |

### Additional Windows issues found (not in this PR)

During investigation, **47+ additional instances** of missing Windows compatibility were identified across the codebase:

- `statusline-generator.ts`: Unix-style `2>/dev/null` redirections, missing `shell` options
- `init.ts`: Unix-style `&` background operator, `2>/dev/null` redirections
- `security.ts`: Missing shell options for `npm audit` commands
- `browser-tools.ts`: Missing shell for `agent-browser` spawn
- `gcs.ts`: Hardcoded `/tmp` paths (should use `os.tmpdir()`)
- `container-worker-pool.ts`: Missing shell for docker spawn
- Various other files with Unix-specific shell assumptions

**Recommendation:** Consider adding a shared `shellOption()` helper:
```typescript
const shellOption = () => process.platform === 'win32';
```

### Testing

Tested on:
- **OS:** Windows 11
- **Shell:** PowerShell + Git Bash
- **Node.js:** v22+ (via nvm)
- **Claude Code:** v2.1.34
- **claude-flow:** v3.1.0-alpha.3

All three core scenarios now work:
1. `claude-flow doctor` correctly detects Claude Code CLI
2. `claude-flow swarm` successfully spawns Claude instances
3. `claude-flow mcp start` auto-installs packages via npm

Closes #615