### PR TITLE
fix(cli): remove CommonJS require from autopilot ESM modules

### DIFF
--- a/v3/@claude-flow/cli/__tests__/autopilot.test.ts
+++ b/v3/@claude-flow/cli/__tests__/autopilot.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:crypto', () => ({
+  randomUUID: vi.fn(() => 'session-test-id'),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  renameSync: vi.fn(),
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    writeln: vi.fn(),
+    printJson: vi.fn(),
+    success: (str: string) => str,
+    bold: (str: string) => str,
+    dim: (str: string) => str,
+  },
+}));
+
+import { output } from '../src/output.js';
+import { autopilotCommand } from '../src/commands/autopilot.js';
+
+describe('autopilot command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs status in ESM mode without require errors', async () => {
+    const statusCommand = autopilotCommand.subcommands?.find(command => command.name === 'status');
+
+    const result = await statusCommand?.action?.({
+      args: [],
+      flags: {},
+      cwd: process.cwd(),
+      interactive: false,
+      config: {},
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(output.writeln).toHaveBeenCalledWith('Autopilot: ✗ DISABLED');
+    expect(output.writeln).toHaveBeenCalledWith('Session: session-...');
+  });
+});

--- a/v3/@claude-flow/cli/src/autopilot-state.ts
+++ b/v3/@claude-flow/cli/src/autopilot-state.ts
@@ -8,6 +8,11 @@
  * Security: Addresses prototype pollution, NaN bypass, input validation
  */
 
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 // ── Constants ─────────────────────────────────────────────────
 
 export const STATE_DIR = '.claude-flow/data';
@@ -113,7 +118,6 @@ export function validateTaskSources(sources: unknown): string[] {
 // ── State Management ──────────────────────────────────────────
 
 export function getDefaultState(): AutopilotState {
-  const crypto = require('crypto') as typeof import('crypto');
   return {
     sessionId: crypto.randomUUID(),
     enabled: false,
@@ -128,8 +132,6 @@ export function getDefaultState(): AutopilotState {
 }
 
 export function loadState(): AutopilotState {
-  const fs = require('fs') as typeof import('fs');
-  const path = require('path') as typeof import('path');
   const filePath = path.resolve(STATE_FILE);
   const defaults = getDefaultState();
   try {
@@ -154,8 +156,6 @@ export function loadState(): AutopilotState {
 }
 
 export function saveState(state: AutopilotState): void {
-  const fs = require('fs') as typeof import('fs');
-  const path = require('path') as typeof import('path');
   const dir = path.resolve(STATE_DIR);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   // Cap history before saving
@@ -168,8 +168,6 @@ export function saveState(state: AutopilotState): void {
 }
 
 export function appendLog(entry: AutopilotLogEntry): void {
-  const fs = require('fs') as typeof import('fs');
-  const path = require('path') as typeof import('path');
   const filePath = path.resolve(LOG_FILE);
   const dir = path.resolve(STATE_DIR);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -190,8 +188,6 @@ export function appendLog(entry: AutopilotLogEntry): void {
 }
 
 export function loadLog(): AutopilotLogEntry[] {
-  const fs = require('fs') as typeof import('fs');
-  const path = require('path') as typeof import('path');
   const filePath = path.resolve(LOG_FILE);
   try {
     if (fs.existsSync(filePath)) {
@@ -207,9 +203,6 @@ export function loadLog(): AutopilotLogEntry[] {
 // ── Task Discovery ────────────────────────────────────────────
 
 export function discoverTasks(sources: string[]): TaskInfo[] {
-  const fs = require('fs') as typeof import('fs');
-  const path = require('path') as typeof import('path');
-  const os = require('os') as typeof import('os');
   const tasks: TaskInfo[] = [];
 
   // Only process valid sources

--- a/v3/@claude-flow/cli/src/commands/autopilot.ts
+++ b/v3/@claude-flow/cli/src/commands/autopilot.ts
@@ -5,6 +5,8 @@
  * ADR-072: Autopilot Integration
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import {
@@ -212,8 +214,6 @@ const logCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     if (ctx.flags?.clear) {
-      const fs = require('fs') as typeof import('fs');
-      const path = require('path') as typeof import('path');
       try { fs.writeFileSync(path.resolve(LOG_FILE), '[]'); } catch { /* ignore */ }
       output.writeln('Autopilot log cleared');
       return { success: true };


### PR DESCRIPTION
## Summary
- replace runtime `require()` calls in autopilot ESM modules with native `node:` imports
- remove CommonJS usage from `autopilot-state.ts` and the log clear path in `commands/autopilot.ts`
- add a regression test covering `autopilot status`

## Why
`@claude-flow/cli` is published as an ESM package (`"type": "module"`), but the autopilot code path still uses `require()`. On `3.5.48` this makes autopilot commands fail at runtime with `ReferenceError: require is not defined`.

## Validation
- `cd v3 && pnpm --filter @claude-flow/cli test -- autopilot.test.ts`