### PR TITLE
fix: add Python test_*.py naming convention to statusline test detection

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -533,7 +533,7 @@ function getTestStats() {
           countTestFiles(path.join(dir, entry.name), depth + 1);
         } else if (entry.isFile()) {
           const n = entry.name;
-          if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.')) {
+          if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.') || (n.startsWith('test_') && n.endsWith('.py'))) {
             testFiles++;
           }
         }


### PR DESCRIPTION
Fixes #1463

## Problem

The `getTestStats()` function in `.claude/helpers/statusline.cjs` uses pattern matching to detect test files, but only checks for JS/TS conventions (`.test.*`, `.spec.*`) and Go/Rust conventions (`_test.*`, `_spec.*`). It does not detect Python/pytest test files named `test_*.py`, which is the standard pytest naming convention.

As a result, Python projects with tests in `tests/test_*.py` would always show `Tests ●0 (~0 cases)` in the statusline, even with 14+ test files.

## Solution

Add a check for the Python/pytest `test_*.py` naming convention:

```js
// Before
if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.')) {

// After
if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.') || (n.startsWith('test_') && n.endsWith('.py'))) {
```

## Testing

- Verified the pattern correctly matches `test_app.py`, `test_export.py`, etc.
- Does not match `mytest_file.py` (must start with `test_`)
- Does not match `test_data.csv` (must end with `.py`)