### PR TITLE
docs: add portable security notice and clarify risk wording

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,4 +1,26 @@
-## Security Hardening - safer install and configuration flow
+## Security Hardening – safer install and configuration flow
+
+This document introduces an initial security hardening notice focused on reducing supply-chain and persistence risks in installation and configuration flows.
+
+### What was changed
+
+- Added initial security notice document
+- Highlighted ongoing security hardening review
+
+### Why
+
+The current installation flow may rely on patterns such as:
+- mutable dependencies (e.g. `@latest`)
+- remote script execution (e.g. `curl | bash`)
+- potential environment-level configuration changes
+
+While no malicious behavior was identified, these patterns can increase risk in stricter threat models.
+
+### Goal
+
+Improve safety without breaking developer experience.
+
+Happy to adjust changes based on feedback.## Security Hardening - safer install and configuration flow
 
 This document introduces an initial security hardening notice focused on reducing supply-chain and persistence risks in installation and configuration flows.
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,23 @@
+## Security Hardening - safer install and configuration flow
+
+This document introduces an initial security hardening notice focused on reducing supply-chain and persistence risks in installation and configuration flows.
+
+### What was changed
+
+- Added initial security notice document
+- Highlighted ongoing security hardening review
+
+### Why
+
+The current installation flow may rely on patterns such as:
+- mutable dependencies (e.g. `@latest`)
+- remote script execution (e.g. `curl | bash`)
+- potential environment-level configuration changes
+
+While no malicious behavior was identified, these patterns can increase risk in stricter threat models.
+
+### Goal
+
+Improve safety without breaking developer experience.
+
+Happy to adjust changes based on feedback.


### PR DESCRIPTION
PR #1420 z plikiem zawierającym : w nazwie nie da się checkoutować na Windows (potwierdzone lokalnie), więc poprawka została przygotowana jako czysty, przenośny branch z bezpieczną ścieżką pliku.
Hi, I identified an issue affecting Windows users.

Problem:
Certain file naming / access patterns cannot be reliably handled on Windows environments (confirmed locally).

Impact:
This may lead to confusion or failure when users try to access or verify files.

Fix:

Added a portable security notice
Clarified risk wording to make behavior explicit
No breaking changes, documentation-only improvement
Goal:
Improve clarity and prevent misuse or misinterpretation, especially across different OS environments.

Let me know if you'd like me to adjust wording or scope.