### PR TITLE
docs: add npx ECOMPROMISED recovery steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7318,6 +7318,25 @@ sudo chown -R $(whoami) ~/.npm
 # Or use nvm to manage Node.js
 ```
 
+**npm ECOMPROMISED / Lock compromised during npx install**
+```bash
+# npm may have stale integrity metadata for frequently updated alpha builds
+npm cache clean --force
+npm cache verify
+
+# Retry with a fresh package resolution
+npx --yes ruflo@latest init
+# or
+npx --yes claude-flow@latest init
+```
+
+If the cache error persists, clear only the integrity index and retry:
+
+```bash
+rm -rf ~/.npm/_cacache/index-v5
+npx --yes ruflo@latest init
+```
+
 **High memory usage**
 ```bash
 # Enable garbage collection


### PR DESCRIPTION
## Summary\n- add a troubleshooting entry for npm `ECOMPROMISED` / `Lock compromised` failures during `npx` installs\n- document safe recovery steps: cache clean/verify first, then integrity-index-only reset if needed\n- include retry commands for both `ruflo` and `claude-flow` packages\n\n## Validation\n- `git diff --check`\n- attempted markdown lint, but README has many pre-existing lint violations unrelated to this change\n\nCloses #1231