### PR TITLE
fix(hooks): read stdin JSON for Claude Code 2.x hook payload

### DIFF
--- a/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
@@ -47,11 +47,22 @@ const session = safeRequire(path.join(helpersDir, 'session.js'));
 const memory = safeRequire(path.join(helpersDir, 'memory.js'));
 const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 
+// Read hook payload from stdin (Claude Code 2.x sends JSON via stdin)
+let stdinPayload = {};
+if (!process.stdin.isTTY) {
+  try {
+    const raw = fs.readFileSync(0, 'utf8').trim();
+    if (raw) stdinPayload = JSON.parse(raw);
+  } catch (e) { /* stdin empty or not JSON -- fall back to env vars below */ }
+}
+
 // Get the command from argv
 const [,, command, ...args] = process.argv;
 
-// Get prompt from environment variable (set by Claude Code hooks)
-const prompt = process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
+// Get prompt: prefer stdin JSON (Claude Code 2.x), fall back to env vars (legacy)
+const prompt = stdinPayload.prompt
+  || (stdinPayload.tool_input && stdinPayload.tool_input.command)
+  || process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
 
 const handlers = {
   'route': () => {
@@ -125,7 +136,8 @@ const handlers = {
     // Record edit for intelligence consolidation
     if (intelligence && intelligence.recordEdit) {
       try {
-        const file = process.env.TOOL_INPUT_file_path || args[0] || '';
+        const file = (stdinPayload.tool_input && stdinPayload.tool_input.file_path)
+          || process.env.TOOL_INPUT_file_path || args[0] || '';
         intelligence.recordEdit(file);
       } catch (e) { /* non-fatal */ }
     }


### PR DESCRIPTION
## Summary

Hooks are broken on Claude Code 2.x because `hook-handler.cjs` reads from environment variables (`process.env.PROMPT`, `process.env.TOOL_INPUT_command`, etc.) that Claude Code 2.x never sets. Claude Code 2.x passes everything via stdin as JSON instead.

The result is that `prompt` is always an empty string, so `pre-bash` never catches dangerous commands, `route` has nothing to route, and `post-edit` records empty file paths.

This PR adds a `fs.readFileSync(0, 'utf8')` call to read stdin JSON before the existing env var logic. Env vars still work as fallback, so nothing breaks for older setups.

Fixes #1211

## What changed

Only `hook-handler.cjs` — added a stdin read block before line 54:

```js
let stdinPayload = {};
if (!process.stdin.isTTY) {
  try {
    const raw = fs.readFileSync(0, 'utf8').trim();
    if (raw) stdinPayload = JSON.parse(raw);
  } catch (e) { /* fall back to env vars */ }
}
```

Then `prompt` and `file` prefer stdin fields over env vars:

```js
const prompt = stdinPayload.prompt
  || (stdinPayload.tool_input && stdinPayload.tool_input.command)
  || process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
```

Same pattern for `file_path` in the `post-edit` handler.

The `isTTY` check is there so running `node hook-handler.cjs route` manually in a terminal doesn't hang waiting for stdin.

`fs` is already imported on line 17, so no new dependencies.

## How I tested

```bash
# stdin works
echo '{"tool_input":{"command":"rm -rf /"}}' | node hook-handler.cjs pre-bash
# -> [BLOCKED] Dangerous command detected: rm -rf /  (exit 1)

echo '{"tool_input":{"command":"ls"}}' | node hook-handler.cjs pre-bash
# -> [OK] Command validated  (exit 0)

echo '{"prompt":"refactor auth"}' | node hook-handler.cjs route
# -> routes "refactor auth"

# empty / bad stdin doesn't crash
echo '' | node hook-handler.cjs route          # falls back to env
echo 'not json' | node hook-handler.cjs route  # falls back to env

# env var fallback still works
PROMPT="test" node hook-handler.cjs route      # routes "test"
```