### PR TITLE
Fix benchmark environment lookup in ESM

### DIFF
--- a/v3/@claude-flow/performance/__tests__/benchmark.test.ts
+++ b/v3/@claude-flow/performance/__tests__/benchmark.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { BenchmarkRunner } from '../src/framework/benchmark';
+
+describe('BenchmarkRunner', () => {
+  it('collects environment info without CommonJS require', async () => {
+    const runner = new BenchmarkRunner('esm-benchmark-suite');
+
+    const suite = await runner.runAll([
+      {
+        name: 'noop',
+        fn: () => {},
+        options: {
+          iterations: 1,
+          warmup: 0,
+          minRuns: 1,
+          targetTime: 1,
+        },
+      },
+    ]);
+
+    expect(suite.environment).toMatchObject({
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    });
+    expect(suite.environment.cpus).toBeGreaterThan(0);
+    expect(suite.environment.memory).toBeGreaterThan(0);
+  });
+});

--- a/v3/@claude-flow/performance/src/framework/benchmark.ts
+++ b/v3/@claude-flow/performance/src/framework/benchmark.ts
@@ -16,6 +16,7 @@
  */
 
 import { performance, PerformanceObserver } from 'perf_hooks';
+import os from 'node:os';
 
 // ============================================================================
 // Types and Interfaces
@@ -367,7 +368,6 @@ export class BenchmarkRunner {
    * Get environment information
    */
   private getEnvironmentInfo(): EnvironmentInfo {
-    const os = require('os');
     return {
       nodeVersion: process.version,
       platform: process.platform,


### PR DESCRIPTION
## Summary

- replace the CommonJS-only `require('os')` call in the benchmark framework with an ESM-safe `node:os` import
- add a focused benchmark runner test that proves `runAll()` can collect environment info under the package's ESM test runtime
- keep the patch scoped to the performance benchmark framework, independent from the already-open PluginManager PR line

## Validation

- `cd v3 && npx vitest run @claude-flow/performance/__tests__/benchmark.test.ts`
- `lsp_diagnostics` clean on `v3/@claude-flow/performance/src/framework/benchmark.ts`
- `lsp_diagnostics` clean on `v3/@claude-flow/performance/__tests__/benchmark.test.ts`

## Notes

- `cd v3/@claude-flow/performance && npm run build` still fails because of pre-existing `@ruvector/attention` export mismatches in `src/attention-benchmarks.ts` / `src/attention-integration.ts`; this PR does not touch that existing build breakage