### PR TITLE
feat: add launch.json with dev server configurations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "MeetingToTasks AI (port 3001)",
+      "cwd": "C:/Users/SokMa/OneDrive/Downloads/04_Proyectos/MeetingToTasks",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["next", "dev", "-p", "3001"],
+      "port": 3001
+    },
+    {
+      "name": "AI Content Studio (port 3000)",
+      "cwd": "C:/Users/SokMa/OneDrive/Downloads/04_Proyectos/AI_Content_Studio",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["next", "dev", "-p", "3000"],
+      "port": 3000
+    },
+    {
+      "name": "Investment Dashboard (port 3002)",
+      "cwd": "C:/Users/SokMa/OneDrive/Downloads/04_Proyectos/investment-dashboard",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["react-scripts", "start"],
+      "port": 3002
+    }
+  ]
+}


### PR DESCRIPTION
Adds .claude/launch.json with configurations for all detected dev servers:
- MeetingToTasks AI (Next.js, port 3001)
- AI Content Studio (Next.js, port 3000)
- Investment Dashboard (React, port 3002)