### PR TITLE
fix(ruflo): exit cleanly after one-shot commands + suppress AgentDB warnings

### DIFF
--- a/ruflo/bin/ruflo.js
+++ b/ruflo/bin/ruflo.js
@@ -4,6 +4,21 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 import { existsSync } from 'node:fs';
 
+// Mirror suppression from @claude-flow/cli/bin/cli.js — ruflo imports dist/src/index.js
+// directly so it bypasses the canonical entry's console.warn patch.
+const _origWarn = console.warn;
+console.warn = (...args) => {
+  const msg = String(args[0] ?? '');
+  if (msg.includes('[AgentDB Patch]')) return;
+  _origWarn.apply(console, args);
+};
+const _origLog = console.log;
+console.log = (...args) => {
+  const msg = String(args[0] ?? '');
+  if (msg.includes('[AgentDB Patch]')) return;
+  _origLog.apply(console, args);
+};
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Walk up from ruflo/bin/ to find @claude-flow/cli in node_modules
@@ -43,8 +58,14 @@ if (isMCPMode) {
     name: 'ruflo',
     description: 'Ruflo - AI Agent Orchestration Platform',
   });
-  cli.run().catch((error) => {
-    console.error('Fatal error:', error.message);
-    process.exit(1);
-  });
+  cli.run()
+    .then(() => {
+      // #1552: Exit cleanly after one-shot commands. Mirrors @claude-flow/cli/bin/cli.js.
+      // Long-running commands (daemon foreground, mcp, status --watch) never resolve.
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Fatal error:', error.message);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
Closes #1641

## Summary

The ruflo wrapper (`ruflo/bin/ruflo.js`) imports `@claude-flow/cli`'s `dist/src/index.js` directly, bypassing the canonical `@claude-flow/cli/bin/cli.js` entry point. As a result, it does not inherit two fixes that live in that canonical entry:

1. **No `process.exit(0)` on success.** `cli.run()` is only handled with `.catch()`. One-shot commands (`status`, `memory list`, `--version`, etc.) print their output and then hang for ~2 minutes waiting for a leaked handle somewhere in `@claude-flow/cli` to drain. Canonical `cli.js` has an explicit `.then(() => process.exit(0))` branch with a comment citing issue #1552 for exactly this reason.
2. **No `[AgentDB Patch]` warning suppression.** Canonical `cli.js` patches `console.warn` to drop those messages. The ruflo wrapper does not, so the warning leaks through on every invocation.

This PR copies both patterns into `ruflo/bin/ruflo.js`. MCP mode is unchanged (it already delegates to canonical `cli.js`).

## Before / After (ruflo@3.5.80, Windows 11, Node 24.14.1)

```
# before
$ time ruflo status
...status output...
[AgentDB Patch] Controller index not found: C:\Users\petrb\node_modules\agentdb\dist\controllers\index.js
# hangs ~120s then exits

# after
$ time ruflo status
...status output...
real    0m2.940s
```

Also `ruflo --version` now returns silently in ~2s.

## Test plan
- [x] `ruflo --version` returns in <3s, no warning
- [x] `ruflo status` prints full output and exits cleanly in <3s
- [ ] MCP mode still delegates to canonical `cli.js` (unchanged code path)
- [ ] Long-running commands (`daemon foreground`, `mcp`, `status --watch`) still never resolve — the new `.then(() => process.exit(0))` only fires when `cli.run()` actually resolves, which those commands don't