### PR TITLE
feat: add Novita OpenAI-compatible provider

### DIFF
--- a/v3/@claude-flow/providers/src/__tests__/novita-provider.test.ts
+++ b/v3/@claude-flow/providers/src/__tests__/novita-provider.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NovitaProvider } from '../novita-provider.js';
+import { consoleLogger } from '../base-provider.js';
+
+describe('NovitaProvider', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('uses Novita OpenAI-compatible endpoint and returns novita provider label', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe('https://api.novita.ai/openai/chat/completions');
+      return new Response(
+        JSON.stringify({
+          id: 'cmpl-test',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'gpt-4o-mini',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'hello from novita' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 5,
+            completion_tokens: 3,
+            total_tokens: 8,
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new NovitaProvider({
+      config: {
+        provider: 'novita',
+        apiKey: 'test-key',
+        model: 'gpt-4o-mini',
+      },
+      logger: consoleLogger,
+    });
+
+    await provider.initialize();
+    const response = await provider.complete({
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(response.provider).toBe('novita');
+    expect(response.content).toBe('hello from novita');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    provider.destroy();
+  });
+});

--- a/v3/@claude-flow/providers/src/index.ts
+++ b/v3/@claude-flow/providers/src/index.ts
@@ -31,6 +31,7 @@ export type { BaseProviderOptions, ILogger } from './base-provider.js';
 // Export providers
 export { AnthropicProvider } from './anthropic-provider.js';
 export { OpenAIProvider } from './openai-provider.js';
+export { NovitaProvider } from './novita-provider.js';
 export { GoogleProvider } from './google-provider.js';
 export { CohereProvider } from './cohere-provider.js';
 export { OllamaProvider } from './ollama-provider.js';

--- a/v3/@claude-flow/providers/src/novita-provider.ts
+++ b/v3/@claude-flow/providers/src/novita-provider.ts
@@ -1,0 +1,25 @@
+/**
+ * V3 Novita Provider
+ *
+ * OpenAI-compatible provider configured for Novita endpoint.
+ *
+ * @module @claude-flow/providers/novita-provider
+ */
+
+import { BaseProviderOptions } from './base-provider.js';
+import { OpenAIProvider } from './openai-provider.js';
+
+const NOVITA_API_URL = 'https://api.novita.ai/openai';
+
+export class NovitaProvider extends OpenAIProvider {
+  constructor(options: BaseProviderOptions) {
+    super({
+      ...options,
+      config: {
+        ...options.config,
+        provider: 'novita',
+        apiUrl: options.config.apiUrl || NOVITA_API_URL,
+      },
+    });
+  }
+}

--- a/v3/@claude-flow/providers/src/provider-manager.ts
+++ b/v3/@claude-flow/providers/src/provider-manager.ts
@@ -31,6 +31,7 @@ import {
 import { BaseProviderOptions, ILogger, consoleLogger } from './base-provider.js';
 import { AnthropicProvider } from './anthropic-provider.js';
 import { OpenAIProvider } from './openai-provider.js';
+import { NovitaProvider } from './novita-provider.js';
 import { GoogleProvider } from './google-provider.js';
 import { CohereProvider } from './cohere-provider.js';
 import { OllamaProvider } from './ollama-provider.js';
@@ -119,6 +120,8 @@ export class ProviderManager extends EventEmitter {
         return new AnthropicProvider(options);
       case 'openai':
         return new OpenAIProvider(options);
+      case 'novita':
+        return new NovitaProvider(options);
       case 'google':
         return new GoogleProvider(options);
       case 'cohere':

--- a/v3/@claude-flow/providers/src/types.ts
+++ b/v3/@claude-flow/providers/src/types.ts
@@ -14,6 +14,7 @@ import { EventEmitter } from 'events';
 export type LLMProvider =
   | 'anthropic'
   | 'openai'
+  | 'novita'
   | 'google'
   | 'cohere'
   | 'ollama'


### PR DESCRIPTION
## Summary
- add novita as a first-class provider type in providers package
- introduce NovitaProvider that reuses OpenAI provider behavior with default endpoint https://api.novita.ai/openai
- wire Novita into provider exports and provider manager switch
- update OpenAI provider internals to honor runtime provider label (openai or novita)
- add unit test for Novita endpoint routing and response provider label

## Verification
- attempted: npm test -- src/__tests__/novita-provider.test.ts
- result: failed with vitest not found because test dependency is not installed in this workspace