### PR TITLE
fix(daemon): prevent self-PID detection causing immediate exit

### DIFF
--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -95,10 +95,11 @@ const startCommand: Command = {
         fs.mkdirSync(stateDir, { recursive: true });
       }
 
-      // Write PID file for foreground mode
-      fs.writeFileSync(pidFile, String(process.pid));
-
       // Clean up PID file on exit
+      // NOTE: do NOT write daemon.pid here. WorkerDaemon.start() is the sole
+      // writer via writePidFile(). Writing it before startDaemon() causes
+      // checkExistingDaemon() to see the current process as "already running",
+      // skip scheduling workers, drain the event loop, and exit with code 0.
       const cleanup = () => {
         try {
           if (fs.existsSync(pidFile)) {

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -458,6 +458,12 @@ export class WorkerDaemon extends EventEmitter {
     try {
       const pid = parseInt(readFileSync(this.pidFile, 'utf-8').trim(), 10);
       if (isNaN(pid)) return null;
+      // If the PID file contains our own PID we are the daemon, not a conflict.
+      // This guards against the foreground command writing daemon.pid before
+      // calling startDaemon(), which would cause start() to see itself as
+      // "already running" and skip scheduling workers entirely — leaving the
+      // event loop empty and the process exiting immediately with code 0.
+      if (pid === process.pid) return null;
       // Check if process is alive (signal 0 = existence check)
       process.kill(pid, 0);
       return pid; // Process is alive


### PR DESCRIPTION
## Problem

`daemon start` reports success but `daemon status` immediately shows STOPPED.
The daemon process exits silently with code 0. Affects Linux, macOS, and Windows.
Reported in #1039, symptoms also visible in #984.

## Root Cause

The foreground command writes `daemon.pid` with the current process PID *before*
calling `startDaemon()`. When `WorkerDaemon.start()` runs `checkExistingDaemon()`,
it reads that file, finds the current process's own PID, calls `process.kill(pid, 0)`
on itself (which always succeeds), and concludes a daemon is already running —
returning early without scheduling any workers.

With no timers scheduled, the Node.js event loop has nothing to do and the process
exits with code 0. The daemon never ran.

## Fix (belt and suspenders)

1. **Root cause** (`daemon.ts`): Remove the premature `daemon.pid` write.
   `WorkerDaemon.writePidFile()` inside `start()` is the correct and only writer.
   The `process.on('exit', cleanup)` handler remains as a crash safety net.

2. **Defensive guard** (`worker-daemon.ts`): In `checkExistingDaemon()`, skip
   the conflict check when the stored PID equals `process.pid`. A process cannot
   conflict with itself.

## Testing

Verified on Ubuntu 24.04 via SSH. After fix:
- `daemon start` → process stays alive (confirmed via `ps aux`)
- `daemon status` → shows `● RUNNING (background)`  
- Workers begin executing (map worker ran within 10s)