### PR TITLE
fix: ESM/CJS interop for @ruvector packages (rebased from #1334)

### DIFF
--- a/v3/@claude-flow/cli/src/services/ruvector-training.ts
+++ b/v3/@claude-flow/cli/src/services/ruvector-training.ts
@@ -41,6 +41,15 @@ interface SonaEngineInstance {
   flush(): void;
 }
 
+
+/**
+ * ESM/CJS interop helper — handles `.default` for CJS modules.
+ * Uses `'default' in mod` check which is safer than `mod.default || mod`.
+ */
+async function importWithInterop<T = any>(packageName: string): Promise<T> {
+  const mod = await import(packageName);
+  return ('default' in mod) ? (mod as any).default : mod;
+}
 // Lazy-loaded WASM modules
 let microLoRA: WasmMicroLoRA | null = null;
 let scopedLoRA: WasmScopedLoRA | null = null;
@@ -352,7 +361,7 @@ export async function initializeTraining(config: TrainingConfig = {}): Promise<{
 
   // --- Attention mechanisms (optional, independent of WASM) ---
   try {
-    const attention: any = await import('@ruvector/attention');
+    const attention: any = await importWithInterop('@ruvector/attention');
 
     if (config.useFlashAttention !== false) {
       flashAttention = new attention.FlashAttention(dim, 64);
@@ -398,9 +407,8 @@ export async function initializeTraining(config: TrainingConfig = {}): Promise<{
   // --- SONA (optional, backward compatible) ---
   if (config.useSona !== false) {
     try {
-      const sona = await import('@ruvector/sona');
+      const sona = await importWithInterop('@ruvector/sona');
       const sonaRank = config.sonaRank || 4;
-      // @ts-expect-error - SonaEngine accepts 4 positional args but types say 1
       sonaEngine = new sona.SonaEngine(dim, sonaRank, alpha, lr) as SonaEngineInstance;
       sonaAvailable = true;
       features.push(`SONA (${dim}-dim, rank-${sonaRank}, 624k learn/s)`);
@@ -667,7 +675,7 @@ export async function benchmarkTraining(
   dim?: number,
   iterations?: number
 ): Promise<BenchmarkResult[]> {
-  const attention: any = await import('@ruvector/attention');
+  const attention: any = await importWithInterop('@ruvector/attention');
   lastBenchmark = attention.benchmarkAttention(dim || 256, 100, iterations || 1000);
   return lastBenchmark ?? [];
 }


### PR DESCRIPTION
## Summary
- Adds `importWithInterop` helper for CJS module interop using `'default' in mod` check
- Applied at 3 `@ruvector` import sites in `ruvector-training.ts`
- Rebased from #1334 by @fjdevel onto current main (post-v3.5.22)

Based on the original work by @fjdevel in #1334.

## Test plan
- [ ] `tsc` builds cleanly
- [ ] WASM imports still work when `@ruvector` packages installed
- [ ] JS fallback classes still function when WASM unavailable

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

Co-Authored-By: fjdevel <fjdevel@users.noreply.github.com>