### PR TITLE
fix: compute ADR count dynamically in statusline instead of hardcoded 0/0 (#1047)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-adr-count.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-adr-count.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for #1047: Statusline ADR count hardcoded to 0/0
+ *
+ * The statusline displayed `ADRs ●0/0` but the count was never computed.
+ * Fix: scan well-known ADR directories and count ADR markdown files.
+ *
+ * Tests verify:
+ * 1. ADR scanning counts files in expected directories
+ * 2. Only files matching ADR naming conventions are counted
+ * 3. Accepted/Implemented status detection works
+ * 4. Source guard: hardcoded ●0/0 is no longer in hooks.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Helper to simulate ADR counting logic (mirrors the fix in hooks.ts)
+function countADRs(cwd: string): { count: number; implemented: number } {
+  const fs = require('fs');
+  const path = require('path');
+
+  const adrStats = { count: 0, implemented: 0 };
+  const adrPaths = [
+    path.join(cwd, 'v3', 'implementation', 'adrs'),
+    path.join(cwd, 'docs', 'adrs'),
+    path.join(cwd, 'docs', 'adr'),
+    path.join(cwd, '.claude-flow', 'adrs'),
+  ];
+
+  for (const adrPath of adrPaths) {
+    try {
+      if (fs.existsSync(adrPath)) {
+        const files = fs.readdirSync(adrPath).filter((f: string) =>
+          f.endsWith('.md') && (f.startsWith('ADR-') || f.startsWith('adr-') || /^\d{4}-/.test(f))
+        );
+        adrStats.count = files.length;
+        for (const file of files) {
+          try {
+            const content = fs.readFileSync(path.join(adrPath, file), 'utf-8');
+            if (/Status\s*[:\*]*\s*(Accepted|Implemented)/i.test(content)) {
+              adrStats.implemented++;
+            }
+          } catch { /* ignore */ }
+        }
+        if (adrStats.count === 0) continue;
+        break;
+      }
+    } catch { /* ignore */ }
+  }
+
+  return adrStats;
+}
+
+describe('ADR count in hooks statusline (#1047)', () => {
+  let tmpDir: string;
+
+  it('returns 0/0 when no ADR directory exists', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'adr-test-'));
+    try {
+      const result = countADRs(tmpDir);
+      expect(result.count).toBe(0);
+      expect(result.implemented).toBe(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it('counts ADR files in docs/adrs directory', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'adr-test-'));
+    const adrDir = join(tmpDir, 'docs', 'adrs');
+    mkdirSync(adrDir, { recursive: true });
+    writeFileSync(join(adrDir, 'ADR-001-use-typescript.md'), '# ADR-001\n\nStatus: Proposed\n\nBody here.');
+    writeFileSync(join(adrDir, 'ADR-002-use-vitest.md'), '# ADR-002\n\nStatus: Accepted\n\nBody here.');
+    writeFileSync(join(adrDir, 'ADR-003-memory-backend.md'), '# ADR-003\n\nStatus: Implemented\n\nBody here.');
+    writeFileSync(join(adrDir, 'README.md'), '# ADR Index'); // should not count
+
+    try {
+      const result = countADRs(tmpDir);
+      expect(result.count).toBe(3);        // 3 ADR- files, not README
+      expect(result.implemented).toBe(2);  // ADR-002 (Accepted) + ADR-003 (Implemented)
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it('counts ADRs with bold markdown Status: **Accepted**', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'adr-test-'));
+    const adrDir = join(tmpDir, 'docs', 'adrs');
+    mkdirSync(adrDir, { recursive: true });
+    writeFileSync(join(adrDir, 'ADR-010-bold-status.md'), '# ADR-010\n\n**Status**: Accepted\n\nBody.');
+
+    try {
+      const result = countADRs(tmpDir);
+      expect(result.count).toBe(1);
+      expect(result.implemented).toBe(1);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it('counts numeric-prefixed ADR files (e.g. 0001-use-postgres.md)', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'adr-test-'));
+    const adrDir = join(tmpDir, 'docs', 'adrs');
+    mkdirSync(adrDir, { recursive: true });
+    writeFileSync(join(adrDir, '0001-use-postgres.md'), '# ADR\n\nStatus: Accepted\n');
+    writeFileSync(join(adrDir, '0002-use-redis.md'), '# ADR\n\nStatus: Proposed\n');
+
+    try {
+      const result = countADRs(tmpDir);
+      expect(result.count).toBe(2);
+      expect(result.implemented).toBe(1);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+});
+
+// ============================================================================
+// Source guard: the hardcoded ●0/0 must be gone from hooks.ts
+// ============================================================================
+describe('hooks.ts source guard (#1047)', () => {
+  it('must not contain hardcoded ADR count ●0/0', async () => {
+    const { readFileSync } = await import('fs');
+    const source = readFileSync(
+      new URL('../src/commands/hooks.ts', import.meta.url),
+      'utf-8'
+    );
+
+    // The literal hardcoded string that caused the bug must be gone
+    expect(source).not.toContain('●0/0');
+
+    // The dynamic ADR counting must be present
+    expect(source).toContain('adrStats');
+    expect(source).toContain('adrPaths');
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -4338,6 +4338,36 @@ const statuslineCommand: Command = {
       } catch { /* ignore */ }
     }
 
+    // Get ADR stats — scan well-known ADR directories for .md files
+    const adrStats = { count: 0, implemented: 0 };
+    const adrPaths = [
+      path.join(process.cwd(), 'v3', 'implementation', 'adrs'),
+      path.join(process.cwd(), 'docs', 'adrs'),
+      path.join(process.cwd(), 'docs', 'adr'),
+      path.join(process.cwd(), '.claude-flow', 'adrs'),
+    ];
+    for (const adrPath of adrPaths) {
+      try {
+        if (fs.existsSync(adrPath)) {
+          const files = fs.readdirSync(adrPath).filter((f: string) =>
+            f.endsWith('.md') && (f.startsWith('ADR-') || f.startsWith('adr-') || /^\d{4}-/.test(f))
+          );
+          adrStats.count = files.length;
+          // Count implemented/accepted ADRs by scanning file content
+          for (const file of files) {
+            try {
+              const content = fs.readFileSync(path.join(adrPath, file), 'utf-8');
+              if (/Status\s*[:\*]*\s*(Accepted|Implemented)/i.test(content)) {
+                adrStats.implemented++;
+              }
+            } catch { /* ignore */ }
+          }
+          if (adrStats.count === 0) continue; // Empty dir, try next
+          break;
+        }
+      } catch { /* ignore */ }
+    }
+
     const domainsColor = progress.domainsCompleted >= 3 ? c.brightGreen : progress.domainsCompleted > 0 ? c.yellow : c.red;
     // Dynamic perf indicator based on patterns/HNSW
     let perfIndicator = `${c.dim}⚡ target: 150x-12500x${c.reset}`;
@@ -4367,8 +4397,9 @@ const statuslineCommand: Command = {
       `${c.brightPurple}🧠 ${String(system.intelligencePct).padStart(3)}%${c.reset}`;
 
     const dddColor = progress.dddProgress >= 50 ? c.brightGreen : progress.dddProgress > 0 ? c.yellow : c.red;
+    const adrColor = adrStats.implemented > 0 ? c.brightGreen : c.dim;
     const line3 = `${c.brightPurple}🔧 Architecture${c.reset}    ` +
-      `${c.cyan}ADRs${c.reset} ${c.dim}●0/0${c.reset}  ${c.dim}│${c.reset}  ` +
+      `${c.cyan}ADRs${c.reset} ${adrColor}●${adrStats.implemented}/${adrStats.count}${c.reset}  ${c.dim}│${c.reset}  ` +
       `${c.cyan}DDD${c.reset} ${dddColor}●${String(progress.dddProgress).padStart(3)}%${c.reset}  ${c.dim}│${c.reset}  ` +
       `${c.cyan}Security${c.reset} ${securityColor}●${security.status}${c.reset}`;
 


### PR DESCRIPTION
## Summary

Fixes #1047

- The statusline showed `ADRs ●0/0` permanently because the count was a hardcoded string — never reading actual ADR files
- Adds an inline ADR scan in `hooks.ts` (matching the inline pattern used for `hooksStats`, `agentdbStats`, `testStats`, `mcpStats`)
- Scans four well-known ADR directories: `docs/adrs`, `docs/adr`, `v3/implementation/adrs`, `.claude-flow/adrs`
- Counts `.md` files matching ADR naming conventions (`ADR-`, `adr-`, numeric prefix `0001-`)
- Detects Accepted/Implemented status via content scan (handles both plain `Status: Accepted` and bold `**Status**: Accepted`)
- ADR count shown in green when any are implemented, dim otherwise

## Verification

- [x] Baseline tests: 8 pre-existing failures (unchanged)
- [x] Post-fix tests: no regressions
- [x] New tests: 5 added — counts, status detection, naming conventions, source guard
- [x] Review agent: issue alignment verified, no scope creep

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/commands/hooks.ts` | Add ADR scanning block; replace hardcoded `●0/0` with dynamic `●implemented/count` |
| `v3/@claude-flow/cli/__tests__/hooks-adr-count.test.ts` | New regression tests for #1047 |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
