### PR TITLE
Fix plugin/marketplace manifests to match Claude Code schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,9 +22,6 @@
       },
       "homepage": "https://claude-flow.ruv.io",
       "repository": "https://github.com/ruvnet/claude-flow",
-      "bugs": {
-        "url": "https://github.com/ruvnet/claude-flow/issues"
-      },
       "license": "MIT",
       "keywords": [
         "ai-agents",
@@ -55,22 +52,6 @@
         "neural-network",
         "enterprise"
       ],
-      "features": [
-        "150+ slash commands across 19 categories",
-        "74+ specialized AI agents",
-        "Multi-agent swarm coordination (Hierarchical, Mesh, Ring, Star)",
-        "SPARC methodology integration (18 development modes)",
-        "GitHub automation (PR management, code review, releases)",
-        "Neural training with WASM acceleration (2.8-4.4x speed)",
-        "Cross-session memory persistence",
-        "Real-time performance monitoring",
-        "110+ MCP tools across 3 servers",
-        "84.8% SWE-Bench solve rate"
-      ],
-      "requirements": {
-        "claudeCode": ">=2.0.0",
-        "node": ">=20.0.0"
-      },
       "mcpServers": {
         "claude-flow": {
           "command": "npx",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,13 +7,8 @@
     "email": "ruv@ruv.net"
   },
   "homepage": "https://github.com/ruvnet/claude-flow",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ruvnet/claude-flow.git"
-  },
-  "bugs": {
-    "url": "https://github.com/ruvnet/claude-flow/issues"
-  },
+  "repository": "https://github.com/ruvnet/claude-flow.git",
+  "bugs": "https://github.com/ruvnet/claude-flow/issues",
   "license": "MIT",
   "keywords": [
     "ai-agents",


### PR DESCRIPTION
## Summary

`claude plugin install claude-flow@claude-flow-marketplace` currently fails on Claude Code 2.1.119 with two schema validation errors. This PR makes the manifests pass `claude plugin validate` while preserving every functional field (mcpServers, keywords, tags, author, license, homepage, repository).

### Reproduction (against `main`)

```
$ claude plugin marketplace add ruvnet/ruflo
✔ Successfully added marketplace: claude-flow-marketplace

$ claude plugin install claude-flow@claude-flow-marketplace
✘ Failed: Plugin temp_local_… has an invalid manifest file at .claude-plugin/plugin.json.
Validation errors: repository: Invalid input: expected string, received object

$ claude plugin validate .
✘ plugins.0: Unrecognized keys: "bugs", "features", "requirements"
```

### Fix

**`.claude-plugin/plugin.json`**
- `repository`: npm-style `{type, url}` object → URL string
- `bugs`: `{url}` object → URL string

**`.claude-plugin/marketplace.json`** (per-plugin entry)
- Removed `bugs` — object form rejected, and the marketplace plugin-entry schema does not currently accept this key in any form.
- Removed `features` and `requirements` — not in the schema. Engine constraints already live in `plugin.json` under `engines`, so nothing is lost.

After the change, both files validate cleanly:

```
$ claude plugin validate .
✔ Validation passed
```

…and `claude plugin install claude-flow@claude-flow-marketplace` succeeds end-to-end (38 skills, 23 commands, agents, and MCP servers all register).

## Test plan

- [x] `claude plugin validate .` passes on Claude Code 2.1.119
- [x] `claude plugin install claude-flow@claude-flow-marketplace` succeeds against a marketplace cache built from this branch
- [x] `claude plugin list` shows `claude-flow@claude-flow-marketplace 2.5.0 ✔ enabled`
- [x] `claude mcp list` shows the plugin's MCP servers reachable
- [x] No functional fields modified (diff is JSON-shape-only for `repository`/`bugs`, plus removal of three keys not in the schema)