### PR TITLE
fix: upgrade form-data to 2.5.4, 3.0.4, 4.0.4 (CVE-2025-7783)

### DIFF
--- a/ruflo/src/ruvocal/package-lock.json
+++ b/ruflo/src/ruvocal/package-lock.json
@@ -20,6 +20,7 @@
 				"devalue": "^5.6.3",
 				"dotenv": "^16.5.0",
 				"file-type": "^21.0.0",
+				"form-data": "^4.0.4",
 				"handlebars": "^4.7.8",
 				"highlight.js": "^11.7.0",
 				"hono": "^4.12.0",
@@ -5625,9 +5626,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",

--- a/ruflo/src/ruvocal/package.json
+++ b/ruflo/src/ruvocal/package.json
@@ -83,6 +83,7 @@
 		"devalue": "^5.6.3",
 		"dotenv": "^16.5.0",
 		"file-type": "^21.0.0",
+		"form-data": "^4.0.4",
 		"handlebars": "^4.7.8",
 		"highlight.js": "^11.7.0",
 		"hono": "^4.12.0",


### PR DESCRIPTION
## Summary
Upgrade form-data from 4.0.3 to 2.5.4, 3.0.4, 4.0.4 to fix CVE-2025-7783.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-7783 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-7783` |
| **File** | `ruflo/src/ruvocal/package-lock.json` |

**Description**: form-data: Unsafe random function in form-data

## Changes
- `ruflo/src/ruvocal/package.json`
- `ruflo/src/ruvocal/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
