### PR TITLE
fix: statusline generator always overwrites legacy copy from writeHelpers

### DIFF
--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -1131,17 +1131,15 @@ async function writeStatusline(
     }
   }
 
-  // ALWAYS generate statusline.cjs — settings.json references this path
-  // regardless of whether advanced statusline files were also copied.
+  // ALWAYS generate statusline.cjs — the generated version includes AgentDB
+  // vectors/size, tests, ADRs, hooks, and integration stats that the
+  // pre-installed static copy in the npm package lacks.
+  // This must overwrite any copy from writeHelpers() which copies the legacy file.
   const statuslineScript = generateStatuslineScript(options);
   const statuslinePath = path.join(helpersDir, 'statusline.cjs');
 
-  if (!fs.existsSync(statuslinePath) || options.force) {
-    fs.writeFileSync(statuslinePath, statuslineScript, 'utf-8');
-    result.created.files.push('.claude/helpers/statusline.cjs');
-  } else {
-    result.skipped.push('.claude/helpers/statusline.cjs');
-  }
+  fs.writeFileSync(statuslinePath, statuslineScript, 'utf-8');
+  result.created.files.push('.claude/helpers/statusline.cjs');
 }
 
 /**


### PR DESCRIPTION
## Summary
- `writeHelpers()` copies the pre-installed 577-line legacy `statusline.cjs` from the npm package
- `writeStatusline()` then skipped writing because the file already existed
- The full 758-line generated version (with AgentDB vectors/size, tests, ADRs, hooks, integration stats) was never used in fresh installs
- Fix: `writeStatusline()` now always writes the generated version, overwriting the legacy copy

## Before vs After

| Feature | Before (577 lines) | After (758 lines) |
|---------|--------------------|--------------------|
| `getAgentDBStats()` | missing | included |
| `getTestStats()` | missing | included |
| `getHooksStatus()` | missing | included |
| `getADRStatus()` | missing | included |
| AgentDB vectors/size line | missing | `📊 AgentDB Vectors ●0 │ Size 0KB │ Tests ●0 │ MCP ●1/1` |

## Test plan
- [x] Docker build + `ruflo init` — generated statusline is 758 lines with all functions
- [x] `node .claude/helpers/statusline.cjs --json` shows `agentdb`, `hooks`, `tests`, `adrs` in output
- [x] Visual output shows AgentDB line with vectors/size/tests/MCP

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)