### PR TITLE
feat: add NextAuth.js v5 example with credentials and OAuth providers

### DIFF
--- a/examples/nextauth-app/.env.example
+++ b/examples/nextauth-app/.env.example
@@ -1,0 +1,13 @@
+# Required: Generate with `openssl rand -base64 32`
+AUTH_SECRET=your-secret-here
+
+# Production URL (e.g. https://yourapp.com)
+# AUTH_URL=https://yourapp.com
+
+# GitHub OAuth
+AUTH_GITHUB_ID=your-github-client-id
+AUTH_GITHUB_SECRET=your-github-client-secret
+
+# Google OAuth
+AUTH_GOOGLE_ID=your-google-client-id
+AUTH_GOOGLE_SECRET=your-google-client-secret

--- a/examples/nextauth-app/app/admin/page.tsx
+++ b/examples/nextauth-app/app/admin/page.tsx
@@ -1,0 +1,43 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+
+/**
+ * Admin-only page — requires the "admin" role.
+ * Middleware blocks non-admin users at the edge (returns 403).
+ * This component also verifies the role for defence in depth.
+ */
+export default async function AdminPage() {
+  const session = await auth();
+
+  if (!session) {
+    redirect("/login?callbackUrl=/admin");
+  }
+
+  if (session.user?.role !== "admin") {
+    return (
+      <main style={{ fontFamily: "sans-serif", maxWidth: 600, margin: "4rem auto", padding: "0 1rem" }}>
+        <h1>403 — Forbidden</h1>
+        <p>You do not have permission to view this page.</p>
+        <a href="/dashboard">Back to Dashboard</a>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ fontFamily: "sans-serif", maxWidth: 600, margin: "4rem auto", padding: "0 1rem" }}>
+      <h1>Admin Panel</h1>
+      <p>
+        Signed in as admin: <strong>{session.user?.email}</strong>
+      </p>
+
+      <section style={{ marginTop: "1.5rem" }}>
+        <h2>Admin Actions</h2>
+        <ul>
+          <li>Manage users</li>
+          <li>View audit logs</li>
+          <li>Configure system settings</li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/examples/nextauth-app/app/api/auth/[...nextauth]/route.ts
+++ b/examples/nextauth-app/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,13 @@
+import { handlers } from "@/auth";
+
+/**
+ * Auth.js v5 route handler.
+ * Handles all /api/auth/* routes:
+ *   GET  /api/auth/session
+ *   GET  /api/auth/csrf
+ *   GET  /api/auth/providers
+ *   GET  /api/auth/callback/:provider
+ *   POST /api/auth/signin/:provider
+ *   POST /api/auth/signout
+ */
+export const { GET, POST } = handlers;

--- a/examples/nextauth-app/app/api/protected/route.ts
+++ b/examples/nextauth-app/app/api/protected/route.ts
@@ -1,0 +1,39 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+
+/**
+ * Protected API route example.
+ * Returns 401 for unauthenticated requests and 403 for non-admin users on
+ * admin-only resources.
+ */
+export async function GET() {
+  const session = await auth();
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.json({
+    message: "This is a protected resource.",
+    user: {
+      id: session.user.id,
+      email: session.user.email,
+      role: session.user.role,
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (session.user.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  return NextResponse.json({ message: "Admin action completed.", data: body });
+}

--- a/examples/nextauth-app/app/dashboard/page.tsx
+++ b/examples/nextauth-app/app/dashboard/page.tsx
@@ -1,0 +1,50 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+
+/**
+ * Protected dashboard page — only accessible to authenticated users.
+ * Unauthenticated users are redirected to /login by middleware, but we
+ * also check here as a defence-in-depth measure for direct Server Component
+ * access (e.g. RSC calls bypassing middleware).
+ */
+export default async function DashboardPage() {
+  const session = await auth();
+
+  if (!session) {
+    redirect("/login?callbackUrl=/dashboard");
+  }
+
+  return (
+    <main style={{ fontFamily: "sans-serif", maxWidth: 600, margin: "4rem auto", padding: "0 1rem" }}>
+      <h1>Dashboard</h1>
+      <p>Welcome back, <strong>{session.user?.name ?? session.user?.email}</strong>!</p>
+
+      <section style={{ marginTop: "1.5rem" }}>
+        <h2>Your Session</h2>
+        <pre style={{ background: "#f4f4f4", padding: "1rem", borderRadius: "4px", overflow: "auto" }}>
+          {JSON.stringify(
+            {
+              id: session.user?.id,
+              email: session.user?.email,
+              name: session.user?.name,
+              role: session.user?.role,
+              image: session.user?.image,
+            },
+            null,
+            2
+          )}
+        </pre>
+      </section>
+
+      {session.user?.role === "admin" && (
+        <section style={{ marginTop: "1.5rem" }}>
+          <h2>Admin Tools</h2>
+          <p>
+            You have admin access. Visit the{" "}
+            <a href="/admin">Admin Panel</a>.
+          </p>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/examples/nextauth-app/app/layout.tsx
+++ b/examples/nextauth-app/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { SessionProvider } from "next-auth/react";
+import { auth } from "@/auth";
+
+export const metadata: Metadata = {
+  title: "NextAuth.js Example",
+  description: "Auth.js v5 with credentials and OAuth providers",
+};
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+
+  return (
+    <html lang="en">
+      <body>
+        {/*
+          SessionProvider makes session data available to Client Components via
+          useSession(). The initial session is passed from the Server Component
+          to avoid a client-side fetch on first render.
+        */}
+        <SessionProvider session={session}>{children}</SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/examples/nextauth-app/app/login/page.tsx
+++ b/examples/nextauth-app/app/login/page.tsx
@@ -1,0 +1,104 @@
+import { signIn } from "@/auth";
+import { AuthError } from "next-auth";
+import { redirect } from "next/navigation";
+
+interface LoginPageProps {
+  searchParams: Promise<{ callbackUrl?: string; error?: string }>;
+}
+
+/**
+ * Login page with:
+ * - Email/password credentials form (Server Action)
+ * - GitHub OAuth button
+ * - Google OAuth button
+ * - Error display for failed login attempts
+ */
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const { callbackUrl, error } = await searchParams;
+  const destination = callbackUrl ?? "/dashboard";
+
+  return (
+    <main style={{ fontFamily: "sans-serif", maxWidth: 400, margin: "4rem auto", padding: "0 1rem" }}>
+      <h1>Sign In</h1>
+
+      {error && (
+        <div style={{ color: "red", marginBottom: "1rem" }}>
+          {error === "CredentialsSignin"
+            ? "Invalid email or password."
+            : "An error occurred. Please try again."}
+        </div>
+      )}
+
+      {/* Credentials form */}
+      <form
+        action={async (formData: FormData) => {
+          "use server";
+          try {
+            await signIn("credentials", {
+              email: formData.get("email"),
+              password: formData.get("password"),
+              redirectTo: destination,
+            });
+          } catch (err) {
+            if (err instanceof AuthError) {
+              redirect(`/login?error=${err.type}&callbackUrl=${destination}`);
+            }
+            throw err;
+          }
+        }}
+        style={{ display: "flex", flexDirection: "column", gap: "0.75rem", marginBottom: "1.5rem" }}
+      >
+        <label>
+          Email
+          <input
+            type="email"
+            name="email"
+            required
+            placeholder="user@example.com"
+            style={{ display: "block", width: "100%", padding: "0.4rem", marginTop: "0.25rem" }}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            name="password"
+            required
+            placeholder="••••••••"
+            style={{ display: "block", width: "100%", padding: "0.4rem", marginTop: "0.25rem" }}
+          />
+        </label>
+        <button type="submit" style={{ padding: "0.5rem", cursor: "pointer" }}>
+          Sign in with Email
+        </button>
+      </form>
+
+      <hr />
+
+      {/* GitHub OAuth */}
+      <form
+        action={async () => {
+          "use server";
+          await signIn("github", { redirectTo: destination });
+        }}
+        style={{ margin: "1rem 0" }}
+      >
+        <button type="submit" style={{ width: "100%", padding: "0.5rem", cursor: "pointer" }}>
+          Sign in with GitHub
+        </button>
+      </form>
+
+      {/* Google OAuth */}
+      <form
+        action={async () => {
+          "use server";
+          await signIn("google", { redirectTo: destination });
+        }}
+      >
+        <button type="submit" style={{ width: "100%", padding: "0.5rem", cursor: "pointer" }}>
+          Sign in with Google
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/examples/nextauth-app/app/page.tsx
+++ b/examples/nextauth-app/app/page.tsx
@@ -1,0 +1,48 @@
+import { auth } from "@/auth";
+import { signOut } from "@/auth";
+import Link from "next/link";
+
+/**
+ * Public home page — visible to all users.
+ * Reads the session server-side to conditionally render nav items.
+ */
+export default async function HomePage() {
+  const session = await auth();
+
+  return (
+    <main style={{ fontFamily: "sans-serif", maxWidth: 600, margin: "4rem auto", padding: "0 1rem" }}>
+      <h1>NextAuth.js Example</h1>
+      <p>Auth.js v5 with Credentials, GitHub, and Google providers.</p>
+
+      {session ? (
+        <div>
+          <p>
+            Signed in as <strong>{session.user?.email}</strong> (role:{" "}
+            <strong>{session.user?.role}</strong>)
+          </p>
+
+          <nav style={{ display: "flex", gap: "1rem", margin: "1rem 0" }}>
+            <Link href="/dashboard">Dashboard</Link>
+            {session.user?.role === "admin" && <Link href="/admin">Admin Panel</Link>}
+          </nav>
+
+          <form
+            action={async () => {
+              "use server";
+              await signOut({ redirectTo: "/" });
+            }}
+          >
+            <button type="submit">Sign out</button>
+          </form>
+        </div>
+      ) : (
+        <div>
+          <p>You are not signed in.</p>
+          <Link href="/login">
+            <button>Sign in</button>
+          </Link>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/examples/nextauth-app/auth.ts
+++ b/examples/nextauth-app/auth.ts
@@ -1,0 +1,114 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+import Google from "next-auth/providers/google";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcryptjs";
+import type { NextAuthConfig } from "next-auth";
+
+/**
+ * Mock user database — replace with a real DB adapter (e.g. Prisma, Drizzle).
+ * In production use @auth/prisma-adapter or @auth/drizzle-adapter.
+ */
+const USERS: { id: string; email: string; passwordHash: string; role: "user" | "admin" }[] = [
+  {
+    id: "1",
+    email: "admin@example.com",
+    // bcrypt hash of "password123"
+    passwordHash: "$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQyCkQJnO.V7Z1M5c1VL5uqjS",
+    role: "admin",
+  },
+  {
+    id: "2",
+    email: "user@example.com",
+    // bcrypt hash of "password123"
+    passwordHash: "$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQyCkQJnO.V7Z1M5c1VL5uqjS",
+    role: "user",
+  },
+];
+
+export const authConfig: NextAuthConfig = {
+  providers: [
+    /**
+     * GitHub OAuth provider.
+     * Set AUTH_GITHUB_ID and AUTH_GITHUB_SECRET in .env.local.
+     * GitHub OAuth app callback URL: /api/auth/callback/github
+     */
+    GitHub({
+      clientId: process.env.AUTH_GITHUB_ID,
+      clientSecret: process.env.AUTH_GITHUB_SECRET,
+    }),
+
+    /**
+     * Google OAuth provider.
+     * Set AUTH_GOOGLE_ID and AUTH_GOOGLE_SECRET in .env.local.
+     * Google OAuth consent screen callback URL: /api/auth/callback/google
+     */
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+
+    /**
+     * Credentials provider for email/password login.
+     * Validates against hashed passwords with bcrypt.
+     */
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) return null;
+
+        const email = credentials.email as string;
+        const password = credentials.password as string;
+
+        const user = USERS.find((u) => u.email === email);
+        if (!user) return null;
+
+        const isValid = await bcrypt.compare(password, user.passwordHash);
+        if (!isValid) return null;
+
+        return { id: user.id, email: user.email, role: user.role };
+      },
+    }),
+  ],
+
+  callbacks: {
+    /**
+     * Enrich the JWT token with custom fields (e.g. role).
+     * Called whenever a token is created or refreshed.
+     */
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+        token.role = (user as { role?: string }).role ?? "user";
+      }
+      return token;
+    },
+
+    /**
+     * Expose custom JWT fields on the session object.
+     * Called whenever session data is read in Server/Client Components.
+     */
+    async session({ session, token }) {
+      if (token) {
+        session.user.id = token.id as string;
+        session.user.role = token.role as string;
+      }
+      return session;
+    },
+  },
+
+  pages: {
+    signIn: "/login",
+    error: "/login",
+  },
+
+  session: {
+    strategy: "jwt",
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+};
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);

--- a/examples/nextauth-app/lib/auth-helpers.ts
+++ b/examples/nextauth-app/lib/auth-helpers.ts
@@ -1,0 +1,39 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+
+/**
+ * Reusable RBAC guards for Server Components and Server Actions.
+ */
+
+/**
+ * Require an authenticated session. Redirects to /login if not authenticated.
+ * Returns the session for use in the calling component.
+ */
+export async function requireAuth() {
+  const session = await auth();
+  if (!session) {
+    redirect("/login");
+  }
+  return session;
+}
+
+/**
+ * Require a specific role. Returns 403-like result if role doesn't match.
+ * Usage: const session = await requireRole("admin");
+ */
+export async function requireRole(role: string) {
+  const session = await requireAuth();
+  if (session.user?.role !== role) {
+    throw new Error(`Forbidden: requires role "${role}"`);
+  }
+  return session;
+}
+
+/**
+ * Check if the current user has a given role without redirecting.
+ * Useful for conditional rendering inside authenticated pages.
+ */
+export async function hasRole(role: string): Promise<boolean> {
+  const session = await auth();
+  return session?.user?.role === role;
+}

--- a/examples/nextauth-app/middleware.ts
+++ b/examples/nextauth-app/middleware.ts
@@ -1,0 +1,58 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Middleware for route protection using Auth.js v5.
+ *
+ * Public routes are accessible without authentication.
+ * Protected routes redirect unauthenticated users to /login.
+ * Admin routes additionally require the "admin" role.
+ */
+
+const PUBLIC_ROUTES = ["/", "/login", "/api/auth"];
+const ADMIN_ROUTES = ["/admin"];
+
+function isPublic(pathname: string): boolean {
+  return PUBLIC_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(route + "/")
+  );
+}
+
+function isAdmin(pathname: string): boolean {
+  return ADMIN_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(route + "/")
+  );
+}
+
+export default auth(function middleware(req: NextRequest & { auth: Awaited<ReturnType<typeof auth>> }) {
+  const { pathname } = req.nextUrl;
+  const session = (req as any).auth;
+
+  // Allow public routes unconditionally
+  if (isPublic(pathname)) {
+    return NextResponse.next();
+  }
+
+  // Redirect unauthenticated users to login
+  if (!session) {
+    const loginUrl = new URL("/login", req.url);
+    loginUrl.searchParams.set("callbackUrl", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Admin-only routes require the "admin" role
+  if (isAdmin(pathname) && session.user?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return NextResponse.next();
+});
+
+export const config = {
+  /**
+   * Run middleware on all routes except static assets, images, and favicons.
+   * Adjust the matcher to match your route structure.
+   */
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};

--- a/examples/nextauth-app/next-auth.d.ts
+++ b/examples/nextauth-app/next-auth.d.ts
@@ -1,0 +1,33 @@
+import type { DefaultSession, DefaultJWT } from "next-auth";
+
+declare module "next-auth" {
+  /**
+   * Extend the built-in Session type to include custom fields.
+   * These are populated via the `session` callback in auth.ts.
+   */
+  interface Session {
+    user: {
+      id: string;
+      role: string;
+    } & DefaultSession["user"];
+  }
+
+  /**
+   * Extend the built-in User type returned from the `authorize` callback
+   * and OAuth providers.
+   */
+  interface User {
+    role?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  /**
+   * Extend the built-in JWT type to persist custom fields between requests.
+   * These are populated via the `jwt` callback in auth.ts.
+   */
+  interface JWT extends DefaultJWT {
+    id: string;
+    role: string;
+  }
+}

--- a/examples/nextauth-app/next.config.ts
+++ b/examples/nextauth-app/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // Enable experimental features if needed
+};
+
+export default nextConfig;

--- a/examples/nextauth-app/package.json
+++ b/examples/nextauth-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "nextauth-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "next-auth": "beta",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "bcryptjs": "^2.4.3",
+    "@auth/core": "^0.37.0"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/nextauth-app/tsconfig.json
+++ b/examples/nextauth-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Implements a complete **Auth.js v5** (NextAuth.js beta) example for Next.js App Router
- Adds `examples/nextauth-app/` with credentials, GitHub, and Google OAuth providers
- Includes JWT session strategy with custom `id` and `role` fields via callbacks
- Provides edge middleware for route protection and RBAC
- Includes TypeScript type extensions and reusable auth helpers

## Files Added

| File | Purpose |
|------|---------|
| `auth.ts` | NextAuth config: Credentials + GitHub + Google providers, JWT/session callbacks |
| `middleware.ts` | Edge middleware: protects routes, redirects to `/login`, enforces admin role |
| `next-auth.d.ts` | TypeScript module augmentation for `Session`, `User`, and `JWT` |
| `app/api/auth/[...nextauth]/route.ts` | Auth.js catch-all route handler |
| `app/api/protected/route.ts` | Protected API returning 401/403 |
| `app/layout.tsx` | Root layout with `SessionProvider` |
| `app/login/page.tsx` | Login page with credentials form + OAuth buttons (Server Actions) |
| `app/dashboard/page.tsx` | Protected dashboard page |
| `app/admin/page.tsx` | Admin-only page with role guard |
| `lib/auth-helpers.ts` | Reusable `requireAuth` / `requireRole` / `hasRole` guards |

## Test plan

- [ ] Copy `.env.example` to `.env.local` and fill in `AUTH_SECRET`, GitHub, and Google credentials
- [ ] Run `npm install && npm run dev`
- [ ] Verify `/` shows sign-in link when unauthenticated
- [ ] Verify `/dashboard` and `/admin` redirect to `/login` without a session
- [ ] Sign in with credentials (`user@example.com` / `password123`)
- [ ] Verify dashboard shows session data and role
- [ ] Sign in with GitHub or Google OAuth
- [ ] Verify admin page is accessible only when role is `"admin"`
- [ ] Verify `GET /api/protected` returns 401 without session, 200 with session
- [ ] Verify `POST /api/protected` returns 403 for non-admin, 200 for admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)