### PR TITLE
fix(agents): make base-template-generator frontmatter parseable

### DIFF
--- a/v3/@claude-flow/cli/.claude/agents/templates/base-template-generator.md
+++ b/v3/@claude-flow/cli/.claude/agents/templates/base-template-generator.md
@@ -2,7 +2,28 @@
 name: base-template-generator
 version: "2.0.0-alpha"
 updated: "2025-12-03"
-description: Use this agent when you need to create foundational templates, boilerplate code, or starter configurations for new projects, components, or features. This agent excels at generating clean, well-structured base templates that follow best practices and can be easily customized. Enhanced with pattern learning, GNN-based template search, and fast generation. Examples: <example>Context: User needs to start a new React component and wants a solid foundation. user: 'I need to create a new user profile component' assistant: 'I'll use the base-template-generator agent to create a comprehensive React component template with proper structure, TypeScript definitions, and styling setup.' <commentary>Since the user needs a foundational template for a new component, use the base-template-generator agent to create a well-structured starting point.</commentary></example> <example>Context: User is setting up a new API endpoint and needs a template. user: 'Can you help me set up a new REST API endpoint for user management?' assistant: 'I'll use the base-template-generator agent to create a complete API endpoint template with proper error handling, validation, and documentation structure.' <commentary>The user needs a foundational template for an API endpoint, so use the base-template-generator agent to provide a comprehensive starting point.</commentary></example>
+description: >-
+  Use this agent when you need to create foundational templates, boilerplate code,
+  or starter configurations for new projects, components, or features. This agent
+  excels at generating clean, well-structured base templates that follow best
+  practices and can be easily customized. Enhanced with pattern learning,
+  GNN-based template search, and fast generation.
+
+  Examples: <example>Context: User needs to start a new React component and wants
+  a solid foundation. user: 'I need to create a new user profile component'
+  assistant: 'I'll use the base-template-generator agent to create a comprehensive
+  React component template with proper structure, TypeScript definitions, and
+  styling setup.' <commentary>Since the user needs a foundational template for a
+  new component, use the base-template-generator agent to create a
+  well-structured starting point.</commentary></example>
+
+  <example>Context: User is setting up a new API endpoint and needs a template.
+  user: 'Can you help me set up a new REST API endpoint for user management?'
+  assistant: 'I'll use the base-template-generator agent to create a complete API
+  endpoint template with proper error handling, validation, and documentation
+  structure.' <commentary>The user needs a foundational template for an API
+  endpoint, so use the base-template-generator agent to provide a comprehensive
+  starting point.</commentary></example>
 color: orange
 metadata:
   v2_capabilities:


### PR DESCRIPTION
## Summary
- convert the `description` field in `v3/@claude-flow/cli/.claude/agents/templates/base-template-generator.md` frontmatter to a folded YAML scalar
- preserve the same descriptive content while avoiding unquoted-colon YAML parsing failures

## Verification
- ran a frontmatter validation script across `v3/@claude-flow/cli/.claude/agents/**/*.md`
- result after change: `parse_errors=0`, `missing_description=0`

Fixes #1051