### PR TITLE
fix(cli): prevent TS2307 for optional @claude-flow/codex import

### DIFF
--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -40,9 +40,11 @@ async function initCodexAction(
     let CodexInitializer: any;
 
     // Try multiple resolution strategies for the @claude-flow/codex package
+    // Use a variable to prevent TypeScript from statically resolving the optional module
+    const codexModuleId = '@claude-flow/codex';
     const resolutionStrategies = [
       // Strategy 1: Direct import (works if installed as CLI dependency)
-      async () => (await import('@claude-flow/codex')).CodexInitializer,
+      async () => (await import(codexModuleId)).CodexInitializer,
       // Strategy 2: Project node_modules (works if installed in user's project)
       async () => {
         const projectPath = path.join(ctx.cwd, 'node_modules', '@claude-flow', 'codex', 'dist', 'index.js');


### PR DESCRIPTION
## Summary

- Fix V3 CI/CD build failure (`Build V3` job) on all 3 platforms (ubuntu, macos, windows) introduced in PR #1303
- Root cause: `import('@claude-flow/codex')` string literal is statically resolved by TypeScript, but `@claude-flow/codex` is built **after** `@claude-flow/cli` (circular peer dependency), so types are unavailable at compile time
- Fix: move module specifier into a variable — TypeScript skips static resolution for `import(variable)`, returning `Promise<any>` instead

## Test plan

- [x] Full clean `pnpm build` in `v3/` — all 20 packages build successfully
- [x] Verified `@ts-expect-error` does NOT work here (causes TS2578 "unused directive" when codex types ARE available)
- [ ] V3 CI/CD Pipeline should pass `Build V3` on all 3 platforms

tim