### PR TITLE
fix: memory_store MCP tool crashes on undefined/null value (#1032)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts
@@ -1636,13 +1636,25 @@ describe('memory_store undefined value guard (#1032)', () => {
     expect(result.error).toContain('Missing required parameter: value (cannot be null or undefined)');
   });
 
-  it('should not crash and should include key in error response', async () => {
+  it('should not crash and should include full error payload', async () => {
     const { memoryTools } = await import('../src/mcp-tools/memory-tools.js');
     const tool = memoryTools.find(t => t.name === 'memory_store')!;
 
     const result: any = await tool.handler({ key: 'my-key', value: undefined });
     expect(result.success).toBe(false);
     expect(result.key).toBe('my-key');
+    expect(result.namespace).toBe('default');
     expect(result.stored).toBe(false);
+    expect(result.hasEmbedding).toBe(false);
+  });
+
+  it('should return error when value is empty string', async () => {
+    const { memoryTools } = await import('../src/mcp-tools/memory-tools.js');
+    const tool = memoryTools.find(t => t.name === 'memory_store')!;
+
+    const result: any = await tool.handler({ key: 'empty-key', value: '' });
+    expect(result.success).toBe(false);
+    expect(result.stored).toBe(false);
+    expect(result.error).toContain('Value is required');
   });
 });

--- a/v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts
@@ -1611,3 +1611,38 @@ describe('Edge Cases', () => {
     });
   });
 });
+
+// =============================================================================
+// memory_store handler: undefined/null value guard (#1032)
+// =============================================================================
+
+describe('memory_store undefined value guard (#1032)', () => {
+  it('should return error when value is undefined', async () => {
+    const { memoryTools } = await import('../src/mcp-tools/memory-tools.js');
+    const tool = memoryTools.find(t => t.name === 'memory_store')!;
+    expect(tool).toBeDefined();
+
+    const result: any = await tool.handler({ key: 'test-key' });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Missing required parameter: value (cannot be null or undefined)');
+  });
+
+  it('should return error when value is null', async () => {
+    const { memoryTools } = await import('../src/mcp-tools/memory-tools.js');
+    const tool = memoryTools.find(t => t.name === 'memory_store')!;
+
+    const result: any = await tool.handler({ key: 'test-key', value: null });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Missing required parameter: value (cannot be null or undefined)');
+  });
+
+  it('should not crash and should include key in error response', async () => {
+    const { memoryTools } = await import('../src/mcp-tools/memory-tools.js');
+    const tool = memoryTools.find(t => t.name === 'memory_store')!;
+
+    const result: any = await tool.handler({ key: 'my-key', value: undefined });
+    expect(result.success).toBe(false);
+    expect(result.key).toBe('my-key');
+    expect(result.stored).toBe(false);
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -209,7 +209,17 @@ export const memoryTools: MCPTool[] = [
       const key = input.key as string;
       const namespace = (input.namespace as string) || 'default';
       const rawValue = input.value;
-      const value = typeof rawValue === 'string' ? rawValue : (rawValue !== undefined ? JSON.stringify(rawValue) : '');
+      if (rawValue === undefined || rawValue === null) {
+        return {
+          success: false,
+          key,
+          namespace,
+          stored: false,
+          hasEmbedding: false,
+          error: 'Missing required parameter: value (cannot be null or undefined)',
+        };
+      }
+      const value = typeof rawValue === 'string' ? rawValue : JSON.stringify(rawValue);
       const tags = (input.tags as string[]) || [];
       const ttl = input.ttl as number | undefined;
       const upsert = (input.upsert as boolean) || false;

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -2083,7 +2083,7 @@ export async function storeEntry(options: {
     let embeddingDimensions: number | null = null;
     let embeddingModel: string | null = null;
 
-    if (generateEmbeddingFlag && value.length > 0) {
+    if (generateEmbeddingFlag && value && value.length > 0) {
       const embResult = await generateEmbedding(value);
       embeddingJson = JSON.stringify(embResult.embedding);
       embeddingDimensions = embResult.dimensions;


### PR DESCRIPTION
## Summary

Fixes #1032

- **`memory-tools.ts`**: Early return with `{success: false, error: "Missing required parameter: value"}` when `value` is `undefined` or `null`, instead of crashing with `Cannot read properties of undefined (reading 'length')`
- **`memory-initializer.ts`**: Added null guard on `value.length` in `storeEntry()` to protect against direct callers bypassing the MCP handler

## Test plan

- [x] 3 new tests added to `memory-ruvector-deep.test.ts` covering undefined, null, and error response shape
- [x] All 148 tests pass (`npx vitest run __tests__/memory-ruvector-deep.test.ts`)
- [x] No regressions in existing 145 tests

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts` | Explicit null/undefined guard before value coercion |
| `v3/@claude-flow/cli/src/memory/memory-initializer.ts` | `value && value.length > 0` null-safe check |
| `v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts` | 3 new test cases |

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)