### PR TITLE
fix: close semantic routing learning loop in hooks-tools

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -4,7 +4,7 @@
  */
 
 import { mkdirSync, writeFileSync, existsSync, readFileSync, statSync } from 'fs';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 import type { MCPTool } from './types.js';
 
 // Real vector search functions - lazy loaded to avoid circular imports
@@ -203,7 +203,7 @@ function loadRoutingOutcomes(): RoutingOutcome[] {
 
 function saveRoutingOutcomes(outcomes: RoutingOutcome[]): void {
   try {
-    const dir = ROUTING_OUTCOMES_PATH.replace(/[/\\][^/\\]+$/, '');
+    const dir = dirname(ROUTING_OUTCOMES_PATH);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     // Cap at 500 entries to bound file size
     const capped = outcomes.slice(-500);
@@ -922,9 +922,10 @@ export const hooksRoute: MCPTool = {
         backendInfo = 'native VectorDb (HNSW)';
 
         // Convert results to semantic format
+        const mergedPatterns = getMergedTaskPatterns();
         semanticResult = results.map((r: { id: string; score: number }) => {
           const [patternName] = r.id.split(':');
-          const pattern = getMergedTaskPatterns()[patternName];
+          const pattern = mergedPatterns[patternName];
           return {
             intent: patternName,
             score: 1 - r.score, // Native uses distance (lower is better), convert to similarity
@@ -1246,7 +1247,7 @@ export const hooksPostTask: MCPTool = {
     const taskText = (params.task as string) || '';
     const outcomeKeywords = extractKeywords(taskText);
     let outcomePersisted = false;
-    if (taskText && agent) {
+    if (taskText && agent && agent.length <= 100 && /^[a-zA-Z0-9_-]+$/.test(agent)) {
       try {
         const outcomes = loadRoutingOutcomes();
         outcomes.push({


### PR DESCRIPTION
## Summary

Fixes #1310 — the semantic routing learning loop is dead.

The `hooks/route` tool uses static `TASK_PATTERNS` for routing, and `hooks/post-task` never persists outcomes to a retrievable store. The router never improves based on actual task completions.

### Changes (3 patches to `hooks-tools.ts`)

- **Patch A — Learning infrastructure**: `extractKeywords()`, `loadRoutingOutcomes()`, `saveRoutingOutcomes()`, `loadLearnedPatterns()`, `getMergedTaskPatterns()` with file-based persistence to `.claude-flow/routing-outcomes.json` (capped at 500 entries, FIFO eviction)

- **Patch B — Router wiring**: Replaces `TASK_PATTERNS` with `getMergedTaskPatterns()` in both HNSW native and pure-JS semantic router initialization. Fixes native result mapper to extract agent name from `learned-<agent>` key prefix. Adds learned keyword matching to `suggestAgentsForTask()` fallback (requires ≥2 keyword overlap, confidence 0.6–0.85)

- **Patch C — Post-task persistence**: Extends `hooksPostTask` schema with `task` (string) and `storeDecisions` (boolean) params. After existing bridge feedback + causal edge recording, persists outcome to file. Optionally stores in memory DB via `storeEntry()`

### Stats

- 1 file changed, 161 insertions, 6 deletions
- Zero new TypeScript errors (33 pre-existing missing-module errors in other files unchanged)

## Test plan

Tested end-to-end on @claude-flow/cli 3.5.7:

- [x] `hooks/route` returns baseline routing for 3 test tasks
- [x] `hooks/post-task` with `task` + `agent` params returns `outcomePersisted: true`
- [x] `.claude-flow/routing-outcomes.json` contains correct entries with extracted keywords
- [x] `loadLearnedPatterns()` produces correct `learned-<agent>` pattern shapes
- [x] TypeScript compiles clean (zero new errors)
- [ ] Re-route after MCP server restart picks up learned patterns (requires session restart)

## Design decisions

| Decision | Rationale |
|----------|-----------|
| File-based persistence over memory DB | `getRealStoreFunction()` bridge often returns null; file is always reliable. Memory DB is opt-in via `storeDecisions` |
| Keyword overlap threshold ≥ 2 | Prevents false positives from single common words |
| Confidence range 0.6–0.85 | Learned patterns score below static patterns (0.8–0.95) to prefer curated rules |
| 500-entry cap with FIFO | Bounds file size growth while keeping recent history |
| Patterns indexed at init | Matches existing HNSW initialization model; learned patterns take effect on next server start |

🤖 Generated with [Claude Code](https://claude.com/claude-code)