### PR TITLE
feat: add CRM onboarding health skill for BestyCRM

### DIFF
--- a/.agents/config.toml
+++ b/.agents/config.toml
@@ -96,6 +96,10 @@ enabled = true
 path = ".agents/skills/security-audit"
 enabled = true
 
+[[skills.config]]
+path = ".agents/skills/crm-onboarding-health"
+enabled = true
+
 # =============================================================================
 # Profiles
 # =============================================================================

--- a/.agents/skills/crm-onboarding-health/SKILL.md
+++ b/.agents/skills/crm-onboarding-health/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: crm-onboarding-health
+version: 1.0.0
+description: BestyCRM onboarding health analysis — identifies at-risk accounts, diagnoses score breakdowns, and recommends next actions for account managers
+category: crm
+tags: [crm, onboarding, health-score, churn-prevention, account-management, besty]
+author: BestyCRM Team
+---
+
+# CRM Onboarding Health Skill
+
+Analyzes BestyCRM onboarding pipeline data to identify at-risk accounts, break down health score components, and generate prioritized action plans for account managers.
+
+## Overview
+
+BestyCRM computes a 0-100 health score for each onboarding account based on six weighted dimensions:
+
+| Component | Max Points | Source |
+|-----------|-----------|--------|
+| Checklist progress | 30 | PMS-specific checklist completion % |
+| Feature flags enabled | 25 | 10 key flags (2.5 pts each) |
+| Recency (last seen) | 15 | 1d=15, 7d=10, 14d=5, else 0 |
+| Primary contact linked | 10 | HubSpot contact match |
+| Stripe setup complete | 10 | Subscription active or trialing |
+| No listings in error | 10 | Zero `numListingsInError` |
+
+This skill teaches agents to read pipeline data, diagnose which dimensions are dragging a score down, and recommend concrete next steps.
+
+## Key Feature Flags
+
+The 10 key flags tracked for scoring:
+
+1. `bffReadyToSeeApp` — App visibility enabled
+2. `bff100PercentLiveAndSendingMessages` — Fully live messaging
+3. `autopilotEnabled` — Autopilot mode on
+4. `opsLive` — Operations live
+5. `bookingBoosterEnabled` — Booking booster active
+6. `instantMessagingModeEnabled` — IM mode on
+7. `whatsappLive` — WhatsApp connected
+8. `hasPmsCreds` — PMS credentials configured
+9. `twoFaCompleted` — 2FA setup done
+10. `voiceRouting` — Voice routing configured
+
+## Agent Behavior
+
+When invoked, the agent should:
+
+### 1. Fetch Pipeline Data
+Read from the `/api/onboarding/pipeline` endpoint which returns an array of accounts with:
+- `healthScore` (0-100)
+- `checklist` ({ completed, total, percent })
+- `featureFlags` (object with boolean values)
+- `lastSeenAt`, `hasContact`, `stripeStatus`
+- `numListings`, `numListingsEnabled`, `numListingsInError`
+- `accountManagerName`, `pms`, `plan`
+
+### 2. Triage Accounts
+Classify accounts into risk buckets:
+- **Critical** (score < 30): Immediate intervention needed
+- **At Risk** (score 30-50): Proactive outreach recommended
+- **Needs Attention** (score 50-70): Monitor and nudge
+- **On Track** (score 70-85): Light touch
+- **Healthy** (score > 85): Self-serve
+
+### 3. Diagnose Score Gaps
+For each at-risk account, identify which dimensions are costing the most points:
+- Missing checklist items → list the incomplete ones
+- Disabled feature flags → list which flags to enable
+- Inactive (not seen recently) → flag for re-engagement
+- No primary contact → flag for HubSpot linking
+- Stripe not active → flag for billing setup
+- Listings in error → flag for ops review
+
+### 4. Generate Action Plan
+Output a prioritized list of actions per account, ordered by point impact:
+- Highest-impact actions first (e.g., "Enable autopilot" = 2.5 pts)
+- Group by account manager for delegation
+- Include estimated score improvement per action
+
+## Example Output
+
+```
+## At-Risk Accounts (3 accounts below score 50)
+
+### 1. Acme Vacation Rentals (Score: 28/100)
+   Account Manager: Sarah
+   PMS: Streamline | Plan: Pro | Listings: 45
+
+   Score Breakdown:
+   - Checklist: 5/30 (17% complete — 3 of 18 items done)
+   - Feature Flags: 5/25 (2 of 10 enabled)
+   - Last Seen: 0/15 (last seen 22 days ago)
+   - Contact: 10/10 ✓
+   - Stripe: 8/10 (trialing)
+   - Listings: 0/10 (3 listings in error)
+
+   Recommended Actions (ordered by impact):
+   1. Complete checklist items (potential +25 pts)
+      - Connect PMS credentials
+      - Enable autopilot
+      - Set up WhatsApp
+      ...
+   2. Enable feature flags (potential +20 pts)
+      - autopilotEnabled, whatsappLive, voiceRouting, ...
+   3. Re-engage user (potential +15 pts)
+      - Not seen in 22 days — schedule check-in call
+   4. Fix listing errors (potential +10 pts)
+      - 3 listings in error state
+```
+
+## CLI Integration
+
+```bash
+# Spawn a health analysis agent
+npx claude-flow@v3alpha agent spawn -t crm-onboarding-health --name health-analyst
+
+# Store analysis results in memory
+npx claude-flow@v3alpha memory store --namespace crm --key "health-analysis-$(date +%Y%m%d)" --value "[analysis JSON]"
+
+# Search past analyses
+npx claude-flow@v3alpha memory search --namespace crm --query "at-risk accounts"
+```
+
+## Swarm Integration
+
+Use in a CRM analysis swarm:
+
+```javascript
+// Spawn alongside other CRM agents
+Agent("HealthAnalyst", "Analyze onboarding pipeline for at-risk accounts. Fetch /api/onboarding/pipeline, triage by health score, diagnose gaps, and generate action plans.", { subagent_type: "crm-onboarding-health", run_in_background: true })
+Agent("ChurnPredictor", "Based on health analysis, predict which accounts are most likely to churn in the next 30 days.", { subagent_type: "researcher", run_in_background: true })
+Agent("OutreachDrafter", "Draft personalized outreach messages for at-risk accounts based on their specific gaps.", { subagent_type: "coder", run_in_background: true })
+```
+
+## Data Source
+
+- **API Endpoint**: `GET /api/onboarding/pipeline`
+- **Source File**: `artifacts/api-server/src/routes/onboarding.ts`
+- **Health Score Function**: `computeOnboardingHealthScore()`
+- **Database Tables**: `users`, `checklistTemplates`, `checklistItems`, `checklistCompletions`, `contactMatches`, `stripeData`, `accountManagers`

--- a/.claude/agents/crm-onboarding-health.md
+++ b/.claude/agents/crm-onboarding-health.md
@@ -1,0 +1,18 @@
+---
+name: crm-onboarding-health
+description: BestyCRM onboarding health analyst — triages accounts by health score, diagnoses gaps, generates action plans
+---
+
+You are a CRM onboarding health analyst for BestyCRM.
+Your job is to analyze the onboarding pipeline, identify at-risk accounts (health score < 50), break down which of the six scoring dimensions are underperforming, and produce prioritized action plans grouped by account manager.
+
+Health score dimensions (0-100 total):
+- Checklist progress (0-30 pts): PMS-specific onboarding checklist completion
+- Feature flags (0-25 pts): 10 key flags at 2.5 pts each
+- Recency (0-15 pts): days since last seen (1d=15, 7d=10, 14d=5)
+- Primary contact (0-10 pts): HubSpot contact linked
+- Stripe setup (0-10 pts): subscription active or trialing
+- Listing health (0-10 pts): zero listings in error
+
+Always prioritize recommendations by potential point impact (highest first).
+Store analysis results in ruflo memory namespace "crm" for historical tracking.

--- a/.claude/skills/crm-onboarding-health/SKILL.md
+++ b/.claude/skills/crm-onboarding-health/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: "CRM Onboarding Health Analysis"
+description: "Analyze BestyCRM onboarding pipeline to identify at-risk accounts, diagnose health score gaps, and generate prioritized action plans for account managers."
+version: "1.0.0"
+category: "crm"
+tags: ["crm", "onboarding", "health-score", "churn-prevention", "besty"]
+---
+
+# CRM Onboarding Health Analysis
+
+## What This Skill Does
+
+Analyzes the BestyCRM onboarding pipeline to surface accounts that need attention. It reads health scores (0-100), breaks down which of the six scoring dimensions are underperforming, and produces a prioritized action plan grouped by account manager.
+
+## Health Score Model
+
+Each account is scored on six dimensions:
+
+| Dimension | Max | How to Improve |
+|-----------|-----|----------------|
+| Checklist progress | 30 | Complete PMS-specific onboarding items |
+| Feature flags (10 key) | 25 | Enable missing flags (2.5 pts each) |
+| Recency (last seen) | 15 | Re-engage inactive users |
+| Primary contact linked | 10 | Link HubSpot contact |
+| Stripe active/trialing | 10 | Complete billing setup |
+| No listing errors | 10 | Resolve errored listings |
+
+## Risk Tiers
+
+| Tier | Score Range | Action |
+|------|------------|--------|
+| Critical | < 30 | Immediate intervention |
+| At Risk | 30-50 | Proactive outreach |
+| Needs Attention | 50-70 | Monitor and nudge |
+| On Track | 70-85 | Light touch |
+| Healthy | > 85 | Self-serve |
+
+## Usage
+
+### Analyze full pipeline
+```
+Analyze the onboarding pipeline for at-risk accounts and generate an action plan.
+```
+
+### Focus on a specific account manager
+```
+Show me all at-risk accounts assigned to Sarah with their score breakdowns.
+```
+
+### Track week-over-week changes
+```
+Compare this week's health scores against last week's analysis stored in memory.
+```
+
+## Approach
+
+1. **Fetch** pipeline data from `/api/onboarding/pipeline`
+2. **Triage** accounts into risk tiers by health score
+3. **Diagnose** each at-risk account's score breakdown to find the biggest gaps
+4. **Prioritize** actions by potential point impact (highest first)
+5. **Group** recommendations by account manager for delegation
+6. **Store** analysis in ruflo memory for historical comparison
+
+## MCP Toolkit
+
+```bash
+# Store analysis results
+npx claude-flow@v3alpha memory store --namespace crm --key "health-$(date +%Y%m%d)" --value "[results]"
+
+# Search past analyses
+npx claude-flow@v3alpha memory search --namespace crm --query "at-risk accounts"
+
+# Retrieve previous analysis
+npx claude-flow@v3alpha memory retrieve --namespace crm --key "health-20260414"
+```


### PR DESCRIPTION
## Summary

- Adds a new `crm-onboarding-health` Ruflo skill that analyzes BestyCRM's onboarding pipeline to identify at-risk accounts
- Creates an agent definition specialized for health score triage and gap diagnosis
- Wires the skill into `.agents/config.toml`

The skill teaches Ruflo agents BestyCRM's 6-dimension health scoring model (checklist progress, feature flags, recency, contacts, Stripe, listing health) so they can diagnose which dimensions are dragging an account's score down and produce prioritized action plans grouped by account manager.

## Files Changed

| File | What |
|------|------|
| `.agents/skills/crm-onboarding-health/SKILL.md` | Full skill definition with scoring model, risk tiers, diagnostic approach, CLI/swarm integration examples |
| `.claude/skills/crm-onboarding-health/SKILL.md` | Claude Code skill for direct invocation |
| `.claude/agents/crm-onboarding-health.md` | Agent persona (analyst role) |
| `.agents/config.toml` | Added skill to enabled list |

## Test plan

- [x] Agent spawns successfully (`agent spawn -t analyst --name health-analyst`)
- [x] Memory store/retrieve round-trips with vector embedding (`memory store --namespace crm`)
- [x] Semantic search finds stored health analysis (`memory search --query "at-risk accounts"`)
- [x] Doctor passes with skill registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)