### PR TITLE
fix: hive-mind_status reads real agent state (#1382)

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/hive-mind-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hive-mind-tools.ts
@@ -356,13 +356,17 @@ export const hiveMindTools: MCPTool[] = [
           electedAt: state.queen.electedAt,
           term: state.queen.term,
         } : { id: 'N/A', status: 'offline', load: 0, tasksQueued: 0 },
-        workers: state.workers.map(w => ({
-          id: w,
-          type: 'worker',
-          status: 'idle',
-          currentTask: null,
-          tasksCompleted: 0,
-        })),
+        workers: state.workers.map(w => {
+          const agentStore = loadAgentStore();
+          const agent = agentStore.agents[w] as Record<string, unknown> | undefined;
+          return {
+            id: w,
+            type: (agent?.agentType as string) || 'worker',
+            status: (agent?.status as string) || 'unknown',
+            currentTask: (agent?.currentTask as string) || null,
+            tasksCompleted: (agent?.taskCount as number) || 0,
+          };
+        }),
         metrics: {
           totalTasks: state.consensus.history.length + state.consensus.pending.length,
           completedTasks: state.consensus.history.length,


### PR DESCRIPTION
## Summary

Fix v3 regression where `hive-mind_status` hardcoded all workers as `idle` with `tasksCompleted: 0` regardless of actual state.

## Change

Workers now read from the agent store (`loadAgentStore()`) to get real `status`, `currentTask`, `tasksCompleted`, and `agentType` values.

## Test plan
- [x] TypeScript build passes
- [x] Worker fields now reflect agent store state

Closes #1382

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)