### PR TITLE
- Add ClaudeCodePassthroughAdapter with lazy SDK import

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,81 @@
+# Ruflo — Claude Code Passthrough Setup
+
+Modified version of Ruflo (Claude Flow) that routes LLM calls through your Claude Code subscription instead of requiring a separate Anthropic API key.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 9+
+- Claude Code installed and logged in (subscription active)
+
+## Setup on a New Machine
+
+### 1. Install dependencies and build
+
+```bash
+cd ~/Documents/ruflo/v2
+npm install --legacy-peer-deps
+npx swc src -d dist --config-file .swcrc
+npm link
+```
+
+### 2. Configure a project to use Ruflo
+
+In any project directory, create `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-flow": {
+      "command": "node",
+      "args": ["<full-path-to>/ruflo/v2/bin/claude-flow.js", "mcp", "start"],
+      "type": "stdio"
+    }
+  }
+}
+```
+
+Replace `<full-path-to>` with the actual path, e.g. `/Users/yourname/Documents/ruflo/v2/bin/claude-flow.js`.
+
+### 3. Start Claude Code
+
+Open Claude Code in that project directory. It picks up `.mcp.json` automatically and connects to the Ruflo MCP server.
+
+**Do not set `ANTHROPIC_API_KEY`** — with no key present, the passthrough adapter activates and routes all LLM calls through your Claude Code subscription.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | If set, Ruflo uses direct API (original behaviour). If unset, passthrough activates. |
+| `RUFLO_USE_CLAUDE_CODE_AUTH=1` | Force passthrough mode even when an API key is present. |
+
+## How It Works
+
+When no API key is detected, the `ClaudeFlowSDKAdapter` automatically swaps in a `ClaudeCodePassthroughAdapter` that routes LLM calls through the Claude Code SDK's `query()` function. This function inherits authentication from your active Claude Code subscription — no separate API key or billing required.
+
+The detection is automatic:
+- API key present → direct Anthropic API (faster, original behaviour)
+- No API key → Claude Code passthrough (uses subscription auth)
+- `RUFLO_USE_CLAUDE_CODE_AUTH=1` → passthrough regardless
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `v2/src/sdk/claude-code-passthrough.ts` | **New file** — the passthrough adapter |
+| `v2/src/sdk/sdk-config.ts` | Auto-detects missing key, routes to passthrough |
+| `v2/src/api/claude-client-v2.5.ts` | Made `apiKey` optional |
+| `v2/src/swarm/executor-sdk.ts` | Removed forced `apiKey!` assertion |
+| `v2/src/memory/*.js` (7 stub files) | Fixed pre-existing missing module references |
+
+## Troubleshooting
+
+**MCP server won't start:**
+Ensure dependencies are installed (`npm install --legacy-peer-deps`) and the project is built (`npx swc src -d dist --config-file .swcrc`).
+
+**"Claude Code SDK not available" error:**
+The passthrough only works when Ruflo runs as an MCP server inside a Claude Code session. It cannot work standalone — Claude Code must be the parent process.
+
+**Want to use a direct API key instead:**
+Set `ANTHROPIC_API_KEY` in your environment or `.env` file. The passthrough will automatically deactivate.

--- a/v2/src/api/claude-client-v2.5.ts
+++ b/v2/src/api/claude-client-v2.5.ts
@@ -18,7 +18,7 @@ import {
 } from './claude-api-errors.js';
 
 export interface ClaudeAPIConfig {
-  apiKey: string;
+  apiKey?: string;
   apiUrl?: string;
   model?: ClaudeModel;
   temperature?: number;
@@ -92,7 +92,7 @@ export class ClaudeClientV25 extends EventEmitter {
     this.config = config;
     this.logger = logger;
 
-    // Initialize SDK adapter
+    // Initialize SDK adapter (auto-detects passthrough mode when no API key)
     this.adapter = new ClaudeFlowSDKAdapter({
       apiKey: config.apiKey,
       maxRetries: config.retryAttempts || 3,
@@ -104,9 +104,11 @@ export class ClaudeClientV25 extends EventEmitter {
     this.sdk = this.adapter.getSDK();
     this.compatibility = new SDKCompatibilityLayer(this.adapter);
 
-    this.logger?.info('Claude Client v2.5 initialized with SDK', {
+    const mode = this.adapter.isUsingPassthrough() ? 'Claude Code passthrough' : 'direct API';
+    this.logger?.info(`Claude Client v2.5 initialized (${mode})`, {
       model: config.model,
-      swarmMode: config.enableSwarmMode
+      swarmMode: config.enableSwarmMode,
+      passthrough: this.adapter.isUsingPassthrough(),
     });
   }
 

--- a/v2/src/sdk/claude-code-passthrough.ts
+++ b/v2/src/sdk/claude-code-passthrough.ts
@@ -1,0 +1,320 @@
+/**
+ * Claude Code Passthrough Adapter
+ *
+ * Routes LLM calls through the Claude Code SDK's query() function,
+ * which uses the user's existing Claude Code subscription auth.
+ * No separate ANTHROPIC_API_KEY required.
+ *
+ * The Claude Code SDK is loaded lazily (dynamic import) so this module
+ * can be imported even when the SDK isn't installed — it only needs
+ * to be present at runtime when passthrough is actually used.
+ */
+
+// Lazy-loaded SDK reference
+let _query: any = null;
+
+async function getQuery(): Promise<any> {
+  if (!_query) {
+    try {
+      const sdk = await import('@anthropic-ai/claude-code/sdk');
+      _query = sdk.query;
+    } catch (err) {
+      throw new Error(
+        '[Passthrough] Claude Code SDK not available. ' +
+        'Ensure you are running inside Claude Code, or install @anthropic-ai/claude-code. ' +
+        `Original error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  return _query;
+}
+
+export interface PassthroughMessage {
+  id: string;
+  type: 'message';
+  role: 'assistant';
+  content: Array<{ type: 'text'; text: string }>;
+  model: string;
+  stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence';
+  stop_sequence?: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+export interface PassthroughRequest {
+  model?: string;
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  system?: string;
+  max_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  stop_sequences?: string[];
+  stream?: boolean;
+}
+
+/**
+ * Detect whether we're running inside a Claude Code environment
+ * and can use the SDK's query() for auth passthrough.
+ */
+export function isClaudeCodeEnvironment(): boolean {
+  return !!(
+    process.env.CLAUDE_CODE === '1' ||
+    process.env.CLAUDE_CODE_SDK === '1' ||
+    process.env.CLAUDE_SESSION_ID ||
+    process.env.CLAUDE_CODE_ENTRYPOINT
+  );
+}
+
+/**
+ * Detect whether we should use the passthrough adapter.
+ * True when: no API key is available, OR explicitly opted in.
+ */
+export function shouldUsePassthrough(): boolean {
+  // Explicit opt-in always wins
+  if (process.env.RUFLO_USE_CLAUDE_CODE_AUTH === '1') {
+    return true;
+  }
+
+  // If an API key is set, prefer direct API (faster, no CLI overhead)
+  const hasApiKey = !!(
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.CLAUDE_API_KEY
+  );
+
+  if (hasApiKey) {
+    return false;
+  }
+
+  // No API key — use Claude Code passthrough
+  return true;
+}
+
+/**
+ * Claude Code Passthrough Adapter
+ *
+ * Implements the same message-creation interface as ClaudeFlowSDKAdapter
+ * but routes through Claude Code's query() function, which inherits
+ * the user's subscription authentication.
+ */
+export class ClaudeCodePassthroughAdapter {
+  private swarmMetadata: Map<string, Record<string, unknown>> = new Map();
+  private swarmMode: boolean;
+
+  constructor(options: { swarmMode?: boolean } = {}) {
+    this.swarmMode = options.swarmMode !== false;
+  }
+
+  /**
+   * Create a message by routing through Claude Code SDK query().
+   */
+  async createMessage(params: PassthroughRequest): Promise<PassthroughMessage> {
+    const queryFn = await getQuery();
+    const prompt = this.buildQueryPrompt(params);
+    const startTime = Date.now();
+
+    const queryInstance = queryFn({
+      prompt,
+      options: {
+        maxTurns: 1,
+        systemPrompt: params.system || undefined,
+        allowedTools: [],
+      },
+    });
+
+    let resultText = '';
+    let model = params.model || 'claude-sonnet-4-20250514';
+
+    for await (const message of queryInstance) {
+      if (message.type === 'assistant') {
+        if (typeof message.message === 'string') {
+          resultText += message.message;
+        } else if (Array.isArray(message.message)) {
+          for (const block of message.message) {
+            if (block.type === 'text') {
+              resultText += block.text;
+            }
+          }
+        }
+      } else if (message.type === 'result') {
+        if (message.result && typeof message.result === 'string') {
+          resultText = message.result;
+        } else if (message.result?.text) {
+          resultText = message.result.text;
+        }
+        if (message.model) {
+          model = message.model;
+        }
+      }
+    }
+
+    const executionTime = Date.now() - startTime;
+    const estimatedInputTokens = Math.ceil(prompt.length / 4);
+    const estimatedOutputTokens = Math.ceil(resultText.length / 4);
+
+    const response: PassthroughMessage = {
+      id: `msg_passthrough_${Date.now()}`,
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: resultText }],
+      model,
+      stop_reason: 'end_turn',
+      usage: {
+        input_tokens: estimatedInputTokens,
+        output_tokens: estimatedOutputTokens,
+      },
+    };
+
+    if (this.swarmMode && response.id) {
+      this.swarmMetadata.set(response.id, {
+        timestamp: Date.now(),
+        model,
+        tokensUsed: response.usage,
+        executionTime,
+        passthrough: true,
+      });
+    }
+
+    return response;
+  }
+
+  /**
+   * Create a streaming message via passthrough.
+   */
+  async createStreamingMessage(
+    params: PassthroughRequest,
+    options?: { onChunk?: (chunk: any) => void }
+  ): Promise<PassthroughMessage> {
+    const queryFn = await getQuery();
+    const prompt = this.buildQueryPrompt(params);
+
+    const queryInstance = queryFn({
+      prompt,
+      options: {
+        maxTurns: 1,
+        systemPrompt: params.system || undefined,
+        allowedTools: [],
+      },
+    });
+
+    let resultText = '';
+    let model = params.model || 'claude-sonnet-4-20250514';
+
+    for await (const message of queryInstance) {
+      if (message.type === 'assistant') {
+        let chunkText = '';
+        if (typeof message.message === 'string') {
+          chunkText = message.message;
+        } else if (Array.isArray(message.message)) {
+          for (const block of message.message) {
+            if (block.type === 'text') {
+              chunkText += block.text;
+            }
+          }
+        }
+
+        resultText += chunkText;
+
+        if (options?.onChunk && chunkText) {
+          options.onChunk({
+            type: 'content_block_delta',
+            delta: { text: chunkText },
+          });
+        }
+      } else if (message.type === 'result') {
+        if (message.result && typeof message.result === 'string') {
+          resultText = message.result;
+        }
+        if (message.model) {
+          model = message.model;
+        }
+      }
+    }
+
+    const estimatedInputTokens = Math.ceil(prompt.length / 4);
+    const estimatedOutputTokens = Math.ceil(resultText.length / 4);
+
+    return {
+      id: `msg_passthrough_${Date.now()}`,
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: resultText }],
+      model,
+      stop_reason: 'end_turn',
+      usage: {
+        input_tokens: estimatedInputTokens,
+        output_tokens: estimatedOutputTokens,
+      },
+    };
+  }
+
+  /**
+   * Build a query prompt from the request parameters.
+   */
+  private buildQueryPrompt(params: PassthroughRequest): string {
+    const parts: string[] = [];
+
+    for (const msg of params.messages) {
+      if (msg.role === 'user') {
+        parts.push(msg.content);
+      } else if (msg.role === 'assistant') {
+        parts.push(`[Previous assistant response]: ${msg.content}`);
+      }
+    }
+
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Validate that Claude Code SDK is accessible.
+   */
+  async validateConfiguration(): Promise<boolean> {
+    try {
+      const queryFn = await getQuery();
+
+      const testQuery = queryFn({
+        prompt: 'Reply with just the word "ok".',
+        options: {
+          maxTurns: 1,
+          allowedTools: [],
+        },
+      });
+
+      for await (const message of testQuery) {
+        if (message.type === 'result') {
+          return true;
+        }
+      }
+
+      return true;
+    } catch (error) {
+      console.error('[Passthrough] Claude Code SDK validation failed:', error);
+      return false;
+    }
+  }
+
+  getSwarmMetadata(messageId: string): Record<string, unknown> | undefined {
+    return this.swarmMetadata.get(messageId);
+  }
+
+  clearSwarmMetadata(): void {
+    this.swarmMetadata.clear();
+  }
+
+  getUsageStats(): { totalTokens: number; messageCount: number } {
+    let totalTokens = 0;
+    let messageCount = 0;
+
+    this.swarmMetadata.forEach((metadata) => {
+      if (metadata.tokensUsed) {
+        const usage = metadata.tokensUsed as { input_tokens: number; output_tokens: number };
+        totalTokens += (usage.input_tokens || 0) + (usage.output_tokens || 0);
+        messageCount++;
+      }
+    });
+
+    return { totalTokens, messageCount };
+  }
+}

--- a/v2/src/sdk/sdk-config.ts
+++ b/v2/src/sdk/sdk-config.ts
@@ -4,9 +4,19 @@
  *
  * This module provides the configuration adapter for integrating
  * the Anthropic SDK as the foundation layer for Claude-Flow.
+ *
+ * When no ANTHROPIC_API_KEY is available, automatically falls back
+ * to the Claude Code SDK passthrough adapter, which uses the user's
+ * existing Claude Code subscription for authentication.
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import {
+  ClaudeCodePassthroughAdapter,
+  shouldUsePassthrough,
+  type PassthroughMessage,
+  type PassthroughRequest,
+} from './claude-code-passthrough.js';
 
 export interface SDKConfiguration {
   apiKey?: string;
@@ -24,12 +34,17 @@ export interface SDKConfiguration {
 
 /**
  * Claude-Flow SDK Adapter
- * Wraps the Anthropic SDK with Claude-Flow extensions
+ * Wraps the Anthropic SDK with Claude-Flow extensions.
+ *
+ * Automatically detects whether to use direct Anthropic API (with key)
+ * or Claude Code passthrough (subscription auth, no key needed).
  */
 export class ClaudeFlowSDKAdapter {
-  private sdk: Anthropic;
+  private sdk: Anthropic | null = null;
+  private passthrough: ClaudeCodePassthroughAdapter | null = null;
   private config: SDKConfiguration;
   private swarmMetadata: Map<string, Record<string, unknown>> = new Map();
+  private usingPassthrough: boolean;
 
   constructor(config: SDKConfiguration = {}) {
     this.config = {
@@ -44,21 +59,49 @@ export class ClaudeFlowSDKAdapter {
       memoryNamespace: config.memoryNamespace || 'claude-flow'
     };
 
-    // Initialize Anthropic SDK with configuration
-    this.sdk = new Anthropic({
-      apiKey: this.config.apiKey,
-      baseURL: this.config.baseURL,
-      maxRetries: this.config.maxRetries,
-      timeout: this.config.timeout,
-      defaultHeaders: this.config.defaultHeaders
-    });
+    // Decide which execution path to use
+    this.usingPassthrough = shouldUsePassthrough();
+
+    if (this.usingPassthrough) {
+      // No API key — route through Claude Code subscription
+      console.log('[SDK] No ANTHROPIC_API_KEY detected. Using Claude Code subscription passthrough.');
+      this.passthrough = new ClaudeCodePassthroughAdapter({
+        swarmMode: this.config.swarmMode,
+      });
+    } else {
+      // Standard path — direct Anthropic SDK with API key
+      this.sdk = new Anthropic({
+        apiKey: this.config.apiKey,
+        baseURL: this.config.baseURL,
+        maxRetries: this.config.maxRetries,
+        timeout: this.config.timeout,
+        defaultHeaders: this.config.defaultHeaders
+      });
+    }
   }
 
   /**
-   * Get the underlying Anthropic SDK instance
+   * Whether this adapter is using Claude Code passthrough (no API key)
+   */
+  isUsingPassthrough(): boolean {
+    return this.usingPassthrough;
+  }
+
+  /**
+   * Get the underlying Anthropic SDK instance.
+   * Returns null if using passthrough mode.
    */
   getSDK(): Anthropic {
-    return this.sdk;
+    if (this.usingPassthrough) {
+      // Return a dummy Anthropic instance for type compatibility.
+      // Callers should use createMessage() instead of accessing the SDK directly.
+      console.warn(
+        '[SDK] getSDK() called in passthrough mode. Use createMessage() for LLM calls.'
+      );
+      // Create a minimal instance — it won't be used for actual API calls
+      return new Anthropic({ apiKey: 'passthrough-mode-no-key-needed' });
+    }
+    return this.sdk!;
   }
 
   /**
@@ -69,14 +112,24 @@ export class ClaudeFlowSDKAdapter {
   }
 
   /**
-   * Create a message with automatic retry handling
+   * Create a message with automatic retry handling.
+   * Routes through passthrough if no API key is available.
    */
   async createMessage(params: Anthropic.MessageCreateParams): Promise<Anthropic.Message> {
-    try {
-      // SDK handles retry automatically based on configuration
-      const message = await this.sdk.messages.create(params);
+    if (this.usingPassthrough && this.passthrough) {
+      return this.createMessageViaPassthrough(params);
+    }
 
-      // Store in swarm metadata if in swarm mode
+    return this.createMessageViaDirect(params);
+  }
+
+  /**
+   * Direct Anthropic SDK path (original behaviour)
+   */
+  private async createMessageViaDirect(params: Anthropic.MessageCreateParams): Promise<Anthropic.Message> {
+    try {
+      const message = await this.sdk!.messages.create(params) as Anthropic.Message;
+
       if (this.config.swarmMode && message.id) {
         this.swarmMetadata.set(message.id, {
           timestamp: Date.now(),
@@ -87,9 +140,52 @@ export class ClaudeFlowSDKAdapter {
 
       return message;
     } catch (error) {
-      // Enhanced error handling for swarm mode
       if (this.config.swarmMode) {
         console.error('[SDK] Message creation failed in swarm mode:', error);
+        this.logSwarmError(error);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Claude Code passthrough path (subscription auth)
+   */
+  private async createMessageViaPassthrough(params: Anthropic.MessageCreateParams): Promise<Anthropic.Message> {
+    try {
+      // Convert Anthropic SDK params to passthrough format
+      const passthroughRequest: PassthroughRequest = {
+        model: params.model as string,
+        messages: (params.messages as Array<{ role: 'user' | 'assistant'; content: string }>).map(m => ({
+          role: m.role as 'user' | 'assistant',
+          content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        })),
+        system: typeof params.system === 'string' ? params.system : undefined,
+        max_tokens: params.max_tokens,
+        temperature: params.temperature ?? undefined,
+        top_p: params.top_p ?? undefined,
+        top_k: params.top_k ?? undefined,
+        stop_sequences: params.stop_sequences ?? undefined,
+      };
+
+      const response = await this.passthrough!.createMessage(passthroughRequest);
+
+      // Convert to Anthropic.Message shape for compatibility
+      const message = response as unknown as Anthropic.Message;
+
+      if (this.config.swarmMode && message.id) {
+        this.swarmMetadata.set(message.id, {
+          timestamp: Date.now(),
+          model: params.model,
+          tokensUsed: message.usage,
+          passthrough: true,
+        });
+      }
+
+      return message;
+    } catch (error) {
+      if (this.config.swarmMode) {
+        console.error('[SDK] Passthrough message creation failed in swarm mode:', error);
         this.logSwarmError(error);
       }
       throw error;
@@ -103,7 +199,29 @@ export class ClaudeFlowSDKAdapter {
     params: Anthropic.MessageCreateParams,
     options?: { onChunk?: (chunk: any) => void }
   ): Promise<Anthropic.Message> {
-    const stream = await this.sdk.messages.create({
+    if (this.usingPassthrough && this.passthrough) {
+      const passthroughRequest: PassthroughRequest = {
+        model: params.model as string,
+        messages: (params.messages as Array<{ role: 'user' | 'assistant'; content: string }>).map(m => ({
+          role: m.role as 'user' | 'assistant',
+          content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        })),
+        system: typeof params.system === 'string' ? params.system : undefined,
+        max_tokens: params.max_tokens,
+        temperature: params.temperature ?? undefined,
+        stream: true,
+      };
+
+      const response = await this.passthrough.createStreamingMessage(
+        passthroughRequest,
+        options
+      );
+
+      return response as unknown as Anthropic.Message;
+    }
+
+    // Direct SDK streaming path
+    const stream = await this.sdk!.messages.create({
       ...params,
       stream: true
     });
@@ -115,13 +233,11 @@ export class ClaudeFlowSDKAdapter {
         options.onChunk(chunk);
       }
 
-      // Accumulate the message
       if (chunk.type === 'message_start') {
         fullMessage = chunk.message;
       } else if (chunk.type === 'content_block_delta') {
         // Handle content updates
       } else if (chunk.type === 'message_delta') {
-        // Handle message updates
         if (chunk.delta?.stop_reason) {
           fullMessage.stop_reason = chunk.delta.stop_reason;
         }
@@ -135,9 +251,12 @@ export class ClaudeFlowSDKAdapter {
    * Check if the SDK is properly configured
    */
   async validateConfiguration(): Promise<boolean> {
+    if (this.usingPassthrough && this.passthrough) {
+      return this.passthrough.validateConfiguration();
+    }
+
     try {
-      // Test the configuration with a minimal request
-      await this.sdk.messages.create({
+      await this.sdk!.messages.create({
         model: 'claude-3-haiku-20240307',
         max_tokens: 1,
         messages: [{ role: 'user', content: 'test' }]
@@ -193,7 +312,7 @@ export class ClaudeFlowSDKAdapter {
 
     this.swarmMetadata.forEach((metadata) => {
       if (metadata.tokensUsed) {
-        totalTokens += metadata.tokensUsed.total_tokens || 0;
+        totalTokens += (metadata.tokensUsed as any).total_tokens || 0;
         messageCount++;
       }
     });

--- a/v2/src/swarm/executor-sdk.ts
+++ b/v2/src/swarm/executor-sdk.ts
@@ -63,7 +63,7 @@ export class TaskExecutorSDK extends EventEmitter {
 
     this.logger = new Logger('TaskExecutorSDK');
 
-    // Initialize SDK adapter
+    // Initialize SDK adapter (auto-detects passthrough when no API key)
     this.sdkAdapter = new ClaudeFlowSDKAdapter({
       apiKey: this.config.apiKey,
       maxRetries: this.config.maxRetries,
@@ -72,15 +72,16 @@ export class TaskExecutorSDK extends EventEmitter {
       checkpointInterval: this.config.checkpointInterval
     });
 
-    // Initialize Claude client with SDK
+    // Initialize Claude client (passthrough mode activates automatically)
     this.claudeClient = new ClaudeClientV25({
-      apiKey: this.config.apiKey!,
+      apiKey: this.config.apiKey,
       retryAttempts: this.config.maxRetries,
       timeout: this.config.timeout,
       enableSwarmMode: this.config.swarmMode
     }, this.logger);
 
-    this.logger.info('Task Executor SDK initialized', {
+    const mode = this.sdkAdapter.isUsingPassthrough() ? 'Claude Code passthrough' : 'direct API';
+    this.logger.info(`Task Executor SDK initialized (${mode})`, {
       swarmMode: this.config.swarmMode,
       maxRetries: this.config.maxRetries
     });


### PR DESCRIPTION
- Auto-detect missing API key in ClaudeFlowSDKAdapter and switch modes
- Make apiKey optional in ClaudeClientV25 and TaskExecutorSDK
- Support explicit opt-in via RUFLO_USE_CLAUDE_CODE_AUTH=1