### PR TITLE
fix: register 12 missing plugins in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,6 +105,66 @@
       "name": "ruflo-goals",
       "source": "./plugins/ruflo-goals",
       "description": "Long-horizon goal planning, deep research orchestration, and adaptive replanning using GOAP"
+    },
+    {
+      "name": "ruflo-adr",
+      "source": "./plugins/ruflo-adr",
+      "description": "ADR lifecycle management — create, index, supersede, and link Architecture Decision Records to code"
+    },
+    {
+      "name": "ruflo-cost-tracker",
+      "source": "./plugins/ruflo-cost-tracker",
+      "description": "Token usage tracking, model cost attribution per agent, budget alerts, and optimization recommendations"
+    },
+    {
+      "name": "ruflo-ddd",
+      "source": "./plugins/ruflo-ddd",
+      "description": "Domain-Driven Design scaffolding — bounded contexts, aggregate roots, domain events, and anti-corruption layers"
+    },
+    {
+      "name": "ruflo-federation",
+      "source": "./plugins/ruflo-federation",
+      "description": "Cross-installation agent federation with zero-trust security, PII-gated data flow, and compliance-grade audit trails"
+    },
+    {
+      "name": "ruflo-iot-cognitum",
+      "source": "./plugins/ruflo-iot-cognitum",
+      "description": "IoT device lifecycle, telemetry anomaly detection, fleet management, and witness chain verification for Cognitum Seed hardware"
+    },
+    {
+      "name": "ruflo-knowledge-graph",
+      "source": "./plugins/ruflo-knowledge-graph",
+      "description": "Knowledge graph construction — entity extraction, relation mapping, and pathfinder graph traversal"
+    },
+    {
+      "name": "ruflo-market-data",
+      "source": "./plugins/ruflo-market-data",
+      "description": "Market data ingestion — feed normalization, OHLCV vectorization, and HNSW-indexed pattern matching"
+    },
+    {
+      "name": "ruflo-migrations",
+      "source": "./plugins/ruflo-migrations",
+      "description": "Schema migration management — generate, validate, dry-run, and rollback database migrations"
+    },
+    {
+      "name": "ruflo-neural-trader",
+      "source": "./plugins/ruflo-neural-trader",
+      "description": "Neural trading strategies — self-learning LSTM/Transformer/N-BEATS models with Rust/NAPI backtesting"
+    },
+    {
+      "name": "ruflo-observability",
+      "source": "./plugins/ruflo-observability",
+      "description": "Structured logging, distributed tracing, and metrics — correlate agent swarm activity with application telemetry"
+    },
+    {
+      "name": "ruflo-ruvector",
+      "source": "./plugins/ruflo-ruvector",
+      "description": "Self-learning vector database — HNSW, FlashAttention-3, Graph RAG, hybrid search, DiskANN, and Brain AGI"
+    },
+    {
+      "name": "ruflo-sparc",
+      "source": "./plugins/ruflo-sparc",
+      "description": "SPARC methodology — Specification, Pseudocode, Architecture, Refinement, Completion phases with quality gates"
     }
   ]
 }


### PR DESCRIPTION
## Summary
The marketplace registry at \`.claude-plugin/marketplace.json\` only listed **20 of 32** plugin source directories, so users running \`/plugin marketplace add ruvnet/ruflo\` never received the remaining 12. This is why slash commands like \`/iot\` were silently missing — the underlying plugin was never installed.

## Plugins added (12)

| Plugin | Provides |
|---|---|
| ruflo-adr | \`/adr\` — ADR lifecycle |
| ruflo-cost-tracker | \`/ruflo-cost\` — token/cost tracking |
| ruflo-ddd | \`/ddd\` — DDD scaffolding |
| ruflo-federation | \`/federation\` — cross-installation agent federation |
| ruflo-iot-cognitum | \`/iot\` — IoT device lifecycle |
| ruflo-knowledge-graph | \`/kg\` — entity extraction & graph traversal |
| ruflo-market-data | \`/market\` — OHLCV vectorization |
| ruflo-migrations | \`/migrate\` — schema migrations |
| ruflo-neural-trader | \`/trader\` — neural trading strategies |
| ruflo-observability | \`/observe\` — logging & tracing |
| ruflo-ruvector | \`/vector\` — vector DB |
| ruflo-sparc | \`/ruflo-sparc\` — SPARC methodology |

Marketplace now registers all 32 plugins, matching the \`plugins/\` source tree.

## Test plan
- [ ] After merge, run \`/plugin marketplace add ruvnet/ruflo\` (or remove + re-add to refresh) and verify all 32 plugins install
- [ ] Confirm \`/iot\`, \`/adr\`, \`/ddd\`, \`/federation\`, \`/kg\`, \`/market\`, \`/migrate\`, \`/trader\`, \`/observe\`, \`/vector\`, \`/ruflo-sparc\`, \`/ruflo-cost\` are reachable via autocomplete
- [ ] \`/reload-plugins\` reports 33 plugins (32 ruflo + ruflo-core baseline already counted)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)