### PR TITLE
fix(daemon): resolve silent exit due to self-PID collision and event loop drain

### DIFF
--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -364,7 +364,7 @@ export class WorkerDaemon extends EventEmitter {
           if (this.runningWorkers.size === 0) {
             // No workers running means nobody will trigger the finally-block
             // callback, so schedule a backoff retry to avoid a stuck queue.
-            setTimeout(() => this.processPendingWorkers(), 30_000).unref();
+            setTimeout(() => this.processPendingWorkers(), 30_000); // must not .unref() — keeps event loop alive when all workers are resource-deferred (#1478 Bug 3)
           }
           break;
         }
@@ -458,6 +458,12 @@ export class WorkerDaemon extends EventEmitter {
     try {
       const pid = parseInt(readFileSync(this.pidFile, 'utf-8').trim(), 10);
       if (isNaN(pid)) return null;
+      // If the PID file contains our own PID, the parent wrote it pre-emptively
+      // before we finished initializing — treat as "no existing daemon" (#1478 Bug 2).
+      if (pid === process.pid) {
+        try { unlinkSync(this.pidFile); } catch { /* ignore */ }
+        return null;
+      }
       // Check if process is alive (signal 0 = existence check)
       process.kill(pid, 0);
       return pid; // Process is alive


### PR DESCRIPTION
## Summary

Fixes two bugs that combine to make the background daemon completely non-functional on any machine under moderate CPU load. The daemon would report "started" but immediately exit silently with no log output.

### Root Causes

**Bug 1 — Self-PID collision (parent writes PID file before child initializes)**

`startBackgroundDaemon()` writes `daemon.pid` with the child's PID immediately after spawning. When the child starts and calls `WorkerDaemon.start()`, `checkExistingDaemon()` reads that file, finds its own PID alive via `process.kill(pid, 0)`, and returns early — treating itself as a duplicate. No workers are ever scheduled.

**Fix:** Added a self-PID guard in `checkExistingDaemon()`: if the PID in the file equals `process.pid`, clear the stale file and return `null`.

**Bug 2 — Event loop drain when all workers are resource-deferred**

When system CPU load exceeds `maxCpuLoad`, all workers are pushed to `pendingWorkers`. The only retry is scheduled via `setTimeout(..., 30_000).unref()`. The `.unref()` means this timer doesn't keep the Node.js event loop alive — so if all workers are deferred simultaneously (common on a busy dev machine), the process exits silently.

**Fix:** Removed `.unref()` from the backoff retry timer in `processPendingWorkers()`.

### Impact

Both bugs compound: the self-PID issue prevents workers from ever being scheduled, so there are no active timers. Even if that were fixed, the `.unref()`'d retry timer means any machine where `loadavg()[0]` exceeds `maxCpuLoad` (the default `cpuCount × 0.8`) at startup will also silently exit. On a 12-core machine doing normal dev work, this threshold is routinely exceeded.

## Test plan

- [ ] Run `claude-flow daemon start` and verify `daemon status` shows `● RUNNING` after 3–5 seconds
- [ ] Verify on a machine with `loadavg > cpuCount × 0.8` (busy machine) — daemon stays running
- [ ] Verify `daemon.pid` file is created and contains a live PID
- [ ] Verify `daemon stop` cleanly stops the process

---

*From your friends at CPUcoin.io. Enjoy!*