### PR TITLE
fix: use 'patterns' namespace consistently in hooks-tools (fixes #1136)

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -2028,7 +2028,7 @@ export const hooksPatternStore: MCPTool = {
           storeResult = await storeFn({
             key: patternId,
             value: JSON.stringify({ pattern, type, confidence, metadata, timestamp }),
-            namespace: 'pattern',
+            namespace: 'patterns',
             generateEmbeddingFlag: true,
             tags: [type, `confidence-${Math.round(confidence * 100)}`, 'reasoning-pattern'],
           });
@@ -2068,7 +2068,7 @@ export const hooksPatternSearch: MCPTool = {
       query: { type: 'string', description: 'Search query' },
       topK: { type: 'number', description: 'Number of results' },
       minConfidence: { type: 'number', description: 'Minimum similarity threshold (0-1)' },
-      namespace: { type: 'string', description: 'Namespace to search (default: pattern)' },
+      namespace: { type: 'string', description: 'Namespace to search (default: patterns)' },
     },
     required: ['query'],
   },
@@ -2076,7 +2076,7 @@ export const hooksPatternSearch: MCPTool = {
     const query = params.query as string;
     const topK = (params.topK as number) || 5;
     const minConfidence = (params.minConfidence as number) || 0.3;
-    const namespace = (params.namespace as string) || 'pattern';
+    const namespace = (params.namespace as string) || 'patterns';
 
     // Phase 3: Try ReasoningBank search via bridge first
     try {
@@ -2136,7 +2136,7 @@ export const hooksPatternSearch: MCPTool = {
           results: [],
           searchTimeMs: searchResult.searchTime,
           backend: 'real-vector-search',
-          note: searchResult.error || 'No matching patterns found. Store patterns first using memory/store with namespace "pattern".',
+          note: searchResult.error || 'No matching patterns found. Store patterns first using memory/store with namespace "patterns".',
         };
       } catch (error) {
         // Fall through to empty response with error


### PR DESCRIPTION
Fixes #1136

## Problem

`hooks-tools.ts` used singular `'pattern'` as the memory namespace in 4 locations, while the rest of the codebase (`workers/index.ts`, `reasoningbank/index.ts`, README examples) consistently uses `'patterns'` (plural).

This caused a **silent data loss bug**: intelligence hooks stored patterns in namespace `'pattern'`, but `memory_search` and `memory_list` searched in `'patterns'` — stored entries were invisible to normal memory operations.

## Fix

Changed all 4 occurrences in `hooks-tools.ts`:
- `namespace: 'pattern'` → `namespace: 'patterns'`
- `|| 'pattern'` default → `|| 'patterns'`
- Description string updated to reflect correct default

```diff
- namespace: 'pattern',
+ namespace: 'patterns',

- const namespace = (params.namespace as string) || 'pattern';
+ const namespace = (params.namespace as string) || 'patterns';
```