### PR TITLE
fix: hooks list reads settings.json to show actual enabled state (#1038)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-list-enabled.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-list-enabled.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for hooks_list MCP tool reading .claude/settings.json
+ * Regression tests for #1038
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('hooks_list reads .claude/settings.json (#1038)', () => {
+  // Read the source to verify the fix at the source level
+  const hooksToolsSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/mcp-tools/hooks-tools.ts'),
+    'utf-8'
+  );
+
+  describe('Source-level verification', () => {
+    it('reads settings.json to determine enabled hooks', () => {
+      expect(hooksToolsSource).toContain('settings.json');
+      expect(hooksToolsSource).toContain('configuredTypes');
+    });
+
+    it('does not return hardcoded enabled status', () => {
+      // The old code had only { name, type, status: "active" } without any enabled field
+      // The new code should have configuredTypes.has() to dynamically determine enabled
+      expect(hooksToolsSource).toContain("configuredTypes.has(h.type)");
+    });
+
+    it('returns enabled field in hook objects', () => {
+      expect(hooksToolsSource).toContain("enabled: configuredTypes.has(h.type)");
+    });
+
+    it('checks for PreToolUse hook type', () => {
+      expect(hooksToolsSource).toContain("type: 'PreToolUse'");
+    });
+
+    it('checks for PostToolUse hook type', () => {
+      expect(hooksToolsSource).toContain("type: 'PostToolUse'");
+    });
+
+    it('checks for SessionStart hook type', () => {
+      expect(hooksToolsSource).toContain("type: 'SessionStart'");
+    });
+
+    it('checks for Stop hook type for session-end', () => {
+      // session-end maps to the Claude Code 'Stop' hook type
+      expect(hooksToolsSource).toContain("type: 'Stop'");
+    });
+  });
+
+  describe('Handler behavior with settings.json', () => {
+    let tmpDir: string;
+    let origCwd: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-list-test-'));
+      origCwd = process.cwd();
+      // Create .claude directory
+      fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+    });
+
+    afterEach(() => {
+      process.chdir(origCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('shows hooks as enabled when their type is configured in settings.json', async () => {
+      // Write a settings.json with PreToolUse and PostToolUse configured
+      const settings = {
+        hooks: {
+          PreToolUse: [
+            { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo pre-bash' }] }
+          ],
+          PostToolUse: [
+            { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo post-bash' }] }
+          ]
+        }
+      };
+      fs.writeFileSync(
+        path.join(tmpDir, '.claude', 'settings.json'),
+        JSON.stringify(settings)
+      );
+
+      // Temporarily set CLAUDE_FLOW_CWD to our temp dir
+      const origEnv = process.env.CLAUDE_FLOW_CWD;
+      process.env.CLAUDE_FLOW_CWD = tmpDir;
+
+      try {
+        // Dynamically import the hooks_list tool
+        const mod = await import('../src/mcp-tools/hooks-tools.js');
+        const result = await mod.hooksList.handler({});
+
+        // PreToolUse hooks should be enabled
+        const preEdit = result.hooks.find((h: any) => h.name === 'pre-edit');
+        expect(preEdit).toBeDefined();
+        expect(preEdit.enabled).toBe(true);
+        expect(preEdit.status).toBe('active');
+
+        // PostToolUse hooks should be enabled
+        const postEdit = result.hooks.find((h: any) => h.name === 'post-edit');
+        expect(postEdit).toBeDefined();
+        expect(postEdit.enabled).toBe(true);
+
+        // SessionStart hooks should NOT be enabled (not in settings)
+        const sessionStart = result.hooks.find((h: any) => h.name === 'session-start');
+        expect(sessionStart).toBeDefined();
+        expect(sessionStart.enabled).toBe(false);
+        expect(sessionStart.status).toBe('inactive');
+      } finally {
+        if (origEnv !== undefined) {
+          process.env.CLAUDE_FLOW_CWD = origEnv;
+        } else {
+          delete process.env.CLAUDE_FLOW_CWD;
+        }
+      }
+    });
+
+    it('shows all hooks as disabled when no settings.json exists', async () => {
+      // Point to a dir without settings.json
+      const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-empty-'));
+      const origEnv = process.env.CLAUDE_FLOW_CWD;
+      process.env.CLAUDE_FLOW_CWD = emptyDir;
+
+      try {
+        const mod = await import('../src/mcp-tools/hooks-tools.js');
+        const result = await mod.hooksList.handler({});
+
+        // All hooks should be disabled
+        for (const hook of result.hooks) {
+          expect(hook.enabled).toBe(false);
+        }
+      } finally {
+        if (origEnv !== undefined) {
+          process.env.CLAUDE_FLOW_CWD = origEnv;
+        } else {
+          delete process.env.CLAUDE_FLOW_CWD;
+        }
+        fs.rmSync(emptyDir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns correct total count', async () => {
+      const origEnv = process.env.CLAUDE_FLOW_CWD;
+      process.env.CLAUDE_FLOW_CWD = tmpDir;
+
+      try {
+        const mod = await import('../src/mcp-tools/hooks-tools.js');
+        const result = await mod.hooksList.handler({});
+        expect(result.total).toBe(result.hooks.length);
+        expect(result.total).toBeGreaterThanOrEqual(17);
+      } finally {
+        if (origEnv !== undefined) {
+          process.env.CLAUDE_FLOW_CWD = origEnv;
+        } else {
+          delete process.env.CLAUDE_FLOW_CWD;
+        }
+      }
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -1125,42 +1125,68 @@ export const hooksList: MCPTool = {
     properties: {},
   },
   handler: async () => {
+    // Read .claude/settings.json to determine which hooks are actually configured
+    const configuredTypes = new Set<string>();
+    const settingsPath = join(getProjectCwd(), '.claude', 'settings.json');
+    if (existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+        if (settings.hooks && typeof settings.hooks === 'object') {
+          for (const [hookType, entries] of Object.entries(settings.hooks)) {
+            if (Array.isArray(entries) && entries.length > 0) {
+              configuredTypes.add(hookType);
+            }
+          }
+        }
+      } catch { /* ignore malformed settings */ }
+    }
+
+    // Map hook names to their Claude Code hook types
+    const hookDefinitions = [
+      // Core hooks
+      { name: 'pre-edit', type: 'PreToolUse' },
+      { name: 'post-edit', type: 'PostToolUse' },
+      { name: 'pre-command', type: 'PreToolUse' },
+      { name: 'post-command', type: 'PostToolUse' },
+      { name: 'pre-task', type: 'PreToolUse' },
+      { name: 'post-task', type: 'PostToolUse' },
+      // Routing hooks
+      { name: 'route', type: 'intelligence' },
+      { name: 'explain', type: 'intelligence' },
+      // Session hooks
+      { name: 'session-start', type: 'SessionStart' },
+      { name: 'session-end', type: 'Stop' },
+      { name: 'session-restore', type: 'SessionStart' },
+      // Learning hooks
+      { name: 'pretrain', type: 'intelligence' },
+      { name: 'build-agents', type: 'intelligence' },
+      { name: 'transfer', type: 'intelligence' },
+      { name: 'metrics', type: 'analytics' },
+      // System hooks
+      { name: 'init', type: 'system' },
+      { name: 'notify', type: 'coordination' },
+      // Intelligence subcommands
+      { name: 'intelligence', type: 'intelligence' },
+      { name: 'intelligence_trajectory-start', type: 'intelligence' },
+      { name: 'intelligence_trajectory-step', type: 'intelligence' },
+      { name: 'intelligence_trajectory-end', type: 'intelligence' },
+      { name: 'intelligence_pattern-store', type: 'intelligence' },
+      { name: 'intelligence_pattern-search', type: 'intelligence' },
+      { name: 'intelligence_stats', type: 'analytics' },
+      { name: 'intelligence_learn', type: 'intelligence' },
+      { name: 'intelligence_attention', type: 'intelligence' },
+    ];
+
+    const hooks = hookDefinitions.map(h => ({
+      name: h.name,
+      type: h.type,
+      enabled: configuredTypes.has(h.type),
+      status: configuredTypes.has(h.type) ? 'active' : 'inactive',
+    }));
+
     return {
-      hooks: [
-        // Core hooks
-        { name: 'pre-edit', type: 'PreToolUse', status: 'active' },
-        { name: 'post-edit', type: 'PostToolUse', status: 'active' },
-        { name: 'pre-command', type: 'PreToolUse', status: 'active' },
-        { name: 'post-command', type: 'PostToolUse', status: 'active' },
-        { name: 'pre-task', type: 'PreToolUse', status: 'active' },
-        { name: 'post-task', type: 'PostToolUse', status: 'active' },
-        // Routing hooks
-        { name: 'route', type: 'intelligence', status: 'active' },
-        { name: 'explain', type: 'intelligence', status: 'active' },
-        // Session hooks
-        { name: 'session-start', type: 'SessionStart', status: 'active' },
-        { name: 'session-end', type: 'SessionEnd', status: 'active' },
-        { name: 'session-restore', type: 'SessionStart', status: 'active' },
-        // Learning hooks
-        { name: 'pretrain', type: 'intelligence', status: 'active' },
-        { name: 'build-agents', type: 'intelligence', status: 'active' },
-        { name: 'transfer', type: 'intelligence', status: 'active' },
-        { name: 'metrics', type: 'analytics', status: 'active' },
-        // System hooks
-        { name: 'init', type: 'system', status: 'active' },
-        { name: 'notify', type: 'coordination', status: 'active' },
-        // Intelligence subcommands
-        { name: 'intelligence', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_trajectory-start', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_trajectory-step', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_trajectory-end', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_pattern-store', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_pattern-search', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_stats', type: 'analytics', status: 'active' },
-        { name: 'intelligence_learn', type: 'intelligence', status: 'active' },
-        { name: 'intelligence_attention', type: 'intelligence', status: 'active' },
-      ],
-      total: 26,
+      hooks,
+      total: hooks.length,
     };
   },
 };


### PR DESCRIPTION
## Summary

Fixes #1038

- `hooks_list` MCP tool returned hardcoded hook data with no `enabled` field, causing `hooks list` CLI to show all hooks as `Enabled: No`
- Now reads `.claude/settings.json` to determine which hook types (PreToolUse, PostToolUse, SessionStart, Stop) are actually configured
- Returns `enabled: true/false` and `status: active/inactive` based on real configuration

## Verification

- [x] Baseline tests: 107 MCP tools tests pass
- [x] Post-fix tests: no regressions
- [x] New tests: 10 added, all pass (source verification + runtime behavior with mock settings.json)
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts` | `hooks_list` handler reads `.claude/settings.json` to determine enabled state |
| `v3/@claude-flow/cli/__tests__/hooks-list-enabled.test.ts` | NEW: 10 regression tests for #1038 |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
