### PR TITLE
fix: quote process.execPath for headless workers on Windows (#1446)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -280,7 +280,7 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
   if (minFreeMemory && SPAWN_NUMERIC_RE.test(minFreeMemory)) {
     spawnArgs.push('--min-free-memory', minFreeMemory);
   }
-  const child = spawn(process.execPath, spawnArgs, spawnOpts);
+  const child = spawn(isWin ? `"${process.execPath}"` : process.execPath, spawnArgs, spawnOpts);
 
   // Get PID from spawned process directly (no shell echo needed)
   const pid = child.pid;


### PR DESCRIPTION
Fixes #1446. The daemon's `spawn(process.execPath, ...)` can crash with `ENOENT` on Windows if the Node.js installation path contains spaces (e.g. `C:\\Program Files\\nodejs\\node.exe`). Since `shell: true` is used on Windows, the path must be quoted to avoid syntax errors in `cmd.exe`.\n\n*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*\n\n