### PR TITLE
fix: update swarm-activity.json on agent spawn/stop

### DIFF
--- a/v3/@claude-flow/cli/src/commands/agent.ts
+++ b/v3/@claude-flow/cli/src/commands/agent.ts
@@ -7,6 +7,44 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Update swarm-activity.json metrics after agent count changes.
+ * The statusline reads this file to display the swarm agent count.
+ */
+function updateSwarmActivityMetrics(agentCountDelta: number): void {
+  try {
+    const metricsDir = path.join(process.cwd(), '.claude-flow', 'metrics');
+    const activityPath = path.join(metricsDir, 'swarm-activity.json');
+
+    let data: Record<string, unknown> = {
+      timestamp: new Date().toISOString(),
+      swarm: { active: false, agent_count: 0, coordination_active: false },
+    };
+
+    if (fs.existsSync(activityPath)) {
+      data = JSON.parse(fs.readFileSync(activityPath, 'utf-8'));
+    } else {
+      fs.mkdirSync(metricsDir, { recursive: true });
+    }
+
+    const swarm = (data.swarm as Record<string, unknown>) ?? {};
+    const currentCount = Math.max(0, (swarm.agent_count as number) || 0);
+    const newCount = Math.max(0, currentCount + agentCountDelta);
+
+    swarm.agent_count = newCount;
+    swarm.active = newCount > 0;
+    swarm.coordination_active = newCount > 0;
+    data.swarm = swarm;
+    data.timestamp = new Date().toISOString();
+
+    fs.writeFileSync(activityPath, JSON.stringify(data, null, 2));
+  } catch {
+    // Non-critical — don't fail the command if metrics update fails
+  }
+}
 
 // Available agent types with descriptions
 const AGENT_TYPES = [
@@ -146,6 +184,9 @@ const spawnCommand: Command = {
 
       output.writeln();
       output.printSuccess(`Agent ${agentName} spawned successfully`);
+
+      // Update swarm-activity.json so statusline reflects the new agent count
+      updateSwarmActivityMetrics(1);
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);
@@ -417,6 +458,9 @@ const stopCommand: Command = {
       }
 
       output.printSuccess(`Agent ${agentId} stopped successfully`);
+
+      // Update swarm-activity.json so statusline reflects the reduced agent count
+      updateSwarmActivityMetrics(-1);
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);


### PR DESCRIPTION
## Summary

Partial fix for #1322, #1015, #1034, #1279 - swarm state not persisted to disk.

- The statusline reads agent count from `.claude-flow/metrics/swarm-activity.json`, but `agent spawn` and `agent stop` commands never updated this file
- This caused the statusline to always show `0/N` agents even when agents were successfully spawned and active
- Added `updateSwarmActivityMetrics()` helper that increments/decrements `agent_count` in `swarm-activity.json` after successful spawn (+1) and stop (-1)

## Changes

- `v3/@claude-flow/cli/src/commands/agent.ts`: Added `updateSwarmActivityMetrics(delta)` function and calls it after successful spawn (+1) and stop (-1)

## Related Issues

- Fixes the agent count portion of #1322 (swarm_init doesn't write state files)
- Addresses #1015 (no swarm status reported)
- Addresses #1034 (swarm state not persisted between MCP calls)
- Addresses #1279 (zero swarms always)

## Test plan

- [ ] Spawn an agent with `ruflo agent spawn --type coder` and verify `swarm-activity.json` shows `agent_count: 1`
- [ ] Spawn a second agent and verify count increments to 2
- [ ] Stop an agent and verify count decrements
- [ ] Verify statusline reflects the correct agent count
- [ ] Verify graceful handling when `.claude-flow/metrics/` directory doesn't exist