### PR TITLE
fix: ADR-060 Sprint 1 — 10 fixes (hook stdin, learning loop, MCP tools)

### DIFF
--- a/.claude/helpers/auto-memory-hook.mjs
+++ b/.claude/helpers/auto-memory-hook.mjs
@@ -139,17 +139,30 @@ async function loadMemoryPackage() {
     } catch { /* fall through */ }
   }
 
-  // Strategy 2: npm installed @claude-flow/memory
+  // Strategy 2: Use createRequire for CJS-style resolution (handles nested node_modules
+  // when installed as a transitive dependency via npx ruflo / npx claude-flow)
+  try {
+    const { createRequire } = await import('module');
+    const require = createRequire(join(PROJECT_ROOT, 'package.json'));
+    return require('@claude-flow/memory');
+  } catch { /* fall through */ }
+
+  // Strategy 3: ESM import (works when @claude-flow/memory is a direct dependency)
   try {
     return await import('@claude-flow/memory');
   } catch { /* fall through */ }
 
-  // Strategy 3: Installed via @claude-flow/cli which includes memory
-  const cliMemory = join(PROJECT_ROOT, 'node_modules/@claude-flow/memory/dist/index.js');
-  if (existsSync(cliMemory)) {
-    try {
-      return await import(`file://${cliMemory}`);
-    } catch { /* fall through */ }
+  // Strategy 4: Walk up from PROJECT_ROOT looking for @claude-flow/memory in any node_modules
+  let searchDir = PROJECT_ROOT;
+  const { parse } = await import('path');
+  while (searchDir !== parse(searchDir).root) {
+    const candidate = join(searchDir, 'node_modules', '@claude-flow', 'memory', 'dist', 'index.js');
+    if (existsSync(candidate)) {
+      try {
+        return await import(`file://${candidate}`);
+      } catch { /* fall through */ }
+    }
+    searchDir = dirname(searchDir);
   }
 
   return null;

--- a/.claude/helpers/hook-handler.cjs
+++ b/.claude/helpers/hook-handler.cjs
@@ -36,7 +36,30 @@ const memory = safeRequire(path.join(helpersDir, 'memory.cjs'));
 const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 
 const [,, command, ...args] = process.argv;
-const prompt = process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
+
+// Read stdin — Claude Code sends hook data as JSON via stdin
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
+}
+
+async function main() {
+  let stdinData = '';
+  try { stdinData = await readStdin(); } catch (e) { /* ignore stdin errors */ }
+
+  let hookInput = {};
+  if (stdinData.trim()) {
+    try { hookInput = JSON.parse(stdinData); } catch (e) { /* ignore parse errors */ }
+  }
+
+  // Merge stdin data into prompt resolution: prefer stdin fields, then env, then argv
+  const prompt = hookInput.prompt || hookInput.command || hookInput.toolInput
+    || process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
 
 const handlers = {
   'route': () => {
@@ -63,7 +86,7 @@ const handlers = {
   },
 
   'pre-bash': () => {
-    var cmd = prompt.toLowerCase();
+    var cmd = (hookInput.command || prompt).toLowerCase();
     var dangerous = ['rm -rf /', 'format c:', 'del /s /q c:\\', ':(){:|:&};:'];
     for (var i = 0; i < dangerous.length; i++) {
       if (cmd.includes(dangerous[i])) {
@@ -80,7 +103,8 @@ const handlers = {
     }
     if (intelligence && intelligence.recordEdit) {
       try {
-        var file = process.env.TOOL_INPUT_file_path || args[0] || '';
+        var file = hookInput.file_path || (hookInput.toolInput && hookInput.toolInput.file_path)
+          || process.env.TOOL_INPUT_file_path || args[0] || '';
         intelligence.recordEdit(file);
       } catch (e) { /* non-fatal */ }
     }
@@ -179,13 +203,18 @@ const handlers = {
 };
 
 if (command && handlers[command]) {
-  try {
-    handlers[command]();
-  } catch (e) {
-    console.log('[WARN] Hook ' + command + ' encountered an error: ' + e.message);
+    try {
+      handlers[command]();
+    } catch (e) {
+      console.log('[WARN] Hook ' + command + ' encountered an error: ' + e.message);
+    }
+  } else if (command) {
+    console.log('[OK] Hook: ' + command);
+  } else {
+    console.log('Usage: hook-handler.cjs <route|pre-bash|post-edit|session-restore|session-end|pre-task|post-task|compact-manual|compact-auto|status|stats>');
   }
-} else if (command) {
-  console.log('[OK] Hook: ' + command);
-} else {
-  console.log('Usage: hook-handler.cjs <route|pre-bash|post-edit|session-restore|session-end|pre-task|post-task|compact-manual|compact-auto|status|stats>');
 }
+
+main().catch(function(e) {
+  console.log('[WARN] Hook handler error: ' + e.message);
+});

--- a/v3/@claude-flow/cli/.claude/helpers/auto-memory-hook.mjs
+++ b/v3/@claude-flow/cli/.claude/helpers/auto-memory-hook.mjs
@@ -139,17 +139,30 @@ async function loadMemoryPackage() {
     } catch { /* fall through */ }
   }
 
-  // Strategy 2: npm installed @claude-flow/memory
+  // Strategy 2: Use createRequire for CJS-style resolution (handles nested node_modules
+  // when installed as a transitive dependency via npx ruflo / npx claude-flow)
+  try {
+    const { createRequire } = await import('module');
+    const require = createRequire(join(PROJECT_ROOT, 'package.json'));
+    return require('@claude-flow/memory');
+  } catch { /* fall through */ }
+
+  // Strategy 3: ESM import (works when @claude-flow/memory is a direct dependency)
   try {
     return await import('@claude-flow/memory');
   } catch { /* fall through */ }
 
-  // Strategy 3: Installed via @claude-flow/cli which includes memory
-  const cliMemory = join(PROJECT_ROOT, 'node_modules/@claude-flow/memory/dist/index.js');
-  if (existsSync(cliMemory)) {
-    try {
-      return await import(`file://${cliMemory}`);
-    } catch { /* fall through */ }
+  // Strategy 4: Walk up from PROJECT_ROOT looking for @claude-flow/memory in any node_modules
+  let searchDir = PROJECT_ROOT;
+  const { parse } = await import('path');
+  while (searchDir !== parse(searchDir).root) {
+    const candidate = join(searchDir, 'node_modules', '@claude-flow', 'memory', 'dist', 'index.js');
+    if (existsSync(candidate)) {
+      try {
+        return await import(`file://${candidate}`);
+      } catch { /* fall through */ }
+    }
+    searchDir = dirname(searchDir);
   }
 
   return null;

--- a/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
@@ -50,8 +50,29 @@ const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 // Get the command from argv
 const [,, command, ...args] = process.argv;
 
-// Get prompt from environment variable (set by Claude Code hooks)
-const prompt = process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
+// Read stdin — Claude Code sends hook data as JSON via stdin
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
+}
+
+async function main() {
+  let stdinData = '';
+  try { stdinData = await readStdin(); } catch (e) { /* ignore stdin errors */ }
+
+  let hookInput = {};
+  if (stdinData.trim()) {
+    try { hookInput = JSON.parse(stdinData); } catch (e) { /* ignore parse errors */ }
+  }
+
+  // Merge stdin data into prompt resolution: prefer stdin fields, then env, then argv
+  const prompt = hookInput.prompt || hookInput.command || hookInput.toolInput
+    || process.env.PROMPT || process.env.TOOL_INPUT_command || args.join(' ') || '';
 
 const handlers = {
   'route': () => {
@@ -105,8 +126,8 @@ const handlers = {
   },
 
   'pre-bash': () => {
-    // Basic command safety check
-    const cmd = prompt.toLowerCase();
+    // Basic command safety check — prefer stdin command data from Claude Code
+    const cmd = (hookInput.command || prompt).toLowerCase();
     const dangerous = ['rm -rf /', 'format c:', 'del /s /q c:\\', ':(){:|:&};:'];
     for (const d of dangerous) {
       if (cmd.includes(d)) {
@@ -122,10 +143,11 @@ const handlers = {
     if (session && session.metric) {
       try { session.metric('edits'); } catch (e) { /* no active session */ }
     }
-    // Record edit for intelligence consolidation
+    // Record edit for intelligence consolidation — prefer stdin data from Claude Code
     if (intelligence && intelligence.recordEdit) {
       try {
-        const file = process.env.TOOL_INPUT_file_path || args[0] || '';
+        const file = hookInput.file_path || (hookInput.toolInput && hookInput.toolInput.file_path)
+          || process.env.TOOL_INPUT_file_path || args[0] || '';
         intelligence.recordEdit(file);
       } catch (e) { /* non-fatal */ }
     }
@@ -216,17 +238,22 @@ const handlers = {
   },
 };
 
-// Execute the handler
-if (command && handlers[command]) {
-  try {
-    handlers[command]();
-  } catch (e) {
-    // Hooks should never crash Claude Code - fail silently
-    console.log(`[WARN] Hook ${command} encountered an error: ${e.message}`);
+  // Execute the handler
+  if (command && handlers[command]) {
+    try {
+      handlers[command]();
+    } catch (e) {
+      // Hooks should never crash Claude Code - fail silently
+      console.log(`[WARN] Hook ${command} encountered an error: ${e.message}`);
+    }
+  } else if (command) {
+    // Unknown command - pass through without error
+    console.log(`[OK] Hook: ${command}`);
+  } else {
+    console.log('Usage: hook-handler.cjs <route|pre-bash|post-edit|session-restore|session-end|pre-task|post-task|stats>');
   }
-} else if (command) {
-  // Unknown command - pass through without error
-  console.log(`[OK] Hook: ${command}`);
-} else {
-  console.log('Usage: hook-handler.cjs <route|pre-bash|post-edit|session-restore|session-end|pre-task|post-task|stats>');
 }
+
+main().catch((e) => {
+  console.log(`[WARN] Hook handler error: ${e.message}`);
+});

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -208,10 +208,15 @@ async function checkDiskSpace(): Promise<HealthCheck> {
     if (process.platform === 'win32') {
       return { name: 'Disk Space', status: 'pass', message: 'Check skipped on Windows' };
     }
-    const output_str = await runCommand('df -h . | tail -1');
+    // Use df -Ph for POSIX mode (guarantees single-line output even with long device names)
+    const output_str = await runCommand('df -Ph . | tail -1');
     const parts = output_str.split(/\s+/);
+    // POSIX format: Filesystem Size Used Avail Capacity Mounted
     const available = parts[3];
     const usePercent = parseInt(parts[4]?.replace('%', '') || '0', 10);
+    if (isNaN(usePercent)) {
+      return { name: 'Disk Space', status: 'warn', message: `${available || 'unknown'} available (unable to parse usage)` };
+    }
 
     if (usePercent > 90) {
       return { name: 'Disk Space', status: 'fail', message: `${available} available (${usePercent}% used)`, fix: 'Free up disk space' };

--- a/v3/@claude-flow/cli/src/commands/mcp.ts
+++ b/v3/@claude-flow/cli/src/commands/mcp.ts
@@ -284,7 +284,20 @@ const statusCommand: Command = {
   description: 'Show MCP server status',
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     try {
-      const status = await getMCPServerStatus();
+      let status = await getMCPServerStatus();
+
+      // If PID-based check says not running, detect stdio mode
+      if (!status.running) {
+        const isStdio = !process.stdin.isTTY;
+        const envTransport = process.env.CLAUDE_FLOW_MCP_TRANSPORT;
+        if (isStdio || envTransport === 'stdio') {
+          status = {
+            running: true,
+            pid: process.pid,
+            transport: 'stdio',
+          };
+        }
+      }
 
       if (ctx.flags.format === 'json') {
         output.printJson(status);
@@ -311,13 +324,17 @@ const statusCommand: Command = {
         return { success: true, data: status };
       }
 
-      const displayData = [
+      const displayData: Array<{ metric: string; value: unknown }> = [
         { metric: 'Status', value: output.success('Running') },
         { metric: 'PID', value: status.pid },
         { metric: 'Transport', value: status.transport },
-        { metric: 'Host', value: status.host },
-        { metric: 'Port', value: status.port },
       ];
+
+      // Only show host/port for non-stdio transports
+      if (status.transport !== 'stdio') {
+        displayData.push({ metric: 'Host', value: status.host });
+        displayData.push({ metric: 'Port', value: status.port });
+      }
 
       if (status.uptime !== undefined) {
         displayData.push({ metric: 'Uptime', value: formatUptime(status.uptime) });

--- a/v3/@claude-flow/cli/src/commands/status.ts
+++ b/v3/@claude-flow/cli/src/commands/status.ts
@@ -297,7 +297,11 @@ function displayStatus(status: Awaited<ReturnType<typeof getSystemStatus>>): voi
   // MCP section
   output.writeln(output.bold('MCP Server'));
   if (status.mcp.running) {
-    output.printInfo(`  Running on port ${status.mcp.port} (${status.mcp.transport})`);
+    if (status.mcp.transport === 'stdio') {
+      output.printInfo('  Running (stdio mode)');
+    } else {
+      output.printInfo(`  Running on port ${status.mcp.port} (${status.mcp.transport})`);
+    }
   } else {
     output.printInfo('  Not running');
   }
@@ -407,7 +411,9 @@ async function performHealthCheck(
     checks.push({
       name: 'MCP Server',
       status: status.mcp.running ? 'pass' : 'warn',
-      message: status.mcp.running ? `Running on port ${status.mcp.port}` : 'Not running'
+      message: status.mcp.running
+        ? (status.mcp.transport === 'stdio' ? 'Running (stdio mode)' : `Running on port ${status.mcp.port}`)
+        : 'Not running'
     });
 
     // Check memory backend

--- a/v3/@claude-flow/cli/src/init/helpers-generator.ts
+++ b/v3/@claude-flow/cli/src/init/helpers-generator.ts
@@ -804,10 +804,34 @@ const dim = (msg) => console.log(\`  \${DIM}\${msg}\${RESET}\`);
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
+async function loadMemoryPackage() {
+  // Strategy 1: Use createRequire for CJS-style resolution (handles nested node_modules
+  // when installed as a transitive dependency via npx ruflo / npx claude-flow)
+  try {
+    const { createRequire } = await import('module');
+    const require = createRequire(join(PROJECT_ROOT, 'package.json'));
+    return require('@claude-flow/memory');
+  } catch { /* fall through */ }
+
+  // Strategy 2: ESM import (works when @claude-flow/memory is a direct dependency)
+  try { return await import('@claude-flow/memory'); } catch { /* fall through */ }
+
+  // Strategy 3: Walk up from PROJECT_ROOT looking for the package in any node_modules
+  let searchDir = PROJECT_ROOT;
+  const { parse } = await import('path');
+  while (searchDir !== parse(searchDir).root) {
+    const candidate = join(searchDir, 'node_modules', '@claude-flow', 'memory', 'dist', 'index.js');
+    if (existsSync(candidate)) {
+      try { return await import(\`file://\${candidate}\`); } catch { /* fall through */ }
+    }
+    searchDir = dirname(searchDir);
+  }
+
+  return null;
+}
+
 async function doImport() {
-  // Try loading @claude-flow/memory for full functionality
-  let memPkg = null;
-  try { memPkg = await import('@claude-flow/memory'); } catch {}
+  const memPkg = await loadMemoryPackage();
 
   if (!memPkg || !memPkg.AutoMemoryBridge) {
     dim('Memory package not available — auto memory import skipped (non-critical)');
@@ -824,8 +848,7 @@ async function doSync() {
     return;
   }
 
-  let memPkg = null;
-  try { memPkg = await import('@claude-flow/memory'); } catch {}
+  const memPkg = await loadMemoryPackage();
 
   if (!memPkg || !memPkg.AutoMemoryBridge) {
     dim('Memory package not available — sync skipped (non-critical)');

--- a/v3/@claude-flow/cli/src/mcp-server.ts
+++ b/v3/@claude-flow/cli/src/mcp-server.ts
@@ -201,6 +201,21 @@ export class MCPServerManager extends EventEmitter {
     const pid = await this.readPidFile();
 
     if (!pid) {
+      // No PID file found. Detect if we are running in stdio mode
+      // (e.g., launched by Claude Code via `claude mcp add`).
+      const isStdio = !process.stdin.isTTY;
+      const envTransport = process.env.CLAUDE_FLOW_MCP_TRANSPORT;
+      if (isStdio || envTransport === 'stdio' || this.options.transport === 'stdio') {
+        return {
+          running: true,
+          pid: process.pid,
+          transport: 'stdio',
+          startedAt: this.startTime?.toISOString(),
+          uptime: this.startTime
+            ? Math.floor((Date.now() - this.startTime.getTime()) / 1000)
+            : undefined,
+        };
+      }
       return { running: false };
     }
 
@@ -588,6 +603,7 @@ export class MCPServerManager extends EventEmitter {
         this.emit('health-error', error);
       }
     }, 30000);
+    this.healthCheckInterval.unref();
   }
 
   /**

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -633,6 +633,21 @@ export const hooksPostEdit: MCPTool = {
   handler: async (params: Record<string, unknown>) => {
     const filePath = params.filePath as string;
     const success = params.success !== false;
+    const agent = params.agent as string | undefined;
+
+    // Wire recordFeedback through bridge (issue #1209)
+    let feedbackResult: { success: boolean; controller: string; updated: number } | null = null;
+    try {
+      const bridge = await import('../memory/memory-bridge.js');
+      feedbackResult = await bridge.bridgeRecordFeedback({
+        taskId: `edit-${filePath}-${Date.now()}`,
+        success,
+        quality: success ? 0.85 : 0.3,
+        agent,
+      });
+    } catch {
+      // Bridge not available — continue with basic response
+    }
 
     return {
       recorded: true,
@@ -640,6 +655,11 @@ export const hooksPostEdit: MCPTool = {
       success,
       timestamp: new Date().toISOString(),
       learningUpdate: success ? 'pattern_reinforced' : 'pattern_adjusted',
+      feedback: feedbackResult ? {
+        recorded: feedbackResult.success,
+        controller: feedbackResult.controller,
+        updates: feedbackResult.updated,
+      } : { recorded: false, controller: 'unavailable', updates: 0 },
     };
   },
 };

--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -368,4 +368,94 @@ export const systemTools: MCPTool[] = [
       };
     },
   },
+  {
+    name: 'mcp_status',
+    description: 'Get MCP server status, including stdio mode detection',
+    category: 'system',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      // Detect if we are running inside an MCP stdio session.
+      // When Claude Code launches us via `claude mcp add`, stdin is piped (not a TTY)
+      // and the process IS the MCP server, so it is running.
+      const isStdio = !process.stdin.isTTY;
+      const transport = process.env.CLAUDE_FLOW_MCP_TRANSPORT || (isStdio ? 'stdio' : 'http');
+      const port = parseInt(process.env.CLAUDE_FLOW_MCP_PORT || '3000', 10);
+
+      if (transport === 'stdio' || isStdio) {
+        // In stdio mode the MCP server is this process itself
+        return {
+          running: true,
+          pid: process.pid,
+          transport: 'stdio',
+          port: null,
+          host: null,
+        };
+      }
+
+      // For HTTP/WebSocket, try to check if the server is listening
+      const host = process.env.CLAUDE_FLOW_MCP_HOST || 'localhost';
+      try {
+        const { createConnection } = await import('node:net');
+        const connected = await new Promise<boolean>((resolve) => {
+          const socket = createConnection({ host, port }, () => {
+            socket.destroy();
+            resolve(true);
+          });
+          socket.on('error', () => resolve(false));
+          socket.setTimeout(2000, () => {
+            socket.destroy();
+            resolve(false);
+          });
+        });
+
+        return {
+          running: connected,
+          transport,
+          port,
+          host,
+        };
+      } catch {
+        return {
+          running: false,
+          transport,
+          port,
+          host,
+        };
+      }
+    },
+  },
+  {
+    name: 'task_summary',
+    description: 'Get a summary of all tasks by status',
+    category: 'task',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      // Read from the task store file
+      const storePath = join(process.cwd(), '.claude-flow', 'tasks', 'store.json');
+      let tasks: Array<{ status: string }> = [];
+      try {
+        if (existsSync(storePath)) {
+          const data = readFileSync(storePath, 'utf-8');
+          const store = JSON.parse(data);
+          tasks = Object.values(store.tasks || {});
+        }
+      } catch {
+        // empty store
+      }
+
+      return {
+        total: tasks.length,
+        pending: tasks.filter(t => t.status === 'pending').length,
+        running: tasks.filter(t => t.status === 'in_progress').length,
+        completed: tasks.filter(t => t.status === 'completed').length,
+        failed: tasks.filter(t => t.status === 'failed').length,
+      };
+    },
+  },
 ];

--- a/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
@@ -307,6 +307,46 @@ export const taskTools: MCPTool[] = [
     },
   },
   {
+    name: 'task_assign',
+    description: 'Assign a task to one or more agents',
+    category: 'task',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskId: { type: 'string', description: 'Task ID to assign' },
+        agentIds: { type: 'array', items: { type: 'string' }, description: 'Agent IDs to assign' },
+        unassign: { type: 'boolean', description: 'Unassign all agents from task' },
+      },
+      required: ['taskId'],
+    },
+    handler: async (input) => {
+      const store = loadTaskStore();
+      const taskId = input.taskId as string;
+      const task = store.tasks[taskId];
+
+      if (!task) {
+        return { taskId, error: 'Task not found' };
+      }
+
+      const previouslyAssigned = [...task.assignedTo];
+
+      if (input.unassign) {
+        task.assignedTo = [];
+      } else {
+        const agentIds = (input.agentIds as string[]) || [];
+        task.assignedTo = agentIds;
+      }
+
+      saveTaskStore(store);
+
+      return {
+        taskId: task.taskId,
+        assignedTo: task.assignedTo,
+        previouslyAssigned,
+      };
+    },
+  },
+  {
     name: 'task_cancel',
     description: 'Cancel a task',
     category: 'task',

--- a/v3/@claude-flow/cli/src/mcp-tools/workflow-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/workflow-tools.ts
@@ -79,6 +79,104 @@ function saveWorkflowStore(store: WorkflowStore): void {
 
 export const workflowTools: MCPTool[] = [
   {
+    name: 'workflow_run',
+    description: 'Run a workflow from a template or file',
+    category: 'workflow',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        template: { type: 'string', description: 'Template name to run' },
+        file: { type: 'string', description: 'Workflow file path' },
+        task: { type: 'string', description: 'Task description' },
+        options: {
+          type: 'object',
+          description: 'Workflow options',
+          properties: {
+            parallel: { type: 'boolean', description: 'Run stages in parallel' },
+            maxAgents: { type: 'number', description: 'Maximum agents to use' },
+            timeout: { type: 'number', description: 'Timeout in seconds' },
+            dryRun: { type: 'boolean', description: 'Validate without executing' },
+          },
+        },
+      },
+    },
+    handler: async (input) => {
+      const store = loadWorkflowStore();
+      const template = input.template as string | undefined;
+      const task = input.task as string | undefined;
+      const options = (input.options as Record<string, unknown>) || {};
+      const dryRun = options.dryRun as boolean | undefined;
+
+      // Build workflow from template or inline
+      const workflowId = `workflow-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const stages: Array<{ name: string; status: string; agents: string[]; duration?: number }> = [];
+
+      // Generate stages based on template
+      const templateName = template || 'custom';
+      const stageNames: string[] = (() => {
+        switch (templateName) {
+          case 'feature':
+            return ['Research', 'Design', 'Implement', 'Test', 'Review'];
+          case 'bugfix':
+            return ['Investigate', 'Fix', 'Test', 'Review'];
+          case 'refactor':
+            return ['Analyze', 'Refactor', 'Test', 'Review'];
+          case 'security':
+            return ['Scan', 'Analyze', 'Report'];
+          default:
+            return ['Execute'];
+        }
+      })();
+
+      for (const name of stageNames) {
+        stages.push({
+          name,
+          status: dryRun ? 'validated' : 'pending',
+          agents: [],
+        });
+      }
+
+      if (!dryRun) {
+        // Create and save the workflow
+        const steps: WorkflowStep[] = stageNames.map((name, i) => ({
+          stepId: `step-${i + 1}`,
+          name,
+          type: 'task' as const,
+          config: { task: task || name },
+          status: 'pending' as const,
+        }));
+
+        const workflow: WorkflowRecord = {
+          workflowId,
+          name: task || `${templateName} workflow`,
+          description: task,
+          steps,
+          status: 'running',
+          currentStep: 0,
+          variables: { template: templateName, ...options },
+          createdAt: new Date().toISOString(),
+          startedAt: new Date().toISOString(),
+        };
+
+        store.workflows[workflowId] = workflow;
+        saveWorkflowStore(store);
+      }
+
+      return {
+        workflowId,
+        template: templateName,
+        status: dryRun ? 'validated' : 'running',
+        stages,
+        metrics: {
+          totalStages: stages.length,
+          completedStages: 0,
+          agentsSpawned: 0,
+          estimatedDuration: `${stages.length * 30}s`,
+        },
+      };
+    },
+  },
+  {
     name: 'workflow_create',
     description: 'Create a new workflow',
     category: 'workflow',

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -88,6 +88,7 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
               tieredCache: true,
               hierarchicalMemory: true,
               memoryConsolidation: true,
+              memoryGraph: true, // issue #1214: enable MemoryGraph for graph-aware ranking
             },
           });
         } finally {

--- a/v3/@claude-flow/cli/src/output.ts
+++ b/v3/@claude-flow/cli/src/output.ts
@@ -599,6 +599,7 @@ export class Spinner {
       this.render();
       this.frameIndex = (this.frameIndex + 1) % this.frames.length;
     }, 100);
+    this.interval.unref();
 
     this.render();
   }

--- a/v3/@claude-flow/cli/src/services/container-worker-pool.ts
+++ b/v3/@claude-flow/cli/src/services/container-worker-pool.ts
@@ -671,6 +671,7 @@ export class ContainerWorkerPool extends EventEmitter {
     this.healthCheckTimer = setInterval(async () => {
       await this.runHealthChecks();
     }, this.config.healthCheckIntervalMs);
+    this.healthCheckTimer.unref();
   }
 
   /**
@@ -718,6 +719,7 @@ export class ContainerWorkerPool extends EventEmitter {
     this.idleCheckTimer = setInterval(async () => {
       await this.runIdleChecks();
     }, 60000); // Check every minute
+    this.idleCheckTimer.unref();
   }
 
   /**

--- a/v3/@claude-flow/cli/src/services/worker-queue.ts
+++ b/v3/@claude-flow/cli/src/services/worker-queue.ts
@@ -156,6 +156,7 @@ class InMemoryStore {
   startCleanup(): void {
     if (this.cleanupTimer) return;
     this.cleanupTimer = setInterval(() => this.cleanupExpired(), 60000);
+    this.cleanupTimer.unref();
   }
 
   /**
@@ -683,6 +684,7 @@ export class WorkerQueue extends EventEmitter {
         this.store.setWorker(this.workerId, registration);
       }
     }, this.config.heartbeatIntervalMs);
+    this.heartbeatTimer.unref();
   }
 
   /**


### PR DESCRIPTION
## Summary

Sprint 1 fixes from ADR-060, addressing 10 issues across the intelligence pipeline, MCP tools, and CLI UX.

### Fixes

| Issue | Description | Impact |
|-------|-------------|--------|
| #1211 | hook-handler.cjs reads stdin JSON | **Highest leverage** — unblocks entire learning pipeline |
| #1209 | recordFeedback() wired into post-edit | Completes JUDGE step of learning loop |
| #1214 | MemoryGraph enabled in ControllerRegistry | Enables relationship tracking |
| #1287 | auto-memory-hook uses createRequire fallback | Fixes npx/monorepo memory resolution |
| #1256 | .unref() on 6 setInterval timers | CLI exits cleanly without Ctrl+C |
| #1288 | Doctor disk space uses df -P | Correct capacity percentage |
| #1281 | 4 missing MCP tools registered | task_assign, workflow_run, mcp_status, task_summary |
| #1289 | MCP stdio mode detection | Status shows "Running (stdio)" not "Stopped" |
| #1238/62/67/68 | Closed 4 empty rollback stubs | Issue tracker cleanup |

### Files Changed (17)

- `hook-handler.cjs` — stdin buffering + JSON parse
- `auto-memory-hook.mjs` — createRequire + walk-up resolution
- `helpers-generator.ts` — template updated for new installs
- `hooks-tools.ts` — recordFeedback in post-edit handler
- `memory-bridge.ts` — memoryGraph: true in config
- `system-tools.ts` — mcp_status + task_summary tools
- `task-tools.ts` — task_assign tool
- `workflow-tools.ts` — workflow_run tool
- `mcp-server.ts` — stdio transport detection in getStatus()
- `mcp.ts` / `status.ts` — stdio-aware display
- `doctor.ts` — df -P + NaN guard
- `output.ts` / `worker-queue.ts` / `container-worker-pool.ts` — .unref()

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Hook stdin smoke test: `echo '{"prompt":"test"}' | node hook-handler.cjs route` → reads prompt
- [x] Hook backward compat: `node hook-handler.cjs status` → works without stdin
- [x] Dangerous command detection via stdin: blocks `rm -rf /`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)