### PR TITLE
fix: statusline branding RuFlo V3.5, Opus 4.6 (1M context)

### DIFF
--- a/v3/@claude-flow/cli/.claude/helpers/auto-commit.sh
+++ b/v3/@claude-flow/cli/.claude/helpers/auto-commit.sh
@@ -90,7 +90,7 @@ Automatic checkpoint created by Claude Code
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>" --quiet 2>/dev/null; then
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>" --quiet 2>/dev/null; then
         log "Created commit: $message"
 
         # Push if enabled

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Claude Flow V3 Statusline Generator
+ * RuFlo V3.5 Statusline Generator
  * Displays real-time V3 implementation progress and system status
  *
  * Usage: node statusline.cjs [options]
@@ -121,8 +121,8 @@ function getUserInfo() {
             }
           }
           // Parse model ID to human-readable name
-          if (modelId.includes('opus')) modelName = 'Opus 4.5';
-          else if (modelId.includes('sonnet')) modelName = 'Sonnet 4';
+          if (modelId.includes('opus')) modelName = 'Opus 4.6 (1M context)';
+          else if (modelId.includes('sonnet')) modelName = 'Sonnet 4.6';
           else if (modelId.includes('haiku')) modelName = 'Haiku 4.5';
           else modelName = modelId.split('-').slice(1, 3).join(' ');
         }
@@ -404,7 +404,7 @@ function generateStatusline() {
   const lines = [];
 
   // Header Line
-  let header = `${c.bold}${c.brightPurple}▊ Claude Flow V3 ${c.reset}`;
+  let header = `${c.bold}${c.brightPurple}▊ RuFlo V3.5 ${c.reset}`;
   header += `${swarm.coordinationActive ? c.brightCyan : c.dim}● ${c.brightCyan}${user.name}${c.reset}`;
   if (user.gitBranch) {
     header += `  ${c.dim}│${c.reset}  ${c.brightBlue}⎇ ${user.gitBranch}${c.reset}`;
@@ -486,7 +486,7 @@ function generateSingleLine() {
   const securityStatus = security.status === 'CLEAN' ? '✓' :
                          security.cvesFixed > 0 ? '~' : '✗';
 
-  return `${c.brightPurple}CF-V3${c.reset} ${c.dim}|${c.reset} ` +
+  return `${c.brightPurple}RuFlo${c.reset} ${c.dim}|${c.reset} ` +
     `${c.cyan}D:${progress.domainsCompleted}/${progress.totalDomains}${c.reset} ${c.dim}|${c.reset} ` +
     `${c.yellow}S:${swarmIndicator}${swarm.activeAgents}/${swarm.maxAgents}${c.reset} ${c.dim}|${c.reset} ` +
     `${security.status === 'CLEAN' ? c.green : c.red}CVE:${securityStatus}${security.cvesFixed}/${security.totalCves}${c.reset} ${c.dim}|${c.reset} ` +
@@ -510,7 +510,7 @@ function generateSafeStatusline() {
   const lines = [];
 
   // Header Line
-  let header = `${c.bold}${c.brightPurple}▊ Claude Flow V3 ${c.reset}`;
+  let header = `${c.bold}${c.brightPurple}▊ RuFlo V3.5 ${c.reset}`;
   header += `${swarm.coordinationActive ? c.brightCyan : c.dim}● ${c.brightCyan}${user.name}${c.reset}`;
   if (user.gitBranch) {
     header += `  ${c.dim}│${c.reset}  ${c.brightBlue}⎇ ${user.gitBranch}${c.reset}`;
@@ -529,16 +529,16 @@ function generateSafeStatusline() {
     `${c.brightYellow}⚡ 1.0x${c.reset} ${c.dim}→${c.reset} ${c.brightYellow}2.49x-7.47x${c.reset}`
   );
 
-  // Line 2 (COLLISION LINE): Swarm status with 24 spaces padding after emoji
-  // The emoji (🤖) is 2 columns. 24 spaces pushes content to column 26, past the collision zone (15-25)
+  // Line 2 (COLLISION LINE): Swarm status with padding after label
+  // The emoji+label is ~10 columns. Padding pushes content past collision zone (cols 15-25)
   const swarmIndicator = swarm.coordinationActive ? `${c.brightGreen}◉${c.reset}` : `${c.dim}○${c.reset}`;
   const agentsColor = swarm.activeAgents > 0 ? c.brightGreen : c.red;
   let securityIcon = security.status === 'CLEAN' ? '🟢' : security.status === 'IN_PROGRESS' ? '🟡' : '🔴';
   let securityColor = security.status === 'CLEAN' ? c.brightGreen : security.status === 'IN_PROGRESS' ? c.brightYellow : c.brightRed;
 
-  // CRITICAL: 24 spaces after 🤖 (emoji is 2 cols, so 2+24=26, past collision zone cols 15-25)
+  // Padding after "🤖 Swarm" (emoji 2 cols + " Swarm" 6 cols = 8, pad 18 to reach col 26)
   lines.push(
-    `${c.brightYellow}🤖${c.reset}                        ` +  // 24 spaces padding
+    `${c.brightYellow}🤖 Swarm${c.reset}                  ` +  // 18 spaces padding
     `${swarmIndicator} [${agentsColor}${String(swarm.activeAgents).padStart(2)}${c.reset}/${c.brightWhite}${swarm.maxAgents}${c.reset}]  ` +
     `${c.brightPurple}👥 ${system.subAgents}${c.reset}  ` +
     `${securityIcon} ${securityColor}CVE ${security.cvesFixed}${c.reset}/${c.brightWhite}${security.totalCves}${c.reset}  ` +

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.js
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Claude Flow V3 Statusline Generator
+ * RuFlo V3.5 Statusline Generator
  * Displays real-time V3 implementation progress and system status
  *
  * Usage: node statusline.js [--json] [--compact]
@@ -47,7 +47,7 @@ const c = {
 function getUserInfo() {
   let name = 'user';
   let gitBranch = '';
-  let modelName = 'Opus 4.5';
+  let modelName = 'Opus 4.6 (1M context)';
 
   try {
     name = execSync('git config user.name 2>/dev/null || echo "user"', { encoding: 'utf-8' }).trim();
@@ -242,7 +242,7 @@ function generateStatusline() {
   const lines = [];
 
   // Header Line
-  let header = `${c.bold}${c.brightPurple}▊ Claude Flow V3 ${c.reset}`;
+  let header = `${c.bold}${c.brightPurple}▊ RuFlo V3.5 ${c.reset}`;
   header += `${swarm.coordinationActive ? c.brightCyan : c.dim}● ${c.brightCyan}${user.name}${c.reset}`;
   if (user.gitBranch) {
     header += `  ${c.dim}│${c.reset}  ${c.brightBlue}⎇ ${user.gitBranch}${c.reset}`;

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -3465,7 +3465,7 @@ const statuslineCommand: Command = {
     function getUserInfo() {
       let name = 'user';
       let gitBranch = '';
-      const modelName = 'Opus 4.5';
+      const modelName = 'Opus 4.6 (1M context)';
       const isWindows = process.platform === 'win32';
 
       try {

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -15,7 +15,7 @@ import type { InitOptions } from './types.js';
 /**
  * Generate optimized statusline script
  * Output format:
- * ▊ RuFlo V3 ● user  │  ⎇ branch  │  Opus 4.6
+ * ▊ RuFlo V3.5 ● user  │  ⎇ branch  │  Opus 4.6 (1M context)
  * ─────────────────────────────────────────────────────
  * 🏗️  DDD Domains    [●●○○○]  2/5    ⚡ HNSW 150x
  * 🤖 Swarm  ◉ [ 5/15]  👥 2    🪝 10/17    🟢 CVE 3/3    💾 4MB    🧠  63%
@@ -179,7 +179,7 @@ function getModelName() {
                 const ts = usage[id] && usage[id].lastUsedAt ? new Date(usage[id].lastUsedAt).getTime() : 0;
                 if (ts > latest) { latest = ts; modelId = id; }
               }
-              if (modelId.includes('opus')) return 'Opus 4.6';
+              if (modelId.includes('opus')) return 'Opus 4.6 (1M context)';
               if (modelId.includes('sonnet')) return 'Sonnet 4.6';
               if (modelId.includes('haiku')) return 'Haiku 4.5';
               return modelId.split('-').slice(1, 3).join(' ');
@@ -195,7 +195,7 @@ function getModelName() {
   const settings = getSettings();
   if (settings && settings.model) {
     const m = settings.model;
-    if (m.includes('opus')) return 'Opus 4.6';
+    if (m.includes('opus')) return 'Opus 4.6 (1M context)';
     if (m.includes('sonnet')) return 'Sonnet 4.6';
     if (m.includes('haiku')) return 'Haiku 4.5';
   }
@@ -582,7 +582,7 @@ function generateStatusline() {
   const lines = [];
 
   // Header
-  let header = c.bold + c.brightPurple + '\\u258A RuFlo V3 ' + c.reset;
+  let header = c.bold + c.brightPurple + '\\u258A RuFlo V3.5 ' + c.reset;
   header += (swarm.coordinationActive ? c.brightCyan : c.dim) + '\\u25CF ' + c.brightCyan + git.name + c.reset;
   if (git.gitBranch) {
     header += '  ' + c.dim + '\\u2502' + c.reset + '  ' + c.brightBlue + '\\u23C7 ' + git.gitBranch + c.reset;


### PR DESCRIPTION
## Summary
- Replace "Claude Flow V3" → "RuFlo V3.5" in all statusline headers (statusline.js, statusline.cjs, statusline-generator.ts)
- Update model detection: "Opus 4.5" → "Opus 4.6 (1M context)", "Sonnet 4" → "Sonnet 4.6"
- Restore missing "Swarm" label in safe mode collision-avoidance output
- Update single-line mode "CF-V3" → "RuFlo"
- Fix auto-commit co-author to Opus 4.6
- All `$CLAUDE_PROJECT_DIR` hook path fixes preserved

Fixes #1351

## Test plan
- [ ] Run `node v3/@claude-flow/cli/.claude/helpers/statusline.cjs` — verify header shows "RuFlo V3.5"
- [ ] Verify "Swarm" label appears in safe mode output
- [ ] Run `npx ruflo@latest init` in clean project — verify generated statusline shows correct branding
- [ ] Verify Docker build still works: `docker build -t ruflo:lite -f v3/@claude-flow/cli/docker/Dockerfile .`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)