### PR TITLE
fix: add missing items for MCP array schemas

### DIFF
--- a/v3/@claude-flow/cli/__tests__/mcp-schema-array-items.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-schema-array-items.test.ts
@@ -1,0 +1,66 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function findArraySchemasMissingItems(source: string): number[] {
+  const matches: number[] = [];
+  const pattern = /type:\s*['\"]array['\"]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(source)) !== null) {
+    const typeIndex = match.index;
+
+    const objectStart = source.lastIndexOf('{', typeIndex);
+    if (objectStart === -1) {
+      continue;
+    }
+
+    let depth = 0;
+    let objectEnd = -1;
+    for (let i = objectStart; i < source.length; i += 1) {
+      const char = source[i];
+      if (char === '{') {
+        depth += 1;
+      } else if (char === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          objectEnd = i;
+          break;
+        }
+      }
+    }
+
+    if (objectEnd !== -1) {
+      const objectText = source.slice(objectStart, objectEnd + 1);
+      if (!/\bitems\s*:/.test(objectText)) {
+        const line = source.slice(0, typeIndex).split('\n').length;
+        matches.push(line);
+      }
+    }
+  }
+
+  return matches;
+}
+
+describe('MCP schema array validation', () => {
+  it('ensures every array schema defines items', () => {
+    const mcpToolsDir = join(process.cwd(), 'src', 'mcp-tools');
+    const files = readdirSync(mcpToolsDir).filter(file => file.endsWith('.ts'));
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const filePath = join(mcpToolsDir, file);
+      const source = readFileSync(filePath, 'utf-8');
+      const lines = findArraySchemasMissingItems(source);
+
+      for (const line of lines) {
+        violations.push(`src/mcp-tools/${file}:${line}`);
+      }
+    }
+
+    expect(
+      violations,
+      `Array schemas missing items:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
@@ -489,7 +489,7 @@ export const coordinationTools: MCPTool[] = [
       type: 'object',
       properties: {
         task: { type: 'string', description: 'Task to orchestrate' },
-        agents: { type: 'array', description: 'Agent IDs to coordinate' },
+        agents: { type: 'array', items: { type: 'string' }, description: 'Agent IDs to coordinate' },
         strategy: { type: 'string', enum: ['parallel', 'sequential', 'pipeline', 'broadcast'], description: 'Orchestration strategy' },
         timeout: { type: 'number', description: 'Timeout in ms' },
       },

--- a/v3/@claude-flow/cli/src/mcp-tools/daa-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/daa-tools.ts
@@ -98,7 +98,7 @@ export const daaTools: MCPTool[] = [
         cognitivePattern: { type: 'string', enum: ['convergent', 'divergent', 'lateral', 'systems', 'critical', 'adaptive'], description: 'Cognitive pattern' },
         learningRate: { type: 'number', description: 'Learning rate (0-1)' },
         enableMemory: { type: 'boolean', description: 'Enable persistent memory' },
-        capabilities: { type: 'array', description: 'Agent capabilities' },
+        capabilities: { type: 'array', items: { type: 'string' }, description: 'Agent capabilities' },
       },
       required: ['id'],
     },
@@ -151,7 +151,7 @@ export const daaTools: MCPTool[] = [
         agentId: { type: 'string', description: 'Agent ID' },
         feedback: { type: 'string', description: 'Feedback message' },
         performanceScore: { type: 'number', description: 'Performance score (0-1)' },
-        suggestions: { type: 'array', description: 'Improvement suggestions' },
+        suggestions: { type: 'array', items: { type: 'string' }, description: 'Improvement suggestions' },
       },
       required: ['agentId'],
     },
@@ -200,7 +200,11 @@ export const daaTools: MCPTool[] = [
       properties: {
         id: { type: 'string', description: 'Workflow ID' },
         name: { type: 'string', description: 'Workflow name' },
-        steps: { type: 'array', description: 'Workflow steps' },
+        steps: {
+          type: 'array',
+          items: { anyOf: [{ type: 'string' }, { type: 'object' }] },
+          description: 'Workflow steps',
+        },
         strategy: { type: 'string', enum: ['parallel', 'sequential', 'adaptive'], description: 'Execution strategy' },
         dependencies: { type: 'object', description: 'Step dependencies' },
       },
@@ -243,7 +247,7 @@ export const daaTools: MCPTool[] = [
       type: 'object',
       properties: {
         workflowId: { type: 'string', description: 'Workflow ID' },
-        agentIds: { type: 'array', description: 'Agent IDs to use' },
+        agentIds: { type: 'array', items: { type: 'string' }, description: 'Agent IDs to use' },
         parallelExecution: { type: 'boolean', description: 'Enable parallel execution' },
       },
       required: ['workflowId'],
@@ -288,7 +292,7 @@ export const daaTools: MCPTool[] = [
       type: 'object',
       properties: {
         sourceAgentId: { type: 'string', description: 'Source agent ID' },
-        targetAgentIds: { type: 'array', description: 'Target agent IDs' },
+        targetAgentIds: { type: 'array', items: { type: 'string' }, description: 'Target agent IDs' },
         knowledgeDomain: { type: 'string', description: 'Knowledge domain' },
         knowledgeContent: { type: 'object', description: 'Knowledge to share' },
       },

--- a/v3/@claude-flow/cli/src/mcp-tools/github-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/github-tools.ts
@@ -241,8 +241,8 @@ export const githubTools: MCPTool[] = [
         issueNumber: { type: 'number', description: 'Issue number' },
         title: { type: 'string', description: 'Issue title' },
         body: { type: 'string', description: 'Issue body' },
-        labels: { type: 'array', description: 'Issue labels' },
-        assignees: { type: 'array', description: 'Assignees' },
+        labels: { type: 'array', items: { type: 'string' }, description: 'Issue labels' },
+        assignees: { type: 'array', items: { type: 'string' }, description: 'Assignees' },
       },
     },
     handler: async (input) => {

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -2346,7 +2346,7 @@ export const hooksIntelligenceLearn: MCPTool = {
   inputSchema: {
     type: 'object',
     properties: {
-      trajectoryIds: { type: 'array', description: 'Specific trajectories to learn from' },
+      trajectoryIds: { type: 'array', items: { type: 'string' }, description: 'Specific trajectories to learn from' },
       consolidate: { type: 'boolean', description: 'Run EWC++ consolidation' },
     },
   },

--- a/v3/@claude-flow/cli/src/mcp-tools/performance-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/performance-tools.ts
@@ -93,7 +93,7 @@ export const performanceTools: MCPTool[] = [
       properties: {
         timeRange: { type: 'string', description: 'Time range (1h, 24h, 7d)' },
         format: { type: 'string', enum: ['json', 'summary', 'detailed'], description: 'Report format' },
-        components: { type: 'array', description: 'Components to include' },
+        components: { type: 'array', items: { type: 'string' }, description: 'Components to include' },
       },
     },
     handler: async (input) => {

--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -83,7 +83,7 @@ export const systemTools: MCPTool[] = [
       type: 'object',
       properties: {
         verbose: { type: 'boolean', description: 'Include detailed information' },
-        components: { type: 'array', description: 'Specific components to check' },
+        components: { type: 'array', items: { type: 'string' }, description: 'Specific components to check' },
       },
     },
     handler: async (input) => {
@@ -200,7 +200,7 @@ export const systemTools: MCPTool[] = [
       type: 'object',
       properties: {
         deep: { type: 'boolean', description: 'Perform deep health check' },
-        components: { type: 'array', description: 'Components to check' },
+        components: { type: 'array', items: { type: 'string' }, description: 'Components to check' },
         fix: { type: 'boolean', description: 'Attempt to fix issues' },
       },
     },
@@ -283,7 +283,7 @@ export const systemTools: MCPTool[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        include: { type: 'array', description: 'Information to include' },
+        include: { type: 'array', items: { type: 'string' }, description: 'Information to include' },
       },
     },
     handler: async () => {


### PR DESCRIPTION
## Summary
- Fix MCP tool schemas that defined `type: 'array'` without `items`, which breaks strict JSON Schema validation.
- This was reproduced in **OpenCode**: start a session with **opus**, then switch to **codex**; tool schema validation fails with `array schema missing items`.
- Add a regression test to scan `src/mcp-tools/*.ts` and fail if any array schema omits `items`.
## Validation
- `npx vitest run __tests__/mcp-schema-array-items.test.ts`
## Context
- Reported in #1294 (OpenCode -> Codex session switch path).
- Closes #1294