### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent git hook bypass

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs\" pre-bash",
             "timeout": 5000
           }
@@ -220,9 +229,15 @@
     "memory": {
       "backend": "hybrid",
       "enableHNSW": true,
-      "learningBridge": { "enabled": true },
-      "memoryGraph": { "enabled": true },
-      "agentScopes": { "enabled": true }
+      "learningBridge": {
+        "enabled": true
+      },
+      "memoryGraph": {
+        "enabled": true
+      },
+      "agentScopes": {
+        "enabled": true
+      }
     },
     "neural": {
       "enabled": true
@@ -242,18 +257,40 @@
         "benchmark"
       ],
       "schedules": {
-        "audit": { "interval": "1h", "priority": "critical" },
-        "optimize": { "interval": "30m", "priority": "high" },
-        "consolidate": { "interval": "2h", "priority": "low" },
-        "document": { "interval": "1h", "priority": "normal" },
-        "deepdive": { "interval": "4h", "priority": "normal" },
-        "ultralearn": { "interval": "1h", "priority": "normal" }
+        "audit": {
+          "interval": "1h",
+          "priority": "critical"
+        },
+        "optimize": {
+          "interval": "30m",
+          "priority": "high"
+        },
+        "consolidate": {
+          "interval": "2h",
+          "priority": "low"
+        },
+        "document": {
+          "interval": "1h",
+          "priority": "normal"
+        },
+        "deepdive": {
+          "interval": "4h",
+          "priority": "normal"
+        },
+        "ultralearn": {
+          "interval": "1h",
+          "priority": "normal"
+        }
       }
     },
     "learning": {
       "enabled": true,
       "autoTrain": true,
-      "patterns": ["coordination", "optimization", "prediction"],
+      "patterns": [
+        "coordination",
+        "optimization",
+        "prediction"
+      ],
       "retention": {
         "shortTerm": "24h",
         "longTerm": "30d"


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a new PreToolUse Bash hook entry in `.claude/settings.json` to prevent AI agents (in swarm or standalone mode) from bypassing git hooks via the hook-skip flag.

The hook is inserted as the first entry in the existing `PreToolUse` array alongside the existing `pre-bash` hook-handler entries.

## Why

In a 15-agent swarm context, any agent can bypass pre-commit, commit-msg, and pre-push hooks using the git hook-skip flag. This silently disables linters, type-checkers, and test gates with no error. This closes the last git enforcement gap in an otherwise security-first hook stack.

## Changes

- `.claude/settings.json` — new `matcher: "Bash"` PreToolUse entry running `npx block-no-verify@1.1.2`

No custom scripts, no new dependencies in `package.json`.

Closes #1387

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
