### PR TITLE
Security audit & pin agent-browser version in postinstall

### DIFF
--- a/docs/security/API-KEY-AUDIT-2026-03-26.md
+++ b/docs/security/API-KEY-AUDIT-2026-03-26.md
@@ -1,0 +1,43 @@
+# API Key & Secrets Security Audit
+
+**Date:** 2026-03-26
+**Scope:** Full repository scan for leaked API keys, hardcoded secrets, and supply chain risks
+**Triggered by:** Python supply chain attack advisory
+
+## Result: CLEAN - No Real API Keys Leaked
+
+### Scan Coverage
+
+| Pattern | Matches | Status |
+|---------|---------|--------|
+| Real API keys (`sk-ant-*`, `AKIA*`, `ghp_*`, `github_pat_*`) | 0 real | PASS |
+| Hardcoded passwords in source code | 0 real | PASS |
+| Private keys (RSA/EC/DSA) | 0 real | PASS |
+| Committed `.env` files | 0 | PASS |
+| Live JWT tokens | 0 | PASS |
+| Pinata/IPFS credentials | 0 | PASS |
+
+### False Positives (Reviewed & Safe)
+
+- **Documentation placeholders**: `sk-ant-...`, `hf_***`, `your_api_key` in ADR docs, CLAUDE.md, SKILL.md files
+- **Secret-detection test fixtures**: Synthetic keys in `v3/@claude-flow/guidance/tests/`, `v3/plugins/code-intelligence/tests/`, `v3/plugins/agentic-qe/__tests__/`
+- **Example app defaults**: `dev-secret-key` in `v2/examples/flask-api-sparc/src/config.py` (example only, not production)
+
+### Minor Recommendations
+
+1. **`ruflo/docker-compose.yml:100`** — Change `OPENAI_API_KEY=${OPENAI_API_KEY:-sk-placeholder}` to use empty string default
+2. **`v3/@claude-flow/browser/package.json`** — Pin `agent-browser` version in postinstall instead of `@latest` (supply chain hardening)
+3. **Run `npm audit`** periodically across all package.json files
+
+### Supply Chain Review
+
+| File | Script | Verdict |
+|------|--------|---------|
+| `v2/package.json` postinstall | Rebuilds better-sqlite3 + local fixup scripts | SAFE |
+| `v2/package.json` preinstall | Windows warning message only | SAFE |
+| `v3/@claude-flow/browser/package.json` postinstall | `npm install -g agent-browser@latest` | LOW RISK — pin version recommended |
+| `ruflo/src/ruvocal/package.json` prepare | `husky` git hooks | SAFE |
+
+### .gitignore Verification
+
+`.env` is properly listed in `.gitignore` (lines 61, 161). No `.env` files exist in the repository.

--- a/v3/@claude-flow/browser/package.json
+++ b/v3/@claude-flow/browser/package.json
@@ -19,7 +19,7 @@
     "test:e2e": "vitest run tests/e2e",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "postinstall": "node -e \"const{execSync}=require('child_process');try{execSync('agent-browser --version',{stdio:'ignore'});}catch{console.log('\\n📦 Installing agent-browser globally...');try{execSync('npm install -g agent-browser@latest',{stdio:'inherit'});console.log('✅ agent-browser installed successfully!');}catch(e){console.log('⚠️  Could not install agent-browser globally. Run manually:\\n   npm install -g agent-browser@latest');}}\""
+    "postinstall": "node -e \"const{execSync}=require('child_process');try{execSync('agent-browser --version',{stdio:'ignore'});}catch{console.log('\\n📦 Installing agent-browser globally...');try{execSync('npm install -g agent-browser@0.6.0',{stdio:'inherit'});console.log('✅ agent-browser installed successfully!');}catch(e){console.log('⚠️  Could not install agent-browser globally. Run manually:\\n   npm install -g agent-browser@0.6.0');}}\""
   },
   "dependencies": {
     "agent-browser": "^0.6.0",


### PR DESCRIPTION
## Summary

This PR documents a comprehensive security audit of the repository and implements a supply chain hardening recommendation by pinning the `agent-browser` package version in the postinstall script.

## Changes

- **Added security audit report** (`docs/security/API-KEY-AUDIT-2026-03-26.md`): Documents a full repository scan for leaked API keys, hardcoded secrets, and supply chain risks. Results show no real credentials were leaked, with all matches being safe documentation placeholders or test fixtures.

- **Pinned agent-browser version**: Updated `v3/@claude-flow/browser/package.json` postinstall script to install `agent-browser@0.6.0` instead of `@latest`, reducing supply chain attack surface by ensuring deterministic dependency installation.

## Implementation Details

The postinstall script change replaces two instances of `agent-browser@latest` with the pinned version `agent-browser@0.6.0` (matching the version constraint already specified in dependencies). This prevents unexpected major version updates during installation and aligns with the audit's supply chain hardening recommendations.

The security audit confirms:
- ✅ No real API keys or credentials committed
- ✅ No hardcoded passwords in source code
- ✅ No private keys or `.env` files in repository
- ✅ All false positives are safe documentation/test fixtures

