### PR TITLE
fix: resolve ESM/CJS interop in ruvector-training.ts for @ruvector pa…

### DIFF
--- a/v3/@claude-flow/cli/src/services/ruvector-training.ts
+++ b/v3/@claude-flow/cli/src/services/ruvector-training.ts
@@ -41,6 +41,15 @@ interface SonaEngineInstance {
   flush(): void;
 }
 
+/**
+ * ESM/CJS interop helper: handles packages that export via .default in CJS environments.
+ * Returns the module's default export if present, otherwise the raw module.
+ */
+async function importWithInterop<T = any>(packageName: string): Promise<T> {
+  const mod = await import(packageName);
+  return ((mod as any).default || mod) as T;
+}
+
 // Lazy-loaded WASM modules
 let microLoRA: WasmMicroLoRA | null = null;
 let scopedLoRA: WasmScopedLoRA | null = null;
@@ -136,9 +145,7 @@ export async function initializeTraining(config: TrainingConfig = {}): Promise<{
     features.push('TrajectoryBuffer');
 
     // Initialize attention mechanisms
-    // ESM/CJS interop: @ruvector/attention exports via .default in CJS environments
-    const attentionMod: any = await import('@ruvector/attention');
-    const attention: any = attentionMod.default || attentionMod;
+    const attention = await importWithInterop('@ruvector/attention');
 
     if (config.useFlashAttention !== false) {
       flashAttention = new attention.FlashAttention(dim, 64);
@@ -182,9 +189,7 @@ export async function initializeTraining(config: TrainingConfig = {}): Promise<{
     // Initialize SONA (optional, backward compatible)
     if (config.useSona !== false) {
       try {
-        // ESM/CJS interop: @ruvector/sona exports via .default in CJS environments
-        const sonaMod = await import('@ruvector/sona');
-        const sona = (sonaMod as any).default || sonaMod;
+        const sona = await importWithInterop('@ruvector/sona');
         const sonaRank = config.sonaRank || 4;
         // SonaEngine constructor: (dim, rank, alpha, learningRate) - TypeScript types are wrong
         // @ts-expect-error - SonaEngine accepts 4 positional args but types say 1
@@ -463,9 +468,7 @@ export async function benchmarkTraining(
   dim?: number,
   iterations?: number
 ): Promise<BenchmarkResult[]> {
-  // ESM/CJS interop: @ruvector/attention exports via .default in CJS environments
-  const attentionBenchMod: any = await import('@ruvector/attention');
-  const attention: any = attentionBenchMod.default || attentionBenchMod;
+  const attention = await importWithInterop('@ruvector/attention');
   lastBenchmark = attention.benchmarkAttention(dim || 256, 100, iterations || 1000);
   return lastBenchmark ?? [];
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
                                                                                                                                                                                                                                          
   - Fix ESM/CJS module interop for `@ruvector/attention` and `@ruvector/sona` dynamic imports in `ruvector-training.ts`                                                                                                                  
   - Apply `.default || module` pattern to handle CJS environments where ES modules export via `.default`
   - Affects 3 import sites: FlashAttention init, SONA init, and benchmark function
                                                                  
   ## Problem                                                                 

   When running in CJS environments (e.g., via `npx` or bundled builds), `@ruvector` packages export their API under `.default`, causing `undefined` errors on constructors like `FlashAttention` and `SonaEngine`.

   ## Solution

   Use the standard ESM/CJS interop pattern:
   ```typescript
   const mod = await import('@ruvector/attention');
   const attention = mod.default || mod;
   ```

   ## Test plan

   - [ ] Verify `npx @claude-flow/cli@latest hooks pretrain` works in CJS mode
   - [ ] Verify `benchmarkTraining()` resolves attention module correctly
   - [ ] Confirm no regression in native ESM environments)