### PR TITLE
docs: add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material mkdocs-llms-source pymdown-extensions
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !v3/@claude-flow/
 # Binaries
 # Build outputs
+site/
 
 # Claude-Flow specific
 # Dependencies

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mkdocs-material
+mkdocs-llms-source
+pymdown-extensions

--- a/docs/agents/anti-drift.md
+++ b/docs/agents/anti-drift.md
@@ -1,0 +1,60 @@
+# Anti-Drift
+
+Multi-agent swarms can drift from their original goals as agents interact and spawn sub-workers. Ruflo v3 includes built-in anti-drift defaults.
+
+## Why Drift Happens
+
+In large swarms, agents may:
+- Misinterpret ambiguous requirements
+- Over-scope their assigned task
+- Produce output that conflicts with a parallel agent's work
+- Lose track of the original objective after many sub-steps
+
+## Anti-Drift Configuration
+
+```javascript
+// These are the recommended defaults for all coding tasks
+swarm_init({
+  topology: "hierarchical",  // Single coordinator validates every output
+  maxAgents: 8,              // Smaller team = less surface area for drift
+  strategy: "specialized",   // Clear role boundaries — no overlap
+  consensus: "raft"          // Leader maintains authoritative state
+})
+```
+
+## Why Each Setting Matters
+
+| Setting | Why It Prevents Drift |
+|---------|----------------------|
+| `hierarchical` | Coordinator validates each output against the original goal |
+| `maxAgents: 6–8` | Fewer agents → less coordination overhead, easier alignment |
+| `specialized` | Each agent knows exactly what to do — no ambiguous overlap |
+| `raft` consensus | Single leader, no conflicting decisions between agents |
+
+## Additional Safeguards
+
+- **Frequent checkpoints** — `post-task` hooks store snapshots after each agent completes
+- **Shared memory namespace** — all agents read/write the same context; contradictions surface early
+- **Short task cycles** — agents work in small increments with verification gates
+- **Progress hook** — validates ADR spec compliance; blocks merges that violate specifications
+
+## Spec-First Development
+
+The best anti-drift tool is a clear spec written before agents start:
+
+1. Define Architecture Decision Records (ADRs) for key choices
+2. Set bounded contexts so agents know their scope
+3. Use the `coordinator` agent to enforce spec compliance across the swarm
+4. Run `hooks progress` regularly to detect drift before it compounds
+
+## Detecting Drift
+
+```bash
+# Check ADR compliance %
+npx ruflo@latest hooks progress
+
+# View agent memory divergence
+npx ruflo@latest hooks intelligence --status
+```
+
+If compliance drops below 80%, spawn a `reviewer` agent to audit and correct.

--- a/docs/agents/catalog.md
+++ b/docs/agents/catalog.md
@@ -1,0 +1,75 @@
+# Agent Catalog
+
+Ruflo ships with 60+ specialized agents. This page documents the most commonly used ones by category. Run `npx ruflo@latest --list` for the complete list in your installation.
+
+## Core Development
+
+| Agent | Role |
+|-------|------|
+| `coder` | General-purpose code implementation |
+| `architect` | System design, ADR authoring, bounded contexts |
+| `tester` | Unit, integration, and end-to-end test generation |
+| `reviewer` | Code review, best practices, style enforcement |
+| `documenter` | Docstrings, README, API docs generation |
+| `debugger` | Root cause analysis, stack trace interpretation |
+| `refactorer` | Large-scale codebase restructuring |
+
+## Quality & Security
+
+| Agent | Role |
+|-------|------|
+| `security-architect` | Threat modeling, secure design patterns |
+| `auditor` | CVE scanning, dependency review |
+| `perf-engineer` | Profiling, bottleneck identification, optimization |
+| `memory-specialist` | Memory leak detection and optimization |
+
+## Coordination & Analysis
+
+| Agent | Role |
+|-------|------|
+| `coordinator` | Queen-level task decomposition and validation |
+| `researcher` | Web search, documentation lookup, context gathering |
+| `analyst` | Data analysis, metrics interpretation |
+| `optimizer` | Continuous improvement based on learned patterns |
+
+## Additional Agents
+
+The remaining agents cover specialized domains including:
+
+- **DevOps**: CI/CD pipeline generation, Docker configuration, infrastructure-as-code
+- **Database**: Schema design, migration generation, query optimization
+- **Frontend**: Component generation, accessibility auditing, responsive design
+- **API**: OpenAPI spec generation, endpoint testing, contract validation
+
+!!! tip
+    Run `npx ruflo@latest --list` to see every agent available in your installation, including any custom agents you've defined.
+
+## Spawning Agents
+
+=== "MCP (inside Claude Code)"
+
+    ```
+    agent_spawn({ type: "coder", task: "Implement OAuth2 flow" })
+    ```
+
+=== "CLI"
+
+    ```bash
+    npx ruflo@latest --agent coder --task "Implement OAuth2 flow"
+    ```
+
+## Creating Custom Agents
+
+Place YAML files in `.claude/agents/`:
+
+```yaml
+name: my-agent
+role: |
+  You are a specialized agent focused on database migrations.
+  Always use reversible migrations. Prefer additive changes.
+skills:
+  - sql
+  - schema-design
+```
+
+Custom agents are immediately available after creation — no restart needed.

--- a/docs/agents/swarm-config.md
+++ b/docs/agents/swarm-config.md
@@ -1,0 +1,70 @@
+# Swarm Configuration
+
+## Basic Initialization
+
+```javascript
+swarm_init({
+  topology: "hierarchical",   // hierarchical | mesh | ring | star
+  maxAgents: 6,               // recommended: 6–8 for most tasks
+  strategy: "specialized"     // specialized | generalist
+})
+```
+
+## Full Configuration Reference
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `topology` | string | `hierarchical` | Agent coordination pattern |
+| `maxAgents` | number | `5` | Maximum concurrent agents |
+| `strategy` | string | `specialized` | How to assign agent roles |
+| `consensus` | string | `raft` | Consensus algorithm |
+| `checkpointInterval` | number | `10` | Steps between checkpoints |
+| `memoryNamespace` | string | `default` | Shared memory namespace |
+
+## Consensus Algorithm Selection
+
+```javascript
+// For most tasks — authoritative leader maintains state
+swarm_init({ consensus: "raft" })
+
+// For untrusted or noisy agents
+swarm_init({ consensus: "byzantine" })
+
+// For eventually-consistent distributed state
+swarm_init({ consensus: "gossip" })
+```
+
+## Task Routing by Complexity
+
+```javascript
+// Bug fix — small, focused team
+swarm_init({ topology: "hierarchical", maxAgents: 4 })
+agent_spawn({ type: "coordinator" })
+agent_spawn({ type: "researcher" })
+agent_spawn({ type: "coder" })
+agent_spawn({ type: "tester" })
+
+// New feature — cross-functional team
+swarm_init({ topology: "hierarchical", maxAgents: 6 })
+agent_spawn({ type: "coordinator" })
+agent_spawn({ type: "architect" })
+agent_spawn({ type: "coder" })
+agent_spawn({ type: "tester" })
+agent_spawn({ type: "reviewer" })
+
+// Security audit — specialized pipeline
+swarm_init({ topology: "hierarchical", maxAgents: 4, consensus: "byzantine" })
+agent_spawn({ type: "coordinator" })
+agent_spawn({ type: "security-architect" })
+agent_spawn({ type: "auditor" })
+```
+
+## Monitoring Swarm State
+
+```bash
+# Check hook intelligence (includes swarm status)
+npx ruflo@latest hooks intelligence --status
+
+# Check progress (validates ADR compliance)
+npx ruflo@latest hooks progress
+```

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -1,0 +1,121 @@
+# Intelligence & Memory
+
+Ruflo's memory system is the core of its self-learning capability. Every task execution feeds patterns into a persistent vector store that improves future routing and context retrieval.
+
+## Memory Architecture
+
+```mermaid
+flowchart LR
+    subgraph Input["📥 Input"]
+        Query[Query/Pattern]
+        Insight[New Insight]
+    end
+
+    subgraph Processing["⚙️ Processing"]
+        Embed[ONNX Embeddings]
+        Normalize[Normalization]
+        Learn["LearningBridge<br/>SONA + ReasoningBank"]
+    end
+
+    subgraph Storage["💾 Storage"]
+        HNSW[("HNSW Index<br/>150x faster")]
+        SQLite[(SQLite Cache)]
+        AgentDB[(AgentDB)]
+        Graph["MemoryGraph<br/>PageRank + Communities"]
+    end
+
+    subgraph Retrieval["🔍 Retrieval"]
+        Vector[Vector Search]
+        Semantic[Semantic Match]
+        Rank[Graph-Aware Ranking]
+        Results[Top-K Results]
+    end
+
+    Query --> Embed
+    Embed --> Normalize
+    Normalize --> HNSW
+    Normalize --> SQLite
+    Insight --> Learn
+    Learn --> AgentDB
+    AgentDB --> Graph
+    HNSW --> Vector
+    SQLite --> Vector
+    AgentDB --> Semantic
+    Vector --> Rank
+    Semantic --> Rank
+    Graph --> Rank
+    Rank --> Results
+```
+
+## RuVector Components
+
+| Component | Purpose | Performance |
+|-----------|---------|-------------|
+| **SONA** | Self-Optimizing Neural Architecture — learns optimal routing | <0.05ms adaptation |
+| **EWC++** | Elastic Weight Consolidation — prevents catastrophic forgetting | Preserves learned patterns |
+| **Flash Attention** | Optimized attention computation | 2.49–7.47x speedup |
+| **HNSW** | Hierarchical Navigable Small World vector search | Sub-millisecond retrieval |
+| **ReasoningBank** | Pattern storage with BM25+semantic hybrid search | RETRIEVE→JUDGE→DISTILL |
+| **Hyperbolic (Poincaré)** | Hierarchical code relationship embeddings | Better tree-structured data |
+| **LoRA / MicroLoRA** | Low-Rank Adaptation for efficient fine-tuning | 128x compression |
+| **Int8 Quantization** | Memory-efficient weight storage | ~4x memory reduction |
+| **SemanticRouter** | Semantic task routing via cosine similarity | Fast intent routing |
+| **9 RL Algorithms** | Q-Learning, SARSA, A2C, PPO, DQN, Decision Transformer… | Task-specific learning |
+
+## Hierarchical Memory Tiers
+
+```
+┌─────────────────────────────────────────────┐
+│  Working Memory                             │  ← Active context (1MB limit)
+├─────────────────────────────────────────────┤
+│  Episodic Memory                            │  ← Recent patterns, importance-ranked
+├─────────────────────────────────────────────┤
+│  Semantic Memory                            │  ← Consolidated knowledge, persistent
+└─────────────────────────────────────────────┘
+```
+
+Memories are promoted from Episodic → Semantic via automatic consolidation.
+
+## AgentDB Controllers
+
+Ruflo integrates AgentDB v3, providing 20+ memory controllers:
+
+### Core
+| Controller | Tool | Description |
+|-----------|------|-------------|
+| HierarchicalMemory | `agentdb_hierarchical-store/recall` | 3-tier memory with Ebbinghaus forgetting curves |
+| MemoryConsolidation | `agentdb_consolidate` | Clusters and merges related memories |
+| BatchOperations | `agentdb_batch` | High-throughput bulk memory management |
+| ReasoningBank | `agentdb_pattern-store/search` | BM25+semantic hybrid pattern search |
+
+### Intelligence
+| Controller | Tool | Description |
+|-----------|------|-------------|
+| SemanticRouter | `agentdb_semantic-route` | Routes tasks via vector similarity |
+| ContextSynthesizer | `agentdb_context-synthesize` | Auto-generates context summaries |
+| GNNService | — | Graph neural network for intent classification |
+| SonaTrajectoryService | — | Records and predicts agent learning trajectories |
+
+### Security & Integrity
+| Controller | Tool | Description |
+|-----------|------|-------------|
+| GuardedVectorBackend | — | Cryptographic proof-of-work before vector ops |
+| MutationGuard | — | Token-validated mutations with cryptographic proofs |
+| AttestationLog | — | Immutable audit trail of all memory operations |
+
+## Self-Learning Cycle (ADR-049)
+
+1. **Insights** are extracted from completed tasks
+2. **LearningBridge** routes insights to SONA and ReasoningBank (0.12 ms/insight)
+3. **MemoryGraph** builds a PageRank + community-detection knowledge graph (2.78 ms/1k nodes)
+4. **AgentMemoryScope** handles cross-agent knowledge transfer with 3-scope isolation (1.25 ms/transfer)
+5. Confidence scores decay for unused patterns; frequently-used patterns get boosted
+
+## Vector Search Details
+
+- **Embedding dimensions**: 384 (MiniLM via ONNX — local, no API calls, 75x faster)
+- **Algorithm**: HNSW
+- **Similarity scoring**: 0–1
+  - `> 0.7` — strong match, use pattern directly
+  - `0.5–0.7` — partial match, adapt pattern
+  - `< 0.5` — weak match, create new pattern

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,132 @@
+# Architecture Overview
+
+Ruflo is structured in six layers, from user-facing interfaces down to LLM providers.
+
+## System Diagram
+
+```mermaid
+flowchart TB
+    subgraph User["👤 User Layer"]
+        CC[Claude Code]
+        CLI[CLI Commands]
+    end
+
+    subgraph Orchestration["🎯 Orchestration Layer"]
+        MCP[MCP Server]
+        Router[Intelligent Router]
+        Hooks[Self-Learning Hooks]
+    end
+
+    subgraph Agents["🤖 Agent Layer"]
+        Queen[Queen Coordinator]
+        Workers[60+ Specialized Agents]
+        Swarm[Swarm Manager]
+    end
+
+    subgraph Intelligence["🧠 Intelligence Layer"]
+        SONA[SONA Learning]
+        MoE[Mixture of Experts]
+        HNSW[HNSW Vector Search]
+    end
+
+    subgraph Providers["☁️ Provider Layer"]
+        Anthropic[Anthropic]
+        OpenAI[OpenAI]
+        Google[Google]
+        Ollama[Ollama]
+    end
+
+    CC --> MCP
+    CLI --> MCP
+    MCP --> Router
+    Router --> Hooks
+    Hooks --> Queen
+    Queen --> Workers
+    Queen --> Swarm
+    Workers --> Intelligence
+    Intelligence --> Providers
+```
+
+## Layers Explained
+
+### User Layer
+Entry points: **Claude Code** (interactive) and the **Ruflo CLI** for direct commands.
+
+### Orchestration Layer
+- **MCP Server** — exposes 259 tools to any MCP-compatible client
+- **Intelligent Router** — Q-Learning based routing with 89% accuracy; dispatches to WASM, agent, or swarm
+- **Self-Learning Hooks** — pre/post/progress lifecycle hooks that learn from every execution
+
+### Agent Layer
+- **Queen Coordinator** — strategic, tactical, and adaptive queens that manage and validate agent output
+- **60+ Specialized Agents** — coder, tester, reviewer, architect, security, documenter, and more
+- **Swarm Manager** — coordinates topology (hierarchical/mesh/ring/star) and consensus (Raft/BFT/Gossip)
+
+### Intelligence Layer
+- **SONA** — Self-Optimizing Neural Architecture; learns routing from outcomes in <0.05ms
+- **Mixture of Experts (MoE)** — 8 expert networks with dynamic gating for task classification
+- **HNSW Vector Search** — sub-millisecond pattern retrieval; 150x–12,500x faster than linear scan
+
+### Memory Layer
+See [Intelligence & Memory](memory.md) for the full breakdown.
+
+### Provider Layer
+Supports **6 LLM providers** with automatic failover and cost-based routing:
+Anthropic · OpenAI · Google · Cohere · Groq · Ollama (local)
+
+---
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as Router
+    participant H as Hooks
+    participant A as Agent Pool
+    participant M as Memory
+    participant P as Provider
+
+    U->>R: Submit Task
+    R->>H: pre-task hook
+    H->>H: Analyze complexity
+
+    alt Simple Task
+        H->>A: Agent Booster (WASM)
+        A-->>U: Result (<1ms)
+    else Medium Task
+        H->>A: Spawn Haiku Agent
+        A->>M: Check patterns
+        M-->>A: Cached context
+        A->>P: LLM Call
+        P-->>A: Response
+        A->>H: post-task hook
+        H->>M: Store patterns
+        A-->>U: Result
+    else Complex Task
+        H->>A: Spawn Swarm
+        A->>A: Coordinate agents
+        A->>P: Multiple LLM calls
+        P-->>A: Responses
+        A->>H: post-task hook
+        A-->>U: Result
+    end
+```
+
+## Domain-Driven Design
+
+Ruflo is organized into 5 bounded contexts that prevent cross-domain pollution:
+
+```
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│    Core     │  │   Memory    │  │  Security   │
+│  Agents,    │  │  AgentDB,   │  │  AIDefence, │
+│  Swarms,    │  │  HNSW,      │  │  Validation │
+│  Tasks      │  │  Cache      │  │  CVE Fixes  │
+└─────────────┘  └─────────────┘  └─────────────┘
+┌─────────────┐  ┌─────────────┐
+│ Integration │  │Coordination │
+│ agentic-    │  │  Consensus, │
+│ flow, MCP   │  │  Hive-Mind  │
+└─────────────┘  └─────────────┘
+```

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,0 +1,77 @@
+# Task Routing
+
+Ruflo's 3-tier routing system automatically dispatches tasks to the cheapest handler that can do the job well.
+
+## Routing Tiers
+
+| Tier | Handler | Latency | Cost | Use Cases |
+|------|---------|---------|------|-----------|
+| **1** | Agent Booster (WASM) | <1ms | $0 | Simple transforms: `var→const`, add types, remove console |
+| **2** | Haiku / Sonnet | 500ms–2s | $0.0002–$0.003 | Bug fixes, refactoring, feature implementation |
+| **3** | Opus | 2–5s | $0.015 | Architecture, security design, distributed systems |
+
+**Benchmark**: 100% routing accuracy, 0.57ms average routing decision latency.
+
+## Cost & Usage Impact
+
+| Benefit | Impact |
+|---------|--------|
+| API cost reduction | ~75% lower via right-sized models |
+| Claude Max extension | 2.5x more tasks within quota |
+| Simple task speed | <1ms vs 2–5s with LLM |
+| Token waste | Zero — WASM edits use 0 tokens |
+
+## Agent Booster (WASM)
+
+Agent Booster handles simple code transforms in WebAssembly — no LLM call at all.
+
+### Supported Transforms
+
+| Intent | What It Does |
+|--------|-------------|
+| `var-to-const` | `var x = 1` → `const x = 1` |
+| `add-types` | `function foo(x)` → `function foo(x: string)` |
+| `add-error-handling` | Wraps code in try/catch |
+| `async-await` | Converts `.then()` chains to `await` |
+| `add-logging` | Inserts `console.log` statements |
+| `remove-console` | Strips all `console.*` calls |
+
+### Hook Signals
+
+When Agent Booster is available, you'll see these signals in hook output:
+
+```bash
+[AGENT_BOOSTER_AVAILABLE] Intent: var-to-const
+→ Use Edit tool directly, 352x faster than LLM
+
+[TASK_MODEL_RECOMMENDATION] Use model="haiku"
+→ Pass model="haiku" to Task tool for cost savings
+```
+
+## Mixture of Experts (MoE)
+
+The router uses 8 specialized expert networks with dynamic gating to classify task complexity and route to the right tier. Classification runs in <1ms and achieves 89% accuracy on routing decisions.
+
+## Token Optimizer
+
+| Optimization | Token Savings | How |
+|--------------|---------------|-----|
+| ReasoningBank retrieval | -32% | Relevant patterns instead of full context |
+| Agent Booster edits | -15% | Simple edits skip LLM |
+| Cache (95% hit rate) | -10% | Reuses embeddings and patterns |
+| Optimal batch size | -20% | Groups related operations |
+| **Combined** | **30–50%** | Stacks multiplicatively |
+
+```typescript
+import { getTokenOptimizer } from '@claude-flow/integration';
+const optimizer = await getTokenOptimizer();
+
+// 32% fewer tokens
+const ctx = await optimizer.getCompactContext("auth patterns");
+
+// 352x faster for simple transforms
+await optimizer.optimizedEdit(file, oldStr, newStr, "typescript");
+
+// Optimal config for swarm (100% success rate)
+const config = optimizer.getOptimalConfig(agentCount);
+```

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,0 +1,68 @@
+# Security
+
+Ruflo includes production-grade security via the **AIDefence** layer.
+
+## Security Flow
+
+```mermaid
+flowchart TB
+    subgraph Input["📥 Input Validation"]
+        Req[Request] --> Scan[AIDefence Scan]
+        Scan --> PII[PII Detection]
+        Scan --> Inject[Injection Check]
+        Scan --> Jailbreak[Jailbreak Detection]
+    end
+
+    subgraph Decision["⚖️ Decision"]
+        PII --> Risk{Risk Level}
+        Inject --> Risk
+        Jailbreak --> Risk
+    end
+
+    subgraph Action["🎬 Action"]
+        Risk -->|Safe| Allow[✅ Allow]
+        Risk -->|Warning| Sanitize[🧹 Sanitize]
+        Risk -->|Threat| Block[⛔ Block]
+    end
+
+    subgraph Learn["📚 Learning"]
+        Allow --> Log[Log Pattern]
+        Sanitize --> Log
+        Block --> Log
+        Log --> Update[Update Model]
+    end
+```
+
+## Protections
+
+| Protection | Description |
+|------------|-------------|
+| **Prompt injection** | Detects and blocks injection attempts in user input |
+| **PII detection** | Flags personally identifiable information |
+| **Jailbreak detection** | Identifies attempts to bypass model guidelines |
+| **Path traversal** | Prevents `../` and absolute path escapes |
+| **Command injection** | Blocks shell metacharacters in tool inputs |
+| **Credential handling** | Safe storage, never logged or echoed |
+| **bcrypt** | Password hashing for any persisted credentials |
+| **Input validation** | Zod schemas on all MCP tool parameters |
+
+## AIDefence Performance
+
+- Detection latency: **<10ms**
+- Learns from blocked patterns — new threat signatures are added automatically
+
+## Memory Security
+
+The GuardedVectorBackend controller requires cryptographic **proof-of-work** before allowing vector insert or search operations, preventing unauthorized memory poisoning.
+
+MutationGuard enforces token-validated mutations with cryptographic proofs. Every memory operation is written to an immutable AttestationLog.
+
+## CVE Hardening
+
+Ruflo's dependency tree is regularly audited. Known CVEs are patched before release. Run:
+
+```bash
+npx ruflo@latest --doctor
+```
+
+to check for dependency vulnerabilities in your local install.

--- a/docs/architecture/swarm.md
+++ b/docs/architecture/swarm.md
@@ -1,0 +1,87 @@
+# Swarm Topologies
+
+Ruflo supports four swarm topologies for coordinating multiple agents.
+
+## Topology Overview
+
+```mermaid
+flowchart TB
+    subgraph Hierarchical["👑 Hierarchical (Default)"]
+        Q1[Queen] --> W1[Worker 1]
+        Q1 --> W2[Worker 2]
+        Q1 --> W3[Worker 3]
+    end
+
+    subgraph Mesh["🕸️ Mesh"]
+        M1[Agent] <--> M2[Agent]
+        M2 <--> M3[Agent]
+        M3 <--> M1
+    end
+
+    subgraph Ring["💍 Ring"]
+        R1[Agent] --> R2[Agent]
+        R2 --> R3[Agent]
+        R3 --> R1
+    end
+
+    subgraph Star["⭐ Star"]
+        S1[Hub] --> S2[Agent]
+        S1 --> S3[Agent]
+        S1 --> S4[Agent]
+    end
+```
+
+## Choosing a Topology
+
+| Topology | Best For | Drift Risk |
+|----------|----------|------------|
+| `hierarchical` | Most coding tasks — queen validates output | Low |
+| `mesh` | Research / exploration — peer-to-peer collaboration | Medium |
+| `ring` | Sequential pipelines — output feeds next agent | Low |
+| `star` | Fan-out / fan-in — hub coordinates many workers | Medium |
+
+## Recommended Configuration (Anti-Drift)
+
+```javascript
+swarm_init({
+  topology: "hierarchical",  // Single coordinator enforces alignment
+  maxAgents: 8,              // Smaller teams = less drift surface
+  strategy: "specialized"    // Clear roles reduce ambiguity
+})
+```
+
+## Consensus Protocols
+
+Ruflo supports five consensus algorithms for fault-tolerant agent decisions:
+
+| Protocol | Use Case | Fault Tolerance |
+|----------|----------|-----------------|
+| **Raft** | Leader election, authoritative state | Leader failure |
+| **Byzantine (BFT)** | Untrusted or noisy agents | Up to 1/3 failing |
+| **Gossip** | Eventually-consistent shared state | Network partitions |
+| **CRDT** | Conflict-free concurrent updates | Full partition tolerance |
+| **Majority** | Simple voting | Simple failures |
+
+## Hive Mind
+
+The Hive Mind is the queen-led coordination layer:
+
+| Component | Purpose |
+|-----------|---------|
+| **Strategic Queen** | Long-range planning, architecture decisions |
+| **Tactical Queen** | Task execution coordination |
+| **Adaptive Queen** | Real-time optimization and load balancing |
+| **8 Worker Types** | Researcher, Coder, Analyst, Tester, Architect, Reviewer, Optimizer, Documenter |
+
+Collective memory is shared via LRU cache + SQLite persistence (WAL mode).
+
+## Task → Agent Routing Guide
+
+| Code | Task Type | Recommended Agents |
+|------|-----------|-------------------|
+| 1 | Bug Fix | coordinator, researcher, coder, tester |
+| 3 | Feature | coordinator, architect, coder, tester, reviewer |
+| 5 | Refactor | coordinator, architect, coder, reviewer |
+| 7 | Performance | coordinator, perf-engineer, coder |
+| 9 | Security | coordinator, security-architect, auditor |
+| 11 | Memory | coordinator, memory-specialist, perf-engineer |

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -1,0 +1,63 @@
+# Configuration Reference
+
+## Documentation Site (`mkdocs.yml`)
+
+This docs site is built with [MkDocs](https://www.mkdocs.org/) + [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) + [mkdocs-llms-source](https://github.com/TimChild/mkdocs-llms-source). See the [setup-from-scratch guide](https://TimChild.github.io/mkdocs-llms-source/setup-from-scratch/) for full mkdocs configuration options.
+
+---
+
+## Ruflo Project Configuration
+
+After running `npx ruflo@latest init`, these files are created in your project:
+
+### `CLAUDE.md`
+The agent instruction file read by Claude Code at session start. Customise this to set project context, code style, and agent preferences.
+
+### `.claude/settings.json`
+
+```json
+{
+  "maxAgents": 8,
+  "defaultTopology": "hierarchical",
+  "defaultConsensus": "raft",
+  "memoryNamespace": "default",
+  "logLevel": "info",
+  "enableWasm": true,
+  "enableLearning": true
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `maxAgents` | `8` | Maximum concurrent agents in a swarm |
+| `defaultTopology` | `hierarchical` | Default swarm topology |
+| `defaultConsensus` | `raft` | Default consensus algorithm |
+| `memoryNamespace` | `default` | Shared memory namespace for agents |
+| `logLevel` | `info` | Log verbosity |
+| `enableWasm` | `true` | Enable Agent Booster WASM transforms |
+| `enableLearning` | `true` | Enable SONA self-learning |
+
+### `.claude/agents/`
+Custom agent definitions (YAML). See [Agent Catalog](../agents/catalog.md).
+
+### `.claude/skills/`
+137+ pre-built skills available as `/skill-name` (Claude Code) or `$skill-name` (Codex).
+
+### `.claude/hooks/`
+Pre/post/progress hook scripts. Ruflo installs default hooks — you can extend or replace them.
+
+---
+
+## MCP Server Configuration
+
+Environment variables for `npx ruflo@latest mcp start`:
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key (required for Claude) |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `GOOGLE_API_KEY` | Google Gemini API key |
+| `RUFLO_MAX_AGENTS` | Override max agents |
+| `RUFLO_LOG_LEVEL` | `debug` / `info` / `warn` / `error` |
+| `RUFLO_MEMORY_PATH` | Custom path for AgentDB storage |
+| `RUFLO_WASM_DISABLED` | Set to `1` to disable Agent Booster |

--- a/docs/for-llms.md
+++ b/docs/for-llms.md
@@ -1,0 +1,28 @@
+# For LLMs
+
+This documentation site publishes machine-readable files following the [llms.txt specification](https://llmstxt.org/).
+
+## Available Endpoints
+
+| File | Description |
+|------|-------------|
+| `/llms.txt` | Curated index of documentation pages |
+| `/llms-full.txt` | All documentation in a single file — ideal for LLM context windows |
+| Per-page `.md` files | Raw markdown available at the same URL path as each HTML page (e.g. `/getting-started/quickstart.md`) |
+
+## Usage
+
+### Quick context injection
+
+```bash
+# Fetch the full docs for an LLM prompt
+curl https://ruvnet.github.io/ruflo/llms-full.txt
+```
+
+### Using the index
+
+`/llms.txt` lists all pages with descriptions so an LLM can decide which sections are relevant before fetching the full content.
+
+## About mkdocs-llms-source
+
+These files are generated automatically by the [mkdocs-llms-source](https://github.com/TimChild/mkdocs-llms-source) plugin. They use the original markdown source (not HTML→markdown conversion), which means cleaner output and accurate code blocks.

--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -1,0 +1,93 @@
+# Claude Code Integration
+
+Ruflo was built first and foremost for Claude Code. This page covers how the integration works and how to get the most out of it.
+
+## How it Works
+
+Ruflo installs as an MCP (Model Context Protocol) server that Claude Code can call. It also injects hooks into the Claude Code lifecycle:
+
+```
+Claude Code → pre-task hook → Ruflo Router → Agent(s) → Memory → LLM
+                                           ↑
+                                    (WASM for simple tasks)
+```
+
+## Add Ruflo to Claude Code
+
+```bash
+# One-time setup
+claude mcp add ruflo -- npx -y ruflo@latest mcp start
+
+# Verify
+claude mcp list
+```
+
+Once added, all 259 Ruflo MCP tools are available directly in Claude Code sessions.
+
+## Key MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `swarm_init` | Initialize an agent swarm |
+| `agent_spawn` | Register and spawn a specialized agent |
+| `memory_search` | Semantic vector search over learned patterns |
+| `memory_store` | Persist a pattern for future use |
+| `hooks_route` | Manually trigger intelligent task routing |
+| `neural_train` | Train on accumulated patterns |
+
+## Self-Learning Workflow
+
+```
+1. LEARN:    memory_search(query) → retrieve relevant patterns
+2. COORD:    swarm_init(topology="hierarchical") → set up agents
+3. EXECUTE:  Claude Code writes code / runs commands
+4. REMEMBER: memory_store(key, value, namespace="patterns") → persist
+```
+
+The **Intelligence Loop** automates this cycle via hooks — every session builds the knowledge graph, injects ranked context into routing decisions, and boosts confidence for patterns that work.
+
+## Codex / Dual-Mode
+
+Ruflo also supports **OpenAI Codex CLI** via `@claude-flow/codex`:
+
+```bash
+# Init for Codex CLI (creates AGENTS.md instead of CLAUDE.md)
+npx ruflo@latest init --codex
+
+# Dual mode (both platforms)
+npx ruflo@latest init --dual
+```
+
+In dual mode:
+
+```
+Claude Code (interactive)  ←→  Codex Workers (headless, parallel)
+- Main conversation              - Bulk code generation
+- Architecture decisions         - Test execution
+- Complex reasoning              - File processing
+```
+
+Parallel Codex workers deliver **4-8x speed** for bulk tasks and allow cost routing to cheaper workers.
+
+## Hooks Reference
+
+Ruflo injects three key hooks into Claude Code:
+
+| Hook | When it fires | What it does |
+|------|---------------|--------------|
+| `pre-task` | Before a task starts | Analyzes complexity, routes to WASM/agent/swarm |
+| `post-task` | After task completes | Stores successful patterns, updates knowledge graph |
+| `progress` | During long tasks | Validates spec compliance, checks ADR drift |
+
+## Troubleshooting
+
+```bash
+# Run diagnostics
+npx ruflo@latest --doctor
+
+# Check hook status
+npx ruflo@latest hooks intelligence --status
+
+# Re-initialize (safe, preserves memory)
+npx ruflo@latest init upgrade
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,95 @@
+# Installation
+
+Ruflo requires **Node.js 20+** and **npm 9+** (or pnpm/bun).
+
+!!! info "Prerequisite: Claude Code"
+    Ruflo is designed to work with Claude Code. Install it first:
+    ```bash
+    npm install -g @anthropic-ai/claude-code
+    ```
+
+---
+
+## Option 1: One-Line Installer (Recommended)
+
+```bash
+# Standard install
+curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/claude-flow@main/scripts/install.sh | bash
+
+# Full setup (global install + MCP + diagnostics)
+curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/claude-flow@main/scripts/install.sh | bash -s -- --full
+```
+
+### Installer Options
+
+| Flag | Description |
+|------|-------------|
+| `--global`, `-g` | Install globally (`npm install -g`) |
+| `--minimal`, `-m` | Skip optional ML/embedding deps (~15s) |
+| `--setup-mcp` | Auto-configure MCP server for Claude Code |
+| `--doctor`, `-d` | Run diagnostics after install |
+| `--full`, `-f` | Global + MCP + doctor |
+| `--version=X.X.X` | Install a specific version |
+
+---
+
+## Option 2: npx / npm
+
+```bash
+# Quick start — no install needed
+npx ruflo@latest init
+
+# Install globally
+npm install -g ruflo@latest
+ruflo init
+
+# With Bun (faster)
+bunx ruflo@latest init
+```
+
+---
+
+## Install Profiles
+
+| Profile | Size | Use Case |
+|---------|------|----------|
+| `--omit=optional` | ~45 MB | Core CLI only |
+| Default | ~340 MB | Full ML + embeddings |
+
+```bash
+# Minimal (skip ML/embeddings)
+npm install -g ruflo@latest --omit=optional
+```
+
+---
+
+## Upgrading
+
+!!! note "Version tags"
+    `ruflo@latest` installs the latest stable release. `ruflo@v3alpha` targets the v3 alpha channel with the newest features. Use whichever matches your project.
+
+```bash
+# Update helpers and statusline (preserves data)
+npx ruflo@latest init upgrade
+
+# Update and add any new skills/agents
+npx ruflo@latest init upgrade --add-missing
+```
+
+---
+
+## Install Speed Reference
+
+| Method | Time |
+|--------|------|
+| npx (cached) | ~3s |
+| npx (fresh) | ~20s |
+| global | ~35s |
+| `--minimal` | ~15s |
+
+---
+
+## Next Steps
+
+→ [Quick Start](quickstart.md)  
+→ [Claude Code Integration](claude-code.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,76 @@
+# Quick Start
+
+Get Ruflo running in under 2 minutes.
+
+## 1. Initialize a Project
+
+```bash
+npx ruflo@latest init
+```
+
+This runs the setup wizard and creates:
+
+- `CLAUDE.md` — agent instructions for Claude Code
+- `.claude/` — skills, agents, hooks, and memory
+
+## 2. Start the MCP Server
+
+```bash
+npx ruflo@latest mcp start
+```
+
+Or add it permanently to Claude Code:
+
+```bash
+claude mcp add ruflo -- npx -y ruflo@latest mcp start
+claude mcp list  # verify
+```
+
+## 3. Run Your First Task
+
+Inside a Claude Code session (or via CLI):
+
+```bash
+# Spawn a coder agent
+npx ruflo@latest --agent coder --task "Implement user authentication with JWT"
+
+# List all available agents
+npx ruflo@latest --list
+```
+
+## 4. Use the Swarm
+
+For complex, multi-step tasks, initialize a swarm:
+
+```bash
+# In Claude Code, after MCP is connected:
+# swarm_init(topology="hierarchical", maxAgents=6, strategy="specialized")
+```
+
+---
+
+## What Happens Automatically
+
+Once initialized, Ruflo's hook system runs invisibly in the background:
+
+- **Routes tasks** to the right agent based on complexity
+- **Stores successful patterns** in vector memory (HNSW)
+- **Skips the LLM** for simple transforms using WASM (352x faster, $0)
+- **Learns** from every session to improve future routing
+
+> You don't need to learn 259 MCP tools or 26 CLI commands. Just use Claude Code normally — the hooks system handles coordination.
+
+---
+
+## Verify Everything Works
+
+```bash
+npx ruflo@latest hooks intelligence --status
+```
+
+Expected output includes active agents, memory stats, and routing accuracy.
+
+---
+
+→ [Claude Code Integration](claude-code.md)  
+→ [Architecture Overview](../architecture/overview.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,99 @@
+# 🌊 Ruflo
+
+**The leading agent orchestration platform for Claude.**
+
+Deploy intelligent multi-agent swarms, coordinate autonomous workflows, and build conversational AI systems. Features enterprise-grade architecture, distributed swarm intelligence, RAG integration, and native Claude Code / Codex integration.
+
+---
+
+## What is Ruflo?
+
+Ruflo (formerly Claude Flow) is a comprehensive AI agent orchestration framework that transforms Claude Code into a powerful multi-agent development platform. Teams use it to deploy, coordinate, and optimize 60+ specialized AI agents working together on complex software engineering tasks.
+
+> **Why Ruflo?** Named by Ruv — the "Ru" is the Ruv, the "flo" is the flow. Underneath, WASM kernels written in Rust power the policy engine, embeddings, and proof system. 5,900+ commits later, the alpha is over. This is v3.5.
+
+```bash
+# Get started immediately
+npx ruflo@latest init --wizard
+```
+
+---
+
+## Key Capabilities
+
+### 🤖 60+ Specialized Agents
+Ready-to-use AI agents for coding, code review, testing, security audits, documentation, and DevOps — each optimized for its specific role.
+
+### 🐝 Coordinated Agent Swarms
+Run unlimited agents simultaneously. Agents spawn sub-workers, communicate, share context, and divide work automatically using hierarchical (queen/workers) or mesh (peer-to-peer) patterns.
+
+### 🧠 Self-Learning System
+The system remembers what works. Successful patterns are stored and reused, routing similar tasks to the best-performing agents — gets smarter over time.
+
+### 🔌 Any LLM, Native MCP
+Switch between Claude, GPT, Gemini, Cohere, or local models like Llama. Native MCP integration means you use Ruflo directly inside Claude Code.
+
+### ⚡ 3-Tier Cost Optimization
+Simple code transforms run in WASM (<1ms, $0). Medium tasks route to cheaper models. Only complex reasoning uses Opus. Net result: **75% lower API costs** and **2.5x more tasks** within your quota.
+
+### 🔒 Production-Ready Security
+CVE-hardened with bcrypt, input validation, path traversal prevention, and built-in AIDefence threat detection (<10ms).
+
+---
+
+## Architecture at a Glance
+
+```
+User → Ruflo (CLI/MCP) → Router → Swarm → Agents → Memory → LLM Providers
+                       ↑                          ↓
+                       └──── Learning Loop ←──────┘
+```
+
+See [Architecture Overview](architecture/overview.md) for the full system diagram.
+
+---
+
+## Quick Start
+
+```bash
+# One-line install (recommended)
+curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/claude-flow@main/scripts/install.sh | bash
+
+# Or via npx
+npx ruflo@latest init
+
+# Add to Claude Code as an MCP server
+claude mcp add ruflo -- npx -y ruflo@latest mcp start
+```
+
+→ [Full installation guide](getting-started/installation.md)
+
+---
+
+## Ruflo vs. Alternatives
+
+| Feature | Ruflo v3 | CrewAI | LangGraph | AutoGen |
+|---------|----------|--------|-----------|---------|
+| Self-Learning (SONA + EWC++) | ✅ | ⛔ | ⛔ | ⛔ |
+| Vector Memory (HNSW sub-ms) | ✅ | ⛔ | Via plugins | ⛔ |
+| Swarm Topologies | ✅ 4 types | 1 | 1 | 1 |
+| Consensus Protocols | ✅ 5 (Raft, BFT…) | ⛔ | ⛔ | ⛔ |
+| MCP Integration | ✅ 259 tools | ⛔ | ⛔ | ⛔ |
+| Multi-Provider LLM | ✅ 6 + failover | 2 | 3 | 2 |
+| WASM Code Transforms | ✅ <1ms, $0 | ⛔ | ⛔ | ⛔ |
+
+---
+
+## For AI / LLM Consumers
+
+This site publishes machine-readable documentation:
+
+- `/llms.txt` — curated index following the [llmstxt.org](https://llmstxt.org/) spec
+- `/llms-full.txt` — all docs in one file, ideal for LLM context windows
+- Per-page `.md` files at the same URL path as each HTML page
+
+---
+
+## License
+
+Ruflo is [MIT licensed](https://github.com/ruvnet/ruflo/blob/main/LICENSE).

--- a/docs/mcp/clients.md
+++ b/docs/mcp/clients.md
@@ -1,0 +1,71 @@
+# MCP Client Setup
+
+Quick-reference for connecting Ruflo's MCP server to popular clients.
+
+## Client Compatibility
+
+| Client | Support | Notes |
+|--------|---------|-------|
+| Claude Code (CLI) | ✅ Native | `claude mcp add` |
+| Claude Desktop | ✅ | JSON config file |
+| VS Code | ✅ | Requires v1.102+ |
+| Cursor | ✅ | `.cursor/mcp.json` |
+| Windsurf | ✅ | `.windsurf/mcp.json` |
+| OpenAI Codex CLI | ✅ | `codex mcp add` |
+| Any MCP client | ✅ | stdio transport |
+
+## Claude Code (Recommended)
+
+```bash
+claude mcp add ruflo -- npx -y ruflo@latest mcp start
+```
+
+## Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "ruflo": {
+      "command": "npx",
+      "args": ["ruflo@v3alpha", "mcp", "start"],
+      "env": { "ANTHROPIC_API_KEY": "sk-ant-..." }
+    }
+  }
+}
+```
+
+## VS Code
+
+Command Palette → **MCP: Add Server**:
+```
+npx ruflo@latest mcp start
+```
+
+## Cursor / Windsurf
+
+```json
+{
+  "mcpServers": {
+    "ruflo": {
+      "command": "npx",
+      "args": ["-y", "ruflo@latest", "mcp", "start"]
+    }
+  }
+}
+```
+
+## Codex CLI
+
+```bash
+codex mcp add ruflo -- npx ruflo@v3alpha mcp start
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ANTHROPIC_API_KEY` | Yes (for Claude) | Anthropic API key |
+| `OPENAI_API_KEY` | Optional | For GPT provider |
+| `GOOGLE_API_KEY` | Optional | For Gemini provider |
+| `RUFLO_MAX_AGENTS` | Optional | Override default max agents |
+| `RUFLO_LOG_LEVEL` | Optional | `debug` / `info` / `warn` / `error` |

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -1,0 +1,79 @@
+# MCP Server
+
+Ruflo runs as an MCP (Model Context Protocol) server, making all 259 tools available to any MCP-compatible client.
+
+!!! note "Version tags"
+    Examples below use `ruflo@latest` for CLI commands and `ruflo@v3alpha` in JSON configs (matching the upstream README). Substitute whichever version you're using.
+
+## Starting the Server
+
+```bash
+npx ruflo@latest mcp start
+```
+
+## Connecting to Claude Code
+
+```bash
+# Add permanently
+claude mcp add ruflo -- npx -y ruflo@latest mcp start
+
+# Verify
+claude mcp list
+```
+
+## Connecting to Claude Desktop
+
+Edit `claude_desktop_config.json`:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "ruflo": {
+      "command": "npx",
+      "args": ["ruflo@v3alpha", "mcp", "start"],
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. Look for the hammer icon in the input box.
+
+## Connecting to VS Code
+
+Requires VS Code 1.102+ (MCP is GA).
+
+Open Command Palette → **MCP: Add Server** → enter:
+
+```
+npx ruflo@latest mcp start
+```
+
+## Connecting to Cursor / Windsurf
+
+Add to your MCP configuration file (`.cursor/mcp.json` or `.windsurf/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ruflo": {
+      "command": "npx",
+      "args": ["-y", "ruflo@latest", "mcp", "start"]
+    }
+  }
+}
+```
+
+## Connecting to Codex CLI
+
+```bash
+codex mcp add ruflo -- npx ruflo@v3alpha mcp start
+
+# Verify
+codex mcp list
+```

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,0 +1,103 @@
+# MCP Tool Reference
+
+Ruflo exposes 259 MCP tools. Below are the most commonly used.
+
+## Core Tools
+
+### `swarm_init`
+Initialize an agent swarm.
+
+```json
+{
+  "topology": "hierarchical",
+  "maxAgents": 6,
+  "strategy": "specialized",
+  "consensus": "raft"
+}
+```
+
+### `agent_spawn`
+Register and spawn a specialized agent.
+
+```json
+{
+  "type": "coder",
+  "task": "Implement user authentication with JWT",
+  "memoryNamespace": "auth-project"
+}
+```
+
+### `memory_search`
+Semantic vector search over learned patterns.
+
+```json
+{
+  "query": "authentication patterns",
+  "topK": 5,
+  "minScore": 0.7
+}
+```
+
+Returns patterns ranked by relevance (0–1 score).
+
+### `memory_store`
+Persist a pattern for future retrieval.
+
+```json
+{
+  "key": "jwt-refresh-pattern",
+  "value": "Use sliding window refresh with 7d expiry",
+  "namespace": "patterns"
+}
+```
+
+### `hooks_route`
+Manually trigger task routing.
+
+```json
+{
+  "task": "Convert all var declarations to const",
+  "complexity": "simple"
+}
+```
+
+### `neural_train`
+Train on accumulated patterns.
+
+```json
+{
+  "namespace": "patterns",
+  "epochs": 5
+}
+```
+
+## AgentDB Tools
+
+| Tool | Description |
+|------|-------------|
+| `agentdb_hierarchical-store` | Store to working/episodic/semantic tier |
+| `agentdb_hierarchical-recall` | Recall with Ebbinghaus-weighted scoring |
+| `agentdb_consolidate` | Cluster and merge related memories |
+| `agentdb_batch` | Bulk insert/update/delete |
+| `agentdb_context-synthesize` | Auto-generate context summaries |
+| `agentdb_semantic-route` | Route a task via vector similarity |
+| `agentdb_pattern-store` | Store to ReasoningBank |
+| `agentdb_pattern-search` | BM25+semantic hybrid search |
+| `agentdb_causal-edge` | Add a causal relationship between memories |
+
+## Hooks Tools
+
+| Tool | Description |
+|------|-------------|
+| `hooks_pre_task` | Pre-task analysis and routing |
+| `hooks_post_task` | Post-task pattern storage |
+| `hooks_progress` | Check ADR compliance % |
+| `hooks_intelligence` | Full status: agents, memory, routing accuracy |
+
+## Full Tool List
+
+The complete list of 259 tools is available by running:
+
+```bash
+npx ruflo@latest mcp list-tools
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,92 @@
+site_name: Ruflo
+site_url: https://ruvnet.github.io/ruflo
+site_description: The leading agent orchestration platform for Claude. Deploy intelligent multi-agent swarms, coordinate autonomous workflows, and build conversational AI systems.
+repo_url: https://github.com/ruvnet/ruflo
+repo_name: ruvnet/ruflo
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  icon:
+    logo: material/waves
+  palette:
+    - scheme: slate
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  features:
+    - content.action.edit
+    - content.code.copy
+    - content.code.annotate
+    - navigation.instant
+    - navigation.footer
+    - navigation.top
+    - navigation.tabs
+    - navigation.sections
+    - search.suggest
+    - search.highlight
+    - toc.follow
+
+plugins:
+  - search
+  - llms-source:
+      full_output: true
+      markdown_urls: true
+      description: >
+        Ruflo is an enterprise AI agent orchestration platform for Claude. Deploy 60+
+        specialized agents in coordinated swarms with self-learning capabilities,
+        fault-tolerant consensus, and RAG integration.
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+  - tables
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+    - Claude Code Integration: getting-started/claude-code.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - Swarm Topologies: architecture/swarm.md
+    - Intelligence & Memory: architecture/memory.md
+    - Task Routing: architecture/routing.md
+    - Security: architecture/security.md
+  - Agents:
+    - Agent Catalog: agents/catalog.md
+    - Swarm Configuration: agents/swarm-config.md
+    - Anti-Drift: agents/anti-drift.md
+  - MCP:
+    - MCP Server: mcp/server.md
+    - Tool Reference: mcp/tools.md
+    - Client Setup: mcp/clients.md
+  - Configuration:
+    - Reference: configuration/reference.md
+  - For LLMs: for-llms.md


### PR DESCRIPTION
## Summary

Adds a complete MkDocs Material documentation site with 17 pages covering getting started, architecture, agents, MCP integration, and configuration. Includes a GitHub Actions workflow for automatic deployment to GitHub Pages.

## What's included

- **17 documentation pages** organized into 6 sections (Home, Getting Started, Architecture, Agents, MCP, Configuration)
- **MkDocs Material theme** with dark/light mode toggle, search, navigation tabs, and code copy buttons
- **[mkdocs-llms-source](https://github.com/TimChild/mkdocs-llms-source) plugin** generating `/llms.txt` and `/llms-full.txt` following the [llms.txt spec](https://llmstxt.org/)
- **GitHub Actions workflow** (`.github/workflows/docs.yml`) for auto-deploy on push to `main`
- **`docs-requirements.txt`** for reproducible builds
- **Mermaid diagram support** for architecture visualizations

## Structure

```
docs/
├── index.md                    # Homepage with quick start + comparison table
├── for-llms.md                 # Explains /llms.txt endpoints
├── getting-started/            # Installation, quickstart, Claude Code integration
├── architecture/               # Overview, swarm topologies, memory, routing, security
├── agents/                     # Catalog, swarm config, anti-drift
├── mcp/                        # Server, tools, client setup
└── configuration/              # Settings reference
```

## Build verification

- `mkdocs build --strict` passes with **zero warnings**
- All 17 pages render correctly
- Mermaid diagrams render properly
- `llms.txt` and `llms-full.txt` both generate correctly

## Screenshots

### Homepage
![Homepage](https://raw.githubusercontent.com/TimChild/ruflo/feat/mkdocs-documentation/docs-screenshots/homepage.png)

### Architecture (with Mermaid diagrams)
![Architecture](https://raw.githubusercontent.com/TimChild/ruflo/feat/mkdocs-documentation/docs-screenshots/architecture.png)

## To deploy

After merging, enable GitHub Pages in the repo settings:
**Settings → Pages → Source: GitHub Actions**

The workflow will automatically build and deploy on every push to `main`.

## Notes

- The `docs-screenshots/` directory is only for this PR preview and can be removed before or after merge
- Content was drafted based on the existing README and codebase — happy to adjust any sections
