### PR TITLE
https://github.com/ruvnet/ruflo/issues/1404 - explicitly set types  for r arrays

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/ruvllm-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/ruvllm-tools.ts
@@ -64,7 +64,7 @@ export const ruvllmWasmTools: MCPTool[] = [
       properties: {
         routerId: { type: 'string', description: 'HNSW router ID from ruvllm_hnsw_create' },
         name: { type: 'string', description: 'Pattern name/label' },
-        embedding: { type: 'array', description: 'Float array embedding vector' },
+        embedding: { type: 'array', description: 'Float array embedding vector', items: { type: 'number' } },
         metadata: { type: 'object', description: 'Optional metadata object' },
       },
       required: ['routerId', 'name', 'embedding'],
@@ -92,7 +92,7 @@ export const ruvllmWasmTools: MCPTool[] = [
       type: 'object' as const,
       properties: {
         routerId: { type: 'string', description: 'HNSW router ID' },
-        query: { type: 'array', description: 'Query embedding vector' },
+        query: { type: 'array', description: 'Query embedding vector', items: { type: 'number' } },
         k: { type: 'number', description: 'Number of nearest neighbors (default: 3)' },
       },
       required: ['routerId', 'query'],
@@ -225,6 +225,14 @@ export const ruvllmWasmTools: MCPTool[] = [
         messages: {
           type: 'array',
           description: 'Array of {role, content} message objects',
+          items: {
+            type: 'object',
+            properties: {
+              role: { type: 'string' },
+              content: { type: 'string' },
+            },
+            required: ['role', 'content'],
+          },
         },
         template: { type: 'string', description: 'Template preset (llama3, mistral, chatml, phi, gemma) or model ID for auto-detection' },
       },
@@ -259,7 +267,7 @@ export const ruvllmWasmTools: MCPTool[] = [
         topP: { type: 'number', description: 'Top-p sampling' },
         topK: { type: 'number', description: 'Top-k sampling' },
         repetitionPenalty: { type: 'number', description: 'Repetition penalty' },
-        stopSequences: { type: 'array', description: 'Stop sequences' },
+        stopSequences: { type: 'array', description: 'Stop sequences', items: { type: 'string' } },
       },
     },
     handler: async (args: Record<string, unknown>) => {


### PR DESCRIPTION
As per https://github.com/ruvnet/ruflo/issues/1404  - vscode errors with "Failed to validate tool mcp_ruflo_ruvllm_hnsw_route: Error: tool parameters array type must have items. Please open an issue for the MCP server or extension which provides this tool" style errors, so added explicit types