### PR TITLE
chore: bump to v3.6.12 — RuFlo branding & portable MCP config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-6",
+  "model": "claude-opus-4-7",
   "customInstructions": "Follow the project's CLAUDE.md guidelines. Use concurrent execution for all operations. Prioritize v3 implementation with security-first development, 15-agent swarm coordination, phased performance optimization, and cross-platform helper automation.",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
@@ -144,29 +144,7 @@
         ]
       }
     ],
-    "SubagentStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs\" status",
-            "timeout": 3000
-          }
-        ]
-      }
-    ],
-    "TeammateIdle": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs\" post-task",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
-    "TaskCompleted": [
+    "SubagentStop": [
       {
         "hooks": [
           {
@@ -179,14 +157,14 @@
     ]
   },
   "attribution": {
-    "commit": "Co-Authored-By: claude-flow <ruv@ruv.net>",
-    "pr": "\ud83e\udd16 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)"
+    "commit": "Co-Authored-By: RuFlo <ruv@ruv.net>",
+    "pr": "\ud83e\udd16 Generated with [RuFlo](https://github.com/ruvnet/ruflo)"
   },
   "claudeFlow": {
-    "version": "3.5.2",
+    "version": "3.6.11",
     "enabled": true,
     "modelPreferences": {
-      "default": "claude-opus-4-6",
+      "default": "claude-opus-4-7",
       "routing": "claude-haiku-4-5-20251001"
     },
     "agentTeams": {
@@ -286,20 +264,20 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs\""
+    "command": "sh -c 'exec node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/statusline.cjs\"'"
   },
   "mcpServers": {
     "claude-flow": {
-      "command": "node",
+      "command": "npx",
       "args": [
-        "/workspaces/claude-flow/v3/@claude-flow/cli/bin/cli.js",
+        "-y",
+        "ruflo@latest",
         "mcp",
         "start"
       ]
     }
   },
   "enabledMcpjsonServers": [
-    "claude-flow",
-    "ruv-swarm"
+    "claude-flow"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.6.10",
+  "version": "3.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.6.10",
+      "version": "3.6.12",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/init/mcp-generator.ts
+++ b/v3/@claude-flow/cli/src/init/mcp-generator.ts
@@ -52,10 +52,10 @@ export function generateMCPConfig(options: InitOptions): object {
     npm_config_update_notifier: 'false',
   };
 
-  // Claude Flow MCP server (core)
+  // Claude Flow MCP server (core) — uses ruflo wrapper for portable npm-resolved invocation
   if (config.claudeFlow) {
     mcpServers['claude-flow'] = createMCPServerEntry(
-      ['@claude-flow/cli@latest', 'mcp', 'start'],
+      ['ruflo@latest', 'mcp', 'start'],
       {
         ...npmEnv,
         CLAUDE_FLOW_MODE: 'v3',
@@ -106,7 +106,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
 
   if (isWindows()) {
     if (config.claudeFlow) {
-      commands.push('claude mcp add claude-flow -- cmd /c npx -y @claude-flow/cli@latest mcp start');
+      commands.push('claude mcp add claude-flow -- cmd /c npx -y ruflo@latest mcp start');
     }
     if (config.ruvSwarm) {
       commands.push('claude mcp add ruv-swarm -- cmd /c npx -y ruv-swarm mcp start');
@@ -116,7 +116,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
     }
   } else {
     if (config.claudeFlow) {
-      commands.push("claude mcp add claude-flow -- npx -y @claude-flow/cli@latest mcp start");
+      commands.push("claude mcp add claude-flow -- npx -y ruflo@latest mcp start");
     }
     if (config.ruvSwarm) {
       commands.push("claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start");

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -36,10 +36,10 @@ export function generateSettings(options: InitOptions): object {
     ],
   };
 
-  // Add claude-flow attribution for git commits and PRs
+  // Add RuFlo attribution for git commits and PRs
   settings.attribution = {
-    commit: 'Co-Authored-By: claude-flow <ruv@ruv.net>',
-    pr: '🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)',
+    commit: 'Co-Authored-By: RuFlo <ruv@ruv.net>',
+    pr: '🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)',
   };
 
   // Note: Claude Code expects 'model' to be a string, not an object


### PR DESCRIPTION
## Summary
- Bump `@claude-flow/cli`, `claude-flow` umbrella, and `ruflo` from 3.6.11 → 3.6.12.
- `ruflo init` now spawns the MCP server as `npx -y ruflo@latest mcp start` (was `@claude-flow/cli@latest`) — shorter, ruflo-branded wrapper that forwards to the same CLI.
- `ruflo init` generates RuFlo-branded git/PR attribution (`Co-Authored-By: RuFlo`, `Generated with [RuFlo]`).
- Project `.claude/settings.json`: replace Codespaces-only hardcoded path (`/workspaces/claude-flow/...`) with portable `npx -y ruflo@latest mcp start`; wire `statusLine.command` to existing helper script; drop invalid hook events (`TeammateIdle`, `TaskCompleted`, `SubagentStart`); drop undefined `ruv-swarm` from `enabledMcpjsonServers`.

## Test plan
- [ ] After publish, `npx ruflo@3.6.12 init` writes `mcpServers.claude-flow.args` containing `ruflo@latest`
- [ ] Generated `settings.json` shows `Co-Authored-By: RuFlo <ruv@ruv.net>`
- [ ] Project's `.claude/settings.json` no longer references `/workspaces/...`
- [ ] Statusline renders without errors using `${CLAUDE_PROJECT_DIR}/.claude/helpers/statusline.cjs`
- [ ] No "Invalid key in record" warnings on session start

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)