### PR TITLE
Fix hooks package type export paths

### DIFF
--- a/v3/@claude-flow/hooks/package.json
+++ b/v3/@claude-flow/hooks/package.json
@@ -7,35 +7,35 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./registry": {
-      "types": "./dist/registry/index.d.js",
+      "types": "./dist/registry/index.d.ts",
       "import": "./dist/registry/index.js"
     },
     "./executor": {
-      "types": "./dist/executor/index.d.js",
+      "types": "./dist/executor/index.d.ts",
       "import": "./dist/executor/index.js"
     },
     "./daemons": {
-      "types": "./dist/daemons/index.d.js",
+      "types": "./dist/daemons/index.d.ts",
       "import": "./dist/daemons/index.js"
     },
     "./statusline": {
-      "types": "./dist/statusline/index.d.js",
+      "types": "./dist/statusline/index.d.ts",
       "import": "./dist/statusline/index.js"
     },
     "./mcp": {
-      "types": "./dist/mcp/index.d.js",
+      "types": "./dist/mcp/index.d.ts",
       "import": "./dist/mcp/index.js"
     },
     "./reasoningbank": {
-      "types": "./dist/reasoningbank/index.d.js",
+      "types": "./dist/reasoningbank/index.d.ts",
       "import": "./dist/reasoningbank/index.js"
     },
     "./guidance": {
-      "types": "./dist/reasoningbank/guidance-provider.d.js",
+      "types": "./dist/reasoningbank/guidance-provider.d.ts",
       "import": "./dist/reasoningbank/guidance-provider.js"
     }
   },


### PR DESCRIPTION
## Summary

- replace the broken `.d.js` subpath `types` entries in `@claude-flow/hooks/package.json` with the `.d.ts` files the package actually emits
- keep the fix scoped to package metadata; no runtime hook logic changes
- ensure downstream TypeScript consumers can resolve hook package subpath declarations consistently

## Validation

- `cd v3/@claude-flow/hooks && npm run build`
- static post-build check confirmed every `exports[*].types` target now exists on disk

## Notes

- this PR is independent from the open `plugins`, `performance`, and `OpenSandbox` lines; it only fixes package metadata in `@claude-flow/hooks`