### PR TITLE
Fix v3 CLI state payload mismatches

### DIFF
--- a/v3/@claude-flow/cli/__tests__/commands-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/commands-deep.test.ts
@@ -92,6 +92,7 @@ import { guidanceCommand } from '../src/commands/guidance.js';
 import { applianceCommand } from '../src/commands/appliance.js';
 import updateCommand from '../src/commands/update.js';
 import { ruvectorCommand } from '../src/commands/ruvector/index.js';
+import { callMCPTool } from '../src/mcp-client.js';
 
 import type { Command } from '../src/types.js';
 
@@ -198,6 +199,44 @@ describe('Command Definitions', () => {
   describe('status command', () => {
     it('should have correct name', () => {
       expectValidCommand(statusCommand, 'status');
+    });
+
+    it('should tolerate persisted-store MCP payload shapes', async () => {
+      vi.mocked(callMCPTool).mockImplementation(async (toolName: string) => {
+        if (toolName === 'swarm_status') {
+          return {
+            swarmId: 'swarm-1',
+            topology: 'mesh',
+            status: 'running',
+            agentCount: 2,
+            agents: { total: 2, active: 1, idle: 1 },
+            health: 'healthy',
+            uptime: 5000,
+          };
+        }
+        if (toolName === 'mcp_status') {
+          return { running: true, transport: 'stdio', port: null };
+        }
+        if (toolName === 'memory_stats') {
+          return { totalEntries: 0, backend: 'sql.js + HNSW' };
+        }
+        if (toolName === 'task_summary') {
+          return { total: 2, pending: 0, running: 2, completed: 0, failed: 0 };
+        }
+        return {};
+      });
+
+      const result = await statusCommand.action!({
+        args: [],
+        flags: { _: [] },
+        cwd: process.cwd(),
+        interactive: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).running).toBe(true);
+      expect((result.data as any).swarm.agents.total).toBe(2);
+      expect((result.data as any).memory.entries).toBe(0);
     });
   });
 

--- a/v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 // ============================================================================
 // Mock setup - must be before imports
@@ -454,10 +455,41 @@ describe('MCP Tools Deep Test Suite', () => {
       expect(Array.isArray(result.agents)).toBe(true);
     });
 
+    it('agent_list returns an id field for each agent', async () => {
+      const spawnTool = agentTools.find(t => t.name === 'agent_spawn')!;
+      await spawnTool.handler({ agentType: 'coder' });
+
+      const listTool = agentTools.find(t => t.name === 'agent_list')!;
+      const result: any = await listTool.handler({});
+      expect(result.agents[0].id).toBeDefined();
+    });
+
     it('agent_status returns not_found for unknown agent', async () => {
       const tool = agentTools.find(t => t.name === 'agent_status')!;
       const result: any = await tool.handler({ agentId: 'nonexistent' });
       expect(result.status).toBe('not_found');
+    });
+
+    it('agent_status returns an id plus metrics for existing agents', async () => {
+      const spawnTool = agentTools.find(t => t.name === 'agent_spawn')!;
+      const spawned: any = await spawnTool.handler({ agentType: 'coder' });
+
+      const statusTool = agentTools.find(t => t.name === 'agent_status')!;
+      const result: any = await statusTool.handler({ agentId: spawned.agentId });
+      expect(result.id).toBe(spawned.agentId);
+      expect(result.metrics.tasksInProgress).toBeDefined();
+    });
+
+    it('agent_logs is registered and reads daemon log entries', async () => {
+      writeFileSync(
+        `${process.cwd()}/.claude-flow/logs/daemon.log`,
+        '[2026-01-01T00:00:00.000Z] [INFO] Daemon started\n[2026-01-01T00:00:01.000Z] [WARN] Something happened\n',
+      );
+
+      const tool = agentTools.find(t => t.name === 'agent_logs')!;
+      const result: any = await tool.handler({ agentId: 'agent-1', level: 'info' });
+      expect(result.entries.length).toBe(2);
+      expect(result.entries[0].message).toContain('Daemon started');
     });
 
     it('agent_terminate returns error for unknown agent', async () => {
@@ -589,6 +621,39 @@ describe('MCP Tools Deep Test Suite', () => {
       expect(result.status).toBe('running');
     });
 
+    it('swarm_status reports agent and task counts from persisted stores', async () => {
+      const initTool = swarmTools.find(t => t.name === 'swarm_init')!;
+      await initTool.handler({ topology: 'mesh' });
+
+      writeFileSync(
+        `${process.cwd()}/.claude-flow/agents/store.json`,
+        JSON.stringify({
+          agents: {
+            'agent-active': { status: 'active' },
+            'agent-idle': { status: 'idle' },
+            'agent-dead': { status: 'terminated' },
+          },
+          version: '3.0.0',
+        }),
+      );
+      writeFileSync(
+        `${process.cwd()}/.claude-flow/tasks/store.json`,
+        JSON.stringify({
+          tasks: {
+            'task-1': { status: 'in_progress' },
+            'task-2': { status: 'pending' },
+          },
+          version: '3.0.0',
+        }),
+      );
+
+      const tool = swarmTools.find(t => t.name === 'swarm_status')!;
+      const result: any = await tool.handler({});
+      expect(result.agents).toEqual({ total: 2, active: 1, idle: 1 });
+      expect(result.taskCount).toBe(2);
+      expect(result.health).toBe('healthy');
+    });
+
     it('swarm_shutdown returns success after init', async () => {
       const initTool = swarmTools.find(t => t.name === 'swarm_init')!;
       const initResult: any = await initTool.handler({ topology: 'hierarchical' });
@@ -641,6 +706,63 @@ describe('MCP Tools Deep Test Suite', () => {
       const result: any = await tool.handler({});
       expect(result.tasks).toBeDefined();
       expect(Array.isArray(result.tasks)).toBe(true);
+    });
+
+    it('task_create accepts assignedTo and returns an id alias', async () => {
+      const tool = taskTools.find(t => t.name === 'task_create')!;
+      const result: any = await tool.handler({
+        type: 'feature',
+        description: 'Assigned task',
+        assignedTo: ['agent-1'],
+      });
+      expect(result.id).toBe(result.taskId);
+      expect(result.assignedTo).toEqual(['agent-1']);
+    });
+
+    it('task_list maps running filter to in_progress tasks and returns id fields', async () => {
+      const createTool = taskTools.find(t => t.name === 'task_create')!;
+      const assignTool = taskTools.find(t => t.name === 'task_assign')!;
+      const created: any = await createTool.handler({ type: 'feature', description: 'Running task' });
+      await assignTool.handler({ taskId: created.taskId, agentIds: ['agent-1'] });
+
+      const listTool = taskTools.find(t => t.name === 'task_list')!;
+      const result: any = await listTool.handler({ status: 'running', agentId: 'agent-1' });
+      expect(result.tasks.length).toBeGreaterThan(0);
+      expect(result.tasks[0].id).toBeDefined();
+    });
+
+    it('task_status returns cli-safe arrays and id aliases', async () => {
+      const createTool = taskTools.find(t => t.name === 'task_create')!;
+      const created: any = await createTool.handler({ type: 'feature', description: 'Status task' });
+
+      const statusTool = taskTools.find(t => t.name === 'task_status')!;
+      const result: any = await statusTool.handler({ taskId: created.taskId });
+      expect(result.id).toBe(created.taskId);
+      expect(result.dependencies).toEqual([]);
+      expect(result.dependents).toEqual([]);
+      expect(result.tags).toEqual([]);
+    });
+
+    it('task_assign syncs agent state into the nested agent store file', async () => {
+      writeFileSync(
+        `${process.cwd()}/.claude-flow/agents/store.json`,
+        JSON.stringify({
+          agents: {
+            'agent-123': { status: 'idle', taskCount: 0 },
+          },
+          version: '3.0.0',
+        }),
+      );
+
+      const createTool = taskTools.find(t => t.name === 'task_create')!;
+      const created: any = await createTool.handler({ type: 'feature', description: 'Sync task' });
+
+      const assignTool = taskTools.find(t => t.name === 'task_assign')!;
+      await assignTool.handler({ taskId: created.taskId, agentIds: ['agent-123'] });
+
+      const agentStore = JSON.parse(readFileSync(`${process.cwd()}/.claude-flow/agents/store.json`, 'utf-8'));
+      expect(agentStore.agents['agent-123'].status).toBe('active');
+      expect(agentStore.agents['agent-123'].currentTask).toBe(created.taskId);
     });
 
     it('task_status returns not_found for unknown task', async () => {

--- a/v3/@claude-flow/cli/src/commands/status.ts
+++ b/v3/@claude-flow/cli/src/commands/status.ts
@@ -117,9 +117,11 @@ async function getSystemStatus(): Promise<{
     const swarmStatus = await callMCPTool<{
       swarmId: string;
       topology: string;
-      agents: { total: number; active: number; idle: number; terminated: number };
-      health: string;
-      uptime: number;
+      agents?: { total: number; active: number; idle: number; terminated?: number };
+      agentCount?: number;
+      health?: string;
+      status?: string;
+      uptime?: number;
     }>('swarm_status', { includeMetrics: true });
 
     // Get MCP status
@@ -137,10 +139,11 @@ async function getSystemStatus(): Promise<{
 
     // Get memory status
     const memoryStatus = await callMCPTool<{
-      entries: number;
-      size: number;
+      entries?: number;
+      totalEntries?: number;
+      size?: number;
       backend: string;
-      performance: { avgSearchTime: number; cacheHitRate: number };
+      performance?: { avgSearchTime: number; cacheHitRate: number };
     }>('memory_stats', {});
 
     // Get task status
@@ -159,21 +162,21 @@ async function getSystemStatus(): Promise<{
         id: swarmStatus.swarmId,
         topology: swarmStatus.topology,
         agents: {
-          total: swarmStatus.agents.total,
-          active: swarmStatus.agents.active,
-          idle: swarmStatus.agents.idle
+          total: swarmStatus.agents?.total ?? swarmStatus.agentCount ?? 0,
+          active: swarmStatus.agents?.active ?? 0,
+          idle: swarmStatus.agents?.idle ?? 0
         },
-        health: swarmStatus.health,
-        uptime: swarmStatus.uptime
+        health: swarmStatus.health || (swarmStatus.status === 'running' ? 'healthy' : swarmStatus.status || 'unknown'),
+        uptime: swarmStatus.uptime || 0
       },
       mcp: mcpStatus,
       memory: {
-        entries: memoryStatus.entries,
-        size: formatBytes(memoryStatus.size),
+        entries: memoryStatus.entries ?? memoryStatus.totalEntries ?? 0,
+        size: formatBytes(memoryStatus.size ?? 0),
         backend: memoryStatus.backend,
         performance: {
-          searchTime: memoryStatus.performance.avgSearchTime,
-          cacheHitRate: memoryStatus.performance.cacheHitRate
+          searchTime: memoryStatus.performance?.avgSearchTime ?? 0,
+          cacheHitRate: memoryStatus.performance?.cacheHitRate ?? 0
         }
       },
       tasks: taskStatus,

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -20,12 +20,16 @@ type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'inherit';
 interface AgentRecord {
   agentId: string;
   agentType: string;
-  status: 'idle' | 'busy' | 'terminated';
+  status: 'idle' | 'busy' | 'active' | 'terminated';
   health: number;
   taskCount: number;
   config: Record<string, unknown>;
   createdAt: string;
   domain?: string;
+  currentTask?: string | null;
+  lastActivityAt?: string | null;
+  tasksFailed?: number;
+  averageExecutionTime?: number;
   model?: ClaudeModel;  // Model assigned to this agent
   modelRoutedBy?: 'explicit' | 'router' | 'agent-booster' | 'default';  // How model was determined (ADR-026)
 }
@@ -308,6 +312,7 @@ export const agentTools: MCPTool[] = [
 
       if (agent) {
         return {
+          id: agent.agentId,
           agentId: agent.agentId,
           agentType: agent.agentType,
           status: agent.status,
@@ -315,10 +320,19 @@ export const agentTools: MCPTool[] = [
           taskCount: agent.taskCount,
           createdAt: agent.createdAt,
           domain: agent.domain,
+          lastActivityAt: agent.lastActivityAt || null,
+          metrics: {
+            tasksCompleted: agent.taskCount || 0,
+            tasksInProgress: agent.currentTask ? 1 : 0,
+            tasksFailed: agent.tasksFailed || 0,
+            averageExecutionTime: agent.averageExecutionTime || 0,
+            uptime: agent.createdAt ? Math.max(0, Date.now() - new Date(agent.createdAt).getTime()) : 0,
+          },
         };
       }
 
       return {
+        id: agentId,
         agentId,
         status: 'not_found',
         error: 'Agent not found',
@@ -355,6 +369,7 @@ export const agentTools: MCPTool[] = [
 
       return {
         agents: agents.map(a => ({
+          id: a.agentId,
           agentId: a.agentId,
           agentType: a.agentType,
           status: a.status,
@@ -362,6 +377,7 @@ export const agentTools: MCPTool[] = [
           taskCount: a.taskCount,
           createdAt: a.createdAt,
           domain: a.domain,
+          lastActivityAt: a.lastActivityAt || null,
         })),
         total: agents.length,
         filters: {
@@ -369,6 +385,53 @@ export const agentTools: MCPTool[] = [
           domain: input.domain,
           includeTerminated: input.includeTerminated,
         },
+      };
+    },
+  },
+  {
+    name: 'agent_logs',
+    description: 'Get agent logs from the local daemon log',
+    category: 'agent',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentId: { type: 'string', description: 'ID of agent' },
+        tail: { type: 'number', description: 'Number of log lines to return' },
+        level: { type: 'string', description: 'Minimum log level' },
+      },
+      required: ['agentId'],
+    },
+    handler: async (input) => {
+      const logPath = join(process.cwd(), STORAGE_DIR, 'logs', 'daemon.log');
+      const levelOrder: Record<string, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+      const minLevel = levelOrder[(input.level as string) || 'info'] || 20;
+      let entries: Array<{ timestamp: string; level: string; message: string; context: Record<string, unknown> }> = [];
+
+      try {
+        if (existsSync(logPath)) {
+          const lines = readFileSync(logPath, 'utf-8').split('\n').filter(Boolean);
+          entries = lines
+            .map((line) => {
+              const match = line.match(/^\[([^\]]+)\] \[([A-Z]+)\] (.*)$/);
+              const level = match?.[2]?.toLowerCase() || 'info';
+              return {
+                timestamp: match?.[1] || new Date().toISOString(),
+                level,
+                message: match?.[3] || line,
+                context: {},
+              };
+            })
+            .filter((entry) => (levelOrder[entry.level] || 20) >= minLevel);
+        }
+      } catch {
+        entries = [];
+      }
+
+      const tail = (input.tail as number) || 50;
+      return {
+        agentId: input.agentId as string,
+        entries: entries.slice(-tail),
+        total: entries.length,
       };
     },
   },

--- a/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
@@ -60,6 +60,26 @@ function saveSwarmStore(store: SwarmStore): void {
   writeFileSync(getSwarmStatePath(), JSON.stringify(store, null, 2), 'utf-8');
 }
 
+function loadAgentStore(): { agents: Record<string, { status?: string }> } {
+  try {
+    const path = join(process.cwd(), '.claude-flow', 'agents', 'store.json');
+    if (existsSync(path)) {
+      return JSON.parse(readFileSync(path, 'utf-8'));
+    }
+  } catch { /* ignore */ }
+  return { agents: {} };
+}
+
+function loadTaskStore(): { tasks: Record<string, unknown> } {
+  try {
+    const path = join(process.cwd(), '.claude-flow', 'tasks', 'store.json');
+    if (existsSync(path)) {
+      return JSON.parse(readFileSync(path, 'utf-8'));
+    }
+  } catch { /* ignore */ }
+  return { tasks: {} };
+}
+
 // Input validation
 const VALID_TOPOLOGIES = new Set([
   'hierarchical', 'mesh', 'hierarchical-mesh', 'ring', 'star', 'hybrid', 'adaptive',
@@ -173,16 +193,32 @@ export const swarmTools: MCPTool[] = [
         .map(id => store.swarms[id])
         .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
 
+      const agentStore = loadAgentStore();
+      const taskStore = loadTaskStore();
+      const agentList = Object.values(agentStore.agents || {});
+      const totalAgents = agentList.filter(agent => agent.status !== 'terminated').length;
+      const activeAgents = agentList.filter(agent => agent.status === 'active' || agent.status === 'busy').length;
+      const idleAgents = agentList.filter(agent => agent.status === 'idle').length;
+      const taskCount = Object.keys(taskStore.tasks || {}).length;
+      const uptime = latest.createdAt ? Math.max(0, Date.now() - new Date(latest.createdAt).getTime()) : 0;
+
       return {
         swarmId: latest.swarmId,
         status: latest.status,
         topology: latest.topology,
         maxAgents: latest.maxAgents,
-        agentCount: latest.agents.length,
-        taskCount: latest.tasks.length,
+        agents: {
+          total: totalAgents,
+          active: activeAgents,
+          idle: idleAgents,
+        },
+        agentCount: totalAgents,
+        taskCount,
         config: latest.config,
         createdAt: latest.createdAt,
         updatedAt: latest.updatedAt,
+        health: latest.status === 'running' ? 'healthy' : 'stopped',
+        uptime,
         totalSwarms: swarmIds.length,
       };
     },

--- a/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
@@ -12,6 +12,8 @@ import type { MCPTool } from './types.js';
 const STORAGE_DIR = '.claude-flow';
 const TASK_DIR = 'tasks';
 const TASK_FILE = 'store.json';
+const AGENT_DIR = 'agents';
+const AGENT_FILE = 'store.json';
 
 interface TaskRecord {
   taskId: string;
@@ -25,11 +27,27 @@ interface TaskRecord {
   createdAt: string;
   startedAt: string | null;
   completedAt: string | null;
+  parentId?: string | null;
+  dependencies?: string[];
+  dependents?: string[];
+  logs?: Array<{ timestamp: string; level: string; message: string }>;
+  metrics?: { executionTime: number; retries: number; tokensUsed: number } | null;
   result?: Record<string, unknown>;
 }
 
 interface TaskStore {
   tasks: Record<string, TaskRecord>;
+  version: string;
+}
+
+interface AgentStoreRecord {
+  status?: string;
+  currentTask?: string | null;
+  taskCount?: number;
+}
+
+interface AgentStore {
+  agents: Record<string, AgentStoreRecord>;
   version: string;
 }
 
@@ -66,6 +84,35 @@ function saveTaskStore(store: TaskStore): void {
   writeFileSync(getTaskPath(), JSON.stringify(store, null, 2), 'utf-8');
 }
 
+function getAgentDir(): string {
+  return join(process.cwd(), STORAGE_DIR, AGENT_DIR);
+}
+
+function getAgentPath(): string {
+  return join(getAgentDir(), AGENT_FILE);
+}
+
+function loadAgentStore(): AgentStore {
+  try {
+    const path = getAgentPath();
+    if (existsSync(path)) {
+      const data = readFileSync(path, 'utf-8');
+      return JSON.parse(data);
+    }
+  } catch {
+    // Return empty store on error
+  }
+  return { agents: {}, version: '3.0.0' };
+}
+
+function saveAgentStore(store: AgentStore): void {
+  const dir = getAgentDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(getAgentPath(), JSON.stringify(store, null, 2), 'utf-8');
+}
+
 export const taskTools: MCPTool[] = [
   {
     name: 'task_create',
@@ -85,6 +132,7 @@ export const taskTools: MCPTool[] = [
     handler: async (input) => {
       const store = loadTaskStore();
       const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const assignedTo = ((input.assignTo as string[]) || (input.assignedTo as string[]) || []);
 
       const task: TaskRecord = {
         taskId,
@@ -93,11 +141,16 @@ export const taskTools: MCPTool[] = [
         priority: (input.priority as TaskRecord['priority']) || 'normal',
         status: 'pending',
         progress: 0,
-        assignedTo: (input.assignTo as string[]) || [],
+        assignedTo,
         tags: (input.tags as string[]) || [],
         createdAt: new Date().toISOString(),
         startedAt: null,
         completedAt: null,
+        parentId: (input.parentId as string) || null,
+        dependencies: (input.dependencies as string[]) || [],
+        dependents: [],
+        logs: [],
+        metrics: null,
       };
 
       store.tasks[taskId] = task;
@@ -105,12 +158,13 @@ export const taskTools: MCPTool[] = [
 
       return {
         taskId,
+        id: taskId,
         type: task.type,
         description: task.description,
         priority: task.priority,
         status: task.status,
         createdAt: task.createdAt,
-        assignedTo: task.assignedTo,
+        assignedTo,
         tags: task.tags,
       };
     },
@@ -134,21 +188,28 @@ export const taskTools: MCPTool[] = [
       if (task) {
         return {
           taskId: task.taskId,
+          id: task.taskId,
           type: task.type,
           description: task.description,
           status: task.status,
           progress: task.progress,
           priority: task.priority,
-          assignedTo: task.assignedTo,
-          tags: task.tags,
+          assignedTo: task.assignedTo || [],
+          parentId: task.parentId || null,
+          dependencies: task.dependencies || [],
+          dependents: task.dependents || [],
+          tags: task.tags || [],
           createdAt: task.createdAt,
           startedAt: task.startedAt,
           completedAt: task.completedAt,
+          metrics: task.metrics || null,
+          logs: task.logs || [],
         };
       }
 
       return {
         taskId,
+        id: taskId,
         status: 'not_found',
         error: 'Task not found',
       };
@@ -176,13 +237,17 @@ export const taskTools: MCPTool[] = [
       if (input.status) {
         // Support comma-separated status values
         const statuses = (input.status as string).split(',').map(s => s.trim());
-        tasks = tasks.filter(t => statuses.includes(t.status));
+        if (!statuses.includes('all')) {
+          tasks = tasks.filter(t => statuses.includes(t.status) ||
+            (t.status === 'in_progress' && statuses.includes('running')));
+        }
       }
       if (input.type) {
         tasks = tasks.filter(t => t.type === input.type);
       }
-      if (input.assignedTo) {
-        tasks = tasks.filter(t => t.assignedTo.includes(input.assignedTo as string));
+      const assignedTo = (input.assignedTo as string) || (input.agentId as string);
+      if (assignedTo) {
+        tasks = tasks.filter(t => (t.assignedTo || []).includes(assignedTo));
       }
       if (input.priority) {
         tasks = tasks.filter(t => t.priority === input.priority);
@@ -197,6 +262,7 @@ export const taskTools: MCPTool[] = [
 
       return {
         tasks: tasks.map(t => ({
+          id: t.taskId,
           taskId: t.taskId,
           type: t.type,
           description: t.description,
@@ -210,7 +276,7 @@ export const taskTools: MCPTool[] = [
         filters: {
           status: input.status,
           type: input.type,
-          assignedTo: input.assignedTo,
+          assignedTo,
           priority: input.priority,
         },
       };
@@ -242,12 +308,8 @@ export const taskTools: MCPTool[] = [
 
         // Sync assigned agents back to idle and increment taskCount
         if (task.assignedTo.length > 0) {
-          const agentStorePath = join(process.cwd(), STORAGE_DIR, 'agents.json');
           try {
-            let agentStore: { agents: Record<string, Record<string, unknown>> } = { agents: {} };
-            if (existsSync(agentStorePath)) {
-              agentStore = JSON.parse(readFileSync(agentStorePath, 'utf-8'));
-            }
+            const agentStore = loadAgentStore();
             for (const agentId of task.assignedTo) {
               if (agentStore.agents[agentId]) {
                 agentStore.agents[agentId].status = 'idle';
@@ -256,7 +318,7 @@ export const taskTools: MCPTool[] = [
                   ((agentStore.agents[agentId].taskCount as number) || 0) + 1;
               }
             }
-            writeFileSync(agentStorePath, JSON.stringify(agentStore, null, 2), 'utf-8');
+            saveAgentStore(agentStore);
           } catch {
             // Best-effort agent sync
           }
@@ -353,12 +415,9 @@ export const taskTools: MCPTool[] = [
       const previouslyAssigned = [...task.assignedTo];
 
       // Load agent store to sync worker state
-      const agentStorePath = join(process.cwd(), STORAGE_DIR, 'agents.json');
-      let agentStore: { agents: Record<string, Record<string, unknown>> } = { agents: {} };
+      let agentStore: AgentStore = { agents: {}, version: '3.0.0' };
       try {
-        if (existsSync(agentStorePath)) {
-          agentStore = JSON.parse(readFileSync(agentStorePath, 'utf-8'));
-        }
+        agentStore = loadAgentStore();
       } catch { /* ignore */ }
 
       if (input.unassign) {
@@ -402,7 +461,7 @@ export const taskTools: MCPTool[] = [
       if (!existsSync(agentDir)) {
         mkdirSync(agentDir, { recursive: true });
       }
-      writeFileSync(agentStorePath, JSON.stringify(agentStore, null, 2), 'utf-8');
+      saveAgentStore(agentStore);
 
       return {
         taskId: task.taskId,


### PR DESCRIPTION
## Summary
Fix several V3 CLI/MCP payload mismatches that break persisted-state workflows.

## What this fixes
- `status` no longer reports `STOPPED` when swarm/task/agent state exists in persisted stores
- `task list --all` now shows `in_progress` tasks when the CLI asks for `running`
- `task status` now returns CLI-safe fields (`id`, arrays for dependencies/dependents/tags)
- `agent list` and `agent status` now expose `id` consistently
- adds the missing `agent_logs` MCP tool used by `agent logs`
- fixes task assignment/completion syncing to `.claude-flow/agents/store.json` instead of the wrong legacy path
- derives swarm counts from persisted agent/task stores instead of stale empty arrays in swarm state

## Repro before
- `task list --all` returned "No tasks found matching criteria" even with tasks in `.claude-flow/tasks/store.json`
- `task status <id>` printed `Task: undefined` and could crash on `.join`
- `agent list` showed blank IDs
- `agent logs <id>` failed with `MCP tool not found: agent_logs`
- `status` showed `STOPPED` despite persisted swarm/task state

## Verification
- smoke-tested the built CLI against a seeded temp repo
- confirmed `status`, `task list`, `task status`, `agent list`, `agent status`, `agent logs`, and `task assign` all behave correctly with persisted store data

## Notes
- the repo's current `vitest`/workspace setup still has unrelated package-resolution and coverage issues around optional internal packages, so smoke testing was the cleanest validation path for this fix
