### PR TITLE
fix(daemon): platform-aware resource thresholds for macOS

### DIFF
--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -351,6 +351,9 @@ export class WorkerDaemon extends EventEmitter {
     this.startedAt = new Date();
     this.emit('started', { pid: process.pid, startedAt: this.startedAt });
 
+    const { maxCpuLoad, minFreeMemoryPercent } = this.config.resourceThresholds;
+    this.log('info', `Resource thresholds: maxCpuLoad=${maxCpuLoad} (${os.cpus().length} cores), minFreeMemoryPercent=${minFreeMemoryPercent}% (${process.platform})`);
+
     // Schedule all enabled workers
     for (const workerConfig of this.config.workers) {
       if (workerConfig.enabled) {


### PR DESCRIPTION
## Summary

- Daemon workers (audit, optimize, testgaps) permanently blocked on macOS due to hardcoded resource thresholds that are incompatible with macOS system metric reporting
- CPU threshold of 2.0 is exceeded by `os.loadavg()` on any multi-core Mac at idle (reports aggregate load, not per-core)
- Memory threshold of 20% is unreachable because `os.freemem()` reports only truly unused RAM, not reclaimable cache (macOS typically shows 5-8% "free")
- Compute thresholds from system capabilities: CPU cores × 3 for load, 1% free memory on Darwin (5% on Linux)
- Thresholds remain overridable via config parameter — zero breaking change

## Problem

All daemon workers with resource checks fail with:
```
CPU load too high: 3.80
Memory too low: 7.6% free
```

On a 16-core Mac at idle. Workers have 0% success rate (0 runs out of hundreds of scheduler cycles).

**Root cause**: `os.loadavg()[0]` returns aggregate load (not per-core), and `os.freemem()` excludes reclaimable cache on macOS. The hardcoded thresholds assume Linux-like reporting semantics.

## Approach

1. **`import os from 'os'`** — Use top-level ESM import instead of `await import('os')` in async method. Built-in modules don't need dynamic import, and this enables synchronous access in the constructor.

2. **`getDefaultResourceThresholds()`** — Extract threshold computation into a pure function that:
   - Scales `maxCpuLoad` by core count (`os.cpus().length × 3`), so a 16-core Mac allows load up to 48 instead of 2
   - Sets `minFreeMemoryPercent` to 1% on Darwin (reflects actual memory pressure, not cache usage) and 5% on Linux
   - Documents the "why" with a JSDoc comment linking to #1077

3. **Startup logging** — Log computed thresholds (values, core count, platform) at daemon start for debuggability.

## Test plan

- [x] Verified on 16-core macOS: all 5 workers execute successfully after patch
- [x] `daemon status` shows 100% success rate for audit, optimize, testgaps (were 0% before)
- [x] `daemon trigger --worker audit` completes in <1ms
- [x] Config override still works (config parameter takes precedence over computed defaults)
- [ ] Verify Linux behavior unchanged (same function, higher thresholds: cores×3 for CPU, 5% for memory)

Fixes #1077