### PR TITLE
fix: close stdin pipe on headless workers and force exit after CLI commands

### DIFF
--- a/v3/@claude-flow/cli/src/index.ts
+++ b/v3/@claude-flow/cli/src/index.ts
@@ -241,6 +241,11 @@ export class CLI {
         if (result && !result.success) {
           process.exit(result.exitCode || 1);
         }
+
+        // Force exit after successful command to prevent hanging from
+        // background threads (e.g. ONNX worker threads, open DB handles)
+        // that keep the event loop alive. CLI commands are one-shot.
+        process.exit(0);
       } else {
         // No action - show command help
         this.showCommandHelp(commandName);

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -1125,7 +1125,7 @@ Analyze the above codebase context and provide your response following the forma
       const child = spawn('claude', ['--print', prompt], {
         cwd: this.projectRoot,
         env,
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true, // Prevent phantom console windows on Windows
       });
 


### PR DESCRIPTION
## Summary

Two related process lifecycle bugs that cause resource exhaustion:

- **#1395 (stdin pipe never closed)**: Headless workers spawn `claude --print` with `stdio: ['pipe', 'pipe', 'pipe']` but never write to or close stdin. Claude Code blocks waiting for EOF, causing 100% worker failure rate (exit 143 after SIGTERM timeout). Combined with no daemon singleton enforcement, this caused kernel panic on a 36 GB Mac with 8 projects.

  **Fix**: Change `'pipe'` to `'ignore'` for stdin — one-character change that provides immediate EOF.

- **#1428 (memory init hangs)**: All `memory` subcommands hang after completion because ONNX Runtime worker threads and open SQLite handles keep the Node.js event loop alive. The CLI runner only calls `process.exit()` on failure, not success.

  **Fix**: Add `process.exit(0)` after successful command execution in the CLI runner, since CLI commands are one-shot operations.

## Changed files

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/services/headless-worker-executor.ts:1128` | `stdio: ['pipe'` → `['ignore'` |
| `v3/@claude-flow/cli/src/index.ts:244` | Add `process.exit(0)` after successful command |

## Test plan

- [ ] `npx ruflo memory init` should exit cleanly after "Synced to:" message
- [ ] `npx ruflo memory store -k test --value test` should exit cleanly
- [ ] `npx ruflo daemon start` → headless workers should no longer exit with code 143
- [ ] `npm run build` in `v3/@claude-flow/cli/`

Closes #1395, Closes #1428