### PR TITLE
fix(memory): add .unref() to housekeeping timers to prevent process hang

### DIFF
--- a/v3/@claude-flow/memory/src/cache-manager.ts
+++ b/v3/@claude-flow/memory/src/cache-manager.ts
@@ -397,6 +397,11 @@ export class CacheManager<T = MemoryEntry> extends EventEmitter {
     this.cleanupInterval = setInterval(() => {
       this.cleanupExpired();
     }, 60000);
+
+    // Don't let this housekeeping timer prevent process exit
+    if (this.cleanupInterval.unref) {
+      this.cleanupInterval.unref();
+    }
   }
 
   private cleanupExpired(): void {

--- a/v3/@claude-flow/memory/src/sqljs-backend.ts
+++ b/v3/@claude-flow/memory/src/sqljs-backend.ts
@@ -138,6 +138,11 @@ export class SqlJsBackend extends EventEmitter implements IMemoryBackend {
           this.emit('error', { operation: 'auto-persist', error: err });
         });
       }, this.config.autoPersistInterval);
+
+      // Don't let this housekeeping timer prevent process exit
+      if (this.persistTimer.unref) {
+        this.persistTimer.unref();
+      }
     }
 
     this.initialized = true;


### PR DESCRIPTION
Adds `.unref()` to two `setInterval` timers that prevent the Node.js process from exiting cleanly.
---

**Problem**

`CacheManager.startCleanupTimer()` and SqlJsBackend 's auto-persist timer both call `setInterval()` without `.unref()`, keeping the event loop alive indefinitely. This means any CLI command that touches memory (`memory store`, `memory search`, etc.) hangs after completing its work and never exits - users have to `Ctrl+C` to kill it.

----

**Fix**

Added `.unref()` after each `setInterval` call, guarded by an existence check for environments where `.unref()` may not be available:

+ v3/@claude-flow/memory/src/cache-manager.ts - cleanup timer (line ~397)
+ v3/@claude-flow/memory/src/sqljs-backend.ts - persist timer (line ~136)

----

**Why this is safe**

- These are best-effort housekeeping timers, not critical work. The `shutdown()`  methods already handle final cleanup/persist explicitly.
- Other timers in the same package (`agentdb-backend.js:142`, `auto-memory-bridge.js:534`) already call `.unref()` correctly - this just brings the remaining two in line with that pattern.
- Zero behavioral change when the process is still running; only affects exit behavior.

---

Fixes Issue #1256 