### PR TITLE
Fix ruflo Windows crash: ERR_UNSUPPORTED_ESM_URL_SCHEME (#1164)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.1.0-alpha.43",
+  "version": "3.1.0-alpha.44",
   "description": "Enterprise AI agent orchestration for Claude Code - Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/bin/ruflo.js
+++ b/ruflo/bin/ruflo.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Ruflo CLI - thin wrapper around @claude-flow/cli with ruflo branding
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 import { existsSync } from 'node:fs';
 
@@ -19,6 +19,11 @@ function findCliPath() {
   return null;
 }
 
+// Convert path to file:// URL for cross-platform ESM import (Windows requires this)
+function toImportURL(filePath) {
+  return pathToFileURL(filePath).href;
+}
+
 const pkgDir = findCliPath();
 const cliBase = pkgDir
   ? join(pkgDir, 'node_modules', '@claude-flow', 'cli')
@@ -30,10 +35,10 @@ const isExplicitMCP = cliArgs.length >= 1 && cliArgs[0] === 'mcp' && (cliArgs.le
 const isMCPMode = !process.stdin.isTTY && (process.argv.length === 2 || isExplicitMCP);
 
 if (isMCPMode) {
-  await import(join(cliBase, 'bin', 'cli.js'));
+  await import(toImportURL(join(cliBase, 'bin', 'cli.js')));
 } else {
   // CLI mode: use ruflo branding
-  const { CLI } = await import(join(cliBase, 'dist', 'src', 'index.js'));
+  const { CLI } = await import(toImportURL(join(cliBase, 'dist', 'src', 'index.js')));
   const cli = new CLI({
     name: 'ruflo',
     description: 'Ruflo - AI Agent Orchestration Platform',

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.1.0-alpha.43",
+  "version": "3.1.0-alpha.44",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.1.0-alpha.43",
+  "version": "3.1.0-alpha.44",
   "type": "module",
   "description": "Claude Flow CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- `npx ruflo@latest` crashed on Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME` because `import()` received bare `C:\` paths instead of `file://` URLs
- Added `pathToFileURL()` wrapper for all dynamic `import()` calls in `ruflo/bin/ruflo.js`

Fixes #1164

## Test plan

- [ ] `npx ruflo@latest --version` works on Windows (no ERR_UNSUPPORTED_ESM_URL_SCHEME)
- [x] `node ruflo/bin/ruflo.js --version` works on Linux (no regression)
- [x] Build succeeds

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)