### PR TITLE
feat: add cross-project session cost tracking ledger

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -632,3 +632,105 @@ enabled = true
 - Issues: https://github.com/ruvnet/claude-flow/issues
 
 **Remember: Codex executes, claude-flow orchestrates!**
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **ruflo** (43152 symbols, 114684 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/ruflo/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/ruflo/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/ruflo/clusters` | All functional areas |
+| `gitnexus://repo/ruflo/processes` | All execution flows |
+| `gitnexus://repo/ruflo/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1048,3 +1048,105 @@ Registry source: IPFS via Pinata (`QmXbfEAaR7D2Ujm4GAkbwcGZQMHqAMpwDoje4583uNP83
 ---
 
 Remember: **Claude Flow coordinates, Claude Code creates!**
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **ruflo** (43152 symbols, 114684 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/ruflo/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/ruflo/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/ruflo/clusters` | All functional areas |
+| `gitnexus://repo/ruflo/processes` | All execution flows |
+| `gitnexus://repo/ruflo/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -26,6 +26,7 @@ import {
   generateHookHandler,
   generateIntelligenceStub,
   generateAutoMemoryHook,
+  generateCostLedger,
 } from './helpers-generator.js';
 import { generateClaudeMd } from './claudemd-generator.js';
 
@@ -452,6 +453,22 @@ export async function executeUpgrade(targetDir: string, upgradeSettings = false)
         try { fs.chmodSync(targetPath, '755'); } catch {}
       }
     }
+
+    // 0b. Install cost-ledger globally (~/.claude/helpers/) so it works cross-project
+    try {
+      const { generateCostLedger } = await import('./helpers-generator.js');
+      const costContent = generateCostLedger();
+      const globalHelpersDir = path.join(require('os').homedir(), '.claude', 'helpers');
+      if (!fs.existsSync(globalHelpersDir)) fs.mkdirSync(globalHelpersDir, { recursive: true });
+      const globalCostPath = path.join(globalHelpersDir, 'cost-ledger.cjs');
+      fs.writeFileSync(globalCostPath, costContent, 'utf-8');
+      try { fs.chmodSync(globalCostPath, '755'); } catch {}
+      // Also install to project helpers
+      const projectCostPath = path.join(targetDir, '.claude', 'helpers', 'cost-ledger.cjs');
+      fs.writeFileSync(projectCostPath, costContent, 'utf-8');
+      try { fs.chmodSync(projectCostPath, '755'); } catch {}
+      result.created.push('.claude/helpers/cost-ledger.cjs');
+    } catch { /* non-fatal */ }
 
     // 1. ALWAYS update statusline helper (force overwrite)
     const statuslinePath = path.join(targetDir, '.claude', 'helpers', 'statusline.cjs');

--- a/v3/@claude-flow/cli/src/init/helpers-generator.ts
+++ b/v3/@claude-flow/cli/src/init/helpers-generator.ts
@@ -504,6 +504,19 @@ export function generateHookHandler(): string {
     '  },',
     '',
     "  'session-end': () => {",
+    '    // Record session cost to global ledger',
+    '    try {',
+    "      var ledgerPath = path.join(require('os').homedir(), '.claude', 'helpers', 'cost-ledger.cjs');",
+    '      if (fs.existsSync(ledgerPath)) {',
+    "        var { execSync } = require('child_process');",
+    '        execSync("node \\"" + ledgerPath + "\\" record", {',
+    '          input: JSON.stringify(hookInput) || "",',
+    '          timeout: 3000,',
+    "          stdio: ['pipe', 'pipe', 'pipe'],",
+    '        });',
+    '      }',
+    '    } catch (e) { /* non-fatal — cost tracking should never break session end */ }',
+    '',
     '    if (intelligence && intelligence.consolidate) {',
     '      try {',
     '        var result = intelligence.consolidate();',
@@ -1172,6 +1185,269 @@ module.exports = commands;
 /**
  * Generate all helper files
  */
+/**
+ * Generate cost-ledger.cjs — tracks session costs across all projects.
+ * Stores a JSONL ledger at ~/.claude/cost-ledger.jsonl with per-session
+ * cost, duration, model, and lines changed. Supports daily/weekly/monthly/annual reports.
+ */
+export function generateCostLedger(): string {
+  return `#!/usr/bin/env node
+/**
+ * Claude Code Cost Ledger
+ *
+ * Tracks session costs across all projects on this machine.
+ * Two modes:
+ *   1. "record" — called by session-end hook, appends cost to JSONL ledger
+ *   2. "report" — generates daily/weekly/monthly/annual summaries
+ *
+ * Ledger location: ~/.claude/cost-ledger.jsonl
+ *
+ * Usage:
+ *   node cost-ledger.cjs record          # (reads stdin from Claude Code)
+ *   node cost-ledger.cjs report          # default: last 30 days
+ *   node cost-ledger.cjs report --daily
+ *   node cost-ledger.cjs report --weekly
+ *   node cost-ledger.cjs report --monthly
+ *   node cost-ledger.cjs report --annual
+ *   node cost-ledger.cjs report --project <name>
+ *   node cost-ledger.cjs report --json
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const LEDGER_PATH = path.join(os.homedir(), '.claude', 'cost-ledger.jsonl');
+
+const c = {
+  reset: '\\x1b[0m', bold: '\\x1b[1m', dim: '\\x1b[2m',
+  red: '\\x1b[31m', green: '\\x1b[32m', yellow: '\\x1b[33m',
+  blue: '\\x1b[34m', cyan: '\\x1b[36m', white: '\\x1b[37m',
+  brightGreen: '\\x1b[1;32m', brightYellow: '\\x1b[1;33m',
+  brightCyan: '\\x1b[1;36m', brightWhite: '\\x1b[1;37m',
+};
+
+function readStdinSync() {
+  try {
+    if (process.stdin.isTTY) return null;
+    const chunks = [];
+    const buf = Buffer.alloc(4096);
+    let bytesRead;
+    try {
+      while ((bytesRead = fs.readSync(0, buf, 0, buf.length, null)) > 0) {
+        chunks.push(buf.slice(0, bytesRead));
+      }
+    } catch { /* EOF */ }
+    const raw = Buffer.concat(chunks).toString('utf-8').trim();
+    if (raw && raw.startsWith('{')) return JSON.parse(raw);
+  } catch { /* ignore */ }
+  return null;
+}
+
+function getProjectName() {
+  try {
+    const { execSync } = require('child_process');
+    const remote = execSync('git remote get-url origin 2>/dev/null', {
+      encoding: 'utf-8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    if (remote) {
+      const match = remote.match(/\\/([^/]+?)(?:\\.git)?$/);
+      if (match) return match[1];
+    }
+  } catch { /* ignore */ }
+  return path.basename(process.cwd());
+}
+
+function record() {
+  const data = readStdinSync();
+  const costUsd = (data && data.cost && data.cost.total_cost_usd)
+    || parseFloat(process.env.CLAUDE_SESSION_COST || '0');
+  const durationMs = (data && data.cost && data.cost.total_duration_ms)
+    || parseInt(process.env.CLAUDE_SESSION_DURATION_MS || '0', 10);
+  const linesAdded = (data && data.cost && data.cost.total_lines_added) || 0;
+  const linesRemoved = (data && data.cost && data.cost.total_lines_removed) || 0;
+  const model = (data && data.model && data.model.model_id)
+    || process.env.CLAUDE_MODEL || 'unknown';
+  const sessionId = (data && data.session_id)
+    || process.env.CLAUDE_SESSION_ID || 'session-' + Date.now();
+
+  if (costUsd <= 0 && durationMs <= 0) return;
+
+  const entry = {
+    date: new Date().toISOString().split('T')[0],
+    timestamp: new Date().toISOString(),
+    project: getProjectName(),
+    session_id: sessionId,
+    cost_usd: Math.round(costUsd * 100) / 100,
+    duration_min: Math.round(durationMs / 60000 * 10) / 10,
+    model: model,
+    lines_added: linesAdded,
+    lines_removed: linesRemoved,
+  };
+
+  const dir = path.dirname(LEDGER_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(LEDGER_PATH, JSON.stringify(entry) + '\\n');
+}
+
+function loadLedger() {
+  if (!fs.existsSync(LEDGER_PATH)) return [];
+  const lines = fs.readFileSync(LEDGER_PATH, 'utf-8').trim().split('\\n');
+  const entries = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try { entries.push(JSON.parse(line)); } catch { /* skip */ }
+  }
+  return entries;
+}
+
+function filterByDate(entries, days) {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffStr = cutoff.toISOString().split('T')[0];
+  return entries.filter(e => e.date >= cutoffStr);
+}
+
+function groupBy(entries, keyFn) {
+  const groups = {};
+  for (const e of entries) {
+    const key = keyFn(e);
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(e);
+  }
+  return groups;
+}
+
+function summarize(entries) {
+  const totalCost = entries.reduce((s, e) => s + (e.cost_usd || 0), 0);
+  const totalDuration = entries.reduce((s, e) => s + (e.duration_min || 0), 0);
+  return {
+    cost_usd: Math.round(totalCost * 100) / 100,
+    duration_hours: Math.round(totalDuration / 60 * 10) / 10,
+    sessions: entries.length,
+    lines_added: entries.reduce((s, e) => s + (e.lines_added || 0), 0),
+    lines_removed: entries.reduce((s, e) => s + (e.lines_removed || 0), 0),
+    avg_cost_per_session: entries.length > 0 ? Math.round(totalCost / entries.length * 100) / 100 : 0,
+  };
+}
+
+function getWeekKey(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00');
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  const monday = new Date(d.setDate(diff));
+  return monday.toISOString().split('T')[0];
+}
+
+function formatCost(usd) { return '$' + usd.toFixed(2); }
+function formatDuration(hours) {
+  if (hours < 1) return Math.round(hours * 60) + 'm';
+  return hours.toFixed(1) + 'h';
+}
+
+function report(args) {
+  const entries = loadLedger();
+  if (entries.length === 0) {
+    console.log('No cost data recorded yet. Costs will be tracked after session-end hooks run.');
+    return;
+  }
+
+  const jsonOutput = args.includes('--json');
+  const projectFilter = args.includes('--project')
+    ? args[args.indexOf('--project') + 1] : null;
+
+  let filtered = entries;
+  if (projectFilter) filtered = filtered.filter(e => e.project === projectFilter);
+
+  let groupFn, groupLabel, periodDays;
+  if (args.includes('--annual') || args.includes('--yearly')) {
+    groupFn = e => e.date.substring(0, 4);
+    groupLabel = 'Annual'; periodDays = 3650;
+  } else if (args.includes('--monthly')) {
+    groupFn = e => e.date.substring(0, 7);
+    groupLabel = 'Monthly'; periodDays = 365;
+  } else if (args.includes('--weekly')) {
+    groupFn = e => 'Week of ' + getWeekKey(e.date);
+    groupLabel = 'Weekly'; periodDays = 90;
+  } else if (args.includes('--daily')) {
+    groupFn = e => e.date;
+    groupLabel = 'Daily'; periodDays = 30;
+  } else {
+    groupFn = e => e.project;
+    groupLabel = 'By Project (Last 30 Days)'; periodDays = 30;
+  }
+
+  filtered = filterByDate(filtered, periodDays);
+  if (filtered.length === 0) { console.log('No cost data for the specified period.'); return; }
+
+  const groups = groupBy(filtered, groupFn);
+  const overall = summarize(filtered);
+
+  if (jsonOutput) {
+    const result = { period: groupLabel, overall, breakdown: {} };
+    for (const [key, ents] of Object.entries(groups)) {
+      result.breakdown[key] = summarize(ents);
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log('');
+  console.log(c.bold + c.brightCyan + '  Claude Code Cost Report' + c.reset);
+  console.log(c.dim + '  ' + String.fromCharCode(0x2500).repeat(50) + c.reset);
+  console.log('');
+  console.log(c.bold + '  Overall' + c.reset + (projectFilter ? c.dim + ' (' + projectFilter + ')' + c.reset : ''));
+  console.log(c.brightYellow + '    Total Cost:     ' + c.brightWhite + formatCost(overall.cost_usd) + c.reset);
+  console.log(c.cyan + '    Total Time:     ' + c.white + formatDuration(overall.duration_hours) + c.reset);
+  console.log(c.cyan + '    Sessions:       ' + c.white + overall.sessions + c.reset);
+  console.log(c.cyan + '    Avg/Session:    ' + c.white + formatCost(overall.avg_cost_per_session) + c.reset);
+  console.log(c.cyan + '    Lines +/-:      ' + c.green + '+' + overall.lines_added + c.reset + ' / ' + c.red + '-' + overall.lines_removed + c.reset);
+  console.log('');
+  console.log(c.bold + '  ' + groupLabel + c.reset);
+  console.log(c.dim + '  ' + String.fromCharCode(0x2500).repeat(50) + c.reset);
+
+  var colW = { name: 24, cost: 10, time: 8, sess: 6 };
+  console.log(c.dim + '  ' + 'Period/Project'.padEnd(colW.name) + 'Cost'.padStart(colW.cost) + 'Time'.padStart(colW.time) + 'Sess'.padStart(colW.sess) + c.reset);
+
+  var sorted = Object.entries(groups)
+    .map(function(pair) { var s = summarize(pair[1]); s.key = pair[0]; return s; })
+    .sort(function(a, b) { return b.cost_usd - a.cost_usd; });
+
+  for (var i = 0; i < sorted.length; i++) {
+    var row = sorted[i];
+    var costColor = row.cost_usd > 50 ? c.brightYellow : row.cost_usd > 10 ? c.yellow : c.green;
+    console.log('  ' + c.white + row.key.substring(0, colW.name - 1).padEnd(colW.name) + c.reset +
+      costColor + formatCost(row.cost_usd).padStart(colW.cost) + c.reset +
+      c.cyan + formatDuration(row.duration_hours).padStart(colW.time) + c.reset +
+      c.dim + String(row.sessions).padStart(colW.sess) + c.reset);
+  }
+
+  console.log('');
+  console.log(c.dim + '  Ledger: ' + LEDGER_PATH + c.reset);
+  console.log('');
+}
+
+const [,, cmd, ...cmdArgs] = process.argv;
+if (cmd === 'record') { record(); }
+else if (cmd === 'report') { report(cmdArgs); }
+else {
+  console.log('Claude Code Cost Ledger');
+  console.log('');
+  console.log('Usage:');
+  console.log('  node cost-ledger.cjs record           Record session cost (from hook)');
+  console.log('  node cost-ledger.cjs report            Last 30 days by project');
+  console.log('  node cost-ledger.cjs report --daily    Daily breakdown');
+  console.log('  node cost-ledger.cjs report --weekly   Weekly breakdown');
+  console.log('  node cost-ledger.cjs report --monthly  Monthly breakdown');
+  console.log('  node cost-ledger.cjs report --annual   Annual breakdown');
+  console.log('  node cost-ledger.cjs report --project <name>  Filter by project');
+  console.log('  node cost-ledger.cjs report --json     JSON output');
+  console.log('');
+  console.log('Ledger: ' + LEDGER_PATH);
+}
+`;
+}
+
 export function generateHelpers(options: InitOptions): Record<string, string> {
   const helpers: Record<string, string> = {};
 
@@ -1188,6 +1464,9 @@ export function generateHelpers(options: InitOptions): Record<string, string> {
     // Windows-specific scripts
     helpers['daemon-manager.ps1'] = generateWindowsDaemonManager();
     helpers['daemon-manager.cmd'] = generateWindowsBatchWrapper();
+
+    // Cost tracking (installed to both project and ~/.claude/helpers/)
+    helpers['cost-ledger.cjs'] = generateCostLedger();
   }
 
   if (options.components.statusline) {


### PR DESCRIPTION
## Summary

Adds `cost-ledger.cjs` — a cross-project session cost tracking system that records and reports Claude Code API spend over time.

**Problem:** Claude Code shows per-session cost in the statusline ($X.XX), but this data is lost when the session ends. There's no way to see daily, weekly, monthly, or annual spend across projects.

**Solution:** A JSONL-based cost ledger that:
- Automatically records session cost via the `session-end` hook
- Stores entries at `~/.claude/cost-ledger.jsonl` (global, cross-project)
- Provides pretty-printed and JSON reports with multiple time granularities

### Changes

- **`helpers-generator.ts`**: Added `generateCostLedger()` function (new helper), wired cost recording into `session-end` handler, added to `generateHelpers()` map
- **`executor.ts`**: Installs `cost-ledger.cjs` to both project `.claude/helpers/` and global `~/.claude/helpers/` during init

### Usage

```bash
# Automatic — records on every session end (no user action needed)

# Manual reports
node ~/.claude/helpers/cost-ledger.cjs report            # Last 30 days by project
node ~/.claude/helpers/cost-ledger.cjs report --daily     # Daily breakdown
node ~/.claude/helpers/cost-ledger.cjs report --weekly    # Weekly breakdown
node ~/.claude/helpers/cost-ledger.cjs report --monthly   # Monthly breakdown  
node ~/.claude/helpers/cost-ledger.cjs report --annual    # Annual breakdown
node ~/.claude/helpers/cost-ledger.cjs report --project myapp  # Filter by project
node ~/.claude/helpers/cost-ledger.cjs report --json      # JSON output
```

### Ledger Format (JSONL)

```json
{"date":"2026-03-30","timestamp":"2026-03-30T20:27:10.888Z","project":"matrix-lstm","session_id":"abc123","cost_usd":3.68,"duration_min":110.7,"model":"claude-opus-4-6","lines_added":552,"lines_removed":20}
```

### Design Decisions

- **JSONL** over SQLite — simpler, no dependencies, easy to grep/parse/backup
- **Global ledger** (`~/.claude/`) — works across all projects on the machine
- **Non-fatal hook** — if cost recording fails, session-end still completes normally
- **No new dependencies** — pure Node.js, uses only `fs`, `path`, `os`, `child_process`

## Test plan

- [ ] Run `npx @claude-flow/cli@latest init --only-claude --force` in a project
- [ ] Verify `cost-ledger.cjs` appears in both `.claude/helpers/` and `~/.claude/helpers/`
- [ ] End a Claude Code session and verify a JSONL entry is appended to `~/.claude/cost-ledger.jsonl`
- [ ] Run `node ~/.claude/helpers/cost-ledger.cjs report` and verify output
- [ ] Test `--daily`, `--weekly`, `--monthly`, `--annual`, `--json` flags
- [ ] Test `--project <name>` filtering
- [ ] Verify session-end still works if `cost-ledger.cjs` is missing (graceful fallback)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)