### PR TITLE
fix: prefer project-scoped env vars over CLAUDE_FLOW_CWD fallback

### DIFF
--- a/v3/@claude-flow/cli/__tests__/mcp-tools-project-cwd.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-tools-project-cwd.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getProjectCwd } from '../src/mcp-tools/types.js';
+
+const ORIGINAL_ENV = {
+  CLAUDE_FLOW_PROJECT_DIR: process.env.CLAUDE_FLOW_PROJECT_DIR,
+  CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR,
+  INIT_CWD: process.env.INIT_CWD,
+  CLAUDE_FLOW_CWD: process.env.CLAUDE_FLOW_CWD,
+};
+
+const TEMP_DIRS: string[] = [];
+
+function makeTempDir(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `${name}-`));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+function restoreEnvVar(key: keyof typeof ORIGINAL_ENV): void {
+  const value = ORIGINAL_ENV[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+afterEach(() => {
+  restoreEnvVar('CLAUDE_FLOW_PROJECT_DIR');
+  restoreEnvVar('CLAUDE_PROJECT_DIR');
+  restoreEnvVar('INIT_CWD');
+  restoreEnvVar('CLAUDE_FLOW_CWD');
+
+  while (TEMP_DIRS.length > 0) {
+    const dir = TEMP_DIRS.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('getProjectCwd', () => {
+  it('prefers CLAUDE_PROJECT_DIR over CLAUDE_FLOW_CWD fallback', () => {
+    const projectDir = makeTempDir('project-dir');
+    const fallbackDir = makeTempDir('fallback-dir');
+
+    process.env.CLAUDE_PROJECT_DIR = projectDir;
+    process.env.CLAUDE_FLOW_CWD = fallbackDir;
+
+    expect(getProjectCwd()).toBe(projectDir);
+  });
+
+  it('prefers INIT_CWD over CLAUDE_FLOW_CWD when project dir is absent', () => {
+    const initDir = makeTempDir('init-dir');
+    const fallbackDir = makeTempDir('fallback-dir');
+
+    delete process.env.CLAUDE_PROJECT_DIR;
+    process.env.INIT_CWD = initDir;
+    process.env.CLAUDE_FLOW_CWD = fallbackDir;
+
+    expect(getProjectCwd()).toBe(initDir);
+  });
+
+  it('falls back to CLAUDE_FLOW_CWD when no project-scoped env is set', () => {
+    const fallbackDir = makeTempDir('fallback-dir');
+
+    delete process.env.CLAUDE_FLOW_PROJECT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.INIT_CWD;
+    process.env.CLAUDE_FLOW_CWD = fallbackDir;
+
+    expect(getProjectCwd()).toBe(fallbackDir);
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/mcp-tools-project-cwd.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-tools-project-cwd.test.ts
@@ -39,10 +39,25 @@ afterEach(() => {
 });
 
 describe('getProjectCwd', () => {
+  it('prefers CLAUDE_FLOW_PROJECT_DIR over other env fallbacks', () => {
+    const explicitProjectDir = makeTempDir('flow-project-dir');
+    const claudeProjectDir = makeTempDir('claude-project-dir');
+    const initDir = makeTempDir('init-dir');
+    const fallbackDir = makeTempDir('fallback-dir');
+
+    process.env.CLAUDE_FLOW_PROJECT_DIR = explicitProjectDir;
+    process.env.CLAUDE_PROJECT_DIR = claudeProjectDir;
+    process.env.INIT_CWD = initDir;
+    process.env.CLAUDE_FLOW_CWD = fallbackDir;
+
+    expect(getProjectCwd()).toBe(explicitProjectDir);
+  });
+
   it('prefers CLAUDE_PROJECT_DIR over CLAUDE_FLOW_CWD fallback', () => {
     const projectDir = makeTempDir('project-dir');
     const fallbackDir = makeTempDir('fallback-dir');
 
+    delete process.env.CLAUDE_FLOW_PROJECT_DIR;
     process.env.CLAUDE_PROJECT_DIR = projectDir;
     process.env.CLAUDE_FLOW_CWD = fallbackDir;
 
@@ -53,6 +68,7 @@ describe('getProjectCwd', () => {
     const initDir = makeTempDir('init-dir');
     const fallbackDir = makeTempDir('fallback-dir');
 
+    delete process.env.CLAUDE_FLOW_PROJECT_DIR;
     delete process.env.CLAUDE_PROJECT_DIR;
     process.env.INIT_CWD = initDir;
     process.env.CLAUDE_FLOW_CWD = fallbackDir;

--- a/v3/@claude-flow/cli/src/mcp-tools/types.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/types.ts
@@ -22,11 +22,16 @@ export interface MCPToolResult {
 
 /**
  * Returns the effective project working directory.
- * Prefers CLAUDE_FLOW_CWD (set by the install script for global/MCP installs
- * where process.cwd() may resolve to '/') over the real process.cwd().
+ * Prefers project-scoped env vars exposed by the host runtime over the
+ * installer fallback `CLAUDE_FLOW_CWD`, so globally registered MCP servers can
+ * still isolate state per project when the host provides that context.
  */
 export function getProjectCwd(): string {
-  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+  return process.env.CLAUDE_FLOW_PROJECT_DIR
+    || process.env.CLAUDE_PROJECT_DIR
+    || process.env.INIT_CWD
+    || process.env.CLAUDE_FLOW_CWD
+    || process.cwd();
 }
 
 export interface MCPTool {


### PR DESCRIPTION
## Summary

Fixes the project-boundary bug described in #1617.

`getProjectCwd()` currently prefers the installer fallback `CLAUDE_FLOW_CWD` before project-scoped runtime env vars. On global MCP installs, that means the fallback can mask richer host context and send session/task/agent state into one shared home-scoped `.claude-flow/` tree.

This PR keeps the scope intentionally narrow: it only changes the resolver priority order and adds a regression test for that order.

## Changes

| File | Purpose |
|------|---------|
| `v3/@claude-flow/cli/src/mcp-tools/types.ts` | Prefer project-scoped env vars (`CLAUDE_FLOW_PROJECT_DIR`, `CLAUDE_PROJECT_DIR`, `INIT_CWD`) before the installer fallback `CLAUDE_FLOW_CWD` |
| `v3/@claude-flow/cli/__tests__/mcp-tools-project-cwd.test.ts` | Regression tests covering env-var priority and fallback behavior |

## Why this scope

Recent cwd fixes addressed bootstrap failures when MCP servers start at `/` or `System32`. This PR targets the narrower follow-up problem: once the host *does* provide a project directory, the installer fallback should no longer win.

That keeps the patch small, reviewable, and low-risk.

## Test plan

- [x] `bunx vitest run v3/@claude-flow/cli/__tests__/mcp-tools-project-cwd.test.ts`
- [x] Manual local repro before the patch: with `CLAUDE_FLOW_CWD` pinned to a fake home dir, `session_save` from two different projects wrote into the same shared `.claude-flow/sessions` directory
- [x] Manual local repro after the patch: with `CLAUDE_PROJECT_DIR` set per project and `CLAUDE_FLOW_CWD` still pinned to the fake home dir, `session_save` writes into each project's local `.claude-flow/sessions` directory instead

## Notes

- This does **not** remove `CLAUDE_FLOW_CWD`; it remains the bootstrap fallback for global installs.
- This is complementary to broader cwd hardening work such as #1577 / #1594, but fixes the specific priority-order bug in current `main`.

Closes #1617
