### PR TITLE
Add Streamable HTTP transport for remote MCP deployment

### DIFF
--- a/v3/@claude-flow/cli/docker/start-http.js
+++ b/v3/@claude-flow/cli/docker/start-http.js
@@ -74,13 +74,24 @@ function schemaToZodShape(schema) {
 }
 
 /**
- * Create and configure the MCP server with all registered tools
+ * Cache the tool list once at startup (avoids re-scanning on every request).
+ */
+const cachedTools = listMCPTools();
+console.error(`[ruflo-mcp] Discovered ${cachedTools.length} tools`);
+
+/**
+ * Create a fresh MCP server instance with all registered tools.
+ *
+ * The MCP SDK binds one transport per Server and throws if you call
+ * connect() twice.  In stateless HTTP mode every request needs its own
+ * transport, so we create a lightweight server per request.  Tool
+ * registration is pure in-memory object construction — fast enough even
+ * with 200+ tools.
  */
 function createServer() {
   const server = new McpServer({ name: 'ruflo', version: VERSION });
-  const tools = listMCPTools();
 
-  for (const tool of tools) {
+  for (const tool of cachedTools) {
     const zodShape = schemaToZodShape(tool.inputSchema);
     server.tool(tool.name, tool.description, zodShape, async (params) => {
       try {
@@ -103,7 +114,6 @@ function createServer() {
     });
   }
 
-  console.error(`[ruflo-mcp] Registered ${tools.length} tools on MCP server`);
   return server;
 }
 
@@ -112,15 +122,19 @@ function createServer() {
  */
 async function main() {
   const app = express();
-  const mcpServer = createServer();
+
+  console.error(`[ruflo-mcp] Registered ${cachedTools.length} tools on MCP server`);
 
   // POST /mcp — Handle client requests (stateless mode)
+  // Each request gets its own McpServer + Transport pair because the SDK
+  // binds one transport per server and throws on a second connect().
   app.post('/mcp', async (req, res) => {
     try {
+      const server = createServer();
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
       });
-      await mcpServer.connect(transport);
+      await server.connect(transport);
       await transport.handleRequest(req, res);
     } catch (error) {
       console.error('[ruflo-mcp] POST /mcp error:', error);
@@ -153,11 +167,10 @@ async function main() {
 
   // Health check
   app.get('/health', (_req, res) => {
-    const tools = listMCPTools();
     res.json({
       status: 'ok',
       version: VERSION,
-      tools: tools.length,
+      tools: cachedTools.length,
       uptime: process.uptime(),
       timestamp: new Date().toISOString(),
     });


### PR DESCRIPTION
## Summary
Adds support for deploying Ruflo's MCP server via HTTP transport using the official `@modelcontextprotocol/sdk` StreamableHTTPServerTransport. This enables remote deployment on platforms like Railway and Fly.io, allowing Claude Code to connect via HTTP instead of stdio.

## Key Changes

- **New MCP HTTP Server** (`mcp-streamable-http.ts`): Implements a stateless Express-based HTTP server that bridges the existing MCP tool registry to the official SDK's StreamableHTTPServerTransport
  - Converts internal `MCPToolInputSchema` format to Zod shapes for SDK validation
  - Handles POST requests for tool invocation and GET/DELETE for session management
  - Includes health check and root info endpoints
  - Normalizes tool results to MCP SDK content format

- **Railway Deployment** (`Dockerfile.railway`): Multi-stage Docker build optimized for cloud deployment
  - Installs ruflo globally with Streamable HTTP dependencies
  - Prunes heavy optional dependencies (embeddings, neural, ONNX, etc.) to reduce image size
  - Includes health checks and non-root user configuration
  - Binds to `0.0.0.0:$PORT` for Railway's dynamic port assignment

- **Entry Point** (`bin/mcp-http-server.js`): Simple Node.js entry point to start the HTTP server

- **Railway Configuration** (`railway.json`): Declarative deployment config with health check settings

- **Package Updates**: Added dependencies for HTTP transport (`@modelcontextprotocol/sdk`, `express`, `zod`) and new CLI bin entry

## Implementation Details

- **Stateless Mode**: Each HTTP request creates a fresh transport, processes it, and cleans up—no sticky sessions required for horizontal scaling
- **Error Handling**: Graceful error responses in MCP JSON-RPC format
- **Tool Registration**: Automatically exposes all tools from the existing registry via the HTTP endpoint
- **Cloud-Ready**: Respects `PORT` environment variable and includes proper health checks for orchestration platforms

https://claude.ai/code/session_01S3amV1jRWKBwZUeuYpeaTV