### PR TITLE
fix(security): Sprint 2 — CRIT-02 plugin sandboxing

### DIFF
--- a/v3/@claude-flow/cli/src/commands/plugins.ts
+++ b/v3/@claude-flow/cli/src/commands/plugins.ts
@@ -22,6 +22,15 @@ import {
 import { getPluginManager, type InstalledPlugin } from '../plugins/manager.js';
 import { getBulkRatings } from '../services/registry-api.js';
 
+// CRIT-02: Permission validation for plugin install
+const KNOWN_PLUGIN_PERMISSIONS = new Set([
+  'filesystem', 'network', 'env', 'process', 'memory',
+  'mcp', 'agents', 'cli', 'privileged', 'credentials', 'execute',
+]);
+const DANGEROUS_PLUGIN_PERMISSIONS = new Set([
+  'filesystem', 'network', 'env', 'process', 'privileged', 'credentials', 'execute',
+]);
+
 // List subcommand - Now uses IPFS-based registry
 const listCommand: Command = {
   name: 'list',
@@ -287,6 +296,26 @@ const installCommand: Command = {
 
         if (plugin) {
           spinner.setText(`Found ${plugin.displayName} v${plugin.version}`);
+
+          // CRIT-02: Validate plugin permissions on install
+          if (plugin.trustLevel !== 'official' && plugin.trustLevel !== 'verified') {
+            const unknownPerms = plugin.permissions.filter(
+              (p: string) => !KNOWN_PLUGIN_PERMISSIONS.has(p)
+            );
+            if (unknownPerms.length > 0) {
+              spinner.fail(`Plugin declares unknown permissions: ${unknownPerms.join(', ')}`);
+              return { success: false, exitCode: 1 };
+            }
+            const dangerousPerms = plugin.permissions.filter(
+              (p: string) => DANGEROUS_PLUGIN_PERMISSIONS.has(p)
+            );
+            if (dangerousPerms.length > 0) {
+              output.writeln(
+                output.highlight(`  Warning: requests sensitive permissions: ${dangerousPerms.join(', ')}`)
+              );
+              output.writeln(output.dim('  This plugin will run in a sandboxed environment.'));
+            }
+          }
         }
 
         spinner.setText(`Installing ${name} from npm...`);

--- a/v3/@claude-flow/shared/__tests__/security-sprint2.test.ts
+++ b/v3/@claude-flow/shared/__tests__/security-sprint2.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Sprint 2 Security Tests — CRIT-02 Plugin Sandboxing
+ *
+ * Covers:
+ *   1. validatePermissions() schema enforcement + type checking
+ *   2. DANGEROUS_PERMISSION_KEYS correctness
+ *   3. SandboxedPluginRunner.createSandboxContext() — no process/require/global
+ *   4. SandboxedPluginRunner.runInSandbox() — execution, timeout, eval/Function blocked
+ *   5. SandboxedPluginRunner.createRestrictedContext() — capability gating
+ *   6. Prototype pollution isolation (vm sandbox uses own builtins)
+ *   7. memory/cli permission gating
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  validatePermissions,
+  VALID_PERMISSION_KEYS,
+  DANGEROUS_PERMISSION_KEYS,
+} from '../src/plugin-interface.js';
+import { SandboxedPluginRunner } from '../src/plugin-sandbox.js';
+import type { PluginContext, ServiceContainer } from '../src/plugin-interface.js';
+
+// ─── validatePermissions ───────────────────────────────────
+
+describe('validatePermissions', () => {
+  it('accepts all known permission keys', () => {
+    const perms: Record<string, unknown> = {};
+    for (const key of VALID_PERMISSION_KEYS) {
+      perms[key] = true;
+    }
+    expect(validatePermissions(perms)).toEqual([]);
+  });
+
+  it('rejects unknown permission keys', () => {
+    const errors = validatePermissions({ hackerAccess: true, rootShell: true });
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain('hackerAccess');
+    expect(errors[1]).toContain('rootShell');
+  });
+
+  it('returns empty for empty permissions', () => {
+    expect(validatePermissions({})).toEqual([]);
+  });
+
+  it('rejects non-boolean permission values', () => {
+    const errors = validatePermissions({
+      filesystem: 'yes',
+      network: 42,
+      memory: true,
+    } as Record<string, unknown>);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain('filesystem');
+    expect(errors[0]).toContain('boolean');
+    expect(errors[1]).toContain('network');
+  });
+});
+
+// ─── DANGEROUS_PERMISSION_KEYS ─────────────────────────────
+
+describe('DANGEROUS_PERMISSION_KEYS', () => {
+  it('includes filesystem, network, env, process', () => {
+    expect(DANGEROUS_PERMISSION_KEYS.has('filesystem')).toBe(true);
+    expect(DANGEROUS_PERMISSION_KEYS.has('network')).toBe(true);
+    expect(DANGEROUS_PERMISSION_KEYS.has('env')).toBe(true);
+    expect(DANGEROUS_PERMISSION_KEYS.has('process')).toBe(true);
+  });
+
+  it('does not include memory, mcp, agents, cli', () => {
+    expect(DANGEROUS_PERMISSION_KEYS.has('memory')).toBe(false);
+    expect(DANGEROUS_PERMISSION_KEYS.has('mcp')).toBe(false);
+    expect(DANGEROUS_PERMISSION_KEYS.has('agents')).toBe(false);
+    expect(DANGEROUS_PERMISSION_KEYS.has('cli')).toBe(false);
+  });
+});
+
+// ─── Sandbox context isolation ─────────────────────────────
+
+describe('SandboxedPluginRunner sandbox context', () => {
+  it('does not expose process', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(runner.runInSandbox('typeof process')).toBe('undefined');
+  });
+
+  it('does not expose require', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(runner.runInSandbox('typeof require')).toBe('undefined');
+  });
+
+  it('does not expose global or globalThis', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(runner.runInSandbox('typeof global')).toBe('undefined');
+  });
+
+  it('provides safe globals', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(runner.runInSandbox('JSON.stringify({a:1})')).toBe('{"a":1}');
+    expect(runner.runInSandbox('Math.max(1,2,3)')).toBe(3);
+    expect(runner.runInSandbox('Array.isArray([1,2])')).toBe(true);
+  });
+});
+
+// ─── runInSandbox execution ────────────────────────────────
+
+describe('SandboxedPluginRunner.runInSandbox', () => {
+  it('executes simple expressions', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(runner.runInSandbox('1 + 2')).toBe(3);
+    expect(runner.runInSandbox('"hello".toUpperCase()')).toBe('HELLO');
+  });
+
+  it('throws on timeout for infinite loops', () => {
+    const runner = new SandboxedPluginRunner({ timeout: 50 });
+    expect(() => runner.runInSandbox('while(true){}')).toThrow();
+  });
+
+  it('prevents eval()', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(() => runner.runInSandbox('eval("1+1")')).toThrow();
+  });
+
+  it('prevents new Function()', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(() => runner.runInSandbox('new Function("return 1")()')).toThrow();
+  });
+
+  it('cannot read environment variables', () => {
+    const runner = new SandboxedPluginRunner();
+    const result = runner.runInSandbox(
+      'typeof process === "undefined" ? "blocked" : process.env.HOME'
+    );
+    expect(result).toBe('blocked');
+  });
+
+  it('cannot access Buffer', () => {
+    const runner = new SandboxedPluginRunner();
+    expect(runner.runInSandbox('typeof Buffer')).toBe('undefined');
+  });
+
+  it('Object.prototype pollution in sandbox does not leak to host', () => {
+    const runner = new SandboxedPluginRunner();
+    runner.runInSandbox('Object.prototype.__sandboxTest__ = true');
+    expect((Object.prototype as any).__sandboxTest__).toBeUndefined();
+  });
+
+  it('Array.prototype pollution in sandbox does not leak to host', () => {
+    const runner = new SandboxedPluginRunner();
+    runner.runInSandbox('Array.prototype.__sandboxArr__ = 42');
+    expect((Array.prototype as any).__sandboxArr__).toBeUndefined();
+  });
+});
+
+// ─── Restricted PluginContext (capability gating) ──────────
+
+describe('SandboxedPluginRunner.createRestrictedContext', () => {
+  function makeMockContext(): PluginContext {
+    const services: ServiceContainer = {
+      register: vi.fn(),
+      get: vi.fn().mockReturnValue({ mock: true }),
+      has: vi.fn().mockReturnValue(true),
+      getServiceNames: vi.fn().mockReturnValue(['fs', 'network', 'process', 'memory', 'cli']),
+    };
+    return {
+      config: {
+        features: {},
+        env: { FOO: 'bar' },
+        envVars: { BAZ: 'qux' },
+      } as any,
+      eventBus: { on: vi.fn(), emit: vi.fn() } as any,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      services,
+    };
+  }
+
+  it('blocks fs access without filesystem permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(restricted.services.get('fs')).toBeUndefined();
+    expect(restricted.services.has('fs')).toBe(false);
+  });
+
+  it('allows fs access with filesystem permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(
+      base, { filesystem: true }, 'test-plugin'
+    );
+
+    expect(restricted.services.get('fs')).toEqual({ mock: true });
+    expect(restricted.services.has('fs')).toBe(true);
+  });
+
+  it('blocks network access without permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(restricted.services.get('network')).toBeUndefined();
+  });
+
+  it('blocks process access without permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(restricted.services.get('process')).toBeUndefined();
+  });
+
+  it('strips env config when no env permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect((restricted.config as any).env).toBeUndefined();
+    expect((restricted.config as any).envVars).toBeUndefined();
+  });
+
+  it('preserves env config with env permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(
+      base, { env: true }, 'test-plugin'
+    );
+
+    expect((restricted.config as any).env).toEqual({ FOO: 'bar' });
+  });
+
+  it('replaces eventBus with noop when no mcp/agents permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(() => (restricted.eventBus as any).emit('test')).not.toThrow();
+    expect(() => (restricted.eventBus as any).on('test', () => {})).not.toThrow();
+    expect(restricted.eventBus).not.toBe(base.eventBus);
+  });
+
+  it('preserves eventBus with mcp permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(
+      base, { mcp: true }, 'test-plugin'
+    );
+
+    expect(restricted.eventBus).toBe(base.eventBus);
+  });
+
+  it('prevents service registration in sandboxed mode', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(() => restricted.services.register('evil', {})).toThrow(
+      'cannot register services'
+    );
+  });
+
+  it('filters service names based on permissions', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(
+      base, { memory: true }, 'test-plugin'
+    );
+
+    const names = restricted.services.getServiceNames();
+    expect(names).not.toContain('fs');
+    expect(names).not.toContain('network');
+    expect(names).not.toContain('process');
+    expect(names).not.toContain('cli');
+    expect(names).toContain('memory');
+  });
+
+  it('blocks memory access without memory permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(restricted.services.get('memory')).toBeUndefined();
+    expect(restricted.services.has('memory')).toBe(false);
+  });
+
+  it('allows memory access with memory permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(
+      base, { memory: true }, 'test-plugin'
+    );
+
+    expect(restricted.services.get('memory')).toEqual({ mock: true });
+    expect(restricted.services.has('memory')).toBe(true);
+  });
+
+  it('blocks cli access without cli permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(base, {}, 'test-plugin');
+
+    expect(restricted.services.get('cli')).toBeUndefined();
+    expect(restricted.services.has('cli')).toBe(false);
+  });
+
+  it('allows cli access with cli permission', () => {
+    const runner = new SandboxedPluginRunner();
+    const base = makeMockContext();
+    const restricted = runner.createRestrictedContext(
+      base, { cli: true }, 'test-plugin'
+    );
+
+    expect(restricted.services.get('cli')).toEqual({ mock: true });
+    expect(restricted.services.has('cli')).toBe(true);
+  });
+});

--- a/v3/@claude-flow/shared/src/plugin-interface.ts
+++ b/v3/@claude-flow/shared/src/plugin-interface.ts
@@ -579,6 +579,55 @@ export interface ClaudeFlowPlugin {
    * Optional plugin metadata
    */
   metadata?: Record<string, unknown>;
+
+  /**
+   * Declared permissions this plugin requires (CRIT-02)
+   */
+  readonly permissions?: PluginPermissions;
+
+  /**
+   * Plugin trust level determines sandbox enforcement (CRIT-02)
+   */
+  readonly trustLevel?: PluginTrustLevel;
+}
+
+/**
+ * Trust level determines how a plugin is isolated (CRIT-02)
+ */
+export type PluginTrustLevel = 'official' | 'verified' | 'community' | 'unverified';
+
+/**
+ * Declared permission capabilities for a plugin (CRIT-02)
+ */
+export interface PluginPermissions {
+  filesystem?: boolean;
+  network?: boolean;
+  env?: boolean;
+  process?: boolean;
+  memory?: boolean;
+  mcp?: boolean;
+  agents?: boolean;
+  cli?: boolean;
+}
+
+export const VALID_PERMISSION_KEYS = new Set<string>([
+  'filesystem', 'network', 'env', 'process', 'memory', 'mcp', 'agents', 'cli',
+]);
+
+export const DANGEROUS_PERMISSION_KEYS = new Set<string>([
+  'filesystem', 'network', 'env', 'process',
+]);
+
+export function validatePermissions(permissions: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  for (const [key, value] of Object.entries(permissions)) {
+    if (!VALID_PERMISSION_KEYS.has(key)) {
+      errors.push(`Unknown permission: '${key}'`);
+    } else if (typeof value !== 'boolean') {
+      errors.push(`Permission '${key}' must be a boolean, got ${typeof value}`);
+    }
+  }
+  return errors;
 }
 
 /**
@@ -660,4 +709,6 @@ export type PluginErrorCode =
   | 'CIRCULAR_DEPENDENCY'
   | 'INVALID_PLUGIN'
   | 'DUPLICATE_PLUGIN'
-  | 'HEALTH_CHECK_FAILED';
+  | 'HEALTH_CHECK_FAILED'
+  | 'PERMISSION_DENIED'
+  | 'SANDBOX_VIOLATION';

--- a/v3/@claude-flow/shared/src/plugin-loader.ts
+++ b/v3/@claude-flow/shared/src/plugin-loader.ts
@@ -15,6 +15,7 @@ import type {
 } from './plugin-interface.js';
 import { PluginError } from './plugin-interface.js';
 import type { PluginRegistry } from './plugin-registry.js';
+import { SandboxedPluginRunner } from './plugin-sandbox.js';
 
 /**
  * Plugin loader configuration
@@ -428,10 +429,29 @@ export class PluginLoader {
     const protectedSnapshot = snapshotProtectedEnv();
     const fullEnvBefore = { ...process.env };
 
+    // CRIT-02: Route to sandboxed or full context based on trust level
+    let effectiveContext = context;
+    let trustLevel = plugin.trustLevel ?? 'unverified';
+    // Don't trust self-declared official/verified without namespace verification
+    if ((trustLevel === 'official' || trustLevel === 'verified') &&
+        !plugin.name.startsWith('@claude-flow/')) {
+      trustLevel = 'unverified';
+    }
+    if (trustLevel === 'community' || trustLevel === 'unverified') {
+      const sandbox = new SandboxedPluginRunner({
+        timeout: this.config.initializationTimeout,
+      });
+      effectiveContext = sandbox.createRestrictedContext(
+        context,
+        plugin.permissions ?? {},
+        plugin.name,
+      );
+    }
+
     try {
       // Run initialization with timeout
       await this.withTimeout(
-        plugin.initialize(context),
+        plugin.initialize(effectiveContext),
         this.config.initializationTimeout,
         `Plugin '${plugin.name}' initialization timed out`
       );

--- a/v3/@claude-flow/shared/src/plugin-sandbox.ts
+++ b/v3/@claude-flow/shared/src/plugin-sandbox.ts
@@ -1,0 +1,129 @@
+/**
+ * CRIT-02: Plugin Sandbox Runner
+ *
+ * Tier 1 — Capability-gated PluginContext based on declared permissions.
+ * Tier 2 — vm.createContext() sandbox for executing untrusted code strings.
+ *
+ * Official/verified plugins run in-process with full context.
+ * Community/unverified plugins receive a restricted context that hides
+ * services they didn't declare in their permissions manifest.
+ */
+
+import vm from 'node:vm';
+import type {
+  PluginContext,
+  PluginPermissions,
+  ServiceContainer,
+  PluginConfig,
+} from './plugin-interface.js';
+import type { IEventBus } from './core/interfaces/event.interface.js';
+
+export interface SandboxConfig {
+  timeout?: number;
+}
+
+const DEFAULT_SANDBOX_CONFIG: Required<SandboxConfig> = {
+  timeout: 5000,
+};
+
+export class SandboxedPluginRunner {
+  private config: Required<SandboxConfig>;
+
+  constructor(config?: SandboxConfig) {
+    this.config = { ...DEFAULT_SANDBOX_CONFIG, ...config };
+  }
+
+  createSandboxContext(): vm.Context {
+    // Only add non-ECMAScript globals. ECMAScript builtins (Object, Array,
+    // Promise, Map, Set, JSON, Math, Date, RegExp, Symbol, parseInt, etc.)
+    // are provided automatically by the V8 context as sandbox-local copies.
+    // Passing the host's Object/Array would let sandbox code pollute the
+    // host's prototypes — so we deliberately omit them.
+    const sandbox: Record<string, unknown> = {
+      console: Object.freeze({
+        log: (...args: unknown[]) => console.log('[sandbox]', ...args),
+        warn: (...args: unknown[]) => console.warn('[sandbox]', ...args),
+        error: (...args: unknown[]) => console.error('[sandbox]', ...args),
+        info: (...args: unknown[]) => console.info('[sandbox]', ...args),
+      }),
+    };
+
+    return vm.createContext(sandbox, {
+      name: 'plugin-sandbox',
+      codeGeneration: { strings: false, wasm: false },
+    });
+  }
+
+  runInSandbox(code: string, context?: vm.Context): unknown {
+    const ctx = context ?? this.createSandboxContext();
+    const script = new vm.Script(code, { filename: 'plugin-sandbox.js' });
+    return script.runInContext(ctx, { timeout: this.config.timeout });
+  }
+
+  createRestrictedContext(
+    baseContext: PluginContext,
+    permissions: PluginPermissions,
+    pluginName: string,
+  ): PluginContext {
+    const logger = baseContext.logger;
+
+    const restrictedServices: ServiceContainer = {
+      register<T>(_name: string, _service: T): void {
+        throw new Error(`Plugin '${pluginName}' cannot register services in sandboxed mode`);
+      },
+      get<T>(name: string): T | undefined {
+        if (!isServiceAllowed(name, permissions)) {
+          logger.warn(`Plugin '${pluginName}' denied ${name} access — no permission`);
+          return undefined;
+        }
+        return baseContext.services.get<T>(name);
+      },
+      has(name: string): boolean {
+        if (!isServiceAllowed(name, permissions)) return false;
+        return baseContext.services.has(name);
+      },
+      getServiceNames(): string[] {
+        return baseContext.services.getServiceNames().filter(
+          n => isServiceAllowed(n, permissions),
+        );
+      },
+    };
+
+    const restrictedConfig: PluginConfig = { ...baseContext.config };
+    if (!permissions.env) {
+      delete restrictedConfig['env'];
+      delete restrictedConfig['envVars'];
+    }
+
+    const eventBus = (permissions.mcp || permissions.agents)
+      ? baseContext.eventBus
+      : createNoopEventBus();
+
+    return {
+      config: restrictedConfig,
+      eventBus,
+      logger: baseContext.logger,
+      services: restrictedServices,
+    };
+  }
+}
+
+const SERVICE_PERMISSION_MAP: Record<string, keyof PluginPermissions> = {
+  fs: 'filesystem',
+  network: 'network',
+  process: 'process',
+  memory: 'memory',
+  cli: 'cli',
+};
+
+function isServiceAllowed(name: string, permissions: PluginPermissions): boolean {
+  const requiredPerm = SERVICE_PERMISSION_MAP[name];
+  if (requiredPerm && !permissions[requiredPerm]) return false;
+  return true;
+}
+
+function createNoopEventBus(): IEventBus {
+  return new Proxy({} as IEventBus, {
+    get: () => () => {},
+  });
+}


### PR DESCRIPTION
## Summary

- **Tier 1 — Capability gating**: `PluginPermissions` interface (8 fields: filesystem, network, env, process, memory, mcp, agents, cli). `SandboxedPluginRunner.createRestrictedContext()` wraps `PluginContext` to hide undeclared services, strip env config, and replace eventBus with a noop proxy when mcp/agents not declared. Service registration blocked in sandbox mode.
- **Tier 2 — vm sandbox**: `vm.createContext()` with sandbox-local ECMAScript builtins (no prototype sharing with host), `codeGeneration: {strings: false, wasm: false}` blocks `eval()`/`new Function()`, configurable timeout catches infinite loops.
- **Trust-level routing**: Plugin loader routes `community`/`unverified` plugins through restricted context; `official`/`verified` get full context. Namespace verification prevents non-`@claude-flow/` packages from self-declaring official trust.
- **Install validation**: CLI `plugins install` blocks unknown permissions for non-official plugins, warns about dangerous ones (filesystem, network, env, process, privileged, credentials, execute).

## Files changed

| File | Change |
|------|--------|
| `shared/src/plugin-interface.ts` | `PluginPermissions`, `PluginTrustLevel`, `validatePermissions()`, `VALID_PERMISSION_KEYS`, `DANGEROUS_PERMISSION_KEYS`, new error codes |
| `shared/src/plugin-sandbox.ts` | **New** — `SandboxedPluginRunner` (vm sandbox + capability gating) |
| `shared/src/plugin-loader.ts` | Trust-level routing in `initializePlugin()` with namespace verification |
| `cli/src/commands/plugins.ts` | Permission validation on install |
| `shared/__tests__/security-sprint2.test.ts` | **New** — 32 unit tests |

## Devil's advocate findings addressed

| Finding | Severity | Resolution |
|---------|----------|------------|
| Trust level self-declaration bypass | MEDIUM | Fixed — namespace verification (`@claude-flow/` required for official/verified) |
| `memory`/`cli` permissions not gated | CRITICAL | Fixed — all 8 permission fields now enforced via `SERVICE_PERMISSION_MAP` |
| Prototype pollution via shared builtins | MEDIUM | Fixed — sandbox uses V8-local builtins, not host references |
| `validatePermissions` accepts non-boolean | MEDIUM | Fixed — type checking added |
| Node module scope escape (can still `require('fs')`) | LOW | Accepted — requires Tier 3 worker threads (future sprint) |

## Test plan

- [x] 32 unit tests (vitest) — all pass
- [x] 204 total tests in shared package — all pass (no regressions)
- [x] 55 E2E sandbox isolation tests (temp project, imports built dist)
- [x] 18 E2E install validation tests
- [x] `tsc --noEmit` clean on shared (0 errors), cli (7 pre-existing only)
- [x] Prototype pollution verified: `Object.prototype` and `Array.prototype` mutations in sandbox do NOT leak to host

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)