### PR TITLE
fix(federation): publish plugin-agent-federation@1.0.0-alpha.3 with ruflo-federation bin

### DIFF
--- a/plugins/ruflo-federation/agents/federation-coordinator.md
+++ b/plugins/ruflo-federation/agents/federation-coordinator.md
@@ -23,12 +23,12 @@ You are a federation coordinator agent. Your responsibilities:
 
 ### Tools
 
-- `npx @claude-flow/cli@latest federation init` -- generate keypair, create config
-- `npx @claude-flow/cli@latest federation join <endpoint>` -- connect to peer
-- `npx @claude-flow/cli@latest federation peers` -- list peers with trust levels
-- `npx @claude-flow/cli@latest federation status` -- health dashboard
-- `npx @claude-flow/cli@latest federation audit --compliance hipaa` -- audit logs
-- `npx @claude-flow/cli@latest federation trust <node-id> --review` -- trust breakdown
+- `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation init` -- generate keypair, create config
+- `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation join <endpoint>` -- connect to peer
+- `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation peers` -- list peers with trust levels
+- `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation status` -- health dashboard
+- `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation audit --compliance hipaa` -- audit logs
+- `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation trust <node-id> --review` -- trust breakdown
 
 ### Automatic Downgrade
 

--- a/plugins/ruflo-federation/commands/federation.md
+++ b/plugins/ruflo-federation/commands/federation.md
@@ -19,11 +19,11 @@ Subcommands:
 
 Steps by subcommand:
 
-**init**: `npx @claude-flow/cli@latest federation init`
-**join**: `npx @claude-flow/cli@latest federation join ENDPOINT`
-**leave**: `npx @claude-flow/cli@latest federation leave`
-**peers**: `npx @claude-flow/cli@latest federation peers`
-**status**: `npx @claude-flow/cli@latest federation status`
-**audit**: `npx @claude-flow/cli@latest federation audit --compliance MODE --since DATE`
-**trust**: `npx @claude-flow/cli@latest federation trust NODE_ID --review`
-**config**: `npx @claude-flow/cli@latest federation config --pii-policy PATH`
+**init**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation init`
+**join**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation join ENDPOINT`
+**leave**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation leave`
+**peers**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation peers`
+**status**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation status`
+**audit**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation audit --compliance MODE --since DATE`
+**trust**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation trust NODE_ID --review`
+**config**: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation config --pii-policy PATH`

--- a/plugins/ruflo-federation/skills/federation-audit/SKILL.md
+++ b/plugins/ruflo-federation/skills/federation-audit/SKILL.md
@@ -8,7 +8,7 @@ Query structured federation audit logs. Supports compliance mode filtering (HIPA
 
 Steps:
 1. Parse compliance mode, date range, and severity from arguments
-2. `npx @claude-flow/cli@latest federation audit --compliance MODE --since DATE --severity LEVEL`
+2. `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation audit --compliance MODE --since DATE --severity LEVEL`
 3. Summarize findings: total events, PII detections, threat blocks, trust changes
 4. Highlight any critical or error-severity events
 

--- a/plugins/ruflo-federation/skills/federation-init/SKILL.md
+++ b/plugins/ruflo-federation/skills/federation-init/SKILL.md
@@ -7,8 +7,8 @@ argument-hint: "[--compliance hipaa|soc2|gdpr|none]"
 Initialize this node for federation. Generates an ed25519 keypair, creates the federation config, and optionally sets a compliance mode.
 
 Steps:
-1. `npx @claude-flow/cli@latest federation init`
-2. If a compliance mode is specified, configure it: `npx @claude-flow/cli@latest federation config --compliance MODE`
+1. `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation init`
+2. If a compliance mode is specified, configure it: `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation config --compliance MODE`
 3. Show the node's public key and endpoint for sharing with peers
 
 Store init event:

--- a/plugins/ruflo-federation/skills/federation-status/SKILL.md
+++ b/plugins/ruflo-federation/skills/federation-status/SKILL.md
@@ -7,8 +7,8 @@ argument-hint: ""
 Show the current state of the federation.
 
 Steps:
-1. `npx @claude-flow/cli@latest federation status` -- overall health
-2. `npx @claude-flow/cli@latest federation peers` -- list peers with trust levels and scores
+1. `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation status` -- overall health
+2. `npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation peers` -- list peers with trust levels and scores
 3. Summarize: active sessions, messages exchanged, PII redactions, threat detections
 
 Search memory for federation history:

--- a/plugins/ruflo-swarm/README.md
+++ b/plugins/ruflo-swarm/README.md
@@ -13,7 +13,7 @@ Agent teams, swarm coordination, Monitor streams, and worktree isolation.
 
 - **Agent Teams**: TeamCreate, SendMessage, and Task tool integration for multi-agent coordination
 - **Topologies**: hierarchical, mesh, hierarchical-mesh, ring, star, adaptive
-- **Monitor Streams**: Real-time swarm status via `Monitor("npx @claude-flow/cli swarm watch --stream")`
+- **Monitor Streams**: Real-time swarm status via `Monitor("npx @claude-flow/cli@latest swarm watch --stream")`
 - **Worktree Isolation**: Each agent works in its own git worktree to avoid conflicts
 - **Hive-Mind Consensus**: Byzantine, Raft, Gossip, CRDT, and Quorum strategies
 - **Anti-Drift**: hierarchical topology with specialized strategy for tight coordination

--- a/v3/@claude-flow/plugin-agent-federation/README.md
+++ b/v3/@claude-flow/plugin-agent-federation/README.md
@@ -1,0 +1,45 @@
+# @claude-flow/plugin-agent-federation
+
+Cross-installation agent federation with zero-trust security, PII-gated data flow, and compliance-grade audit trails.
+
+## Install + run
+
+```bash
+npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation --help
+```
+
+## Subcommands
+
+| Command | Description |
+|---|---|
+| `ruflo-federation init` | Initialize federation on this node (generates keypair) |
+| `ruflo-federation join <peer-url>` | Join a federation by connecting to a peer |
+| `ruflo-federation leave` | Leave the current federation |
+| `ruflo-federation peers` | List known peers and their trust levels |
+| `ruflo-federation peers add <node-id>` | Add a peer to the federation |
+| `ruflo-federation peers remove <node-id>` | Remove a peer |
+| `ruflo-federation status` | Show federation health, sessions, trust levels |
+| `ruflo-federation audit` | Query compliance-grade audit logs |
+| `ruflo-federation trust` | Manage trust scores and tiers |
+| `ruflo-federation config` | Show/update federation config |
+
+## Configuration via `.env`
+
+```bash
+FEDERATION_NODE_NAME=my-node           # default: hostname
+FEDERATION_BIND_HOST=0.0.0.0           # default: 0.0.0.0
+FEDERATION_BIND_PORT=8443              # default: 8443
+FEDERATION_TRUST_LEVEL=untrusted       # default: untrusted
+```
+
+## Tests
+
+325 unit tests covering audit, routing, discovery, plugin lifecycle.
+
+```bash
+npm test
+```
+
+## License
+
+MIT — Claude Flow Team.

--- a/v3/@claude-flow/plugin-agent-federation/package.json
+++ b/v3/@claude-flow/plugin-agent-federation/package.json
@@ -1,25 +1,41 @@
 {
   "name": "@claude-flow/plugin-agent-federation",
-  "version": "1.0.0-alpha.1",
-  "description": "Cross-installation agent federation with PII protection and AI defence",
+  "version": "1.0.0-alpha.3",
+  "description": "Cross-installation agent federation with zero-trust security, PII-gated data flow, and compliance-grade audit trails.",
+  "homepage": "https://github.com/ruvnet/ruflo",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "ruflo-federation": "dist/bin.js"
+  },
+  "files": [
+    "dist/**",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },
-  "dependencies": {
-    "@claude-flow/shared": "workspace:*",
-    "@claude-flow/security": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@claude-flow/shared": "workspace:*",
+    "@claude-flow/security": "workspace:*",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"
   },
-  "keywords": ["federation", "multi-agent", "trust", "pii", "security"],
+  "keywords": [
+    "federation",
+    "multi-agent",
+    "trust",
+    "pii",
+    "security",
+    "audit",
+    "compliance"
+  ],
   "author": "Claude Flow Team",
   "license": "MIT"
 }

--- a/v3/@claude-flow/plugin-agent-federation/src/bin.ts
+++ b/v3/@claude-flow/plugin-agent-federation/src/bin.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Standalone CLI shim for @claude-flow/plugin-agent-federation.
+ * Maps `ruflo-federation <subcommand> [args]` -> CLICommandDefinition handlers.
+ *
+ * Auth/config via .env (loaded from CWD or any parent):
+ *   FEDERATION_NODE_NAME      - this node's identity (default: hostname)
+ *   FEDERATION_BIND_HOST      - bind address (default: 0.0.0.0)
+ *   FEDERATION_BIND_PORT      - bind port (default: 8443)
+ *   FEDERATION_TRUST_LEVEL    - default trust tier (default: untrusted)
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { hostname } from 'node:os';
+import { AgentFederationPlugin } from './plugin.js';
+import type { PluginContext } from '@claude-flow/shared/src/plugin-interface.js';
+
+function loadDotenv(): { loaded: string | null; count: number } {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    const candidate = resolve(dir, '.env');
+    if (existsSync(candidate)) {
+      const text = readFileSync(candidate, 'utf8');
+      let count = 0;
+      for (const rawLine of text.split('\n')) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        const eq = line.indexOf('=');
+        if (eq < 1) continue;
+        const key = line.slice(0, eq).trim();
+        let val = line.slice(eq + 1).trim();
+        if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+          val = val.slice(1, -1);
+        }
+        if (process.env[key] === undefined) {
+          process.env[key] = val;
+          count++;
+        }
+      }
+      return { loaded: candidate, count };
+    }
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return { loaded: null, count: 0 };
+}
+
+loadDotenv();
+
+interface ParsedArgs {
+  _: string[];
+  [k: string]: unknown;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq > -1) {
+        out[a.slice(2, eq)] = a.slice(eq + 1);
+      } else {
+        const key = a.slice(2);
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith('-')) {
+          out[key] = true;
+        } else {
+          out[key] = next;
+          i++;
+        }
+      }
+    } else if (a.startsWith('-') && a.length > 1) {
+      const key = a.slice(1);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('-')) {
+        out[key] = true;
+      } else {
+        out[key] = next;
+        i++;
+      }
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+function aliasShortToLong(args: ParsedArgs): ParsedArgs {
+  const aliases: Record<string, string> = {
+    n: 'name',
+    h: 'host',
+    p: 'port',
+    t: 'token',
+    u: 'url',
+    f: 'format',
+  };
+  for (const [s, l] of Object.entries(aliases)) {
+    if (s in args && !(l in args)) {
+      args[l] = args[s];
+    }
+  }
+  return args;
+}
+
+/**
+ * Resolve federation subcommand. Supports multi-word like
+ * `federation peers add`, `federation peers remove`.
+ */
+function resolveCommand(
+  argv: string[],
+  commandNames: string[],
+): { name: string; rest: string[] } | null {
+  const tokens = argv.slice();
+  for (const len of [3, 2, 1]) {
+    if (tokens.length < len) continue;
+    const probe = 'federation ' + tokens.slice(0, len).join(' ');
+    if (commandNames.includes(probe)) {
+      return { name: probe, rest: tokens.slice(len) };
+    }
+  }
+  return null;
+}
+
+function makeContext(): PluginContext {
+  const noop = () => undefined;
+  return {
+    config: {
+      nodeName: process.env.FEDERATION_NODE_NAME ?? hostname(),
+      bindHost: process.env.FEDERATION_BIND_HOST ?? '0.0.0.0',
+      bindPort: Number(process.env.FEDERATION_BIND_PORT ?? 8443),
+      defaultTrustLevel: process.env.FEDERATION_TRUST_LEVEL ?? 'untrusted',
+    },
+    eventBus: { emit: noop, on: noop, off: noop, once: noop } as unknown as PluginContext['eventBus'],
+    logger: {
+      info: () => {},
+      warn: (...a: unknown[]) => console.warn('[warn]', ...a),
+      error: (...a: unknown[]) => console.error('[error]', ...a),
+      debug: (...a: unknown[]) => process.env.DEBUG && console.error('[debug]', ...a),
+    } as unknown as PluginContext['logger'],
+    services: { get: () => undefined, register: noop, has: () => false } as unknown as PluginContext['services'],
+  };
+}
+
+function printHelp(commandNames: string[]): void {
+  console.log('ruflo-federation — Cross-installation agent federation CLI');
+  console.log('');
+  console.log('Usage: ruflo-federation <subcommand> [options]');
+  console.log('');
+  console.log('Config (via .env or env vars):');
+  console.log('  FEDERATION_NODE_NAME, FEDERATION_BIND_HOST, FEDERATION_BIND_PORT, FEDERATION_TRUST_LEVEL');
+  console.log('');
+  console.log('Subcommands:');
+  for (const n of commandNames) {
+    console.log('  ' + n.replace(/^federation /, ''));
+  }
+  console.log('');
+  console.log('Run "ruflo-federation <subcommand> --help" for command-specific options.');
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  const plugin = new AgentFederationPlugin();
+  const context = makeContext();
+  await plugin.initialize(context);
+
+  const commands = plugin.registerCLICommands();
+  const commandNames = commands.map((c) => c.name);
+
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    printHelp(commandNames);
+    return;
+  }
+
+  const resolved = resolveCommand(argv, commandNames);
+  if (!resolved) {
+    console.error('Unknown subcommand: ' + argv.join(' '));
+    console.error('Run "ruflo-federation --help" to list available subcommands.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const cmd = commands.find((c) => c.name === resolved.name)!;
+  const args = aliasShortToLong(parseArgs(resolved.rest));
+
+  try {
+    await cmd.handler(args as never);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('Error: ' + msg);
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((err) => {
+    console.error('Fatal: ' + (err instanceof Error ? err.message : String(err)));
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
Same class of bug as iot-cognitum was: source existed (\`v3/@claude-flow/plugin-agent-federation/\`, 325 tests passing) but unpublished, and the marketplace plugin's skills called \`npx @claude-flow/cli@latest federation <subcmd>\` — \`federation\` isn't a CLI subcommand. End result: every federation skill failed.

## What's in this PR

### Plugin source (\`v3/@claude-flow/plugin-agent-federation\`)
- **New \`src/bin.ts\`** — standalone CLI shim. Bootstraps \`AgentFederationPlugin\` in-memory, parses argv, resolves multi-word commands (\`federation peers add\`, \`federation peers remove\`, etc.), aliases short flags, dispatches to existing handlers in \`cli-commands.ts\`.
- **\`.env\` loader** — reads \`FEDERATION_NODE_NAME\`, \`FEDERATION_BIND_HOST\`, \`FEDERATION_BIND_PORT\`, \`FEDERATION_TRUST_LEVEL\` from \`.env\` (walks up from CWD).
- **\`package.json\`** — adds \`bin: {ruflo-federation: dist/bin.js}\`, files whitelist, homepage. Moves workspace deps to devDependencies (all imports are \`import type\`, erased at compile — zero runtime workspace dep).
- **New \`README.md\`** with full subcommand reference and \`.env\` setup.

### Marketplace plugin (\`plugins/ruflo-federation\`)
Bulk-rewrote 5 files (3 skills + commands/federation.md + agents/federation-coordinator.md) — calls now use \`npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation <subcmd>\`.

### Minor consistency fix
\`plugins/ruflo-swarm/README.md\`: pin \`npx @claude-flow/cli swarm\` → \`npx @claude-flow/cli@latest swarm\` to match the other 31 plugins.

## Audit result post-fix: 32/32 plugins use working invocation patterns

| Pattern | Status |
|---|---|
| 12 verbs against \`@claude-flow/cli@latest\` (memory, hooks, security, neural, swarm, doctor, init, embeddings, status, daemon, config, session) | ✅ all exist |
| \`@claude-flow/plugin-iot-cognitum\` | ✅ alpha.5 published |
| \`@claude-flow/plugin-agent-federation\` | ✅ alpha.3 published (this PR) |
| \`neural-trader\` | ✅ 2.7.1 on npm |
| \`ruvector\` | ✅ 0.2.25 on npm |

## Smoke test (live)

\`\`\`
$ npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation status
Node ID:         node-molxg0b1
Active Sessions: 0
Known Peers:     0
Healthy:         false
\`\`\`

## Caveat (not in this PR)
The 11 plugins that depend on \`mcp__claude-flow__*\` MCP tools (adr, aidefence, autopilot, browser, daa, goals, plugin-creator, ruvllm, sparc, wasm, workflows) require the MCP server to be connected — not audited here. Worth a separate pass.

## Test plan
- [ ] \`npx -y -p @claude-flow/plugin-agent-federation@latest ruflo-federation --help\` lists 10 subcommands
- [ ] After marketplace refresh: \`/ruflo-federation:federation status\` works
- [ ] \`/ruflo-federation:federation init --name test\` initializes successfully

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)