### PR TITLE
fix(goal-ui): stop auto-execution after plan generation

### DIFF
--- a/v3/goal_ui/src/pages/Index.tsx
+++ b/v3/goal_ui/src/pages/Index.tsx
@@ -590,11 +590,6 @@ const Index = () => {
     setIsPlanning(false);
     setPlanGenerated(true);
     setVisibleSteps(1);
-    
-    // Auto-start execution with the generated plan
-    setTimeout(() => {
-      executeResearch(plan, goal);
-    }, 500);
   };
 
   // Execute research plan
@@ -1104,18 +1099,34 @@ const Index = () => {
               </div>
             )}
 
-            {/* Control Button */}
+            {/* Control Buttons */}
             <div ref={objectiveRef} className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-0 mb-6 sm:mb-8">
-              <Button
-                onClick={resetAll}
-                variant="outline"
-                size="sm"
-                disabled={isRunning}
-                className="gap-2"
-              >
-                <RotateCcw className="w-4 h-4" />
-                New Research
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  onClick={resetAll}
+                  variant="outline"
+                  size="sm"
+                  disabled={isRunning}
+                  className="gap-2"
+                >
+                  <RotateCcw className="w-4 h-4" />
+                  New Research
+                </Button>
+                {!isRunning && !showFinalAnalysis && (
+                  <Button
+                    onClick={() => executeResearch()}
+                    size="sm"
+                    className="gap-2"
+                    style={{ 
+                      backgroundColor: widgetConfig.accentColor,
+                      color: '#fff'
+                    }}
+                  >
+                    <Sparkles className="w-4 h-4" />
+                    Execute Research
+                  </Button>
+                )}
+              </div>
               <div className="text-xs sm:text-sm flex-1 min-w-0 text-center px-4" style={{ color: "#a3a3a3" }}>
                 <span className="font-medium" style={{ color: "#f5f5f5" }}>Objective:</span> <span className="break-words">{userGoal}</span>
               </div>


### PR DESCRIPTION
## Summary
- Remove the unconditional `setTimeout` that triggered `executeResearch()` immediately after GOAP plan generation in the Web UI
- Add an explicit "Execute Research" button so users can review the generated plan before starting execution
- Aligns Index page behavior with the Agents page, which already correctly separates research/review/development stages

## Changes
- **`v3/goal_ui/src/pages/Index.tsx`**: Removed auto-execution `setTimeout` at line 594-597 in `handleGoalSubmit()`. Added "Execute Research" button in the control area that appears when plan is generated but execution hasn't started.

## Root Cause
In `handleGoalSubmit()`, after the GOAP planner generated a plan and set state (`setSteps(plan)`, `setPlanGenerated(true)`), the code unconditionally called:
```typescript
setTimeout(() => {
  executeResearch(plan, goal);
}, 500);
```
This meant the "Generate Research Plan" button always triggered full execution, with no way for users to review or revise the plan first.

## Fix
1. Removed the auto-execution `setTimeout` block
2. Added an "Execute Research" button (using `Sparkles` icon, accent-colored) that appears after plan generation when execution hasn't started
3. The button is hidden during execution (`isRunning`) and after completion (`showFinalAnalysis`)

## Testing
- `npx tsc --noEmit` passes (zero type errors)
- `npx vite build` succeeds
- `npx eslint src/pages/Index.tsx` shows only 6 pre-existing errors (all `@typescript-eslint/no-explicit-any`), zero new issues
- Manual verification: plan generates and displays steps without auto-executing; "Execute Research" button triggers execution on click

## Risk/Rollback
- **Risk**: Low. Single file change, removes 5 lines and adds UI controls.
- **Rollback**: Revert commit to restore auto-execution behavior.

Closes #1694