### PR TITLE
fix(daemon): prevent self-PID detection from killing background daemon

### DIFF
--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -458,6 +458,12 @@ export class WorkerDaemon extends EventEmitter {
     try {
       const pid = parseInt(readFileSync(this.pidFile, 'utf-8').trim(), 10);
       if (isNaN(pid)) return null;
+      // Don't treat our own process as an existing daemon — the foreground
+      // child writes its PID to daemon.pid before start() is called, so
+      // without this check the daemon always thinks "another" instance is
+      // already running and skips worker scheduling, causing the process
+      // to exit immediately (no event-loop refs).
+      if (pid === process.pid) return null;
       // Check if process is alive (signal 0 = existence check)
       process.kill(pid, 0);
       return pid; // Process is alive


### PR DESCRIPTION
## Summary

- Background daemon exits immediately after starting on every Linux/macOS install
- `checkExistingDaemon()` reads `daemon.pid` (written by the forked child itself), finds the PID alive (it's checking itself via `process.kill(pid, 0)`), and returns early — skipping all worker scheduling
- With no timers/refs in the event loop, Node.js exits cleanly (code 0)
- Fix: skip self-PID in `checkExistingDaemon()` so the daemon doesn't mistake itself for another instance

## Reproduction

```bash
ruflo daemon start        # Reports success
ruflo daemon status       # Shows STOPPED — process already exited
```

With `strace -f`, you can see the child process exits with `exit_group(0)` moments after starting.

## Fix

One-line guard in `checkExistingDaemon()`:

```typescript
if (pid === process.pid) return null;
```

## Test plan

- [x] `ruflo daemon start` → process stays alive
- [x] `ruflo daemon status` → shows Running
- [x] `ruflo doctor` → Daemon Status passes
- [x] Starting a second daemon still correctly detects the first and skips
