### PR TITLE
chore: bump all packages to v3.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- Bump `@claude-flow/cli`, `claude-flow`, and `ruflo` to 3.6.11
- All three published to npm with latest/alpha/v3alpha tags

## What's in 3.6.11
- **SmartRetrieval** (ADR-090) wired into production `memory_search` MCP tool and CLI
- **#1604** fixed: memory path aligned to `.swarm/memory.db`
- **#1605** fixed: browser tools only registered when agent-browser available
- **#1606** fixed: ensureInitialized() catch prevents stdio crash
- **#1616** fixed: settings copy.json renamed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)