### PR TITLE
fix: use published package name 'claude-flow' in MCP config generator (#1014)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/mcp-generator.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-generator.test.ts
@@ -1,0 +1,60 @@
+/**
+ * MCP Generator Tests
+ *
+ * Verifies that generated MCP config uses the correct published npm package
+ * name (`claude-flow`) instead of the internal directory path (`@claude-flow/cli@latest`).
+ *
+ * Regression test for: https://github.com/ruvnet/ruflo/issues/1014
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateMCPConfig, generateMCPJson, generateMCPCommands } from '../src/init/mcp-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+const optionsWithAll = {
+  ...DEFAULT_INIT_OPTIONS,
+  mcp: {
+    claudeFlow: true,
+    ruvSwarm: true,
+    flowNexus: true,
+    autoStart: false,
+    port: 3000,
+  },
+};
+
+describe('MCP Generator', () => {
+  describe('generateMCPConfig', () => {
+    it('uses the published package name "claude-flow" for the MCP server args', () => {
+      const config = generateMCPConfig(optionsWithAll) as {
+        mcpServers: Record<string, { args?: string[]; command?: string }>;
+      };
+      const cfArgs = config.mcpServers['claude-flow']?.args ?? [];
+      // The args array must not contain the internal path @claude-flow/cli@latest
+      expect(cfArgs).not.toContain('@claude-flow/cli@latest');
+      // It must include the real package name
+      expect(cfArgs).toContain('claude-flow');
+    });
+
+    it('does not reference @claude-flow/cli@latest anywhere in generated config', () => {
+      const json = generateMCPJson(optionsWithAll);
+      expect(json).not.toContain('@claude-flow/cli@latest');
+    });
+  });
+
+  describe('generateMCPCommands', () => {
+    it('manual-setup commands use "claude-flow" not "@claude-flow/cli@latest"', () => {
+      const commands = generateMCPCommands(optionsWithAll);
+      const cfCmd = commands.find(c => c.includes('claude-flow'));
+      expect(cfCmd).toBeDefined();
+      expect(cfCmd).not.toContain('@claude-flow/cli@latest');
+      expect(cfCmd).toContain('claude-flow mcp start');
+    });
+
+    it('none of the generated commands reference the internal @claude-flow/cli package', () => {
+      const commands = generateMCPCommands(optionsWithAll);
+      for (const cmd of commands) {
+        expect(cmd).not.toContain('@claude-flow/cli@latest');
+      }
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/init/mcp-generator.ts
+++ b/v3/@claude-flow/cli/src/init/mcp-generator.ts
@@ -55,7 +55,7 @@ export function generateMCPConfig(options: InitOptions): object {
   // Claude Flow MCP server (core)
   if (config.claudeFlow) {
     mcpServers['claude-flow'] = createMCPServerEntry(
-      ['@claude-flow/cli@latest', 'mcp', 'start'],
+      ['claude-flow', 'mcp', 'start'],
       {
         ...npmEnv,
         CLAUDE_FLOW_MODE: 'v3',
@@ -106,7 +106,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
 
   if (isWindows()) {
     if (config.claudeFlow) {
-      commands.push('claude mcp add claude-flow -- cmd /c npx -y @claude-flow/cli@latest mcp start');
+      commands.push('claude mcp add claude-flow -- cmd /c npx -y claude-flow mcp start');
     }
     if (config.ruvSwarm) {
       commands.push('claude mcp add ruv-swarm -- cmd /c npx -y ruv-swarm mcp start');
@@ -116,7 +116,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
     }
   } else {
     if (config.claudeFlow) {
-      commands.push("claude mcp add claude-flow -- npx -y @claude-flow/cli@latest mcp start");
+      commands.push("claude mcp add claude-flow -- npx -y claude-flow mcp start");
     }
     if (config.ruvSwarm) {
       commands.push("claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start");


### PR DESCRIPTION
## Summary

Fixes #1014

- `generateMCPConfig()` now passes `['claude-flow', 'mcp', 'start']` instead of `['@claude-flow/cli@latest', 'mcp', 'start']` as npx args
- `generateMCPCommands()` now emits `npx -y claude-flow mcp start` on both Windows and POSIX paths
- `@claude-flow/cli@latest` is an internal directory structure, not a published npm package — it silently fails when invoked via `npx`

## Verification

- [x] Baseline tests: 5972 pass, 100 pre-existing failures
- [x] Post-fix tests: no regressions
- [x] New tests: 4 added in `mcp-generator.test.ts`, all pass
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/init/mcp-generator.ts` | Replace 3 occurrences of `@claude-flow/cli@latest` with `claude-flow` |
| `v3/@claude-flow/cli/__tests__/mcp-generator.test.ts` | NEW: 4 tests verifying correct package name in generated config |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
