### PR TITLE
fix(memory): SQLiteBackend schema migration + memory_store metadata support

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -188,6 +188,10 @@ export const memoryTools: MCPTool[] = [
           items: { type: 'string' },
           description: 'Optional tags for filtering',
         },
+        metadata: {
+          type: 'object',
+          description: 'Optional metadata object (e.g. { confidence: 0.9 } for AutoMemoryBridge sync eligibility)',
+        },
         ttl: { type: 'number', description: 'Time-to-live in seconds (optional)' },
         upsert: { type: 'boolean', description: 'If true, update existing key instead of failing (default: false)' },
       },
@@ -202,6 +206,7 @@ export const memoryTools: MCPTool[] = [
       const rawValue = input.value;
       const value = typeof rawValue === 'string' ? rawValue : (rawValue !== undefined ? JSON.stringify(rawValue) : '');
       const tags = (input.tags as string[]) || [];
+      const metadata = (input.metadata as Record<string, unknown>) || {};
       const ttl = input.ttl as number | undefined;
       const upsert = (input.upsert as boolean) || false;
 
@@ -226,6 +231,7 @@ export const memoryTools: MCPTool[] = [
           namespace,
           generateEmbeddingFlag: true,
           tags,
+          metadata,
           ttl,
           upsert,
         });

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -2030,6 +2030,7 @@ export async function storeEntry(options: {
   namespace?: string;
   generateEmbeddingFlag?: boolean;
   tags?: string[];
+  metadata?: Record<string, unknown>;
   ttl?: number;
   dbPath?: string;
   upsert?: boolean;
@@ -2053,6 +2054,7 @@ export async function storeEntry(options: {
     namespace = 'default',
     generateEmbeddingFlag = true,
     tags = [],
+    metadata = {},
     ttl,
     dbPath: customPath,
     upsert = false
@@ -2112,7 +2114,7 @@ export async function storeEntry(options: {
       embeddingDimensions,
       embeddingModel,
       tags.length > 0 ? JSON.stringify(tags) : null,
-      '{}',
+      JSON.stringify(metadata),
       now,
       now,
       ttl ? now + (ttl * 1000) : null

--- a/v3/@claude-flow/memory/src/sqlite-backend.ts
+++ b/v3/@claude-flow/memory/src/sqlite-backend.ts
@@ -654,6 +654,24 @@ export class SQLiteBackend extends EventEmitter implements IMemoryBackend {
         FOREIGN KEY (entry_id) REFERENCES memory_entries(id) ON DELETE CASCADE
       );
     `);
+
+    // Migration: add columns that may be missing when DB was created by an older
+    // schema (e.g. via the MCP sql.js backend which uses a different DDL).
+    // ALTER TABLE ADD COLUMN is a no-op if the column already exists in SQLite ≥3.37.
+    const migrations: Array<{ col: string; ddl: string }> = [
+      { col: 'access_level', ddl: "ALTER TABLE memory_entries ADD COLUMN access_level TEXT NOT NULL DEFAULT 'private'" },
+      { col: 'version',      ddl: 'ALTER TABLE memory_entries ADD COLUMN version INTEGER NOT NULL DEFAULT 1' },
+      { col: 'references',   ddl: 'ALTER TABLE memory_entries ADD COLUMN "references" TEXT NOT NULL DEFAULT \'[]\'' },
+    ];
+    const existing = new Set<string>(
+      (this.db!.prepare("PRAGMA table_info(memory_entries)").all() as Array<{ name: string }>)
+        .map(r => r.name)
+    );
+    for (const m of migrations) {
+      if (!existing.has(m.col)) {
+        this.db!.exec(m.ddl);
+      }
+    }
   }
 
   private rowToEntry(row: any): MemoryEntry {


### PR DESCRIPTION
## Summary

Two related bugs that together make `AutoMemoryBridge.syncToAutoMemory()` always return 0 entries when the database was created by MCP tools.

### Bug 1 — SQLiteBackend crashes on DB created by the MCP sql.js backend

`createSchema()` uses `CREATE TABLE IF NOT EXISTS` but never migrates existing tables. When `.swarm/memory.db` is first created by MCP tools (sql.js backend — `memory-initializer.ts`), the table is created with a different DDL that lacks columns `access_level`, `version`, and `"references"`. Subsequent calls to `rowToEntry()` crash with:

```
SyntaxError: "undefined" is not valid JSON
  at SQLiteBackend.rowToEntry (sqlite-backend.js:537)
```

**Fix:** after `CREATE TABLE IF NOT EXISTS`, run `PRAGMA table_info` and `ALTER TABLE ADD COLUMN` for each missing column (safe no-op if column already exists).

### Bug 2 — `memory_store` MCP tool discards metadata, breaking AutoMemoryBridge sync

`storeEntry()` hardcodes `'{}'` as `metadata` regardless of caller input. The `memory_store` MCP tool has no `metadata` parameter in its input schema. Because `AutoMemoryBridge.queryRecentInsights()` filters on `metadata.confidence >= 0.7` (default `minConfidence`), **every entry stored via MCP is permanently excluded from sync** — `syncToAutoMemory` returns 0 even when the DB contains many entries.

**Fix:**
- Add optional `metadata` parameter to `memory_store` input schema (documented as needed for AutoMemoryBridge)
- Add `metadata` to `storeEntry()` options interface
- Pass `metadata` through to the INSERT instead of hardcoded `'{}'`

## Reproducer

```bash
# Store something via MCP
mcp__claude-flow__memory_store key="test" namespace="learnings" tags=["insight"] value="..."

# Run sync — observe "Synced 0 entries" despite DB having entries
node .claude/helpers/auto-memory-hook.mjs sync
```

## Files changed

- `v3/@claude-flow/memory/src/sqlite-backend.ts` — schema migration in `createSchema()`
- `v3/@claude-flow/cli/src/memory/memory-initializer.ts` — `metadata` option in `storeEntry()`
- `v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts` — `metadata` param in `memory_store` schema

## Test plan

- [ ] Create a fresh DB via MCP `memory_store` → verify `SQLiteBackend.initialize()` no longer throws
- [ ] Store entry with `metadata: { confidence: 0.9 }` via MCP → verify `syncToAutoMemory()` returns it
- [ ] Store entry without `metadata` via MCP → verify existing behaviour unchanged (empty metadata `{}`)
- [ ] Run on existing DB with all columns present → verify `ALTER TABLE` no-ops silently

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)