### PR TITLE
fix: use 'codex' binary for Codex workers instead of hardcoded 'claude' (#1106)

### DIFF
--- a/v3/@claude-flow/codex/src/dual-mode/orchestrator.ts
+++ b/v3/@claude-flow/codex/src/dual-mode/orchestrator.ts
@@ -64,7 +64,7 @@ export class DualModeOrchestrator extends EventEmitter {
       sharedNamespace: config.sharedNamespace ?? 'collaboration',
       timeout: config.timeout ?? 300000, // 5 minutes
       claudeCommand: config.claudeCommand ?? 'claude',
-      codexCommand: config.codexCommand ?? 'claude', // Both use claude CLI
+      codexCommand: config.codexCommand ?? 'codex',
     };
   }
 
@@ -142,17 +142,23 @@ export class DualModeOrchestrator extends EventEmitter {
     // Build the prompt with memory integration
     const enhancedPrompt = this.buildCollaborativePrompt(config);
 
-    const args = [
-      '-p', enhancedPrompt,
-      '--output-format', 'text',
-    ];
-
-    if (config.maxTurns) {
-      args.push('--max-turns', String(config.maxTurns));
-    }
-
-    if (config.model) {
-      args.push('--model', config.model);
+    // Build platform-specific args
+    const args: string[] = [];
+    if (config.platform === 'codex') {
+      // Codex CLI: codex -q "prompt" [--model model]
+      args.push('-q', enhancedPrompt);
+      if (config.model) {
+        args.push('--model', config.model);
+      }
+    } else {
+      // Claude CLI: claude -p "prompt" --output-format text [--max-turns N] [--model model]
+      args.push('-p', enhancedPrompt, '--output-format', 'text');
+      if (config.maxTurns) {
+        args.push('--max-turns', String(config.maxTurns));
+      }
+      if (config.model) {
+        args.push('--model', config.model);
+      }
     }
 
     return new Promise((resolve, reject) => {

--- a/v3/@claude-flow/codex/tests/dual-mode-orchestrator.test.ts
+++ b/v3/@claude-flow/codex/tests/dual-mode-orchestrator.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for dual-mode orchestrator — codex command default and platform-specific args
+ * Regression tests for #1106
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+
+// Read the source file to verify the fix at the source level
+const orchestratorSource = fs.readFileSync(
+  new URL('../src/dual-mode/orchestrator.ts', import.meta.url),
+  'utf-8'
+);
+
+describe('DualModeOrchestrator — Codex command routing (#1106)', () => {
+  describe('Source-level verification', () => {
+    it('codexCommand defaults to "codex", not "claude"', () => {
+      // The default should be 'codex', not 'claude'
+      expect(orchestratorSource).toContain("codexCommand: config.codexCommand ?? 'codex'");
+      // Ensure old bug pattern is gone
+      expect(orchestratorSource).not.toContain("codexCommand: config.codexCommand ?? 'claude'");
+    });
+
+    it('claudeCommand still defaults to "claude"', () => {
+      expect(orchestratorSource).toContain("claudeCommand: config.claudeCommand ?? 'claude'");
+    });
+
+    it('builds platform-specific args for codex workers', () => {
+      // Codex workers should use -q flag, not -p
+      expect(orchestratorSource).toContain("args.push('-q', enhancedPrompt)");
+    });
+
+    it('builds platform-specific args for claude workers', () => {
+      // Claude workers should use -p flag with --output-format
+      expect(orchestratorSource).toContain("args.push('-p', enhancedPrompt, '--output-format', 'text')");
+    });
+
+    it('does not pass --max-turns to codex workers', () => {
+      // --max-turns is Claude-specific; Codex branch should not include it
+      const codexBranch = orchestratorSource.split("if (config.platform === 'codex')")[1]?.split('} else {')[0];
+      expect(codexBranch).toBeDefined();
+      expect(codexBranch).not.toContain('--max-turns');
+    });
+
+    it('does not pass --output-format to codex workers', () => {
+      const codexBranch = orchestratorSource.split("if (config.platform === 'codex')")[1]?.split('} else {')[0];
+      expect(codexBranch).toBeDefined();
+      expect(codexBranch).not.toContain('--output-format');
+    });
+  });
+
+  describe('Constructor defaults', () => {
+    it('uses "codex" as default codexCommand when no override is provided', async () => {
+      // Dynamically import to test runtime behavior
+      const { DualModeOrchestrator } = await import('../src/dual-mode/orchestrator.js');
+      const orchestrator = new DualModeOrchestrator({ projectPath: '/tmp/test' });
+      // Access the private config via type assertion
+      const config = (orchestrator as any).config;
+      expect(config.codexCommand).toBe('codex');
+      expect(config.claudeCommand).toBe('claude');
+    });
+
+    it('respects custom codexCommand override', async () => {
+      const { DualModeOrchestrator } = await import('../src/dual-mode/orchestrator.js');
+      const orchestrator = new DualModeOrchestrator({
+        projectPath: '/tmp/test',
+        codexCommand: '/usr/local/bin/my-codex',
+      });
+      const config = (orchestrator as any).config;
+      expect(config.codexCommand).toBe('/usr/local/bin/my-codex');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1106

- `codexCommand` defaulted to `'claude'`, so Codex workers silently ran the Claude CLI binary instead of the Codex CLI
- CLI arguments (`-p`, `--output-format`, `--max-turns`) were Claude-specific and invalid for the Codex CLI
- Now defaults to `'codex'` and builds platform-specific args: `-q` for Codex, `-p`/`--output-format`/`--max-turns` for Claude

## Verification

- [x] Baseline tests: 170 pass, 0 pre-existing failures
- [x] Post-fix tests: no regressions (170/170)
- [x] New tests: 8 added, all pass
- [x] Review agent: issue alignment verified, no scope creep

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/codex/src/dual-mode/orchestrator.ts` | Fix codexCommand default from `'claude'` to `'codex'`; build platform-specific CLI args |
| `v3/@claude-flow/codex/tests/dual-mode-orchestrator.test.ts` | NEW: 8 regression tests for #1106 |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
