### PR TITLE
fix: Windows daemon ENOENT, keepalive drain, and headless worker shell resolution

### DIFF
--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -177,6 +177,9 @@ const startCommand: Command = {
         await new Promise(() => {}); // Never resolves - daemon runs until killed
       } else {
         await startDaemon(projectRoot, config);
+        // Keep event loop alive with active timer handle (#1446)
+        // A bare Promise(() => {}) may not prevent exit when there's no active I/O
+        setInterval(() => {}, 60_000);
         await new Promise(() => {}); // Keep alive
       }
 
@@ -280,7 +283,10 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
   if (minFreeMemory && SPAWN_NUMERIC_RE.test(minFreeMemory)) {
     spawnArgs.push('--min-free-memory', minFreeMemory);
   }
-  const child = spawn(process.execPath, spawnArgs, spawnOpts);
+  // On Windows with shell: true, quote execPath to handle spaces
+  // in paths like "C:\Program Files\nodejs\node.exe" (#1446)
+  const execPath = isWin ? `"${process.execPath}"` : process.execPath;
+  const child = spawn(execPath, spawnArgs, spawnOpts);
 
   // Get PID from spawned process directly (no shell echo needed)
   const pid = child.pid;

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -1143,11 +1143,14 @@ Analyze the above codebase context and provide your response following the forma
       env.ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || MODEL_IDS[options.model];
 
       // Spawn claude CLI process
+      // On Windows, spawn needs shell: true to resolve 'claude' as 'claude.cmd' (#1446)
+      const isWin = process.platform === 'win32';
       const child = spawn('claude', ['--print', prompt], {
         cwd: this.projectRoot,
         env,
         stdio: ['ignore', 'pipe', 'pipe'], // 'ignore' closes stdin at spawn — fixes #1395 where claude --print blocks on EOF
         windowsHide: true, // Prevent phantom console windows on Windows
+        ...(isWin ? { shell: true } : {}),
       });
 
       // Setup timeout


### PR DESCRIPTION
## Summary

Fixes 3 of 4 bugs reported in #1446 — Windows daemon and headless worker failures:

### Bug 1: Daemon ENOENT with spaced paths
`spawn(process.execPath, ...)` with `shell: true` on Windows fails when `process.execPath` contains spaces (e.g. `C:\Program Files\nodejs\node.exe`) because cmd.exe splits on unquoted spaces.

**Fix**: Quote `process.execPath` on Windows before passing to spawn.

### Bug 2: Daemon dies in quiet/detached mode
`await new Promise(() => {})` alone does not keep the Node.js event loop alive when there's no active I/O handle. The daemon exits within 1-2 seconds.

**Fix**: Add `setInterval(() => {}, 60_000)` as an active timer handle before the blocking promise.

### Bug 3: Headless workers empty output on Windows
`spawn('claude', ...)` without `shell: true` fails on Windows because `claude` is installed as `claude.cmd` — Node's `spawn` doesn't search PATH for `.cmd` extensions without shell mode.

**Fix**: Add `shell: true` to spawn options on Windows.

## Changed files

| File | Line | Change |
|------|------|--------|
| `v3/@claude-flow/cli/src/commands/daemon.ts` | 285 | Quote `process.execPath` on Windows |
| `v3/@claude-flow/cli/src/commands/daemon.ts` | 180 | Add `setInterval` keepalive in quiet mode |
| `v3/@claude-flow/cli/src/services/headless-worker-executor.ts` | 1146 | Add `shell: true` on Windows |

## Test plan

- [ ] On Windows with Node.js installed in `C:\Program Files\`: `npx ruflo daemon start` should succeed
- [ ] Daemon should stay alive in `--foreground --quiet` mode
- [ ] Headless workers should produce non-empty output on Windows
- [ ] Verify no regression on macOS/Linux (changes are Windows-only)

Ref #1446