### PR TITLE
fix: increase default hook timeout from 5000ms to 10000ms (#1060)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hook-timeout-defaults.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hook-timeout-defaults.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Hook Timeout Defaults Tests
+ *
+ * Verifies that the default hook timeout is 10000ms (not 5000ms)
+ * to prevent intermittent hook failures from npx startup overhead.
+ *
+ * Fixes: https://github.com/ruvnet/ruflo/issues/1060
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+describe('Hook timeout defaults (#1060)', () => {
+  it('DEFAULT_INIT_OPTIONS.hooks.timeout should be 10000ms', () => {
+    expect(DEFAULT_INIT_OPTIONS.hooks.timeout).toBe(10000);
+  });
+
+  it('timeout should be at least 10000ms to avoid npx cold-start failures', () => {
+    expect(DEFAULT_INIT_OPTIONS.hooks.timeout).toBeGreaterThanOrEqual(10000);
+  });
+
+  it('continueOnError should be true by default', () => {
+    expect(DEFAULT_INIT_OPTIONS.hooks.continueOnError).toBe(true);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -840,7 +840,7 @@ const hooksCommand: Command = {
             notification: false,
             teammateIdle: false,
             taskCompleted: false,
-            timeout: 5000,
+            timeout: 10000,
             continueOnError: true,
           }
         : DEFAULT_INIT_OPTIONS.hooks,

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -344,7 +344,7 @@ function generateHooksConfig(config: HooksConfig): object {
           {
             type: 'command',
             command: hookHandlerCmd('session-end'),
-            timeout: 5000,
+            timeout: 10000,
           },
         ],
       },
@@ -386,7 +386,7 @@ function generateHooksConfig(config: HooksConfig): object {
         {
           type: 'command',
           command: hookHandlerCmd('post-task'),
-          timeout: 5000,
+          timeout: 10000,
         },
       ],
     },

--- a/v3/@claude-flow/cli/src/init/types.ts
+++ b/v3/@claude-flow/cli/src/init/types.ts
@@ -340,7 +340,7 @@ export const DEFAULT_INIT_OPTIONS: InitOptions = {
     notification: true,
     teammateIdle: true,
     taskCompleted: true,
-    timeout: 5000,
+    timeout: 10000,
     continueOnError: true,
   },
   skills: {


### PR DESCRIPTION
## Summary

Fixes #1060

- Changed default hook timeout from 5000ms to 10000ms in `DEFAULT_INIT_OPTIONS` (`types.ts`)
- Updated hardcoded 5000ms timeouts in `settings-generator.ts` (Stop/session-end and SubagentStop/post-task hooks)
- Updated minimal-mode fallback timeout in `init.ts`

The 5000ms default was too short for `npx` cold-start overhead, causing intermittent `PreToolUse:Bash` and `PostToolUse:Bash` hook errors. Testing showed 10000ms achieves 100% success rate (the `session-restore` hook already used 15000ms, confirming higher values are needed).

## Verification

- [x] Baseline tests: 7846 pass, 246 pre-existing failures
- [x] Post-fix tests: no regressions (7849 pass — 3 new)
- [x] New tests: 3 added in `hook-timeout-defaults.test.ts`, all pass
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/init/types.ts` | Default `timeout: 5000` → `10000` |
| `v3/@claude-flow/cli/src/commands/init.ts` | Minimal-mode fallback `timeout: 5000` → `10000` |
| `v3/@claude-flow/cli/src/init/settings-generator.ts` | Two hardcoded `5000` → `10000` (session-end, post-task) |
| `v3/@claude-flow/cli/__tests__/hook-timeout-defaults.test.ts` | NEW: 3 tests verifying default timeout value |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
