### PR TITLE
fix: remove all remaining simulated scores v3.5.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.5.54",
+  "version": "3.5.55",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.5.54",
+  "version": "3.5.55",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.5.54",
+  "version": "3.5.55",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/benchmarks/pretrain/index.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/pretrain/index.ts
@@ -457,7 +457,7 @@ export async function benchmarkPretrainPipeline(config: BenchmarkConfig): Promis
       id: `pattern-${i}`,
       type: 'code-structure',
       embedding: embeddings[i],
-      confidence: 0.85 + Math.random() * 0.1,
+      confidence: embeddings[i] ? 1.0 : 0, // real: has embedding = confident
     }));
 
     return { files: files.length, patterns: patterns.length };

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -1326,8 +1326,8 @@ export const hooksExplain: MCPTool = {
       if (taskLower.includes(pattern)) {
         matchedPatterns.push({
           pattern,
-          matchScore: 0.85 + Math.random() * 0.1,
-          examples: [`Previous ${pattern} task completed successfully`, `${pattern} patterns from repository analysis`],
+          matchScore: pattern.length / Math.max(taskLower.length, 1), // real ratio: pattern length vs task length
+          examples: [`Keyword "${pattern}" matched in task description`],
         });
       }
     }

--- a/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
@@ -4,10 +4,10 @@
  * V2 Compatibility - Neural network and ML tools
  *
  * ✅ HYBRID Implementation:
- * - Uses @claude-flow/embeddings for REAL embeddings when available
- * - Falls back to simulated embeddings when @claude-flow/embeddings not installed
- * - Pattern storage and search with cosine similarity
- * - Training progress tracked (actual model training requires external tools)
+ * - Uses @claude-flow/embeddings for REAL ML embeddings when available
+ * - Falls back to deterministic hash-based embeddings when ML model not installed
+ * - Pattern storage and search with cosine similarity (real math in all tiers)
+ * - Training stores patterns as searchable embeddings (not simulated)
  *
  * Note: For production neural features, use @claude-flow/neural module
  */
@@ -121,7 +121,7 @@ function saveNeuralStore(store: NeuralStore): void {
   writeFileSync(getNeuralPath(), JSON.stringify(store, null, 2), 'utf-8');
 }
 
-// Generate embedding - uses real embeddings if available, falls back to hash-based
+// Generate embedding - uses real ML embeddings if available, falls back to deterministic hash
 async function generateEmbedding(text?: string, dims: number = 384): Promise<number[]> {
   // If real embeddings available and text provided, use them
   if (realEmbeddings && text) {
@@ -149,8 +149,8 @@ async function generateEmbedding(text?: string, dims: number = 384): Promise<num
     return embedding;
   }
 
-  // Pure random fallback
-  return Array.from({ length: dims }, () => Math.random() * 2 - 1);
+  // No text provided — return zero vector (callers should always provide text)
+  return new Array(dims).fill(0);
 }
 
 // Cosine similarity for pattern search


### PR DESCRIPTION
## Summary
- Replaced `Math.random()` confidence/matchScore in hooks-tools.ts with real keyword ratio
- Replaced random confidence in pretrain benchmark with embedding-presence check
- Replaced pure-random embedding fallback in neural-tools.ts with zero vector
- Updated misleading "simulated" comments to accurately describe hash-based deterministic fallback

**Zero instances of `Math.random()` used for metrics/confidence/accuracy remain.**

## Test plan
- [ ] Verify `hooks explain` returns real match ratios instead of random scores
- [ ] Verify `neural_predict` with no stored patterns returns empty array (not fake labels)
- [ ] Verify `neural_train` stores real embeddings with honest accuracy (1.0 or 0)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)