### PR TITLE
fix: 4 critical bugs — ReasoningBank, SQLite path, namespace, init hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.5.49",
+  "version": "3.5.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.5.49",
+      "version": "3.5.50",
       "license": "MIT",
       "dependencies": {
         "@ruvector/ruvllm-wasm": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.5.49",
+  "version": "3.5.50",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.5.49",
+  "version": "3.5.50",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.5.49",
+  "version": "3.5.50",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -724,14 +724,54 @@ async function writeSettings(
   result: InitResult
 ): Promise<void> {
   const settingsPath = path.join(targetDir, '.claude', 'settings.json');
+  const generated = JSON.parse(generateSettingsJson(options));
 
   if (fs.existsSync(settingsPath) && !options.force) {
-    result.skipped.push('.claude/settings.json');
+    // Merge hooks/env/permissions into existing settings instead of skipping
+    try {
+      const existing = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      let merged = false;
+
+      // Merge hooks (the critical missing piece — #1484)
+      if (generated.hooks && !existing.hooks) {
+        existing.hooks = generated.hooks;
+        merged = true;
+      }
+
+      // Merge env vars (for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS etc.)
+      if (generated.env) {
+        existing.env = { ...(existing.env || {}), ...generated.env };
+        merged = true;
+      }
+
+      // Merge permissions (add ruflo allow rules)
+      if (generated.permissions?.allow) {
+        const existingAllow = existing.permissions?.allow || [];
+        const newRules = generated.permissions.allow.filter(
+          (r: string) => !existingAllow.includes(r)
+        );
+        if (newRules.length > 0) {
+          existing.permissions = existing.permissions || {};
+          existing.permissions.allow = [...existingAllow, ...newRules];
+          merged = true;
+        }
+      }
+
+      if (merged) {
+        fs.writeFileSync(settingsPath, JSON.stringify(existing, null, 2), 'utf-8');
+        result.created.files.push('.claude/settings.json (merged hooks)');
+      } else {
+        result.skipped.push('.claude/settings.json');
+      }
+    } catch {
+      // Existing file is corrupt — overwrite
+      fs.writeFileSync(settingsPath, JSON.stringify(generated, null, 2), 'utf-8');
+      result.created.files.push('.claude/settings.json');
+    }
     return;
   }
 
-  const content = generateSettingsJson(options);
-  fs.writeFileSync(settingsPath, content, 'utf-8');
+  fs.writeFileSync(settingsPath, JSON.stringify(generated, null, 2), 'utf-8');
   result.created.files.push('.claude/settings.json');
 }
 

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -444,7 +444,8 @@ export async function bridgeSearchEntries(options: {
   if (!ctx) return null;
 
   try {
-    const { query: queryStr, namespace = 'default', limit = 10, threshold = 0.3 } = options;
+    const { query: queryStr, namespace, limit = 10, threshold = 0.3 } = options;
+    const effectiveNamespace = namespace || 'all';
     const startTime = Date.now();
 
     // Generate query embedding
@@ -460,7 +461,7 @@ export async function bridgeSearchEntries(options: {
     }
 
     // better-sqlite3: .prepare().all() returns array of objects
-    const nsFilter = namespace !== 'all'
+    const nsFilter = effectiveNamespace !== 'all'
       ? `AND namespace = ?`
       : '';
 
@@ -472,7 +473,7 @@ export async function bridgeSearchEntries(options: {
         WHERE status = 'active' ${nsFilter}
         LIMIT 1000
       `);
-      rows = namespace !== 'all' ? stmt.all(namespace) : stmt.all();
+      rows = effectiveNamespace !== 'all' ? stmt.all(effectiveNamespace) : stmt.all();
     } catch {
       return null;
     }

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -388,14 +388,14 @@ export async function getHNSWIndex(options?: {
 
     const { VectorDb } = ruvectorCore;
 
-    // Persistent storage paths
-    const swarmDir = path.join(process.cwd(), '.swarm');
+    // Persistent storage paths — resolve to absolute to survive CWD changes
+    const swarmDir = path.resolve(process.cwd(), '.swarm');
     if (!fs.existsSync(swarmDir)) {
       fs.mkdirSync(swarmDir, { recursive: true });
     }
     const hnswPath = path.join(swarmDir, 'hnsw.index');
     const metadataPath = path.join(swarmDir, 'hnsw.metadata.json');
-    const dbPath = options?.dbPath || path.join(swarmDir, 'memory.db');
+    const dbPath = options?.dbPath ? path.resolve(options.dbPath) : path.join(swarmDir, 'memory.db');
 
     // Create HNSW index with persistent storage
     // @ruvector/core uses string enum for distanceMetric: 'Cosine', 'Euclidean', 'DotProduct', 'Manhattan'
@@ -2058,8 +2058,8 @@ export async function storeEntry(options: {
     upsert = false
   } = options;
 
-  const swarmDir = path.join(process.cwd(), '.swarm');
-  const dbPath = customPath || path.join(swarmDir, 'memory.db');
+  const swarmDir = path.resolve(process.cwd(), '.swarm');
+  const dbPath = customPath ? path.resolve(customPath) : path.join(swarmDir, 'memory.db');
 
   try {
     if (!fs.existsSync(dbPath)) {
@@ -2180,14 +2180,15 @@ export async function searchEntries(options: {
   // Fallback: raw sql.js
   const {
     query,
-    namespace = 'default',
+    namespace,
     limit = 10,
     threshold = 0.3,
     dbPath: customPath
   } = options;
+  const effectiveNamespace = namespace || 'all';
 
-  const swarmDir = path.join(process.cwd(), '.swarm');
-  const dbPath = customPath || path.join(swarmDir, 'memory.db');
+  const swarmDir = path.resolve(process.cwd(), '.swarm');
+  const dbPath = customPath ? path.resolve(customPath) : path.join(swarmDir, 'memory.db');
   const startTime = Date.now();
 
   try {
@@ -2203,7 +2204,7 @@ export async function searchEntries(options: {
     const queryEmbedding = queryEmb.embedding;
 
     // Try HNSW search first (150x faster)
-    const hnswResults = await searchHNSWIndex(queryEmbedding, { k: limit, namespace });
+    const hnswResults = await searchHNSWIndex(queryEmbedding, { k: limit, namespace: effectiveNamespace });
     if (hnswResults && hnswResults.length > 0) {
       // Filter by threshold
       const filtered = hnswResults.filter(r => r.score >= threshold);
@@ -2223,12 +2224,12 @@ export async function searchEntries(options: {
 
     // Get entries with embeddings
     const searchStmt = db.prepare(
-      namespace !== 'all'
+      effectiveNamespace !== 'all'
         ? `SELECT id, key, namespace, content, embedding FROM memory_entries WHERE status = 'active' AND namespace = ? LIMIT 1000`
         : `SELECT id, key, namespace, content, embedding FROM memory_entries WHERE status = 'active' LIMIT 1000`
     );
-    if (namespace !== 'all') {
-      searchStmt.bind([namespace]);
+    if (effectiveNamespace !== 'all') {
+      searchStmt.bind([effectiveNamespace]);
     }
     const searchRows: unknown[][] = [];
     while (searchStmt.step()) {

--- a/v3/@claude-flow/memory/src/controller-registry.ts
+++ b/v3/@claude-flow/memory/src/controller-registry.ts
@@ -747,7 +747,8 @@ export class ControllerRegistry extends EventEmitter {
           const agentdbModule: any = await import('agentdb');
           const RB = agentdbModule.ReasoningBank;
           if (!RB) return null;
-          return new RB(this.agentdb.database);
+          const embedder = this.createEmbeddingService();
+          return new RB(this.agentdb.database, embedder);
         } catch { return null; }
       }
 

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1789,7 +1789,7 @@
       }
     },
     "@claude-flow/cli": {
-      "version": "3.5.49",
+      "version": "3.5.50",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/mcp": "^3.0.0-alpha.8",


### PR DESCRIPTION
## Summary
- **#1499**: ReasoningBank controller disabled — missing `embedder` param in `ControllerRegistry`. Added `createEmbeddingService()` call matching other controllers.
- **#1490**: SQLite database path relative to CWD — `path.join` → `path.resolve` for all swarmDir/dbPath computations, preventing data loss on MCP server restart.
- **#1489**: `memory_search` defaults to namespace `'default'`, returning empty results — now searches across ALL namespaces when not explicitly specified.
- **#1484**: `init --full` hooks disconnected — `writeSettings` now **merges** hooks into existing `settings.json` instead of skipping the file when it already exists.

## Test plan
- [x] All 1725 tests pass (28 files, 0 failures)
- [x] TypeScript compilation clean for CLI and memory packages
- [x] Published as v3.5.50 to npm (@claude-flow/cli, claude-flow, ruflo)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)