### PR TITLE
fix: Tier A+B blockers (v3.5.82)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.5.81",
+  "version": "3.5.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.5.81",
+      "version": "3.5.82",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.5.81",
+  "version": "3.5.82",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.5.81",
+  "version": "3.5.82",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.5.81",
+  "version": "3.5.82",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -4049,13 +4049,13 @@ const statuslineCommand: Command = {
 
       try {
         const psCmd = isWindows
-          ? 'tasklist /FI "IMAGENAME eq node.exe" 2>NUL | findstr /I /C:"node" >NUL && echo 1 || echo 0'
+          ? 'tasklist /FI "IMAGENAME eq node.exe" /NH 2>NUL | find /c /v "" 2>NUL || echo 0'
           : 'ps aux 2>/dev/null | grep -c agentic-flow || echo "0"';
-        const ps = execSync(psCmd, { encoding: 'utf-8' });
+        const ps = execSync(psCmd, { encoding: 'utf-8', timeout: 3000 });
         activeAgents = Math.max(0, parseInt(ps.trim()) - 1);
         coordinationActive = activeAgents > 0;
       } catch {
-        // Ignore
+        // ps/tasklist unavailable or timed out — report zero
       }
 
       return { activeAgents, maxAgents, coordinationActive };

--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -418,13 +418,13 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
     }
 
     if (!startDaemon && !startAll) {
-      // Next steps (only if not auto-starting)
+      const bin = (process.argv[1] || '').includes('ruflo') ? 'ruflo' : 'claude-flow';
       output.writeln(output.bold('Next steps:'));
       output.printList([
-        `Run ${output.highlight('claude-flow daemon start')} to start background workers`,
-        `Run ${output.highlight('claude-flow memory init')} to initialize memory database`,
-        `Run ${output.highlight('claude-flow swarm init')} to initialize a swarm`,
-        `Or use ${output.highlight('claude-flow init --start-all')} to do all of the above`,
+        `Run ${output.highlight(`${bin} daemon start`)} to start background workers`,
+        `Run ${output.highlight(`${bin} memory init`)} to initialize memory database`,
+        `Run ${output.highlight(`${bin} swarm init`)} to initialize a swarm`,
+        `Or use ${output.highlight(`${bin} init --start-all`)} to do all of the above`,
         options.components.settings ? `Review ${output.highlight('.claude/settings.json')} for hook configurations` : '',
       ].filter(Boolean));
     }

--- a/v3/@claude-flow/cli/src/mcp-tools/guidance-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/guidance-tools.ts
@@ -83,7 +83,7 @@ const CAPABILITY_CATALOG: Record<string, CapabilityArea> = {
   'memory-knowledge': {
     name: 'Memory & Knowledge',
     description: 'Persistent memory with HNSW vector search, AgentDB storage, and embeddings.',
-    tools: ['memory_store', 'memory_retrieve', 'memory_search', 'memory_list', 'memory_delete', 'memory_init', 'memory_export', 'memory_import', 'memory_stats', 'memory_compact', 'memory_namespace'],
+    tools: ['memory_store', 'memory_retrieve', 'memory_search', 'memory_list', 'memory_delete', 'memory_init', 'memory_export', 'memory_import_claude', 'memory_stats', 'memory_compact', 'memory_namespace'],
     commands: ['memory store', 'memory retrieve', 'memory search', 'memory list', 'memory delete', 'memory init'],
     agents: ['swarm-memory-manager', 'v3-memory-specialist'],
     skills: ['v3-memory-unification', 'agentdb-advanced', 'agentdb-vector-search', 'agentdb-memory-patterns', 'agentdb-learning'],

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -2313,6 +2313,21 @@ export const hooksTrajectoryStart: MCPTool = {
 
     activeTrajectories.set(trajectoryId, trajectory);
 
+    // Persist pending trajectory to disk so it survives MCP restarts
+    const storeFn = await getRealStoreFunction();
+    if (storeFn) {
+      try {
+        await storeFn({
+          key: `trajectory-pending-${trajectoryId}`,
+          value: JSON.stringify(trajectory),
+          namespace: 'trajectories',
+          tags: [agent, 'pending', 'sona-trajectory'],
+        });
+      } catch {
+        // Best-effort persistence — trajectory still lives in-memory
+      }
+    }
+
     return {
       trajectoryId,
       task,
@@ -2725,8 +2740,18 @@ export const hooksIntelligenceStats: MCPTool = {
     const flash = await getFlashAttention();
     const lora = await getLoRAAdapter();
 
-    // Fallback to memory store for legacy data
-    const memoryStats = getIntelligenceStatsFromMemory();
+    // Fallback to memory store for legacy data (may not exist yet)
+    let memoryStats: ReturnType<typeof getIntelligenceStatsFromMemory>;
+    try {
+      memoryStats = getIntelligenceStatsFromMemory();
+    } catch {
+      memoryStats = {
+        trajectories: { total: 0, successful: 0 },
+        patterns: { learned: 0, categories: {} },
+        memory: { indexSize: 0, totalAccessCount: 0, memorySizeBytes: 0 },
+        routing: { decisions: 0, avgConfidence: 0 },
+      };
+    }
 
     // SONA stats from real implementation
     let sonaStats = {
@@ -3502,26 +3527,7 @@ export const hooksWorkerDispatch: MCPTool = {
 
     activeWorkers.set(workerId, worker);
 
-    // Update worker progress in background
-    if (background) {
-      setTimeout(() => {
-        const w = activeWorkers.get(workerId);
-        if (w) {
-          w.progress = 50;
-          w.phase = 'processing';
-        }
-      }, 500);
-
-      setTimeout(() => {
-        const w = activeWorkers.get(workerId);
-        if (w) {
-          w.progress = 100;
-          w.phase = 'completed';
-          w.status = 'completed';
-          w.completedAt = new Date();
-        }
-      }, 1500);
-    } else {
+    if (!background) {
       worker.progress = 100;
       worker.phase = 'completed';
       worker.status = 'completed';
@@ -3539,8 +3545,9 @@ export const hooksWorkerDispatch: MCPTool = {
         estimatedDuration: config.estimatedDuration,
         capabilities: config.capabilities,
       },
-      status: background ? 'dispatched' : 'completed',
+      status: background ? 'scheduled' : 'completed',
       background,
+      note: background ? 'Worker scheduled. Use hooks_worker-status to check progress. Start the daemon (daemon start) for real background execution.' : undefined,
       timestamp: new Date().toISOString(),
     };
   },

--- a/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
@@ -291,6 +291,9 @@ export const neuralTools: MCPTool[] = [
         totalPatterns: Object.keys(store.patterns).length,
         epochs,
         trainedAt: model.trainedAt,
+        ...(embeddingServiceName === 'hash-fallback' || embeddingServiceName === 'none' ? {
+          platformNote: 'ONNX embeddings not available — using hash-based fallback. Install @claude-flow/embeddings and run "embeddings init --download" for semantic search.',
+        } : {}),
       };
     },
   },

--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -306,11 +306,13 @@ export const systemTools: MCPTool[] = [
       const checks: Array<{ name: string; status: string; latency?: number; message?: string }> = [];
       const projectCwd = getProjectCwd();
 
-      // Memory DB check — verify the store file exists
+      // Memory DB check — verify any supported store file exists
       {
         const t0 = performance.now();
-        const memoryDbPath = join(projectCwd, '.claude-flow', 'memory', 'store.json');
-        const memoryExists = existsSync(memoryDbPath);
+        const legacyPath = join(projectCwd, '.claude-flow', 'memory', 'store.json');
+        const agentDbPath = join(projectCwd, '.claude-flow', 'memory', 'agentdb.sqlite');
+        const rvfPath = join(projectCwd, '.claude-flow', 'memory', 'store.rvf');
+        const memoryExists = existsSync(legacyPath) || existsSync(agentDbPath) || existsSync(rvfPath);
         const elapsed = performance.now() - t0;
         checks.push({
           name: 'memory',

--- a/v3/@claude-flow/cli/src/mcp-tools/types.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/types.ts
@@ -26,7 +26,11 @@ export interface MCPToolResult {
  * where process.cwd() may resolve to '/') over the real process.cwd().
  */
 export function getProjectCwd(): string {
-  return process.env.CLAUDE_FLOW_CWD || process.cwd();
+  const envCwd = process.env.CLAUDE_FLOW_CWD;
+  if (envCwd && envCwd !== '/' && envCwd !== process.env.HOME) {
+    return envCwd;
+  }
+  return process.cwd();
 }
 
 export interface MCPTool {

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -83,13 +83,15 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
             dbPath: dbPath || getDbPath(),
             embeddingModel: 'Xenova/all-MiniLM-L6-v2',
             dimension: 384,
+            vectorBackend: 'auto',
             controllers: {
               reasoningBank: true,
               learningBridge: false,
               tieredCache: true,
               hierarchicalMemory: true,
               memoryConsolidation: true,
-              memoryGraph: true, // issue #1214: enable MemoryGraph for graph-aware ranking
+              memoryGraph: true,
+              vectorBackend: true,
             },
           });
         } finally {

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -11,7 +11,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync, unlinkSync, renameSync } from 'fs';
 import { cpus } from 'os';
 import { join } from 'path';
 import {
@@ -1087,7 +1087,9 @@ export class WorkerDaemon extends EventEmitter {
     };
 
     try {
-      writeFileSync(this.config.stateFile, JSON.stringify(state, null, 2));
+      const tmpFile = this.config.stateFile + '.tmp';
+      writeFileSync(tmpFile, JSON.stringify(state, null, 2));
+      renameSync(tmpFile, this.config.stateFile);
     } catch (error) {
       this.log('error', `Failed to save state: ${error}`);
     }

--- a/v3/@claude-flow/memory/src/rvf-backend.ts
+++ b/v3/@claude-flow/memory/src/rvf-backend.ts
@@ -458,9 +458,18 @@ export class RvfBackend implements IMemoryBackend {
     }
   }
 
+  private persistQueue: Promise<void> = Promise.resolve();
+
   private async persistToDisk(): Promise<void> {
     if (this.config.databasePath === ':memory:') return;
-    if (this.persisting) return; // Prevent concurrent persist calls
+    // Queue writes so concurrent callers wait instead of silently dropping
+    this.persistQueue = this.persistQueue.then(() => this.doPersist()).catch(() => {});
+    return this.persistQueue;
+  }
+
+  private async doPersist(): Promise<void> {
+    if (!this.dirty) return;
+    if (this.persisting) return;
     this.persisting = true;
 
     try {

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1789,7 +1789,7 @@
       }
     },
     "@claude-flow/cli": {
-      "version": "3.5.81",
+      "version": "3.5.82",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- **Tier A (6 bugs):** #1647 trajectory persistence, #1646 memory_import tool name, #1617 getProjectCwd $HOME fallback, #1619 system_health AgentDB detection, #1614 RvfBackend write queue, #1610 vectorBackend config plumbing
- **Tier B (7 issues):** #1636 worker-dispatch honest status, #1637 daemon-state atomic write, #1620 brand-aware init, #1635/#1633 Windows ps guard, #1631 neural platform note
- Bumps to v3.5.82 across @claude-flow/cli, claude-flow, ruflo

## Fixes
| # | Issue | Fix |
|---|-------|-----|
| #1647 | trajectory-start doesn't persist | Persist pending record to disk via storeFn; wrap intelligence_stats in try/catch |
| #1646 | memory import calls wrong tool | `memory_import` → `memory_import_claude` in guidance catalog |
| #1617 | getProjectCwd prefers stale HOME | Reject CLAUDE_FLOW_CWD when == $HOME or '/' |
| #1619 | system_health false degraded | Also check agentdb.sqlite, store.rvf |
| #1614 | RvfBackend write race | Queue concurrent writes instead of silently dropping |
| #1610 | initAgentDB missing vectorBackend | Pass `vectorBackend: 'auto'` + `controllers.vectorBackend: true` |
| #1636 | worker-dispatch fakes results | Return 'scheduled' status, remove setTimeout fake |
| #1637 | daemon-state.json corruption | Atomic write via tmp file + renameSync |
| #1620 | init says 'claude-flow' not 'ruflo' | Detect binary name from process.argv |
| #1635 | Windows daemon ps crash | Improved tasklist command with /NH and timeout |
| #1633 | Windows daemon STOPPED | Same fix as #1635 |
| #1631 | neural train no-op on Windows | Add platformNote when ONNX unavailable |

## Test plan
- [x] `npm run build` passes for both @claude-flow/cli and @claude-flow/memory
- [x] 1793/1795 tests pass (2 pre-existing failures in commands-deep.test.ts)
- [x] getProjectCwd validated with 4 test cases (no env, valid env, HOME env, root env)
- [ ] Publish @claude-flow/cli, claude-flow, ruflo with alpha+latest tags
- [ ] Validate on Windows via Tailscale

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)