### PR TITLE
fix(memory): add prepublishOnly guard — 6 source files missing from published dist

### DIFF
--- a/v3/@claude-flow/memory/package.json
+++ b/v3/@claude-flow/memory/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "test": "vitest run",
     "bench": "vitest bench",
-    "build": "tsc"
+    "build": "tsc",
+    "prebuild": "rm -rf dist",
+    "prepublishOnly": "npm run build && node -e \"const m = await import('./dist/index.js'); const required = ['ControllerRegistry','HnswLite','PersistentSonaCoordinator','RvfBackend','RvfLearningStore','RvfMigrator']; const missing = required.filter(k => !m[k]); if (missing.length) { console.error('Missing exports:', missing); process.exit(1); } console.log('All required exports present');\""
   },
   "dependencies": {
     "agentdb": "^3.0.0-alpha.10",


### PR DESCRIPTION
## Summary

The published `@claude-flow/memory@3.0.0-alpha.11` is missing 6 compiled files from `dist/`, even though the source files exist in `src/` and are exported in `index.ts`. This breaks the memory bridge in `@claude-flow/cli` (3.5.2–3.5.7).

## Missing files

| Source file | Missing from dist | Exports affected |
|---|---|---|
| `controller-registry.ts` | `controller-registry.js` | `ControllerRegistry`, `INIT_LEVELS` |
| `hnsw-lite.ts` | `hnsw-lite.js` | `HnswLite`, `cosineSimilarity` |
| `persistent-sona.ts` | `persistent-sona.js` | `PersistentSonaCoordinator` |
| `rvf-backend.ts` | `rvf-backend.js` | `RvfBackend` |
| `rvf-learning-store.ts` | `rvf-learning-store.js` | `RvfLearningStore` |
| `rvf-migration.ts` | `rvf-migration.js` | `RvfMigrator` |

## Impact

`memory-bridge.js` in `@claude-flow/cli` does:

```js
const { ControllerRegistry } = await import('@claude-flow/memory');
```

Since `ControllerRegistry` is `undefined`, the bridge sets `bridgeAvailable = false` and **all 14+ bridge functions return null**, disabling:

- BM25 hybrid search (Phase 2 — reciprocal rank fusion)
- `bridgeRecordFeedback` in `hooksPostTask` (Phase 3 — learning system)
- `bridgeRecordCausalEdge` (Phase 3 — causal memory graph)
- `bridgeGenerateEmbedding` / `bridgeSearchHNSW`
- The entire ADR-053 controller activation pipeline

## Root cause

No `prebuild` clean step and no `prepublishOnly` guard, so a stale `dist/` from a previous build was published without the 6 new files.

## Fix

- Add `"prebuild": "rm -rf dist"` to ensure clean builds
- Add `"prepublishOnly"` that builds and then verifies all 6 critical exports exist before allowing `npm publish`

## Immediate action needed

After merging, a rebuild + republish of `@claude-flow/memory` is needed:

```bash
cd v3/@claude-flow/memory
npm run build
npm publish
```

## Test plan

- [ ] Run `npm run build` in `v3/@claude-flow/memory/` — verify all 6 `.js` files appear in `dist/`
- [ ] Run `node -e "import('@claude-flow/memory').then(m => console.log(!!m.ControllerRegistry))"` — should print `true`
- [ ] Run `npm publish --dry-run` — verify `prepublishOnly` passes
- [ ] After publish: verify `memory-bridge.js` in `@claude-flow/cli` successfully initializes the `ControllerRegistry`

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)