### PR TITLE
fix: Tier A blockers #1596, #1567, #1556 (v3.5.80)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.5.75",
+  "version": "3.5.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.5.75",
+      "version": "3.5.80",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.5.78",
+  "version": "3.5.80",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.5.78",
+  "version": "3.5.80",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/__tests__/parser.test.ts
+++ b/v3/@claude-flow/cli/__tests__/parser.test.ts
@@ -481,6 +481,54 @@ describe('CommandParser', () => {
   });
 
   // -------------------------------------------------------------------------
+  // #1596: lazy command routing — `daemon start` must not be mis-routed to
+  // the core `start` command when `daemon` is a lazy-loaded command.
+  // -------------------------------------------------------------------------
+  describe('lazy command routing (#1596)', () => {
+    it('should not mis-route "daemon start" to the sync "start" command', () => {
+      const p = new CommandParser({ allowUnknownFlags: true });
+      // Sync command "start" is registered with full definition
+      p.registerCommand({ name: 'start', description: 'Top-level start', handler: async () => ({ success: true }) } as Command);
+      // "daemon" is lazy — only its name is registered
+      p.registerLazyCommandName('daemon');
+
+      const result = p.parse(['daemon', 'start', '--foreground']);
+      expect(result.command[0]).toBe('daemon');
+      expect(result.positional[0]).toBe('start');
+      expect(result.flags.foreground).toBe(true);
+    });
+
+    it('should still recognize bare "start" as the sync start command', () => {
+      const p = new CommandParser({ allowUnknownFlags: true });
+      p.registerCommand({ name: 'start', description: 'Top-level start', handler: async () => ({ success: true }) } as Command);
+      p.registerLazyCommandName('daemon');
+
+      const result = p.parse(['start']);
+      expect(result.command[0]).toBe('start');
+      expect(result.positional).toHaveLength(0);
+    });
+
+    it('should route lazy command even when a global flag comes first', () => {
+      const p = new CommandParser({ allowUnknownFlags: true });
+      p.registerCommand({ name: 'start', description: '', handler: async () => ({}) } as Command);
+      p.registerLazyCommandName('daemon');
+
+      const result = p.parse(['-v', 'daemon', 'start', '--foreground']);
+      expect(result.command[0]).toBe('daemon');
+      expect(result.positional[0]).toBe('start');
+      expect(result.flags.verbose).toBe(true);
+    });
+
+    it('should resolve bare lazy command (e.g. "doctor")', () => {
+      const p = new CommandParser({ allowUnknownFlags: true });
+      p.registerLazyCommandName('doctor');
+
+      const result = p.parse(['doctor']);
+      expect(result.command[0]).toBe('doctor');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Edge: short flag with value
   // -------------------------------------------------------------------------
   describe('short flag with value', () => {

--- a/v3/@claude-flow/cli/__tests__/validate-input-agent-spawn.test.ts
+++ b/v3/@claude-flow/cli/__tests__/validate-input-agent-spawn.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test for #1567: validateAgentSpawn's Zod call was passing
+ * `{ agentType, name }` to `@claude-flow/security`'s SpawnAgentSchema, which
+ * expects `{ type, id }` — so every call failed with "type: Required" and
+ * the MCP agent_spawn tool returned an input validation error for every
+ * possible input. The fix aligns the field names AND swallows
+ * `invalid_enum_value` errors so custom agent types (beyond the 15-type
+ * hardcoded enum) continue to work.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateAgentSpawn } from '../src/mcp-tools/validate-input.js';
+
+describe('validateAgentSpawn (#1567)', () => {
+  it('accepts a built-in agent type like "tester"', async () => {
+    const r = await validateAgentSpawn({ agentType: 'tester', agentId: 'tester-1' });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('accepts a custom agent type not in the SpawnAgentSchema enum', async () => {
+    // "memory-specialist" is not one of the 15 types that
+    // @claude-flow/security's AgentTypeSchema enumerates, but it's a valid
+    // Claude Flow agent type and should NOT be rejected.
+    const r = await validateAgentSpawn({ agentType: 'memory-specialist', agentId: 'mem-1' });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('still rejects an agentId with invalid characters', async () => {
+    const r = await validateAgentSpawn({
+      agentType: 'tester',
+      agentId: 'has spaces and $pecials',
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
+
+  it('does not require the domain field', async () => {
+    const r = await validateAgentSpawn({ agentType: 'coder', agentId: 'c1' });
+    expect(r.valid).toBe(true);
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.5.78",
+  "version": "3.5.80",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/index.ts
+++ b/v3/@claude-flow/cli/src/commands/index.ts
@@ -319,6 +319,16 @@ export function hasCommand(name: string): boolean {
 }
 
 /**
+ * Get the names of all lazy-loadable commands (the commandLoaders keys).
+ * Used by the CLI constructor to register these names with the parser so
+ * the two-pass argument walker can recognize them as commands before their
+ * modules have been imported. Fix for #1596.
+ */
+export function getLazyCommandNames(): string[] {
+  return Object.keys(commandLoaders);
+}
+
+/**
  * Get all command names (including aliases and lazy-loadable)
  */
 export function getCommandNames(): string[] {

--- a/v3/@claude-flow/cli/src/index.ts
+++ b/v3/@claude-flow/cli/src/index.ts
@@ -11,7 +11,7 @@ import { dirname, join } from 'path';
 import type { Command, CommandContext, CommandResult, V3Config, CLIError } from './types.js';
 import { CommandParser, commandParser } from './parser.js';
 import { OutputFormatter, output } from './output.js';
-import { commands, commandsByCategory, getCommandsByCategory, commandRegistry, getCommand, getCommandAsync, getCommandNames, hasCommand } from './commands/index.js';
+import { commands, commandsByCategory, getCommandsByCategory, commandRegistry, getCommand, getCommandAsync, getCommandNames, getLazyCommandNames, hasCommand } from './commands/index.js';
 import { suggestCommand } from './suggest.js';
 import { runStartupUpdateCheck } from './update/index.js';
 
@@ -57,9 +57,16 @@ export class CLI {
     this.output = output;
     this.interactive = options.interactive ?? process.stdin.isTTY ?? false;
 
-    // Register all commands
+    // Register all core (synchronously loaded) commands with full definitions
     for (const cmd of commands) {
       this.parser.registerCommand(cmd);
+    }
+
+    // Register lazy command names so the parser can recognize them during
+    // argument resolution without importing their modules. Fix for #1596:
+    // prevents `daemon start` from being mis-routed to the `start` command.
+    for (const name of getLazyCommandNames()) {
+      this.parser.registerLazyCommandName(name);
     }
   }
 

--- a/v3/@claude-flow/cli/src/mcp-tools/validate-input.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/validate-input.ts
@@ -124,17 +124,23 @@ export async function validateAgentSpawn(input: Record<string, unknown>): Promis
     if (!r.valid) errors.push(r.error!);
   }
 
-  // Try enhanced Zod validation if available
+  // Try enhanced Zod validation if available.
+  // Fix for #1567: @claude-flow/security's SpawnAgentSchema expects `type` and
+  // `id` (not `agentType`/`name`), so the previous call always failed with
+  // "type: Required". Also swallow `invalid_enum_value` errors because the
+  // schema enumerates only 15 built-in agent types — we support custom types
+  // (the inline validator already checked the identifier is safe).
   const sec = await getSecurityModule();
   if (sec?.SpawnAgentSchema) {
     try {
       sec.SpawnAgentSchema.parse({
-        agentType: input.agentType,
-        name: input.agentId,
+        type: input.agentType,
+        id: input.agentId,
       });
     } catch (zodErr: any) {
       if (zodErr.issues) {
         for (const issue of zodErr.issues) {
+          if (issue.code === 'invalid_enum_value') continue;
           errors.push(`${issue.path.join('.')}: ${issue.message}`);
         }
       }

--- a/v3/@claude-flow/cli/src/parser.ts
+++ b/v3/@claude-flow/cli/src/parser.ts
@@ -25,6 +25,7 @@ export interface ParserOptions {
 export class CommandParser {
   private options: ParserOptions;
   private commands: Map<string, Command> = new Map();
+  private lazyCommandNames: Set<string> = new Set();
   private globalOptions: CommandOption[] = [];
 
   constructor(options: ParserOptions = {}) {
@@ -108,6 +109,20 @@ export class CommandParser {
     }
   }
 
+  /**
+   * Register a lazy-loaded command's name so Pass 1/Pass 2 can recognize it as
+   * a command position even though its full definition hasn't been loaded yet.
+   * Fix for #1596: without this, lazy commands like `daemon start` were
+   * mis-routed because Pass 1 walked past `daemon` and greedy-matched `start`.
+   */
+  registerLazyCommandName(name: string): void {
+    this.lazyCommandNames.add(name);
+  }
+
+  private isKnownCommandName(name: string): boolean {
+    return this.commands.has(name) || this.lazyCommandNames.has(name);
+  }
+
   getCommand(name: string): Command | undefined {
     return this.commands.get(name);
   }
@@ -130,14 +145,32 @@ export class CommandParser {
       raw: [...args]
     };
 
-    // Pass 1: Identify command and subcommand (skip flags)
+    // Pass 1: Identify command and subcommand (skip flags).
+    // Fix for #1596: the first non-flag positional is ALWAYS the command slot.
+    // If it's a known command (sync or lazy) we resolve it; otherwise we stop
+    // searching — we MUST NOT walk past it and greedy-match a later arg as the
+    // command, because that's what caused `daemon start` to resolve as `start`
+    // with `daemon` left as a positional.
     let resolvedCmd: Command | undefined;
     let resolvedSub: Command | undefined;
+    let sawFirstPositional = false;
     for (const arg of args) {
       if (arg.startsWith('-')) continue;
-      if (!resolvedCmd && this.commands.has(arg)) {
-        resolvedCmd = this.commands.get(arg);
-      } else if (resolvedCmd && !resolvedSub && resolvedCmd.subcommands) {
+      if (!sawFirstPositional) {
+        sawFirstPositional = true;
+        if (this.commands.has(arg)) {
+          resolvedCmd = this.commands.get(arg);
+          continue;
+        }
+        // Lazy command: we know its name but not its subcommands. Stop the
+        // walk here — we'll rely on Pass 2 to push it onto commandPath.
+        if (this.lazyCommandNames.has(arg)) {
+          break;
+        }
+        // Unknown first positional — not a command. Stop walking.
+        break;
+      }
+      if (resolvedCmd && !resolvedSub && resolvedCmd.subcommands) {
         resolvedSub = resolvedCmd.subcommands.find(sc => sc.name === arg || sc.aliases?.includes(arg));
       }
     }
@@ -170,12 +203,16 @@ export class CommandParser {
         continue;
       }
 
-      // Handle positional arguments
-      if (result.command.length === 0 && this.commands.has(arg)) {
+      // Handle positional arguments.
+      // Fix for #1596: treat lazy command names as commands here too so that
+      // downstream dispatch sees `commandPath = ['daemon', 'start']` instead of
+      // `commandPath = ['start'], positional = ['daemon']`.
+      if (result.command.length === 0 && this.isKnownCommandName(arg)) {
         // This is a command
         result.command.push(arg);
 
-        // Check for subcommand (level 1)
+        // Check for subcommand (level 1) — only possible for sync commands
+        // whose subcommand definitions are already loaded.
         const cmd = this.commands.get(arg);
         if (cmd?.subcommands && i + 1 < args.length) {
           const nextArg = args[i + 1];

--- a/v3/@claude-flow/memory/package.json
+++ b/v3/@claude-flow/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/memory",
-  "version": "3.0.0-alpha.13",
+  "version": "3.0.0-alpha.14",
   "type": "module",
   "description": "Memory module - AgentDB unification, HNSW indexing, vector search, hybrid SQLite+AgentDB backend (ADR-009)",
   "main": "dist/index.js",
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "bench": "vitest bench",
     "build": "tsc",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rm -rf dist tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run build && node -e \"const m = await import('./dist/index.js'); const required = ['ControllerRegistry','HnswLite','PersistentSonaCoordinator','RvfBackend','RvfLearningStore','RvfMigrator']; const missing = required.filter(k => !m[k]); if (missing.length) { console.error('Missing exports:', missing); process.exit(1); } console.log('All required exports present');\""
   },
   "dependencies": {

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -663,6 +663,36 @@ Already in DB
       expect(indexContent).toContain('Item 49');
       expect(indexContent).not.toContain('Item 0');
     });
+
+    // #1556: curateIndex() used to overwrite a hand-curated MEMORY.md with a
+    // single-line stub when none of the files in memoryDir matched the
+    // hardcoded DEFAULT_TOPIC_MAPPING filenames (as happens when Claude Code's
+    // native `<type>_<topic>.md` convention is used). The fix is to skip the
+    // write entirely when there's nothing to curate.
+    it('should not overwrite hand-curated MEMORY.md when no topic files match (#1556)', async () => {
+      const indexPath = path.join(testDir, 'MEMORY.md');
+      const handCurated = '# My Hand-Curated Memory\n\n## Section 1\nImportant notes\n\n## Section 2\nMore notes\n';
+      fsSync.writeFileSync(indexPath, handCurated, 'utf-8');
+
+      // Write files using Claude Code's native <type>_<topic>.md convention —
+      // none of these filenames appear in DEFAULT_TOPIC_MAPPING.
+      fsSync.writeFileSync(path.join(testDir, 'user_role.md'), '# user role\ndata scientist', 'utf-8');
+      fsSync.writeFileSync(path.join(testDir, 'session_foo.md'), '# session\nfoo bar', 'utf-8');
+      fsSync.writeFileSync(path.join(testDir, 'feedback_tone.md'), '# feedback\nbe concise', 'utf-8');
+
+      let skipEvent: any;
+      bridge.on('index:skipped', (e) => { skipEvent = e; });
+
+      await bridge.curateIndex();
+
+      // MEMORY.md must be byte-identical to what we wrote
+      const after = fsSync.readFileSync(indexPath, 'utf-8');
+      expect(after).toBe(handCurated);
+
+      // And the bridge should emit the skip event with a reason
+      expect(skipEvent).toBeDefined();
+      expect(skipEvent.reason).toBe('no-matching-topic-files');
+    });
   });
 
   describe('getStatus', () => {
@@ -911,17 +941,24 @@ Already in DB
   });
 
   describe('curateIndex - edge cases', () => {
-    it('should handle empty topic files', async () => {
+    it('should skip index write when topic files have no extractable summaries', async () => {
+      // #1556: curateIndex must be non-destructive when there's nothing to
+      // curate. Previously it would overwrite MEMORY.md with a title-only
+      // stub; now it emits 'index:skipped' and leaves any existing file alone.
       fsSync.writeFileSync(
         path.join(testDir, 'debugging.md'),
         '# Debugging\n\n',
         'utf-8',
       );
 
+      let skipEvent: any;
+      bridge.on('index:skipped', (e) => { skipEvent = e; });
+
       await bridge.curateIndex();
-      const content = fsSync.readFileSync(bridge.getIndexPath(), 'utf-8');
-      // Should not include empty section
-      expect(content).not.toContain('Debugging');
+
+      expect(skipEvent).toBeDefined();
+      expect(skipEvent.reason).toBe('no-matching-topic-files');
+      expect(fsSync.existsSync(bridge.getIndexPath())).toBe(false);
     });
 
     it('should emit index:curated event', async () => {

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -471,6 +471,16 @@ export class AutoMemoryBridge extends EventEmitter {
       }
     }
 
+    // Fix for #1556: if no topic files matched (e.g. the memory folder uses
+    // Claude Code's native `<type>_<topic>.md` convention rather than the
+    // hardcoded DEFAULT_TOPIC_MAPPING filenames), do NOT overwrite the
+    // existing MEMORY.md with a one-line stub. A `curate` operation must be
+    // non-destructive when there is nothing to curate.
+    if (Object.keys(sections).length === 0) {
+      this.emit('index:skipped', { reason: 'no-matching-topic-files' });
+      return;
+    }
+
     // ADR-049: Use graph PageRank to prioritize sections
     let sectionOrder: string[] | undefined;
     if (this.memoryGraph) {

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1789,7 +1789,7 @@
       }
     },
     "@claude-flow/cli": {
-      "version": "3.5.75",
+      "version": "3.5.80",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3471,7 +3471,7 @@
       }
     },
     "@claude-flow/memory": {
-      "version": "3.0.0-alpha.13",
+      "version": "3.0.0-alpha.14",
       "cpu": [
         "x64",
         "arm64"
@@ -4865,7 +4865,8 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@google/genai": {
       "version": "1.43.0",
@@ -5874,6 +5875,7 @@
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -5886,6 +5888,7 @@
       "deprecated": "This functionality has been moved to @npmcli/fs",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -10215,6 +10218,7 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11698,6 +11702,7 @@
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -12285,6 +12290,7 @@
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -12315,6 +12321,7 @@
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -12329,6 +12336,7 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12339,6 +12347,7 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12349,6 +12358,7 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -12362,6 +12372,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -12375,6 +12386,7 @@
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -13393,6 +13405,7 @@
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -13403,6 +13416,7 @@
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -13565,7 +13579,8 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -15819,7 +15834,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -15931,6 +15947,7 @@
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -16086,7 +16103,8 @@
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -16398,7 +16416,8 @@
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -17226,6 +17245,7 @@
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -17254,6 +17274,7 @@
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -17269,6 +17290,7 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17282,6 +17304,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17524,6 +17547,7 @@
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -17537,6 +17561,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17550,6 +17575,7 @@
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
@@ -17568,6 +17594,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17581,6 +17608,7 @@
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -17594,6 +17622,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17607,6 +17636,7 @@
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -17620,6 +17650,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17633,6 +17664,7 @@
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -17646,6 +17678,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -17874,6 +17907,7 @@
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -17912,6 +17946,7 @@
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -17927,6 +17962,7 @@
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -17948,6 +17984,7 @@
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -21054,7 +21091,8 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
@@ -21062,6 +21100,7 @@
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -21529,6 +21568,7 @@
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -22720,6 +22760,7 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -22731,6 +22772,7 @@
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -22746,6 +22788,7 @@
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -22870,6 +22913,7 @@
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -22883,6 +22927,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -23898,6 +23943,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
       }
@@ -23908,6 +23954,7 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       }


### PR DESCRIPTION
## Summary

Fixes three Tier A blockers and ships as `@claude-flow/cli@3.5.80` + `@claude-flow/memory@3.0.0-alpha.14`.

- **#1596** — CLI lazy-loaded command routing: two-pass parser was greedy-matching the first positional as a subcommand when the outer command was lazy-loaded. `daemon start`, bare `start`, `doctor` all failed.
- **#1567** — `validateAgentSpawn` passed `{agentType, name}` to `@claude-flow/security`'s `SpawnAgentSchema` (which expects `{type, id}`); every `agent_spawn` call failed with `type: Required`. Also relaxed the strict 15-value enum so custom agent types work.
- **#1556** — `AutoMemoryBridge.curateIndex()` destroyed hand-curated `MEMORY.md` on every Stop-hook tick when no topic files matched the hardcoded `DEFAULT_TOPIC_MAPPING`. Now exits early with an `index:skipped` event.

## Changes

| File | Purpose |
|------|---------|
| `v3/@claude-flow/cli/src/parser.ts` | Lazy command name registry + non-greedy Pass 1 |
| `v3/@claude-flow/cli/src/commands/index.ts` | `getLazyCommandNames()` export |
| `v3/@claude-flow/cli/src/index.ts` | Wire lazy names into parser |
| `v3/@claude-flow/cli/src/mcp-tools/validate-input.ts` | Correct field names, swallow enum errors |
| `v3/@claude-flow/memory/src/auto-memory-bridge.ts` | Non-destructive empty-sections early return |
| `v3/@claude-flow/memory/package.json` | Clean `tsconfig.tsbuildinfo` in `prebuild` |
| `v3/@claude-flow/cli/__tests__/parser.test.ts` | 4 lazy-routing regression tests |
| `v3/@claude-flow/cli/__tests__/validate-input-agent-spawn.test.ts` | 4 agent-spawn regression tests |
| `v3/@claude-flow/memory/src/auto-memory-bridge.test.ts` | Updated empty-topic test + new #1556 preservation test |

## Test plan

- [x] `parser.test.ts` — 52/52 passed
- [x] `validate-input-agent-spawn.test.ts` — 4/4 passed
- [x] `auto-memory-bridge.test.ts` — 74/74 passed
- [x] End-to-end validation against published `@claude-flow/cli@3.5.80` and `@claude-flow/memory@3.0.0-alpha.14` in scratch dir
- [x] `daemon start` routes correctly; `{command:["daemon"], positional:["start"], foreground:true}`
- [x] `tester` and `memory-specialist` both accepted by `validateAgentSpawn`
- [x] Hand-curated `MEMORY.md` preserved byte-for-byte when no topic files match

## Published artifacts

| Package | Version | Tags |
|---------|---------|------|
| `@claude-flow/cli` | 3.5.80 | v3alpha, latest, alpha |
| `@claude-flow/memory` | 3.0.0-alpha.14 | latest, alpha |
| `claude-flow` | 3.5.80 | v3alpha, latest, alpha |
| `ruflo` | 3.5.80 | v3alpha, latest, alpha |

Closes #1596
Closes #1567
Closes #1556

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)