### PR TITLE
fix: align SpawnAgentSchema field name with MCP tool schema and caller

### DIFF
--- a/v3/@claude-flow/security/__tests__/input-validator.test.ts
+++ b/v3/@claude-flow/security/__tests__/input-validator.test.ts
@@ -25,6 +25,7 @@ import {
   PermissionSchema,
   LoginRequestSchema,
   CreateUserSchema,
+  SpawnAgentSchema,
   TaskInputSchema,
   CommandArgumentSchema,
   PathSchema,
@@ -225,6 +226,33 @@ describe('InputValidator', () => {
         email: 'user@example.com',
         password: 'weak',
         role: 'developer',
+      })).toThrow();
+    });
+  });
+
+  describe('SpawnAgentSchema', () => {
+    it('should accept valid agent spawn with agentType', () => {
+      expect(() => SpawnAgentSchema.parse({
+        agentType: 'coder',
+      })).not.toThrow();
+    });
+
+    it('should accept agent spawn with optional name', () => {
+      expect(() => SpawnAgentSchema.parse({
+        agentType: 'tester',
+        name: 'my-tester',
+      })).not.toThrow();
+    });
+
+    it('should reject spawn missing agentType', () => {
+      expect(() => SpawnAgentSchema.parse({
+        name: 'my-agent',
+      })).toThrow();
+    });
+
+    it('should reject spawn with legacy type field instead of agentType', () => {
+      expect(() => SpawnAgentSchema.parse({
+        type: 'coder',
       })).toThrow();
     });
   });

--- a/v3/@claude-flow/security/src/input-validator.ts
+++ b/v3/@claude-flow/security/src/input-validator.ts
@@ -262,7 +262,8 @@ export const AgentTypeSchema = z.enum([
  * Agent spawn request schema
  */
 export const SpawnAgentSchema = z.object({
-  type: AgentTypeSchema,
+  agentType: AgentTypeSchema,
+  name: SafeStringSchema.max(200, 'Name too long').optional(),
   id: IdentifierSchema.optional(),
   config: z.record(z.unknown()).optional(),
   timeout: z.number().positive().optional(),


### PR DESCRIPTION
Fixes #1567

## Problem

`mcp__ruflo__agent_spawn` always fails with `"Input validation failed: type: Required"` because there is a field name mismatch between three components:

1. **MCP tool schema** (`agent-tools.ts`) — exposes `agentType` as the field name
2. **`validate-input.ts`** — calls `SpawnAgentSchema.parse({ agentType: input.agentType, name: input.agentId })`
3. **`SpawnAgentSchema`** (`input-validator.ts`) — expects `type` (not `agentType`) and does not have a `name` field

Zod fails fast with `"type: Required"` because the caller sends `agentType` but the schema requires `type`.

## Solution

Align `SpawnAgentSchema` with the caller convention and the MCP tool schema:

```diff
 export const SpawnAgentSchema = z.object({
-  type: AgentTypeSchema,
+  agentType: AgentTypeSchema,
+  name: SafeStringSchema.max(200, 'Name too long').optional(),
   id: IdentifierSchema.optional(),
   config: z.record(z.unknown()).optional(),
   timeout: z.number().positive().optional(),
 });
```

## Testing

Added tests to `__tests__/input-validator.test.ts` verifying:
- `{ agentType: 'coder' }` is accepted
- `{ agentType: 'tester', name: 'my-tester' }` is accepted  
- Missing `agentType` is rejected
- Legacy `type` field (instead of `agentType`) is rejected

Manually verified with Node.js that all 4 cases produce the expected results.