### PR TITLE
feat: show active embedding provider in memory stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ lerna-debug.log*
 logs/
 mcp-server.log
 memory/backups/
-node_modules/
+**/node_modules/
 npm-debug.log*
 out/
 output/

--- a/v3/@claude-flow/cli/__tests__/commands.test.ts
+++ b/v3/@claude-flow/cli/__tests__/commands.test.ts
@@ -639,6 +639,37 @@ describe('Memory Commands', () => {
       expect(result.data).toHaveProperty('backend');
       expect(result.data).toHaveProperty('version');
     });
+
+    it('should include embedding provider info in JSON output', async () => {
+      const statsCmd = memoryCommand.subcommands?.find(c => c.name === 'stats');
+      expect(statsCmd).toBeDefined();
+
+      ctx.flags = { format: 'json', _: [] };
+      const result = await statsCmd!.action!(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveProperty('embedding');
+      expect(result.data.embedding).toHaveProperty('provider');
+      expect(result.data.embedding).toHaveProperty('dimensions');
+      expect(result.data.embedding).toHaveProperty('hnswAvailable');
+      expect(typeof result.data.embedding.provider).toBe('string');
+      expect(typeof result.data.embedding.dimensions).toBe('number');
+      expect(typeof result.data.embedding.hnswAvailable).toBe('boolean');
+    });
+
+    it('should default embedding to none when memory-initializer is unavailable', async () => {
+      const statsCmd = memoryCommand.subcommands?.find(c => c.name === 'stats');
+      expect(statsCmd).toBeDefined();
+
+      ctx.flags = { format: 'json', _: [] };
+      const result = await statsCmd!.action!(ctx);
+
+      expect(result.success).toBe(true);
+      // In test environment, memory-initializer import will fail gracefully
+      // so embedding fields should have safe defaults
+      expect(result.data.embedding.provider).toBeDefined();
+      expect(result.data.embedding.dimensions).toBeGreaterThanOrEqual(0);
+    });
   });
 
   describe('memory configure', () => {

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -589,11 +589,27 @@ const statsCommand: Command = {
         newestEntry: string | null;
       };
 
+      // Probe embedding provider (non-blocking, best-effort)
+      let embeddingProvider = 'none';
+      let embeddingDimensions = 0;
+      let hnswAvailable = false;
+      try {
+        const { loadEmbeddingModel, getHNSWIndex } = await import('../memory/memory-initializer.js');
+        const embResult = await loadEmbeddingModel();
+        if (embResult.success) {
+          embeddingProvider = embResult.modelName;
+          embeddingDimensions = embResult.dimensions;
+        }
+        hnswAvailable = (await getHNSWIndex()) !== null;
+      } catch {
+        // memory-initializer not available
+      }
+
       const stats = {
         backend: statsResult.backend,
         entries: {
           total: statsResult.totalEntries,
-          vectors: 0, // Would need vector backend support
+          vectors: 0,
           text: statsResult.totalEntries
         },
         storage: {
@@ -602,7 +618,12 @@ const statsCommand: Command = {
         },
         version: statsResult.version,
         oldestEntry: statsResult.oldestEntry,
-        newestEntry: statsResult.newestEntry
+        newestEntry: statsResult.newestEntry,
+        embedding: {
+          provider: embeddingProvider,
+          dimensions: embeddingDimensions,
+          hnswAvailable
+        }
       };
 
       if (ctx.flags.format === 'json') {
@@ -626,6 +647,20 @@ const statsCommand: Command = {
           { metric: 'Total Entries', value: stats.entries.total.toLocaleString() },
           { metric: 'Total Storage', value: stats.storage.total },
           { metric: 'Location', value: stats.storage.location }
+        ]
+      });
+
+      output.writeln();
+      output.writeln(output.bold('Embedding'));
+      output.printTable({
+        columns: [
+          { key: 'metric', header: 'Metric', width: 20 },
+          { key: 'value', header: 'Value', width: 30, align: 'right' }
+        ],
+        data: [
+          { metric: 'Provider', value: stats.embedding.provider },
+          { metric: 'Dimensions', value: stats.embedding.dimensions > 0 ? String(stats.embedding.dimensions) : 'N/A' },
+          { metric: 'HNSW Index', value: stats.embedding.hnswAvailable ? 'active' : 'unavailable' }
         ]
       });
 

--- a/v3/package.json
+++ b/v3/package.json
@@ -50,7 +50,7 @@
     "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
   },
-  "packageManager": "pnpm@8.15.0",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "dependencies": {
     "semantic-release": "25.0.2"
   },


### PR DESCRIPTION
## Summary

- `ruflo memory stats` now shows which embedding provider is active, its vector dimensions, and whether the HNSW index is available
- Adds an "Embedding" section to both table and `--format json` output
- Two new tests covering the embedding info output

## Justification

There is currently **no way to know** which embedding provider ruflo selected for a project without re-running `ruflo memory init --verbose --force` (which reinitializes the database). The embedding provider directly affects:

- **Search quality**: semantic (384/768-dim ONNX) vs keyword-only (128-dim hash fallback)
- **Search speed**: HNSW-indexed (~1ms) vs linear scan
- **Vector compatibility**: entries stored with different providers have different dimensions and can't be compared

When `memory stats` shows `Provider: hash-fallback`, that immediately tells the user their semantic search is degraded and they need to install an ONNX provider. Without this info, memory search silently returns poor results with no indication why.

### Possible provider values

| Provider | Package | Dimensions | Quality |
|----------|---------|-----------|---------|
| `Xenova/all-MiniLM-L6-v2` | `@xenova/transformers` | 384 | Full semantic |
| `agentic-flow/reasoningbank` | `agentic-flow` | 768 | Full semantic |
| `ruvector/onnx` | `ruvector` | 384 | Full semantic |
| `agentic-flow` | `agentic-flow` | 768 | Full semantic |
| `hash-fallback` | (built-in) | 128 | No semantic understanding |
| `none` | — | 0 | memory-initializer unavailable |

### Example output

```
Embedding
+------------+---------------+
| Metric     |         Value |
+------------+---------------+
| Provider   | hash-fallback |
| Dimensions |           128 |
| HNSW Index |        active |
+------------+---------------+
```

## Changes

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/commands/memory.ts` | Probe `loadEmbeddingModel()` and `getHNSWIndex()` in stats command, display Embedding section |
| `v3/@claude-flow/cli/__tests__/commands.test.ts` | Two new tests: embedding info in JSON output, graceful defaults when unavailable |
| `.gitignore` | `**/node_modules/` to catch nested workspace dirs |
| `v3/package.json` | Bump `packageManager` to pnpm@10.33.0 |

## Test plan

- [x] `npx vitest run -t "memory stats"` — both new tests pass
- [x] `node v3/@claude-flow/cli/bin/cli.js memory stats` — Embedding section renders correctly
- [x] `--format json` includes `embedding.provider`, `embedding.dimensions`, `embedding.hnswAvailable`
- [x] Graceful fallback to `provider: "none"` when memory-initializer is unavailable

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)