### PR TITLE
Fix init hook bugs: TOOL_INPUT_prompt overflow (#1160)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow@alpha hooks pre-task --description \"$TOOL_INPUT_prompt\"",
+            "command": "npx claude-flow@alpha hooks pre-task --description \"$(echo \"$TOOL_INPUT_description\" | head -c 200)\"",
             "timeout": 5000,
             "continueOnError": true
           }

--- a/v3/@claude-flow/mcp/.claude/settings.json
+++ b/v3/@claude-flow/mcp/.claude/settings.json
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_INPUT_prompt\" ] && npx @claude-flow/cli@latest hooks pre-task --task-id \"task-$(date +%s)\" --description \"$TOOL_INPUT_prompt\" 2>/dev/null || true",
+            "command": "[ -n \"$TOOL_INPUT_description\" ] && npx @claude-flow/cli@latest hooks pre-task --task-id \"task-$(date +%s)\" --description \"$(echo \"$TOOL_INPUT_description\" | head -c 200)\" 2>/dev/null || true",
             "timeout": 5000,
             "continueOnError": true
           }


### PR DESCRIPTION
## Summary

- Fixed `PreToolUse:Task` hook using `$TOOL_INPUT_prompt` (full agent prompt, thousands of chars) which overflows shell argument limits
- Switched to `$TOOL_INPUT_description` (short 3-5 word field) with `head -c 200` truncation
- Affected files: `v3/@claude-flow/mcp/.claude/settings.json`, `plugin/hooks/hooks.json`

**Note:** The main code path (`settings-generator.ts`) was already fixed in a prior commit to use `node .claude/helpers/hook-handler.cjs` which handles errors internally. This PR fixes the remaining template/reference files.

Fixes #1160

## Test plan

- [ ] Verify `npx claude-flow@alpha init` generates hooks with `$TOOL_INPUT_description` (not `$TOOL_INPUT_prompt`)
- [ ] Verify no `2>NUL` on Linux/macOS in generated hooks
- [ ] Verify JSON files parse correctly
- [ ] Build succeeds with `npm run build`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)