### PR TITLE
fix: map agentType→type and agentId→id in SpawnAgentSchema.parse() (#1567)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/validate-input-schema.test.ts
+++ b/v3/@claude-flow/cli/__tests__/validate-input-schema.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression tests for #1567: agent_spawn MCP tool fails with 'type: Required'
+ *
+ * Root cause: validate-input.ts passed {agentType, name} to SpawnAgentSchema.parse()
+ * but the schema expects {type, id}.
+ *
+ * These tests ensure:
+ * 1. SpawnAgentSchema accepts the correct field names (type, id)
+ * 2. SpawnAgentSchema rejects the old wrong field names (agentType, name)
+ * 3. The source fix maps agentType→type and agentId→id when calling parse()
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ============================================================================
+// Direct schema tests — import SpawnAgentSchema from the local security package
+// ============================================================================
+describe('SpawnAgentSchema field names (#1567)', () => {
+  it('accepts {type, id} — the correct field names', async () => {
+    const { SpawnAgentSchema } = await import(
+      '../../security/src/input-validator.js'
+    );
+    const result = SpawnAgentSchema.safeParse({ type: 'coder', id: 'agent-1' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts {type} without optional id field', async () => {
+    const { SpawnAgentSchema } = await import(
+      '../../security/src/input-validator.js'
+    );
+    const result = SpawnAgentSchema.safeParse({ type: 'tester' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects {agentType, name} — the old wrong field names that caused bug', async () => {
+    const { SpawnAgentSchema } = await import(
+      '../../security/src/input-validator.js'
+    );
+    // This is what validate-input.ts used to pass — must fail with "type: Required"
+    const result = SpawnAgentSchema.safeParse({ agentType: 'coder', name: 'agent-1' });
+    expect(result.success).toBe(false);
+    const issues = result.error?.issues ?? [];
+    expect(issues.some((i: any) => i.path.includes('type'))).toBe(true);
+  });
+
+  it('rejects an unknown agent type', async () => {
+    const { SpawnAgentSchema } = await import(
+      '../../security/src/input-validator.js'
+    );
+    const result = SpawnAgentSchema.safeParse({ type: 'hacker' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Source-guard — validate-input.ts must use {type, id}, not {agentType, name}
+// ============================================================================
+describe('validate-input.ts source guard (#1567)', () => {
+  it('passes type (not agentType) to SpawnAgentSchema.parse()', async () => {
+    const { readFileSync } = await import('fs');
+    const source = readFileSync(
+      new URL('../src/mcp-tools/validate-input.ts', import.meta.url),
+      'utf-8'
+    );
+
+    // Must NOT use the old wrong field names in the SpawnAgentSchema.parse() call
+    expect(source).not.toMatch(/SpawnAgentSchema\.parse\(\s*\{[^}]*agentType:/);
+    expect(source).not.toMatch(/SpawnAgentSchema\.parse\(\s*\{[^}]*name:/);
+
+    // Must use the correct field names
+    expect(source).toMatch(/SpawnAgentSchema\.parse\(\s*\{[^}]*type:/);
+    expect(source).toMatch(/SpawnAgentSchema\.parse\(\s*\{[^}]*id:/);
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/validate-input.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/validate-input.ts
@@ -129,8 +129,8 @@ export async function validateAgentSpawn(input: Record<string, unknown>): Promis
   if (sec?.SpawnAgentSchema) {
     try {
       sec.SpawnAgentSchema.parse({
-        agentType: input.agentType,
-        name: input.agentId,
+        type: input.agentType,
+        id: input.agentId,
       });
     } catch (zodErr: any) {
       if (zodErr.issues) {


### PR DESCRIPTION
## Summary

Fixes #1567

- `validate-input.ts` was calling `SpawnAgentSchema.parse({ agentType, name })` but the Zod schema in `@claude-flow/security` defines `SpawnAgentSchema` with `type` (required) and `id` (optional)
- This caused every `agent_spawn` MCP tool call to fail with `"Input validation failed: type: Required"` even when the caller passed a valid `agentType`
- Fix maps the caller's field names to the schema's expected names: `agentType → type`, `agentId → id`

## Verification

- [x] Baseline tests: 8 pre-existing failures (7 in memory-ruvector-deep, 1 in safe-executor), no new failures
- [x] Post-fix tests: no regressions
- [x] New tests: 5 added (all pass) — schema behavioral tests + source guard
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/mcp-tools/validate-input.ts` | Fix field name mapping in `SpawnAgentSchema.parse()` call |
| `v3/@claude-flow/cli/__tests__/validate-input-schema.test.ts` | New regression tests for #1567 |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
