### PR TITLE
fix(system-health): detect modern sql.js memory DB paths

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -306,11 +306,16 @@ export const systemTools: MCPTool[] = [
       const checks: Array<{ name: string; status: string; latency?: number; message?: string }> = [];
       const projectCwd = getProjectCwd();
 
-      // Memory DB check — verify the store file exists
+      // Memory DB check — verify the store file exists.
+      // Modern backend is sql.js at .swarm/memory.db (see memory-initializer.js).
+      // Fallback paths cover alternate configs and the legacy JSON backend.
       {
         const t0 = performance.now();
-        const memoryDbPath = join(projectCwd, '.claude-flow', 'memory', 'store.json');
-        const memoryExists = existsSync(memoryDbPath);
+        const memoryExists =
+          existsSync(join(projectCwd, '.swarm', 'memory.db')) ||
+          existsSync(join(projectCwd, '.claude-flow', 'memory.db')) ||
+          existsSync(join(projectCwd, 'data', 'memory.db')) ||
+          existsSync(join(projectCwd, '.claude-flow', 'memory', 'store.json'));
         const elapsed = performance.now() - t0;
         checks.push({
           name: 'memory',


### PR DESCRIPTION
## Problem

`system_health` reports memory as `degraded` with `"Memory store not found — run memory init"` on every healthy sql.js install.

Reproduction against v3.5.80:
```
$ ruflo memory init
$ ruflo memory stats
  initialized: true, backend: sql.js + HNSW, ...
$ (call mcp__ruflo__system_health)
  memory: degraded — "Memory store not found — run memory init"
```

## Cause

`v3/@claude-flow/cli/src/mcp-tools/system-tools.ts` at line 312 checks only the **legacy JSON-backend** path:

```ts
const memoryDbPath = join(projectCwd, '.claude-flow', 'memory', 'store.json');
```

The modern sql.js backend — the default on current installs, per `@claude-flow/cli/.../memory-initializer.js:366` — persists to `.swarm/memory.db`. The legacy JSON path never exists on these installs, so the check always reports degraded.

Same file already looks at the sql.js paths elsewhere (`statusline-generator.js` lines 231-233, 501-503) using exactly `.swarm/memory.db`, `.claude-flow/memory.db`, `data/memory.db` — aligning `system_health` with that convention.

## Fix

Check the modern sql.js paths first, fall back to the legacy JSON path for backwards compatibility. Five-line change, no behavior change when either path exists — only fixes the false-positive degraded status.

## Verified

Applied same patch to the built `system-tools.js` locally on v3.5.80; `system_health` flips memory from `degraded` → `healthy` when `.swarm/memory.db` exists (the expected state after `memory init`), and continues to report degraded when no store exists at all.

## Notes

- Every Ruflo user on a sql.js install sees this — it's not install-specific.
- Non-functional: `memory_stats`, `memory_store`, `memory_search` all work correctly; only the health reporting was wrong.