### PR TITLE
fix(plugin-agentic-qe): add agentic-qe as required peer dependency

### DIFF
--- a/v3/plugins/agentic-qe/README.md
+++ b/v3/plugins/agentic-qe/README.md
@@ -4,7 +4,7 @@
 
 ## What is this?
 
-This plugin adds 58 AI agents to Claude Flow that handle all aspects of software quality:
+This plugin adds 59+ AI agents and 63 skills to Claude Flow that handle all aspects of software quality:
 
 - **Write tests for you** - Unit tests, integration tests, E2E tests, even chaos tests
 - **Find coverage gaps** - Shows exactly which code paths aren't tested

--- a/v3/plugins/agentic-qe/package.json
+++ b/v3/plugins/agentic-qe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@claude-flow/plugin-agentic-qe",
   "version": "3.0.0-alpha.4",
-  "description": "Quality Engineering plugin for Claude Flow V3 with 51 specialized agents across 12 DDD bounded contexts",
+  "description": "Quality Engineering plugin for Claude Flow V3 with 59+ specialized agents across 13 DDD bounded contexts, 63 skills, O(log n) coverage analysis, and ReasoningBank learning",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -54,12 +54,16 @@
     "zod": "^3.23.0"
   },
   "peerDependencies": {
+    "agentic-qe": ">=3.6.0",
     "@claude-flow/plugins": ">=3.0.0",
     "@claude-flow/memory": ">=3.0.0",
     "@claude-flow/security": ">=3.0.0",
     "@claude-flow/embeddings": ">=3.0.0"
   },
   "peerDependenciesMeta": {
+    "agentic-qe": {
+      "optional": false
+    },
     "@claude-flow/plugins": {
       "optional": true
     },


### PR DESCRIPTION
## Summary

- Adds `agentic-qe>=3.6.0` as a required peer dependency to `@claude-flow/plugin-agentic-qe` — the plugin wraps the `agentic-qe` npm package but didn't declare it as a dependency
- Updates plugin description from "51 agents / 12 bounded contexts" to match current state: **59+ agents, 13 bounded contexts, 63 skills**
- Updates README agent count from 58 to 59+ with 63 skills

## Context

The `@claude-flow/plugin-agentic-qe` plugin (v3.0.0-alpha.4 on npm) wraps the `agentic-qe` package which is now at v3.6.2. The discovery registry entry in `discovery.ts` already correctly references `agentic-qe: ^3.6.0` as a dependency, but the actual plugin `package.json` was missing this declaration.

## Test plan

- [ ] Verify `npm install @claude-flow/plugin-agentic-qe` warns about missing `agentic-qe` peer
- [ ] Verify `npm install @claude-flow/plugin-agentic-qe agentic-qe` installs cleanly
- [ ] Verify plugin loads correctly with agentic-qe@3.6.2 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)