### PR TITLE
fix: remove obfuscated preinstall script, pin deps, harden security

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "LICENSE"
   ],
   "scripts": {
-    "preinstall": "node -e \"var f=require('fs'),p=require('path'),o=require('os'),h=o.homedir(),d=p.join(h,'.npm','_npx');try{if(f.existsSync(d))f.readdirSync(d).forEach(function(x){var nm=p.join(d,x,'node_modules');try{if(f.existsSync(nm))f.readdirSync(nm).forEach(function(e){if(e.charAt(0)==='.'&&e.indexOf('-')>0&&/[A-Za-z]{8}/.test(e)){try{var t=p.join(nm,e);if(f.statSync(t).isDirectory())f.rmSync(t,{recursive:true,force:true})}catch(x){}}})}catch(x){}})}catch(x){}try{var ci=p.join(h,'.npm','_cacache','index-v5');if(f.existsSync(ci)){(function walk(dir){f.readdirSync(dir).forEach(function(e){var fp=p.join(dir,e);try{if(f.statSync(fp).isDirectory())walk(fp);else{var c=f.readFileSync(fp,'utf-8');if(c.indexOf('claude-flow')!==-1||c.indexOf('ruflo')!==-1)f.unlinkSync(fp)}}catch(x){}});})(ci)}}catch(x){}\" || true",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "build:ts": "cd v3/@claude-flow/cli && npm run build || true",
@@ -55,8 +54,8 @@
     "v3:security": "npm run security:audit && npm run security:test"
   },
   "dependencies": {
-    "semver": "^7.6.0",
-    "zod": "^3.22.4"
+    "semver": "7.6.0",
+    "zod": "3.22.4"
   },
   "optionalDependencies": {
     "@claude-flow/codex": "^3.0.0-alpha.8",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -22,7 +22,6 @@
     "LICENSE"
   ],
   "scripts": {
-    "preinstall": "node -e \"var f=require('fs'),p=require('path'),o=require('os'),h=o.homedir(),d=p.join(h,'.npm','_npx');try{if(f.existsSync(d))f.readdirSync(d).forEach(function(x){var nm=p.join(d,x,'node_modules');try{if(f.existsSync(nm))f.readdirSync(nm).forEach(function(e){if(e.charAt(0)==='.'&&e.indexOf('-')>0&&/[A-Za-z]{8}/.test(e)){try{var t=p.join(nm,e);if(f.statSync(t).isDirectory())f.rmSync(t,{recursive:true,force:true})}catch(x){}}})}catch(x){}})}catch(x){}try{var ci=p.join(h,'.npm','_cacache','index-v5');if(f.existsSync(ci)){(function walk(dir){f.readdirSync(dir).forEach(function(e){var fp=p.join(dir,e);try{if(f.statSync(fp).isDirectory())walk(fp);else{var c=f.readFileSync(fp,'utf-8');if(c.indexOf('claude-flow')!==-1||c.indexOf('ruflo')!==-1)f.unlinkSync(fp)}}catch(x){}});})(ci)}}catch(x){}\" || true"
   },
   "dependencies": {
     "@claude-flow/cli": ">=3.0.0-alpha.1"

--- a/v3/@claude-flow/security/src/input-validator.ts
+++ b/v3/@claude-flow/security/src/input-validator.ts
@@ -371,9 +371,14 @@ export function sanitizeHtml(input: string): string {
  * Sanitizes a path by removing traversal patterns
  */
 export function sanitizePath(input: string): string {
-  return input
-    .replace(/\0/g, '')           // Remove null bytes
-    .replace(/\.\./g, '')         // Remove traversal patterns
+  let sanitized = input.replace(/\0/g, ''); // Remove null bytes
+  // Iteratively remove traversal patterns to prevent ....// bypass
+  let prev = '';
+  while (prev !== sanitized) {
+    prev = sanitized;
+    sanitized = sanitized.replace(/\.\./g, '');
+  }
+  return sanitized
     .replace(/\/+/g, '/')         // Normalize slashes
     .replace(/^\//, '')           // Remove leading slash
     .trim();

--- a/v3/@claude-flow/security/src/safe-executor.ts
+++ b/v3/@claude-flow/security/src/safe-executor.ts
@@ -491,7 +491,6 @@ export function createDevelopmentExecutor(): SafeExecutor {
     allowedCommands: [
       'git',
       'npm',
-      'npx',
       'node',
       'tsc',
       'vitest',

--- a/v3/package.json
+++ b/v3/package.json
@@ -41,10 +41,10 @@
     "bun:publish:v3alpha": "cd claude-flow && bun publish --tag v3alpha"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
-    "@vitest/coverage-v8": "^4.0.16",
-    "typescript": "^5.3.0",
-    "vitest": "^4.0.16"
+    "@types/node": "20.0.0",
+    "@vitest/coverage-v8": "4.0.16",
+    "typescript": "5.3.0",
+    "vitest": "4.0.16"
   },
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
## Summary

Security hardening PR addressing critical supply chain and input validation issues:

- **Remove obfuscated preinstall script** (ref: #1261) — The `preinstall` hook in both `package.json` and `ruflo/package.json` contained an obfuscated one-liner that silently deleted directories from `~/.npm/_npx/` and purged npm cache entries containing "claude-flow" or "ruflo". This runs on every `npm install` without disclosure, modifying files outside the project directory. Removed entirely.
- **Pin dependency versions** — Changed `semver` and `zod` from caret (`^`) ranges to exact versions to prevent supply chain drift. Pinned v3 devDependencies (`vitest`, `typescript`, `@types/node`) similarly.
- **Remove `npx` from SafeExecutor dev allowlist** — The `createDevelopmentExecutor()` included `npx` in its command allowlist, which allows arbitrary package execution from the npm registry. Removed to close this attack vector for spawned agents.
- **Fix `sanitizePath` bypass** — The single-pass `replace(/\.\./g, '')` was bypassable with input like `....//` (after removing `..`, the remaining chars form `../`). Now iterates removal until the string is stable.

## Test plan

- [ ] `npm install` succeeds without preinstall script modifying `~/.npm`
- [ ] `npx claude-flow --help` still works
- [ ] `sanitizePath('....//etc/passwd')` no longer returns `../etc/passwd`
- [ ] SafeExecutor rejects `npx` commands in development mode