### PR TITLE
fix: curateIndex no longer overwrites MEMORY.md when sections empty (#1556)

### DIFF
--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -911,7 +911,12 @@ Already in DB
   });
 
   describe('curateIndex - edge cases', () => {
-    it('should handle empty topic files', async () => {
+    it('should not overwrite MEMORY.md when topic files have no summaries', async () => {
+      // Write an existing MEMORY.md
+      const indexPath = bridge.getIndexPath();
+      fsSync.writeFileSync(indexPath, '# Existing content\n', 'utf-8');
+
+      // Topic file exists but has no bullet-point summaries
       fsSync.writeFileSync(
         path.join(testDir, 'debugging.md'),
         '# Debugging\n\n',
@@ -919,9 +924,9 @@ Already in DB
       );
 
       await bridge.curateIndex();
-      const content = fsSync.readFileSync(bridge.getIndexPath(), 'utf-8');
-      // Should not include empty section
-      expect(content).not.toContain('Debugging');
+      // Empty sections should leave MEMORY.md untouched (#1556)
+      const content = fsSync.readFileSync(indexPath, 'utf-8');
+      expect(content).toBe('# Existing content\n');
     });
 
     it('should emit index:curated event', async () => {
@@ -938,6 +943,20 @@ Already in DB
       expect(handler).toHaveBeenCalledWith(expect.objectContaining({
         lines: expect.any(Number),
       }));
+    });
+
+    it('should not overwrite MEMORY.md when no topic files match (#1556)', async () => {
+      // Write a hand-curated MEMORY.md
+      const indexPath = bridge.getIndexPath();
+      const handCurated = '# My Project Memory\n\n- [User Role](user_role.md) — Senior engineer\n- [Feedback](feedback_testing.md) — Prefer TDD\n';
+      fsSync.writeFileSync(indexPath, handCurated, 'utf-8');
+
+      // No topic files exist (user uses native <type>_<topic>.md convention)
+      // curateIndex should leave MEMORY.md untouched
+      await bridge.curateIndex();
+
+      const content = fsSync.readFileSync(indexPath, 'utf-8');
+      expect(content).toBe(handCurated);
     });
 
     it('should handle pruneStrategy=lru same as fifo', async () => {

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -486,6 +486,13 @@ export class AutoMemoryBridge extends EventEmitter {
         .filter((cat) => sections[cat]);
     }
 
+    // If no topic files matched, leave existing MEMORY.md untouched.
+    // This prevents overwriting hand-curated or native-convention indexes
+    // when the topic mapping doesn't match the filesystem layout. (#1556)
+    if (Object.keys(sections).length === 0) {
+      return;
+    }
+
     // Prune sections before building the index to avoid O(n^2) rebuild loop
     const budget = this.config.maxIndexLines;
     pruneSectionsToFit(sections, budget, this.config.pruneStrategy);


### PR DESCRIPTION
## Summary

Fixes `AutoMemoryBridge.curateIndex()` silently overwriting hand-curated `MEMORY.md` with a stub header (`# Claude Flow V3 Project Memory\n`) when no topic files match the hardcoded `topicMapping`.

This affects **every project** using Claude Code's native `<type>_<topic>.md` filename convention (e.g. `user_role.md`, `feedback_testing.md`), since none of these match the 7 hardcoded filenames (`patterns.md`, `debugging.md`, etc.). The overwrite fires on every `Stop` hook tick.

## Root cause

`curateIndex()` collects summaries from topic files matching `topicMapping`. When none match, `sections` is empty, `buildIndexLines` returns just the title header, and that gets written to `MEMORY.md` — destroying whatever was there.

## Fix (2 files, +30/-4 lines)

**`v3/@claude-flow/memory/src/auto-memory-bridge.ts`**
- Early return when `Object.keys(sections).length === 0` — leave existing MEMORY.md untouched

**`v3/@claude-flow/memory/src/auto-memory-bridge.test.ts`**
- Add test: hand-curated MEMORY.md preserved when no topic files match
- Update existing "empty topic files" test to verify MEMORY.md is untouched (not overwritten with stub)

## Test plan

- [x] New test: hand-curated MEMORY.md survives `curateIndex()` when no matching topic files exist
- [x] Updated test: empty topic file (heading only, no summaries) also leaves MEMORY.md untouched
- [x] Existing test: `curateIndex()` still works correctly when topic files DO match
- [x] All 354 memory tests pass (9 suites)

Closes #1556

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)