### PR TITLE
fix: doctor checks + AgentDB bridge errors (v3.5.19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.5.15",
+  "version": "3.5.19",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.5.15",
+  "version": "3.5.19",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.5.15",
+  "version": "3.5.19",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -70,13 +70,14 @@ async function checkNpmVersion(): Promise<HealthCheck> {
 
 // Check config file
 async function checkConfigFile(): Promise<HealthCheck> {
-  const configPaths = [
+  // JSON configs (parse-validated)
+  const jsonPaths = [
     '.claude-flow/config.json',
     'claude-flow.config.json',
     '.claude-flow.json'
   ];
 
-  for (const configPath of configPaths) {
+  for (const configPath of jsonPaths) {
     if (existsSync(configPath)) {
       try {
         const content = readFileSync(configPath, 'utf8');
@@ -85,6 +86,19 @@ async function checkConfigFile(): Promise<HealthCheck> {
       } catch (e) {
         return { name: 'Config File', status: 'fail', message: `Invalid JSON: ${configPath}`, fix: 'Fix JSON syntax in config file' };
       }
+    }
+  }
+
+  // YAML configs (existence-checked only — no heavy yaml parser dependency)
+  const yamlPaths = [
+    '.claude-flow/config.yaml',
+    '.claude-flow/config.yml',
+    'claude-flow.config.yaml'
+  ];
+
+  for (const configPath of yamlPaths) {
+    if (existsSync(configPath)) {
+      return { name: 'Config File', status: 'pass', message: `Found: ${configPath}` };
     }
   }
 
@@ -144,8 +158,13 @@ async function checkApiKeys(): Promise<HealthCheck> {
     }
   }
 
+  // Detect Claude Code environment — API keys are managed internally
+  const inClaudeCode = !!(process.env.CLAUDE_CODE || process.env.CLAUDE_PROJECT_DIR || process.env.MCP_SESSION_ID);
+
   if (found.includes('ANTHROPIC_API_KEY') || found.includes('CLAUDE_API_KEY')) {
     return { name: 'API Keys', status: 'pass', message: `Found: ${found.join(', ')}` };
+  } else if (inClaudeCode) {
+    return { name: 'API Keys', status: 'pass', message: 'Claude Code (managed internally)' };
   } else if (found.length > 0) {
     return { name: 'API Keys', status: 'warn', message: `Found: ${found.join(', ')} (no Claude key)`, fix: 'export ANTHROPIC_API_KEY=your_key' };
   } else {
@@ -187,11 +206,11 @@ async function checkMcpServers(): Promise<HealthCheck> {
         const content = JSON.parse(readFileSync(configPath, 'utf8'));
         const servers = content.mcpServers || content.servers || {};
         const count = Object.keys(servers).length;
-        const hasClaudeFlow = 'claude-flow' in servers || 'claude-flow_alpha' in servers;
+        const hasClaudeFlow = 'claude-flow' in servers || 'claude-flow_alpha' in servers || 'ruflo' in servers || 'ruflo_alpha' in servers;
         if (hasClaudeFlow) {
-          return { name: 'MCP Servers', status: 'pass', message: `${count} servers (claude-flow configured)` };
+          return { name: 'MCP Servers', status: 'pass', message: `${count} servers (ruflo configured)` };
         } else {
-          return { name: 'MCP Servers', status: 'warn', message: `${count} servers (claude-flow not found)`, fix: 'claude mcp add claude-flow npx @claude-flow/cli@v3alpha mcp start' };
+          return { name: 'MCP Servers', status: 'warn', message: `${count} servers (ruflo not found)`, fix: 'claude mcp add ruflo -- npx -y ruflo@latest mcp start' };
         }
       } catch {
         // continue to next path

--- a/v3/@claude-flow/cli/src/mcp-tools/agentdb-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agentdb-tools.ts
@@ -87,7 +87,7 @@ export const agentdbControllers: MCPTool = {
     try {
       const bridge = await getBridge();
       const controllers = await bridge.bridgeListControllers();
-      if (!controllers) return { available: false, controllers: [], error: 'Bridge not available' };
+      if (!controllers) return { available: false, controllers: [], error: 'AgentDB bridge not available — @claude-flow/memory not installed or missing controller-registry. Use memory_store/memory_search tools instead.' };
       return {
         available: true,
         controllers,
@@ -124,7 +124,7 @@ export const agentdbPatternStore: MCPTool = {
         type: validateString(params.type, 'type', 200) ?? 'general',
         confidence: validateScore(params.confidence, 0.8),
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -188,7 +188,7 @@ export const agentdbFeedback: MCPTool = {
         quality: validateScore(params.quality, 0.85),
         agent: validateString(params.agent, 'agent', 200) ?? undefined,
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -225,7 +225,7 @@ export const agentdbCausalEdge: MCPTool = {
         relation,
         weight: typeof params.weight === 'number' ? validateScore(params.weight, 0.5) : undefined,
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -283,7 +283,7 @@ export const agentdbSessionStart: MCPTool = {
         sessionId,
         context: validateString(params.context, 'context', 10_000) ?? undefined,
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -314,7 +314,7 @@ export const agentdbSessionEnd: MCPTool = {
         summary: validateString(params.summary, 'summary', 50_000) ?? undefined,
         tasksCompleted: validatePositiveInt(params.tasksCompleted, 0, 10_000),
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -352,7 +352,7 @@ export const agentdbHierarchicalStore: MCPTool = {
       }
       const bridge = await getBridge();
       const result = await bridge.bridgeHierarchicalStore({ key, value, tier });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -387,7 +387,7 @@ export const agentdbHierarchicalRecall: MCPTool = {
         tier: tier ?? undefined,
         topK: validatePositiveInt(params.topK, 5, MAX_TOP_K),
       });
-      return result ?? { results: [], error: 'Bridge not available' };
+      return result ?? { results: [], error: 'AgentDB bridge not available. Use memory_search instead.' };
     } catch (error) {
       return { results: [], error: sanitizeError(error) };
     }
@@ -413,7 +413,7 @@ export const agentdbConsolidate: MCPTool = {
         minAge: typeof params.minAge === 'number' ? Math.max(0, params.minAge) : undefined,
         maxEntries: validatePositiveInt(params.maxEntries, 1000, 10_000),
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -478,7 +478,7 @@ export const agentdbBatch: MCPTool = {
         operation,
         entries: validatedEntries,
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -507,7 +507,7 @@ export const agentdbContextSynthesize: MCPTool = {
         query,
         maxEntries: validatePositiveInt(params.maxEntries, 10, MAX_TOP_K),
       });
-      return result ?? { success: false, error: 'Bridge not available' };
+      return result ?? { success: false, error: 'AgentDB bridge not available. Use memory_store/memory_search instead.' };
     } catch (error) {
       return { success: false, error: sanitizeError(error) };
     }
@@ -532,7 +532,7 @@ export const agentdbSemanticRoute: MCPTool = {
       if (!input) return { route: null, error: 'input is required (non-empty string, max 10KB)' };
       const bridge = await getBridge();
       const result = await bridge.bridgeSemanticRoute({ input });
-      return result ?? { route: null, error: 'Bridge not available' };
+      return result ?? { route: null, error: 'AgentDB bridge not available. Use hooks route instead.' };
     } catch (error) {
       return { route: null, error: sanitizeError(error) };
     }

--- a/v3/@claude-flow/memory/package.json
+++ b/v3/@claude-flow/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/memory",
-  "version": "3.0.0-alpha.11",
+  "version": "3.0.0-alpha.12",
   "type": "module",
   "description": "Memory module - AgentDB unification, HNSW indexing, vector search, hybrid SQLite+AgentDB backend (ADR-009)",
   "main": "dist/index.js",

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1789,7 +1789,7 @@
       }
     },
     "@claude-flow/cli": {
-      "version": "3.5.15",
+      "version": "3.5.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3188,7 +3188,7 @@
       }
     },
     "@claude-flow/memory": {
-      "version": "3.0.0-alpha.11",
+      "version": "3.0.0-alpha.12",
       "cpu": [
         "x64",
         "arm64"


### PR DESCRIPTION
## Summary

- **#1339**: Doctor now detects `.claude-flow/config.yaml` and `.yml` config files
- **#1340**: API key warning suppressed inside Claude Code (detects `CLAUDE_PROJECT_DIR`/`CLAUDE_CODE`/`MCP_SESSION_ID`)
- **#1344**: Doctor recognizes `ruflo`/`ruflo_alpha` as valid MCP server names
- **#1313**: `@claude-flow/memory@3.0.0-alpha.12` published with `controller-registry.js` included
- **#1343**: AgentDB MCP tools return actionable error messages pointing to `memory_store`/`memory_search`

## Test plan

- [x] Docker build + init + doctor with YAML config → `✓ Found: .claude-flow/config.yaml`
- [x] Docker doctor with `CLAUDE_PROJECT_DIR` set → `✓ Claude Code (managed internally)`
- [x] Docker doctor with `ruflo` MCP server → `✓ 1 servers (ruflo configured)`
- [x] `npm pack @claude-flow/memory@3.0.0-alpha.12` contains `controller-registry.js`
- [x] CLI build passes (`tsc` clean)

Closes #1339, #1340, #1344, #1343, #1313

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)