### PR TITLE
fix(memory): expose vectorBackend via direct property access in ControllerRegistry

### DIFF
--- a/v3/@claude-flow/memory/src/controller-registry.test.ts
+++ b/v3/@claude-flow/memory/src/controller-registry.test.ts
@@ -192,6 +192,34 @@ describe('ControllerRegistry', () => {
       const report = await registry.healthCheck();
       expect(report.initTimeMs).toBeGreaterThan(0);
     });
+
+    it('should pass vectorBackend config to AgentDB and expose via getController', async () => {
+      const mockVectorBackend = { type: 'ruvector', search: vi.fn() };
+
+      // Mock agentdb module to return instance with vectorBackend property
+      vi.doMock('agentdb', () => ({
+        AgentDB: class MockAgentDB {
+          vectorBackend = mockVectorBackend;
+          vectorBackendName = 'ruvector';
+          vectorDimension = 384;
+          initialized = false;
+          async initialize() { this.initialized = true; }
+          async close() {}
+          get database() { return null; }
+          getController(name: string) {
+            if (['reflexion', 'memory', 'skills', 'causal', 'causalGraph'].includes(name)) return null;
+            throw new Error(`Unknown controller: ${name}`);
+          }
+        },
+      }));
+
+      const reg = new ControllerRegistry();
+      await reg.initialize({ backend: mockBackend, vectorBackend: 'rvf', dimension: 384 });
+
+      const vb = reg.get('vectorBackend');
+      expect(vb).not.toBeNull();
+      expect(vb).toBe(mockVectorBackend);
+    });
   });
 
   // ----- Level-Based Ordering -----

--- a/v3/@claude-flow/memory/src/controller-registry.ts
+++ b/v3/@claude-flow/memory/src/controller-registry.ts
@@ -113,6 +113,9 @@ export interface RuntimeConfig {
   /** Vector dimension (default: 384 for MiniLM) */
   dimension?: number;
 
+  /** Vector backend to use (default: 'auto') */
+  vectorBackend?: 'auto' | 'rvf' | 'hnswlib';
+
   /** Embedding generator function */
   embeddingGenerator?: EmbeddingGenerator;
 
@@ -480,7 +483,11 @@ export class ControllerRegistry extends EventEmitter {
         return;
       }
 
-      this.agentdb = new AgentDBClass({ dbPath });
+      this.agentdb = new AgentDBClass({
+        dbPath,
+        vectorBackend: config.vectorBackend ?? 'auto',
+        vectorDimension: config.dimension || 384,
+      });
 
       // Suppress agentdb's noisy info-level output during init
       // using stderr redirect instead of monkey-patching console.log
@@ -910,6 +917,11 @@ export class ControllerRegistry extends EventEmitter {
         // These are accessed via AgentDB internal state, not direct construction
         if (!this.agentdb) return null;
         try {
+          // vectorBackend is exposed as a direct property on AgentDB instance
+          // agentdb.getController() does not support 'vectorBackend' (only reflexion/skills/causalGraph)
+          if (name === 'vectorBackend' && this.agentdb.vectorBackend) {
+            return this.agentdb.vectorBackend;
+          }
           if (typeof this.agentdb.getController === 'function') {
             return this.agentdb.getController(name) ?? null;
           }

--- a/v3/@claude-flow/memory/src/controller-registry.ts
+++ b/v3/@claude-flow/memory/src/controller-registry.ts
@@ -486,7 +486,7 @@ export class ControllerRegistry extends EventEmitter {
       this.agentdb = new AgentDBClass({
         dbPath,
         vectorBackend: config.vectorBackend ?? 'auto',
-        vectorDimension: config.dimension || 384,
+        vectorDimension: config.dimension ?? 384,
       });
 
       // Suppress agentdb's noisy info-level output during init
@@ -917,8 +917,12 @@ export class ControllerRegistry extends EventEmitter {
         // These are accessed via AgentDB internal state, not direct construction
         if (!this.agentdb) return null;
         try {
-          // vectorBackend is exposed as a direct property on AgentDB instance
-          // agentdb.getController() does not support 'vectorBackend' (only reflexion/skills/causalGraph)
+          // vectorBackend is exposed as a direct property on AgentDB instance.
+          // Note: agentdb.getController() does not support 'vectorBackend'
+          // (only reflexion/skills/causalGraph). Accessing via direct property
+          // is intentional — if AgentDB changes internals, this should be
+          // replaced by a proper getController('vectorBackend') upstream.
+          // TODO: request getController('vectorBackend') support in agentdb.
           if (name === 'vectorBackend' && this.agentdb.vectorBackend) {
             return this.agentdb.vectorBackend;
           }


### PR DESCRIPTION
## Summary

Fixes `vectorBackend` and its 7 dependent controllers always failing in `ControllerRegistry` (ADR-053).

Closes #1610
Related to #1207, #1228

---

## Root Cause

`ControllerRegistry.initAgentDB()` was initializing AgentDB with only `{ dbPath }`, causing AgentDB to fall back to HNSWLib and not expose a `vectorBackend` controller.

The `createController()` case for `'vectorBackend'` then called `agentdb.getController('vectorBackend')`, but `AgentDB.getController()` only supports `reflexion`, `skills`, and `causalGraph` — throwing `Unknown controller: vectorBackend` for anything else.

AgentDB **does** expose its vector backend as a direct property (`agentdb.vectorBackend`), but this was never accessed.

## Changes

### 1. `RuntimeConfig` — add `vectorBackend` field

```typescript
export interface RuntimeConfig {
  dbPath?: string;
  dimension?: number;
  vectorBackend?: 'auto' | 'rvf' | 'hnswlib';  // new
  // ...
}
```

### 2. `initAgentDB()` — pass vectorBackend and vectorDimension to AgentDB

```typescript
// Before
this.agentdb = new AgentDBClass({ dbPath });

// After
this.agentdb = new AgentDBClass({
  dbPath,
  vectorBackend: config.vectorBackend ?? 'auto',
  vectorDimension: config.dimension || 384,
});
```

Using `'auto'` as default preserves backward compatibility — AgentDB tries ruvector first and falls back to HNSWLib gracefully.

### 3. `createController('vectorBackend')` — access direct property instead of getController()

```typescript
// Before: throws "Unknown controller: vectorBackend"
return this.agentdb.getController(name) ?? null;

// After: access direct property first
if (name === 'vectorBackend' && this.agentdb.vectorBackend) {
  return this.agentdb.vectorBackend;
}
if (typeof this.agentdb.getController === 'function') {
  return this.agentdb.getController(name) ?? null;
}
```

## Test Results

**Before this fix:**
```
Activated: 15  Failed: 8
failed: vectorBackend, mutationGuard, gnnService, attestationLog,
        semanticRouter, guardedVectorBackend, rvfOptimizer, graphAdapter
```

**After this fix (with vectorBackend: 'rvf'):**
```
Activated: 16  Failed: 7  (vectorBackend now active)
failed: mutationGuard, gnnService, attestationLog,
        semanticRouter, guardedVectorBackend, rvfOptimizer, graphAdapter
```

The remaining 7 failures are separate issues — they depend on `vectorBackend` being active, but have their own initialization problems that are outside the scope of this fix.

## Environment

- `ruflo@3.5.51`, `agentdb@3.0.0-alpha.11`
- Node.js v22.22.2, Docker ARM64 (aarch64)
- ruvector installed in `agentdb/node_modules/` for correct ESM resolution