### PR TITLE
fix: global install MCP server cwd resolution

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -291,7 +291,7 @@ show_quickstart() {
         echo -e "  ${BOLD}ruflo doctor${NC}"
         echo ""
         echo -e "  ${DIM}# Add as MCP server to Claude Code${NC}"
-        echo -e "  ${BOLD}claude mcp add ruflo -- ruflo mcp start${NC}"
+        echo -e "  ${BOLD}claude mcp add ruflo -e CLAUDE_FLOW_CWD=\"\$HOME\" -- ruflo mcp start${NC}"
     else
         echo -e "  ${DIM}# Initialize project${NC}"
         echo -e "  ${BOLD}npx ruflo@latest init --wizard${NC}"

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -408,6 +408,21 @@ async function installClaudeCode(): Promise<boolean> {
   }
 }
 
+// Check CWD resolution (global install root filesystem issue — #1532)
+async function checkCwd(): Promise<HealthCheck> {
+  const cwd = process.env.CLAUDE_FLOW_CWD || process.cwd();
+  if (cwd === '/') {
+    return {
+      name: 'Working Directory',
+      status: 'fail',
+      message: 'CWD resolved to root (/). File operations will fail on macOS global installs.',
+      fix: 'export CLAUDE_FLOW_CWD="$HOME" or set -e CLAUDE_FLOW_CWD in MCP server registration'
+    };
+  }
+  const source = process.env.CLAUDE_FLOW_CWD ? 'CLAUDE_FLOW_CWD' : 'process.cwd()';
+  return { name: 'Working Directory', status: 'pass', message: `${cwd} (via ${source})` };
+}
+
 // Check agentic-flow v3 integration (filesystem-based to avoid slow WASM/DB init)
 async function checkAgenticFlow(): Promise<HealthCheck> {
   try {
@@ -476,7 +491,7 @@ export const doctorCommand: Command = {
     {
       name: 'component',
       short: 'c',
-      description: 'Check specific component (version, node, npm, config, daemon, memory, api, git, mcp, claude, disk, typescript)',
+      description: 'Check specific component (version, node, npm, config, daemon, memory, api, git, mcp, claude, disk, typescript, cwd)',
       type: 'string'
     },
     {
@@ -518,6 +533,7 @@ export const doctorCommand: Command = {
       checkMemoryDatabase,
       checkApiKeys,
       checkMcpServers,
+      checkCwd,
       checkDiskSpace,
       checkBuildTools,
       checkAgenticFlow
@@ -537,7 +553,8 @@ export const doctorCommand: Command = {
       'mcp': checkMcpServers,
       'disk': checkDiskSpace,
       'typescript': checkBuildTools,
-      'agentic-flow': checkAgenticFlow
+      'agentic-flow': checkAgenticFlow,
+      'cwd': checkCwd
     };
 
     let checksToRun = allChecks;

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -7,8 +7,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validateText, validateAgentSpawn } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -38,7 +39,7 @@ interface AgentStore {
 }
 
 function getAgentDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, AGENT_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, AGENT_DIR);
 }
 
 function getAgentPath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/config-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/config-tools.ts
@@ -6,8 +6,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -35,7 +36,7 @@ const DEFAULT_CONFIG: Record<string, unknown> = {
 };
 
 function getConfigDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR);
+  return join(getBaseCwd(), STORAGE_DIR);
 }
 
 function getConfigPath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
@@ -9,10 +9,11 @@
  * - Useful for single-machine workflow orchestration
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -78,7 +79,7 @@ interface CoordinationStore {
 }
 
 function getCoordDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, COORD_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, COORD_DIR);
 }
 
 function getCoordPath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/cwd-helper.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/cwd-helper.ts
@@ -18,5 +18,9 @@
  * 2. process.cwd()
  */
 export function getBaseCwd(): string {
-  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+  const cwd = process.env.CLAUDE_FLOW_CWD || process.cwd();
+  if (cwd === '/') {
+    console.warn('[ruflo] Warning: CWD resolved to root (/). Set CLAUDE_FLOW_CWD to your project directory.');
+  }
+  return cwd;
 }

--- a/v3/@claude-flow/cli/src/mcp-tools/cwd-helper.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/cwd-helper.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared working-directory helper for MCP tools.
+ *
+ * When ruflo is installed globally and the MCP server is registered without
+ * an explicit cwd, macOS (and some Linux setups) spawn the stdio process at
+ * "/". All process.cwd()-based paths then resolve to the read-only root
+ * filesystem, breaking every file operation.
+ *
+ * This helper checks the CLAUDE_FLOW_CWD environment variable first,
+ * falling back to process.cwd() only when the variable is not set.
+ */
+
+/**
+ * Returns the effective working directory for file operations.
+ *
+ * Resolution order:
+ * 1. CLAUDE_FLOW_CWD environment variable (set by the install script)
+ * 2. process.cwd()
+ */
+export function getBaseCwd(): string {
+  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+}

--- a/v3/@claude-flow/cli/src/mcp-tools/daa-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/daa-tools.ts
@@ -9,10 +9,11 @@
  * - Useful for workflow orchestration and state tracking
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -54,7 +55,7 @@ interface DAAStore {
 }
 
 function getDAADir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, DAA_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, DAA_DIR);
 }
 
 function getDAAPath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/github-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/github-tools.ts
@@ -5,11 +5,12 @@
  * Falls back to local state management when CLI tools are unavailable.
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -38,7 +39,7 @@ interface GitHubStore {
 }
 
 function getGitHubDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, GITHUB_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, GITHUB_DIR);
 }
 
 function getGitHubPath(): string {
@@ -72,7 +73,7 @@ function saveGitHubStore(store: GitHubStore): void {
 /** Run a shell command, return stdout or null on failure */
 function run(cmd: string, cwd?: string): string | null {
   try {
-    return execSync(cmd, { encoding: 'utf-8', timeout: 15000, cwd: cwd || getProjectCwd(), stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    return execSync(cmd, { encoding: 'utf-8', timeout: 15000, cwd: cwd || getBaseCwd(), stdio: ['pipe', 'pipe', 'pipe'] }).trim();
   } catch {
     return null;
   }
@@ -104,7 +105,7 @@ export const githubTools: MCPTool[] = [
 
       const store = loadGitHubStore();
       const branch = (input.branch as string) || 'main';
-      const cwd = getProjectCwd();
+      const cwd = getBaseCwd();
 
       // Try real git analysis first
       const commitCount = run('git rev-list --count HEAD', cwd);
@@ -464,7 +465,7 @@ export const githubTools: MCPTool[] = [
 
       const metric = (input.metric as string) || 'all';
       const timeRange = (input.timeRange as string) || '30d';
-      const cwd = getProjectCwd();
+      const cwd = getBaseCwd();
 
       // Parse time range
       const days = parseInt(timeRange, 10) || 30;

--- a/v3/@claude-flow/cli/src/mcp-tools/guidance-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/guidance-tools.ts
@@ -7,11 +7,12 @@
  * @module @claude-flow/cli/mcp-tools/guidance
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getBaseCwd } from './cwd-helper.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -23,8 +24,8 @@ const CLI_ROOT = join(__dirname, '../../..');
  */
 function findProjectRoot(): string {
   // Strategy 1: CWD (most reliable when invoked by user)
-  if (existsSync(join(getProjectCwd(), '.claude'))) {
-    return getProjectCwd();
+  if (existsSync(join(getBaseCwd(), '.claude'))) {
+    return getBaseCwd();
   }
 
   // Strategy 2: Walk up from CLI package location
@@ -35,7 +36,7 @@ function findProjectRoot(): string {
   }
 
   // Strategy 3: Walk up from CWD
-  let dir = getProjectCwd();
+  let dir = getBaseCwd();
   for (let i = 0; i < 10; i++) {
     if (existsSync(join(dir, '.claude'))) return dir;
     const parent = dirname(dir);
@@ -44,7 +45,7 @@ function findProjectRoot(): string {
   }
 
   // Fallback: CWD
-  return getProjectCwd();
+  return getBaseCwd();
 }
 
 const PROJECT_ROOT = findProjectRoot();

--- a/v3/@claude-flow/cli/src/mcp-tools/hive-mind-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hive-mind-tools.ts
@@ -6,8 +6,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -152,7 +153,7 @@ function tryResolveProposal(
 }
 
 function getHiveDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, HIVE_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, HIVE_DIR);
 }
 
 function getHivePath(): string {
@@ -197,7 +198,7 @@ function saveHiveState(state: HiveState): void {
 import { existsSync as agentStoreExists, readFileSync as readAgentStore, writeFileSync as writeAgentStore, mkdirSync as mkdirAgentStore } from 'node:fs';
 
 function loadAgentStore(): { agents: Record<string, unknown> } {
-  const storePath = join(getProjectCwd(), '.claude-flow', 'agents.json');
+  const storePath = join(getBaseCwd(), '.claude-flow', 'agents.json');
   try {
     if (agentStoreExists(storePath)) {
       return JSON.parse(readAgentStore(storePath, 'utf-8'));
@@ -207,7 +208,7 @@ function loadAgentStore(): { agents: Record<string, unknown> } {
 }
 
 function saveAgentStore(store: { agents: Record<string, unknown> }): void {
-  const storeDir = join(getProjectCwd(), '.claude-flow');
+  const storeDir = join(getBaseCwd(), '.claude-flow');
   if (!agentStoreExists(storeDir)) {
     mkdirAgentStore(storeDir, { recursive: true });
   }
@@ -352,7 +353,7 @@ export const hiveMindTools: MCPTool[] = [
       const agentStore = loadAgentStore();
 
       // Compute real task metrics from task store
-      const taskStorePath = join(getProjectCwd(), '.claude-flow', 'tasks', 'store.json');
+      const taskStorePath = join(getBaseCwd(), '.claude-flow', 'tasks', 'store.json');
       let pendingTaskCount = 0;
       let activeTaskCount = 0;
       let completedTaskCount = 0;

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -5,8 +5,9 @@
 
 import { mkdirSync, writeFileSync, existsSync, readFileSync, statSync, unlinkSync, readdirSync, rmSync } from 'fs';
 import { dirname, join, resolve } from 'path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validateText, validatePath } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Real vector search functions - lazy loaded to avoid circular imports
 let searchEntriesFn: ((options: {
@@ -1360,7 +1361,7 @@ export const hooksPostTask: MCPTool = {
 
     // Persist to auto-memory-store for statusline visibility
     try {
-      const dataDir = join(getProjectCwd(), '.claude-flow', 'data');
+      const dataDir = join(getBaseCwd(), '.claude-flow', 'data');
       if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
       const storePath = join(dataDir, 'auto-memory-store.json');
       let store: Array<Record<string, unknown>> = [];
@@ -1752,7 +1753,7 @@ export const hooksSessionStart: MCPTool = {
     // Auto-regenerate statusline if outdated (fixes older installs)
     // Checks for the old fake heuristic: "Math.floor(sizeKB / 2)"
     try {
-      const statuslinePath = join(getProjectCwd(), '.claude', 'helpers', 'statusline.cjs');
+      const statuslinePath = join(getBaseCwd(), '.claude', 'helpers', 'statusline.cjs');
       if (existsSync(statuslinePath)) {
         const content = readFileSync(statuslinePath, 'utf-8');
         if (content.includes('Math.floor(sizeKB / 2)') || content.includes('Maturity fallback')) {
@@ -1774,7 +1775,7 @@ export const hooksSessionStart: MCPTool = {
       try {
         // Dynamic import to avoid circular dependencies
         const { startDaemon } = await import('../services/worker-daemon.js');
-        const daemon = await startDaemon(getProjectCwd());
+        const daemon = await startDaemon(getBaseCwd());
         const status = daemon.getStatus();
         daemonStatus = {
           started: true,
@@ -1818,7 +1819,7 @@ export const hooksSessionStart: MCPTool = {
 
     // Persist session record to auto-memory-store for statusline visibility
     try {
-      const dataDir = join(getProjectCwd(), '.claude-flow', 'data');
+      const dataDir = join(getBaseCwd(), '.claude-flow', 'data');
       if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
       const storePath = join(dataDir, 'auto-memory-store.json');
       let store: Array<Record<string, unknown>> = [];
@@ -2219,7 +2220,7 @@ export const hooksIntelligenceReset: MCPTool = {
     properties: {},
   },
   handler: async () => {
-    const cwd = getProjectCwd();
+    const cwd = getBaseCwd();
     const cleared = {
       trajectories: 0,
       patterns: 0,

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -13,6 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import type { MCPTool } from './types.js';
+import { getBaseCwd } from './cwd-helper.js';
 import { validateIdentifier } from './validate-input.js';
 
 // Legacy JSON store interface (for migration)
@@ -633,7 +634,7 @@ export const memoryTools: MCPTool[] = [
         }
       } else {
         // Current project only — find by CWD hash
-        const cwd = process.cwd();
+        const cwd = getBaseCwd();
         const projectHash = cwd.replace(/\//g, '-');
         const memDir = join(claudeProjectsDir, projectHash, 'memory');
         if (existsSync(memDir)) {

--- a/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
@@ -12,10 +12,11 @@
  * Note: For production neural features, use @claude-flow/neural module
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Try to import real embeddings — prefer agentic-flow v3 ReasoningBank, then @claude-flow/embeddings
 let realEmbeddings: { embed: (text: string) => Promise<number[]> } | null = null;
@@ -122,7 +123,7 @@ interface NeuralStore {
 }
 
 function getNeuralDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, NEURAL_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, NEURAL_DIR);
 }
 
 function getNeuralPath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/performance-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/performance-tools.ts
@@ -12,11 +12,12 @@
  * Note: Some optimization suggestions are illustrative
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier } from './validate-input.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import * as os from 'node:os';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -53,7 +54,7 @@ interface PerfStore {
 }
 
 function getPerfDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, PERF_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, PERF_DIR);
 }
 
 function getPerfPath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/session-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/session-tools.ts
@@ -6,8 +6,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -32,7 +33,7 @@ interface SessionRecord {
 }
 
 function getSessionDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, SESSION_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, SESSION_DIR);
 }
 
 function getSessionPath(sessionId: string): string {
@@ -90,7 +91,7 @@ function loadRelatedStores(options: { includeMemory?: boolean; includeTasks?: bo
 
   if (options.includeMemory) {
     try {
-      const memoryPath = join(getProjectCwd(), STORAGE_DIR, 'memory', 'store.json');
+      const memoryPath = join(getBaseCwd(), STORAGE_DIR, 'memory', 'store.json');
       if (existsSync(memoryPath)) {
         data.memory = JSON.parse(readFileSync(memoryPath, 'utf-8'));
       }
@@ -99,7 +100,7 @@ function loadRelatedStores(options: { includeMemory?: boolean; includeTasks?: bo
 
   if (options.includeTasks) {
     try {
-      const taskPath = join(getProjectCwd(), STORAGE_DIR, 'tasks', 'store.json');
+      const taskPath = join(getBaseCwd(), STORAGE_DIR, 'tasks', 'store.json');
       if (existsSync(taskPath)) {
         data.tasks = JSON.parse(readFileSync(taskPath, 'utf-8'));
       }
@@ -108,7 +109,7 @@ function loadRelatedStores(options: { includeMemory?: boolean; includeTasks?: bo
 
   if (options.includeAgents) {
     try {
-      const agentPath = join(getProjectCwd(), STORAGE_DIR, 'agents', 'store.json');
+      const agentPath = join(getBaseCwd(), STORAGE_DIR, 'agents', 'store.json');
       if (existsSync(agentPath)) {
         data.agents = JSON.parse(readFileSync(agentPath, 'utf-8'));
       }
@@ -231,7 +232,7 @@ export const sessionTools: MCPTool[] = [
       if (session) {
         // Restore data to respective stores (legacy JSON for backward compat)
         if (session.data?.memory) {
-          const memoryDir = join(getProjectCwd(), STORAGE_DIR, 'memory');
+          const memoryDir = join(getBaseCwd(), STORAGE_DIR, 'memory');
           if (!existsSync(memoryDir)) mkdirSync(memoryDir, { recursive: true });
           writeFileSync(join(memoryDir, 'store.json'), JSON.stringify(session.data.memory, null, 2), 'utf-8');
 
@@ -258,12 +259,12 @@ export const sessionTools: MCPTool[] = [
           }
         }
         if (session.data?.tasks) {
-          const taskDir = join(getProjectCwd(), STORAGE_DIR, 'tasks');
+          const taskDir = join(getBaseCwd(), STORAGE_DIR, 'tasks');
           if (!existsSync(taskDir)) mkdirSync(taskDir, { recursive: true });
           writeFileSync(join(taskDir, 'store.json'), JSON.stringify(session.data.tasks, null, 2), 'utf-8');
         }
         if (session.data?.agents) {
-          const agentDir = join(getProjectCwd(), STORAGE_DIR, 'agents');
+          const agentDir = join(getBaseCwd(), STORAGE_DIR, 'agents');
           if (!existsSync(agentDir)) mkdirSync(agentDir, { recursive: true });
           writeFileSync(join(agentDir, 'store.json'), JSON.stringify(session.data.agents, null, 2), 'utf-8');
         }

--- a/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
@@ -7,8 +7,9 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Swarm state persistence
 const SWARM_DIR = '.claude-flow/swarm';
@@ -32,7 +33,7 @@ interface SwarmStore {
 }
 
 function getSwarmDir(): string {
-  return join(getProjectCwd(), SWARM_DIR);
+  return join(getBaseCwd(), SWARM_DIR);
 }
 
 function getSwarmStatePath(): string {

--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -9,13 +9,14 @@
  * - os module for system information
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier } from './validate-input.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statfsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as os from 'node:os';
 import * as dns from 'node:dns';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Read version dynamically from package.json
 function getPackageVersion(): string {
@@ -49,7 +50,7 @@ interface SystemMetrics {
 }
 
 function getSystemDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, SYSTEM_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, SYSTEM_DIR);
 }
 
 function getMetricsPath(): string {
@@ -200,7 +201,7 @@ export const systemTools: MCPTool[] = [
       // Fallback: JSON store files (backward compatibility)
       if (_metricsSource === 'none') {
         try {
-          const agentStorePath = join(getProjectCwd(), STORAGE_DIR, 'agents', 'store.json');
+          const agentStorePath = join(getBaseCwd(), STORAGE_DIR, 'agents', 'store.json');
           if (existsSync(agentStorePath)) {
             const agentStore = JSON.parse(readFileSync(agentStorePath, 'utf-8'));
             const agents = Object.values(agentStore.agents || {}) as Array<{ status: string }>;
@@ -212,7 +213,7 @@ export const systemTools: MCPTool[] = [
           }
         } catch { /* agent store not available */ }
         try {
-          const taskStorePath = join(getProjectCwd(), STORAGE_DIR, 'tasks', 'store.json');
+          const taskStorePath = join(getBaseCwd(), STORAGE_DIR, 'tasks', 'store.json');
           if (existsSync(taskStorePath)) {
             const taskStore = JSON.parse(readFileSync(taskStorePath, 'utf-8'));
             const tasks = Object.values(taskStore.tasks || {}) as Array<{ status: string }>;
@@ -304,7 +305,7 @@ export const systemTools: MCPTool[] = [
     handler: async (input) => {
       const metrics = loadMetrics();
       const checks: Array<{ name: string; status: string; latency?: number; message?: string }> = [];
-      const projectCwd = getProjectCwd();
+      const projectCwd = getBaseCwd();
 
       // Memory DB check — verify the store file exists
       {
@@ -469,7 +470,7 @@ export const systemTools: MCPTool[] = [
         platform: process.platform,
         arch: process.arch,
         pid: process.pid,
-        cwd: getProjectCwd(),
+        cwd: getBaseCwd(),
         env: process.env.NODE_ENV || 'development',
         features: {
           swarm: true,
@@ -599,7 +600,7 @@ export const systemTools: MCPTool[] = [
     },
     handler: async () => {
       // Read from the task store file
-      const storePath = join(getProjectCwd(), '.claude-flow', 'tasks', 'store.json');
+      const storePath = join(getBaseCwd(), '.claude-flow', 'tasks', 'store.json');
       let tasks: Array<{ status: string }> = [];
       try {
         if (existsSync(storePath)) {

--- a/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/task-tools.ts
@@ -6,8 +6,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -35,7 +36,7 @@ interface TaskStore {
 }
 
 function getTaskDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, TASK_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, TASK_DIR);
 }
 
 function getTaskPath(): string {
@@ -258,7 +259,7 @@ export const taskTools: MCPTool[] = [
 
         // Sync assigned agents back to idle and increment taskCount
         if (task.assignedTo.length > 0) {
-          const agentStorePath = join(getProjectCwd(), STORAGE_DIR, 'agents', 'store.json');
+          const agentStorePath = join(getBaseCwd(), STORAGE_DIR, 'agents', 'store.json');
           try {
             let agentStore: { agents: Record<string, Record<string, unknown>> } = { agents: {} };
             if (existsSync(agentStorePath)) {
@@ -377,7 +378,7 @@ export const taskTools: MCPTool[] = [
       const previouslyAssigned = [...task.assignedTo];
 
       // Load agent store to sync worker state
-      const agentStorePath = join(getProjectCwd(), STORAGE_DIR, 'agents', 'store.json');
+      const agentStorePath = join(getBaseCwd(), STORAGE_DIR, 'agents', 'store.json');
       let agentStore: { agents: Record<string, Record<string, unknown>> } = { agents: {} };
       try {
         if (existsSync(agentStorePath)) {
@@ -422,7 +423,7 @@ export const taskTools: MCPTool[] = [
 
       saveTaskStore(store);
       // Save agent store
-      const agentDir = join(getProjectCwd(), STORAGE_DIR, 'agents');
+      const agentDir = join(getBaseCwd(), STORAGE_DIR, 'agents');
       if (!existsSync(agentDir)) {
         mkdirSync(agentDir, { recursive: true });
       }

--- a/v3/@claude-flow/cli/src/mcp-tools/terminal-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/terminal-tools.ts
@@ -4,11 +4,12 @@
  * Terminal session management with real command execution.
  */
 
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { validateIdentifier, validatePath, validateText } from './validate-input.js';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -32,7 +33,7 @@ interface TerminalStore {
 }
 
 function getTerminalDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, TERMINAL_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, TERMINAL_DIR);
 }
 
 function getTerminalPath(): string {
@@ -96,7 +97,7 @@ export const terminalTools: MCPTool[] = [
         status: 'active',
         createdAt: new Date().toISOString(),
         lastActivity: new Date().toISOString(),
-        workingDir: (input.workingDir as string) || getProjectCwd(),
+        workingDir: (input.workingDir as string) || getBaseCwd(),
         history: [],
         env: (input.env as Record<string, string>) || {},
       };
@@ -153,7 +154,7 @@ export const terminalTools: MCPTool[] = [
           status: 'active',
           createdAt: new Date().toISOString(),
           lastActivity: new Date().toISOString(),
-          workingDir: getProjectCwd(),
+          workingDir: getBaseCwd(),
           history: [],
           env: {},
         };
@@ -161,7 +162,7 @@ export const terminalTools: MCPTool[] = [
       }
 
       const timeout = (input.timeout as number) || 30_000;
-      const cwd = session.workingDir || getProjectCwd();
+      const cwd = session.workingDir || getBaseCwd();
       const startTime = Date.now();
       let output: string;
       let exitCode: number;

--- a/v3/@claude-flow/cli/src/mcp-tools/workflow-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/workflow-tools.ts
@@ -6,8 +6,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import type { MCPTool } from './types.js';
 import { validateIdentifier, validatePath, validateText } from './validate-input.js';
+import { getBaseCwd } from './cwd-helper.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -46,7 +47,7 @@ interface WorkflowStore {
 }
 
 function getWorkflowDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, WORKFLOW_DIR);
+  return join(getBaseCwd(), STORAGE_DIR, WORKFLOW_DIR);
 }
 
 function getWorkflowPath(): string {

--- a/v3/@claude-flow/cli/src/memory/cwd-helper.ts
+++ b/v3/@claude-flow/cli/src/memory/cwd-helper.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared working-directory helper for memory modules.
+ *
+ * When ruflo is installed globally, macOS spawns the MCP stdio process at "/".
+ * All process.cwd()-based paths then resolve to the read-only root filesystem.
+ * This helper checks CLAUDE_FLOW_CWD first, falling back to process.cwd().
+ */
+export function getBaseCwd(): string {
+  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+}

--- a/v3/@claude-flow/cli/src/memory/cwd-helper.ts
+++ b/v3/@claude-flow/cli/src/memory/cwd-helper.ts
@@ -6,5 +6,9 @@
  * This helper checks CLAUDE_FLOW_CWD first, falling back to process.cwd().
  */
 export function getBaseCwd(): string {
-  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+  const cwd = process.env.CLAUDE_FLOW_CWD || process.cwd();
+  if (cwd === '/') {
+    console.warn('[ruflo] Warning: CWD resolved to root (/). Set CLAUDE_FLOW_CWD to your project directory.');
+  }
+  return cwd;
 }

--- a/v3/@claude-flow/cli/src/memory/ewc-consolidation.ts
+++ b/v3/@claude-flow/cli/src/memory/ewc-consolidation.ts
@@ -23,6 +23,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // ============================================================================
 // Types
@@ -147,7 +148,7 @@ const DEFAULT_EWC_CONFIG: EWCConfig = {
   maxPatterns: 1000,
   fisherDecayRate: 0.01,
   importanceThreshold: 0.3,
-  storagePath: path.join(process.cwd(), '.swarm', 'ewc-fisher.json'),
+  storagePath: path.join(getBaseCwd(), '.swarm', 'ewc-fisher.json'),
   onlineMode: true,
   dimensions: 384
 };

--- a/v3/@claude-flow/cli/src/memory/intelligence.ts
+++ b/v3/@claude-flow/cli/src/memory/intelligence.ts
@@ -14,6 +14,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // ============================================================================
 // Persistence Configuration
@@ -25,7 +26,7 @@ import { dirname, join } from 'node:path';
  * falling back to home directory
  */
 function getDataDir(): string {
-  const cwd = process.cwd();
+  const cwd = getBaseCwd();
   const localDir = join(cwd, '.claude-flow', 'neural');
   const homeDir = join(homedir(), '.claude-flow', 'neural');
 

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -19,6 +19,7 @@
 
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { getBaseCwd } from './cwd-helper.js';
 
 // ===== Lazy singleton =====
 
@@ -32,12 +33,12 @@ let bridgeAvailable: boolean | null = null;
  * or the special ':memory:' path.
  */
 function getDbPath(customPath?: string): string {
-  const swarmDir = path.resolve(process.cwd(), '.swarm');
+  const swarmDir = path.resolve(getBaseCwd(), '.swarm');
   if (!customPath) return path.join(swarmDir, 'memory.db');
   if (customPath === ':memory:') return ':memory:';
   const resolved = path.resolve(customPath);
   // Ensure the path doesn't escape the working directory
-  const cwd = process.cwd();
+  const cwd = getBaseCwd();
   if (!resolved.startsWith(cwd)) {
     return path.join(swarmDir, 'memory.db'); // fallback to safe default
   }

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -11,6 +11,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // ADR-053: Lazy import of AgentDB v3 bridge
 let _bridge: typeof import('./memory-bridge.js') | null | undefined;
@@ -389,7 +390,7 @@ export async function getHNSWIndex(options?: {
     const { VectorDb } = ruvectorCore;
 
     // Persistent storage paths — resolve to absolute to survive CWD changes
-    const swarmDir = path.resolve(process.cwd(), '.swarm');
+    const swarmDir = path.resolve(getBaseCwd(), '.swarm');
     if (!fs.existsSync(swarmDir)) {
       fs.mkdirSync(swarmDir, { recursive: true });
     }
@@ -498,7 +499,7 @@ function saveHNSWMetadata(): void {
   if (!hnswIndex?.entries) return;
 
   try {
-    const swarmDir = path.join(process.cwd(), '.swarm');
+    const swarmDir = path.join(getBaseCwd(), '.swarm');
     const metadataPath = path.join(swarmDir, 'hnsw.metadata.json');
     const metadata = Array.from(hnswIndex.entries.entries());
     fs.writeFileSync(metadataPath, JSON.stringify(metadata));
@@ -1052,10 +1053,10 @@ export async function checkAndMigrateLegacy(options: {
 
   // Check for legacy locations
   const legacyPaths = [
-    path.join(process.cwd(), 'memory.db'),
-    path.join(process.cwd(), '.claude/memory.db'),
-    path.join(process.cwd(), 'data/memory.db'),
-    path.join(process.cwd(), '.claude-flow/memory.db')
+    path.join(getBaseCwd(), 'memory.db'),
+    path.join(getBaseCwd(), '.claude/memory.db'),
+    path.join(getBaseCwd(), 'data/memory.db'),
+    path.join(getBaseCwd(), '.claude-flow/memory.db')
   ];
 
   for (const legacyPath of legacyPaths) {
@@ -1166,7 +1167,7 @@ export async function initializeMemoryDatabase(options: {
     migrate = true
   } = options;
 
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const swarmDir = path.join(getBaseCwd(), '.swarm');
   const dbPath = customPath || path.join(swarmDir, 'memory.db');
   const dbDir = path.dirname(dbPath);
 
@@ -1374,7 +1375,7 @@ export async function checkMemoryInitialization(dbPath?: string): Promise<{
   };
   tables?: string[];
 }> {
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const swarmDir = path.join(getBaseCwd(), '.swarm');
   const path_ = dbPath || path.join(swarmDir, 'memory.db');
 
   if (!fs.existsSync(path_)) {
@@ -1434,7 +1435,7 @@ export async function applyTemporalDecay(dbPath?: string): Promise<{
   patternsDecayed: number;
   error?: string;
 }> {
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const swarmDir = path.join(getBaseCwd(), '.swarm');
   const path_ = dbPath || path.join(swarmDir, 'memory.db');
 
   try {
@@ -2058,7 +2059,7 @@ export async function storeEntry(options: {
     upsert = false
   } = options;
 
-  const swarmDir = path.resolve(process.cwd(), '.swarm');
+  const swarmDir = path.resolve(getBaseCwd(), '.swarm');
   const dbPath = customPath ? path.resolve(customPath) : path.join(swarmDir, 'memory.db');
 
   try {
@@ -2187,7 +2188,7 @@ export async function searchEntries(options: {
   } = options;
   const effectiveNamespace = namespace || 'all';
 
-  const swarmDir = path.resolve(process.cwd(), '.swarm');
+  const swarmDir = path.resolve(getBaseCwd(), '.swarm');
   const dbPath = customPath ? path.resolve(customPath) : path.join(swarmDir, 'memory.db');
   const startTime = Date.now();
 
@@ -2359,7 +2360,7 @@ export async function listEntries(options: {
     dbPath: customPath
   } = options;
 
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const swarmDir = path.join(getBaseCwd(), '.swarm');
   const dbPath = customPath || path.join(swarmDir, 'memory.db');
 
   try {
@@ -2487,7 +2488,7 @@ export async function getEntry(options: {
     dbPath: customPath
   } = options;
 
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const swarmDir = path.join(getBaseCwd(), '.swarm');
   const dbPath = customPath || path.join(swarmDir, 'memory.db');
 
   try {
@@ -2621,7 +2622,7 @@ export async function deleteEntry(options: {
     dbPath: customPath
   } = options;
 
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const swarmDir = path.join(getBaseCwd(), '.swarm');
   const dbPath = customPath || path.join(swarmDir, 'memory.db');
 
   try {

--- a/v3/@claude-flow/cli/src/memory/sona-optimizer.ts
+++ b/v3/@claude-flow/cli/src/memory/sona-optimizer.ts
@@ -16,6 +16,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
+import { getBaseCwd } from './cwd-helper.js';
 
 // ============================================================================
 // Types
@@ -830,7 +831,7 @@ export class SONAOptimizer {
    */
   private loadFromDisk(): boolean {
     try {
-      const fullPath = join(process.cwd(), this.persistencePath);
+      const fullPath = join(getBaseCwd(), this.persistencePath);
       if (!existsSync(fullPath)) {
         return false;
       }
@@ -872,7 +873,7 @@ export class SONAOptimizer {
    */
   private saveToDisk(): boolean {
     try {
-      const fullPath = join(process.cwd(), this.persistencePath);
+      const fullPath = join(getBaseCwd(), this.persistencePath);
       const dir = dirname(fullPath);
 
       // Ensure directory exists

--- a/v3/mcp/__tests__/cwd-helper.test.ts
+++ b/v3/mcp/__tests__/cwd-helper.test.ts
@@ -7,7 +7,7 @@
  * Closes #1532
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { getBaseCwd } from '../tools/cwd-helper.js';
 
 describe('getBaseCwd', () => {

--- a/v3/mcp/__tests__/cwd-helper.test.ts
+++ b/v3/mcp/__tests__/cwd-helper.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for cwd-helper.ts
+ *
+ * Verifies that getBaseCwd() respects the CLAUDE_FLOW_CWD environment
+ * variable, falling back to process.cwd() when unset.
+ *
+ * Closes #1532
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getBaseCwd } from '../tools/cwd-helper.js';
+
+describe('getBaseCwd', () => {
+  const originalEnv = process.env.CLAUDE_FLOW_CWD;
+
+  afterEach(() => {
+    // Restore original env
+    if (originalEnv === undefined) {
+      delete process.env.CLAUDE_FLOW_CWD;
+    } else {
+      process.env.CLAUDE_FLOW_CWD = originalEnv;
+    }
+  });
+
+  it('returns CLAUDE_FLOW_CWD when set', () => {
+    process.env.CLAUDE_FLOW_CWD = '/Users/testuser';
+    expect(getBaseCwd()).toBe('/Users/testuser');
+  });
+
+  it('returns process.cwd() when CLAUDE_FLOW_CWD is not set', () => {
+    delete process.env.CLAUDE_FLOW_CWD;
+    expect(getBaseCwd()).toBe(process.cwd());
+  });
+
+  it('returns process.cwd() when CLAUDE_FLOW_CWD is empty string', () => {
+    process.env.CLAUDE_FLOW_CWD = '';
+    // Empty string is falsy, so falls back to process.cwd()
+    expect(getBaseCwd()).toBe(process.cwd());
+  });
+
+  it('does not return "/" (root) when CLAUDE_FLOW_CWD is set to a home dir', () => {
+    process.env.CLAUDE_FLOW_CWD = '/home/user';
+    const result = getBaseCwd();
+    expect(result).not.toBe('/');
+    expect(result).toBe('/home/user');
+  });
+});

--- a/v3/mcp/tools/config-tools.ts
+++ b/v3/mcp/tools/config-tools.ts
@@ -12,11 +12,12 @@
 import { z } from 'zod';
 import { MCPTool, ToolContext } from '../types.js';
 import { resolve, normalize } from 'path';
+import { getBaseCwd } from './cwd-helper.js';
 
 /**
  * Validate and sanitize config file path to prevent path traversal
  */
-function validateConfigPath(inputPath: string, cwd: string = process.cwd()): string {
+function validateConfigPath(inputPath: string, cwd: string = getBaseCwd()): string {
   // Normalize the path to resolve .. and .
   const normalizedPath = normalize(inputPath);
 

--- a/v3/mcp/tools/cwd-helper.js
+++ b/v3/mcp/tools/cwd-helper.js
@@ -1,5 +1,5 @@
 /**
- * Shared working-directory helper for MCP tools.
+ * Shared working-directory helper for MCP tools (compiled).
  *
  * When ruflo is installed globally and the MCP server is registered without
  * an explicit cwd, macOS (and some Linux setups) spawn the stdio process at
@@ -17,7 +17,7 @@
  * 1. CLAUDE_FLOW_CWD environment variable (set by the install script)
  * 2. process.cwd()
  */
-export function getBaseCwd(): string {
+export function getBaseCwd() {
   const cwd = process.env.CLAUDE_FLOW_CWD || process.cwd();
   if (cwd === '/') {
     console.warn('[ruflo] Warning: CWD resolved to root (/). Set CLAUDE_FLOW_CWD to your project directory.');

--- a/v3/mcp/tools/cwd-helper.ts
+++ b/v3/mcp/tools/cwd-helper.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared working-directory helper for MCP tools.
+ *
+ * When ruflo is installed globally and the MCP server is registered without
+ * an explicit cwd, macOS (and some Linux setups) spawn the stdio process at
+ * "/". All process.cwd()-based paths then resolve to the read-only root
+ * filesystem, breaking every file operation.
+ *
+ * This helper checks the CLAUDE_FLOW_CWD environment variable first,
+ * falling back to process.cwd() only when the variable is not set.
+ */
+
+/**
+ * Returns the effective working directory for file operations.
+ *
+ * Resolution order:
+ * 1. CLAUDE_FLOW_CWD environment variable (set by the install script)
+ * 2. process.cwd()
+ */
+export function getBaseCwd(): string {
+  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+}

--- a/v3/mcp/tools/hooks-tools.js
+++ b/v3/mcp/tools/hooks-tools.js
@@ -17,6 +17,7 @@
  */
 import { z } from 'zod';
 import { createReasoningBank, } from '../../@claude-flow/neural/src/index.js';
+import { getBaseCwd } from './cwd-helper.js';
 // ============================================================================
 // Singleton ReasoningBank Instance
 // ============================================================================
@@ -493,7 +494,7 @@ async function handleExplain(input, context) {
 async function handlePretrain(input, context) {
     const reasoningBank = await getReasoningBank();
     const startTime = performance.now();
-    const repositoryPath = input.repositoryPath || process.cwd();
+    const repositoryPath = input.repositoryPath || getBaseCwd();
     // Simulate analysis with real pattern extraction
     const trajectories = [];
     // Create sample trajectories for different domains

--- a/v3/mcp/tools/hooks-tools.ts
+++ b/v3/mcp/tools/hooks-tools.ts
@@ -18,6 +18,7 @@
 
 import { z } from 'zod';
 import { MCPTool, ToolContext } from '../types.js';
+import { getBaseCwd } from './cwd-helper.js';
 import {
   ReasoningBank,
   createReasoningBank,
@@ -802,7 +803,7 @@ async function handlePretrain(
 ): Promise<PretrainResult> {
   const reasoningBank = await getReasoningBank();
   const startTime = performance.now();
-  const repositoryPath = input.repositoryPath || process.cwd();
+  const repositoryPath = input.repositoryPath || getBaseCwd();
 
   // Pattern extraction and trajectory analysis
   const trajectories: Trajectory[] = [];

--- a/v3/mcp/tools/session-tools.js
+++ b/v3/mcp/tools/session-tools.js
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { randomBytes, createHash } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { getBaseCwd } from './cwd-helper.js';
 // Secure ID generation helper
 function generateSecureSessionId() {
     const timestamp = Date.now().toString(36);
@@ -108,7 +109,7 @@ function getSessionPath(sessionId) {
     if (!validateSessionId(sessionId)) {
         throw new Error('Invalid session ID: must contain only alphanumeric characters, hyphens, and underscores');
     }
-    const sessionDir = path.join(process.cwd(), DEFAULT_SESSION_DIR);
+    const sessionDir = path.join(getBaseCwd(), DEFAULT_SESSION_DIR);
     const sessionPath = path.join(sessionDir, `${sessionId}.json`);
     // Ensure the resolved path is within the session directory (defense in depth)
     const resolvedPath = path.resolve(sessionPath);
@@ -122,7 +123,7 @@ function getSessionPath(sessionId) {
  * Ensure session directory exists
  */
 async function ensureSessionDir() {
-    const dir = path.join(process.cwd(), DEFAULT_SESSION_DIR);
+    const dir = path.join(getBaseCwd(), DEFAULT_SESSION_DIR);
     await fs.mkdir(dir, { recursive: true });
 }
 // ============================================================================
@@ -435,7 +436,7 @@ async function handleListSessions(input, context) {
     }
     // Try to load sessions from file system
     try {
-        const dir = path.join(process.cwd(), DEFAULT_SESSION_DIR);
+        const dir = path.join(getBaseCwd(), DEFAULT_SESSION_DIR);
         const files = await fs.readdir(dir);
         for (const file of files) {
             if (!file.endsWith('.json'))

--- a/v3/mcp/tools/session-tools.ts
+++ b/v3/mcp/tools/session-tools.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import { randomBytes, createHash } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { getBaseCwd } from './cwd-helper.js';
 import { MCPTool, ToolContext } from '../types.js';
 
 // Secure ID generation helper
@@ -222,7 +223,7 @@ function getSessionPath(sessionId: string): string {
   if (!validateSessionId(sessionId)) {
     throw new Error('Invalid session ID: must contain only alphanumeric characters, hyphens, and underscores');
   }
-  const sessionDir = path.join(process.cwd(), DEFAULT_SESSION_DIR);
+  const sessionDir = path.join(getBaseCwd(), DEFAULT_SESSION_DIR);
   const sessionPath = path.join(sessionDir, `${sessionId}.json`);
 
   // Ensure the resolved path is within the session directory (defense in depth)
@@ -239,7 +240,7 @@ function getSessionPath(sessionId: string): string {
  * Ensure session directory exists
  */
 async function ensureSessionDir(): Promise<void> {
-  const dir = path.join(process.cwd(), DEFAULT_SESSION_DIR);
+  const dir = path.join(getBaseCwd(), DEFAULT_SESSION_DIR);
   await fs.mkdir(dir, { recursive: true });
 }
 
@@ -579,7 +580,7 @@ async function handleListSessions(
 
   // Try to load sessions from file system
   try {
-    const dir = path.join(process.cwd(), DEFAULT_SESSION_DIR);
+    const dir = path.join(getBaseCwd(), DEFAULT_SESSION_DIR);
     const files = await fs.readdir(dir);
 
     for (const file of files) {


### PR DESCRIPTION
## fix: global install MCP server CWD resolution

Closes #1532 | Related to #1524

### Problem

When ruflo is installed globally via `npm i -g` and registered as an MCP server, macOS (and some Linux setups) spawn the stdio process at `/` (the filesystem root). Every `process.cwd()`-based file path then resolves to the read-only root filesystem, causing all storage operations to fail silently or throw `EACCES`.

### Solution

Introduced a `getBaseCwd()` helper that resolves the working directory via:

1. `CLAUDE_FLOW_CWD` environment variable (set by the install script or MCP server registration)
2. `process.cwd()` fallback

A console warning fires when CWD resolves to `/`, making the root-cause immediately visible in logs.

### Layers patched

| Layer | Scope | Files |
|-------|-------|-------|
| **V3 API tools** (`v3/mcp/tools/`) | 7 files — `getBaseCwd()` replaces all `process.cwd()` calls | `cwd-helper.ts` + 6 tool files |
| **CLI runtime tools** (`v3/@claude-flow/cli/src/mcp-tools/`) | 17 files — same pattern | `cwd-helper.ts` + 16 tool files |
| **Memory subsystem** (`v3/@claude-flow/cli/src/memory/`) | 5 files — same pattern | `cwd-helper.ts` + 4 memory files |

### Additional changes

- **`install.sh`** — Sets `CLAUDE_FLOW_CWD` during install so the env var is available at MCP server startup
- **`doctor.ts`** — New `checkCwd` health check: warns when CWD resolves to root, reports which source (`CLAUDE_FLOW_CWD` vs `process.cwd()`) is active
- **Test** — `cwd-helper.test.ts` covers env-var override, empty-string fallback, and non-root assertion

### Verification

After rebase onto latest `main`:
- 107 `getBaseCwd` references across `v3/`
- 0 bare `process.cwd()` calls remain in `mcp-tools/` or `memory/` (outside the helper itself)
- Both `cwd-helper.ts` files emit a root-CWD console warning
- Doctor command includes the CWD check

### Credits

Thanks to @mgatof91 for reporting #1524 and guiding the fix scope across the three subsystem layers.

---

> **AI Disclosure:** This PR was authored with the assistance of Claude (Anthropic). All code changes were human-reviewed before submission.