### PR TITLE
Fix ruflo CLI branding: show ruflo instead of claude-flow (#1162)

### DIFF
--- a/v3/@claude-flow/cli/src/index.ts
+++ b/v3/@claude-flow/cli/src/index.ts
@@ -338,7 +338,7 @@ export class CLI {
     this.output.writeln(`  ${this.name} mcp start                         # Start MCP server`);
     this.output.writeln();
 
-    this.output.writeln(this.output.dim('Run "claude-flow <command> --help" for command help'));
+    this.output.writeln(this.output.dim(`Run "${this.name} <command> --help" for command help`));
     this.output.writeln();
     this.output.writeln(this.output.dim('Created with ❤️ by ruv.io'));
     this.output.writeln();
@@ -429,7 +429,7 @@ export class CLI {
             this.output.dim(`Updates available: ${nonAutoUpdates.map(u => `${u.package}@${u.latestVersion}`).join(', ')}`)
           );
           this.output.writeln(
-            this.output.dim(`Run 'claude-flow update check' for details`)
+            this.output.dim(`Run '${this.name} update check' for details`)
           );
         }
       }


### PR DESCRIPTION
## Summary

- ruflo.js now imports CLI class directly with `{ name: 'ruflo', description: 'Ruflo - AI Agent Orchestration Platform' }` instead of re-importing cli.js with default claude-flow branding
- Fixed two hardcoded `"claude-flow"` strings in help footer and update text to use `this.name`
- MCP mode still delegates to cli.js (branding irrelevant for JSON-RPC)

## Verified

```
$ node ruflo/bin/ruflo.js --version
ruflo v3.1.0-alpha.42

$ node v3/@claude-flow/cli/bin/cli.js --version
claude-flow v3.1.0-alpha.42
```

Fixes #1162

## Test plan

- [x] `ruflo --version` shows `ruflo v3.x.x`
- [x] `ruflo --help` shows ruflo branding in header, usage, examples, footer
- [x] `claude-flow --version` still shows `claude-flow v3.x.x` (no regression)
- [x] Build succeeds

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)