### PR TITLE
feat: add OpenCode as alternative execution backend alongside Claude Code

### DIFF
--- a/v3/@claude-flow/cli/__tests__/open-code-integration.test.ts
+++ b/v3/@claude-flow/cli/__tests__/open-code-integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * OpenCode Integration Tests
+ *
+ * Tests backend routing, configuration, type system, and output normalization
+ * without mocking child_process (vitest ESM mocks are unreliable for spawn).
+ * Integration-level spawn testing happens via manual test scripts in /testing/.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  normalizeOutput,
+  normalizeClaudeOutput,
+  normalizeOpenCodeOutput,
+} from '../src/services/executor-output.js'
+
+describe('ExecutorOutput normalization', () => {
+  describe('normalizeClaudeOutput', () => {
+    it('returns text and exitCode for success', () => {
+      const result = normalizeClaudeOutput('function add(a,b){return a+b}', 0)
+      expect(result.text).toContain('function add')
+      expect(result.exitCode).toBe(0)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('strips ANSI escape sequences', () => {
+      const raw = '\x1b[32mfunction add(a,b){return a+b}\x1b[0m'
+      const result = normalizeClaudeOutput(raw, 0)
+      expect(result.text).not.toContain('\x1b')
+      expect(result.text).toContain('function add')
+    })
+
+    it('strips preamble lines (Claude Code version banner)', () => {
+      const raw = 'Claude Code v2.1.86\nfunction add(a,b){return a+b}'
+      const result = normalizeClaudeOutput(raw, 0)
+      expect(result.text).not.toContain('Claude Code')
+      expect(result.text).toContain('function add')
+    })
+
+    it('returns error for non-zero exit code', () => {
+      const result = normalizeClaudeOutput('', 1)
+      expect(result.exitCode).toBe(1)
+      expect(result.error).toContain('Claude Code exited with code 1')
+    })
+
+    it('truncates long output and includes truncation note', () => {
+      const long = 'x'.repeat(200_000)
+      const result = normalizeClaudeOutput(long, 0, { maxChars: 1000 })
+      expect(result.text.length).toBeLessThan(long.length)
+      expect(result.text).toContain('truncated')
+    })
+  })
+
+  describe('normalizeOpenCodeOutput', () => {
+    it('returns text and exitCode for success', () => {
+      const result = normalizeOpenCodeOutput('def add(a,b): return a+b', 0)
+      expect(result.text).toContain('def add')
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('returns error for non-zero exit code', () => {
+      const result = normalizeOpenCodeOutput('traceback...', 1)
+      expect(result.exitCode).toBe(1)
+      expect(result.error).toContain('OpenCode exited with code 1')
+    })
+
+    it('preserves content on error exit', () => {
+      const result = normalizeOpenCodeOutput('some error output', 1)
+      expect(result.text).toContain('some error output')
+    })
+  })
+
+  describe('normalizeOutput (unified dispatcher)', () => {
+    it('routes to claude normalizer when backend is claude', () => {
+      const result = normalizeOutput('code from claude', 0, 'claude')
+      expect(result.exitCode).toBe(0)
+      expect(result.text).toBe('code from claude')
+    })
+
+    it('routes to opencode normalizer when backend is opencode', () => {
+      const result = normalizeOutput('code from opencode', 0, 'opencode')
+      expect(result.exitCode).toBe(0)
+      expect(result.text).toBe('code from opencode')
+    })
+
+    it('preserves error info for claude', () => {
+      const result = normalizeOutput('', 2, 'claude')
+      expect(result.error).toContain('Claude Code')
+    })
+
+    it('preserves error info for opencode', () => {
+      const result = normalizeOutput('', 2, 'opencode')
+      expect(result.error).toContain('OpenCode')
+    })
+  })
+
+  describe('real-world output samples', () => {
+    it('handles opencode run output with markdown code blocks', () => {
+      const raw = [
+        '> build \u00b7 qwen3.6-plus',
+        '',
+        '```python',
+        'def add(a, b):',
+        '    return a + b',
+        '```',
+      ].join('\n')
+      const result = normalizeOpenCodeOutput(raw, 0)
+      expect(result.text).toContain('def add')
+      expect(result.text).toContain('```python')
+      expect(result.exitCode).toBe(0)
+    })
+  })
+})

--- a/v3/@claude-flow/cli/src/commands/agent.ts
+++ b/v3/@claude-flow/cli/src/commands/agent.ts
@@ -92,6 +92,14 @@ const spawnCommand: Command = {
       default: 'anthropic'
     },
     {
+      name: 'backend',
+      short: 'b',
+      description: 'Coding agent backend: claude (default) or opencode',
+      type: 'string',
+      choices: ['claude', 'opencode'],
+      default: 'claude'
+    },
+    {
       name: 'model',
       short: 'm',
       description: 'Model to use',
@@ -155,6 +163,7 @@ const spawnCommand: Command = {
         id: agentName,
         config: {
           provider: ctx.flags.provider || 'anthropic',
+          backend: ctx.flags.backend || 'claude',
           model: ctx.flags.model,
           task: ctx.flags.task,
           timeout: ctx.flags.timeout,
@@ -164,6 +173,7 @@ const spawnCommand: Command = {
         metadata: {
           name: agentName,
           capabilities: getAgentCapabilities(agentType),
+          backend: ctx.flags.backend || 'claude',
         },
       });
 

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -408,6 +408,43 @@ async function installClaudeCode(): Promise<boolean> {
   }
 }
 
+// Check OpenCode CLI
+async function checkOpenCode(): Promise<HealthCheck> {
+  try {
+    const version = await runCommand('opencode --version');
+    const versionMatch = version.match(/v?(\d+\.\d+\.\d+)/);
+    const versionStr = versionMatch ? `v${versionMatch[1]}` : version;
+    return { name: 'OpenCode CLI', status: 'pass', message: versionStr };
+  } catch {
+    return {
+      name: 'OpenCode CLI',
+      status: 'warn',
+      message: 'Not installed (optional — multi-model coding agent)',
+      fix: 'npm install -g opencode-ai'
+    };
+  }
+}
+
+// Install OpenCode CLI
+async function installOpenCode(): Promise<boolean> {
+  try {
+    output.writeln();
+    output.writeln(output.bold('Installing OpenCode CLI...'));
+    execSync('npm install -g opencode-ai', {
+      encoding: 'utf8',
+      stdio: 'inherit'
+    });
+    output.writeln(output.success('OpenCode CLI installed successfully!'));
+    return true;
+  } catch (error) {
+    output.writeln(output.error('Failed to install OpenCode CLI'));
+    if (error instanceof Error) {
+      output.writeln(output.dim(error.message));
+    }
+    return false;
+  }
+}
+
 // Check agentic-flow v3 integration (filesystem-based to avoid slow WASM/DB init)
 async function checkAgenticFlow(): Promise<HealthCheck> {
   try {
@@ -511,6 +548,7 @@ export const doctorCommand: Command = {
       checkNodeVersion,
       checkNpmVersion,
       checkClaudeCode,
+      checkOpenCode,
       checkGit,
       checkGitRepo,
       checkConfigFile,
@@ -529,6 +567,7 @@ export const doctorCommand: Command = {
       'node': checkNodeVersion,
       'npm': checkNpmVersion,
       'claude': checkClaudeCode,
+      'opencode': checkOpenCode,
       'config': checkConfigFile,
       'daemon': checkDaemonStatus,
       'memory': checkMemoryDatabase,
@@ -595,6 +634,23 @@ export const doctorCommand: Command = {
             results[idx] = newCheck;
             // Update fixes list
             const fixIdx = fixes.findIndex(f => f.startsWith('Claude Code CLI:'));
+            if (fixIdx !== -1 && newCheck.status === 'pass') {
+              fixes.splice(fixIdx, 1);
+            }
+          }
+          output.writeln(formatCheck(newCheck));
+        }
+      }
+
+      const openCodeResult = results.find(r => r.name === 'OpenCode CLI');
+      if (openCodeResult && openCodeResult.status !== 'pass') {
+        const installed = await installOpenCode();
+        if (installed) {
+          const newCheck = await checkOpenCode();
+          const idx = results.findIndex(r => r.name === 'OpenCode CLI');
+          if (idx !== -1) {
+            results[idx] = newCheck;
+            const fixIdx = fixes.findIndex(f => f.startsWith('OpenCode CLI:'));
             if (fixIdx !== -1 && newCheck.status === 'pass') {
               fixes.splice(fixIdx, 1);
             }

--- a/v3/@claude-flow/cli/src/commands/swarm.ts
+++ b/v3/@claude-flow/cli/src/commands/swarm.ts
@@ -284,12 +284,21 @@ const initCommand: Command = {
       description: 'Enable V3 15-agent hierarchical mesh mode',
       type: 'boolean',
       default: false
+    },
+    {
+      name: 'backend',
+      short: 'b',
+      description: 'Coding agent backend: claude (default) or opencode',
+      type: 'string',
+      choices: ['claude', 'opencode'],
+      default: 'claude'
     }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     let topology = ctx.flags.topology as string;
     const maxAgents = ctx.flags.maxAgents as number || 15;
     const v3Mode = ctx.flags.v3Mode as boolean;
+    const backend = ctx.flags.backend as string || 'claude';
 
     // V3 mode enables hierarchical-mesh hybrid
     if (v3Mode) {
@@ -331,10 +340,12 @@ const initCommand: Command = {
           failureHandling: 'retry',
           loadBalancing: true,
           autoScaling: ctx.flags.autoScale ?? true,
+          backend,
         },
         metadata: {
           v3Mode,
           strategy: ctx.flags.strategy || 'development',
+          backend,
         },
       });
 
@@ -381,6 +392,7 @@ const initCommand: Command = {
           maxAgents: result.config.maxAgents,
           strategy: ctx.flags.strategy || 'development',
           v3Mode,
+          backend,
           initializedAt: result.initializedAt,
           status: 'ready'
         }, null, 2));

--- a/v3/@claude-flow/cli/src/services/container-worker-pool.ts
+++ b/v3/@claude-flow/cli/src/services/container-worker-pool.ts
@@ -21,7 +21,7 @@ import { spawn, exec, type ChildProcess } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import type { HeadlessWorkerType, HeadlessExecutionResult, SandboxMode } from './headless-worker-executor.js';
+import type { HeadlessWorkerType, HeadlessExecutionResult, SandboxMode, BackendType } from './headless-worker-executor.js';
 
 const execAsync = promisify(exec);
 
@@ -543,6 +543,7 @@ export class ContainerWorkerPool extends EventEmitter {
         workerType: options.workerType,
         timestamp: new Date(),
         executionId,
+        backend: 'claude',
       };
 
       this.emit('executionComplete', result);
@@ -776,6 +777,7 @@ export class ContainerWorkerPool extends EventEmitter {
       timestamp: new Date(),
       executionId: `error_${Date.now()}`,
       error,
+      backend: 'claude',
     };
   }
 }

--- a/v3/@claude-flow/cli/src/services/executor-output.ts
+++ b/v3/@claude-flow/cli/src/services/executor-output.ts
@@ -1,0 +1,165 @@
+/**
+ * Executor Output Normalization
+ *
+ * Both Claude Code and OpenCode produce stdout output, but their formats differ.
+ * This module normalizes both into a consistent ExecutorOutput shape so downstream
+ * consumers (worker daemon, memory hooks, statusline) are backend-agnostic.
+ *
+ * Key differences handled:
+ * - Claude Code may emit ANSI control sequences; OpenCode uses plain text
+ * - Claude Code wraps code in ``` blocks with language tags; OpenCode may not
+ * - Tool call interleaving differs between the two CLIs
+ * - Exit code semantics: Claude uses 0=success, OpenCode may use non-zero for tool failures
+ */
+
+export interface ExecutorOutput {
+  text: string
+  exitCode: number
+  toolCalls?: ToolCallResult[]
+  error?: string
+}
+
+export interface ToolCallResult {
+  tool: string
+  input: unknown
+  output?: string
+  error?: string
+}
+
+const DEFAULT_MAX_OUTPUT_CHARS = 100_000
+
+/**
+ * Remove ANSI escape sequences from raw CLI output.
+ */
+function stripAnsi(raw: string): string {
+  return raw.replace(
+    /\x1b\[[0-9;]*[a-zA-Z]/g, ''
+  )
+}
+
+/**
+ * Extract JSON from a raw string. Tries code blocks first, then bare JSON.
+ */
+function extractJson(raw: string): unknown | undefined {
+  try {
+    const codeMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/)
+    if (codeMatch) return JSON.parse(codeMatch[1].trim())
+    const jsonMatch = raw.match(/\{[\s\S]*\}/)
+    if (jsonMatch) return JSON.parse(jsonMatch[0])
+    return JSON.parse(raw.trim())
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Strip model-specific preamble lines that Claude Code emits
+ * (e.g. "Claude Code v2.1.86", "Model: claude-sonnet-...", etc.)
+ */
+function stripPreamble(raw: string): string {
+  return raw
+    .replace(/^(Claude Code|OpenCode|Ruflo)\s+v?[\d.]+.*\n?/im, '')
+    .replace(/^Model:\s+.+\n?/im, '')
+    .replace(/^Using .+ backend\n?/im, '')
+    .trim()
+}
+
+/**
+ * Truncate output beyond a character limit to prevent runaway memory usage.
+ * Appends a truncation note when content is cut.
+ */
+function truncate(raw: string, maxChars: number): string {
+  if (raw.length <= maxChars) return raw
+  const half = Math.floor(maxChars / 2)
+  const head = raw.slice(0, half)
+  const tail = raw.slice(raw.length - half)
+  return `${head}\n\n... [truncated ${raw.length - maxChars} chars] ...\n\n${tail}`
+}
+
+/**
+ * Normalize Claude Code stdout into ExecutorOutput.
+ *
+ * Claude Code exit codes:
+ *   0 = success
+ *   1 = general error
+ *   2 = tool call error (content still usable)
+ *
+ * Claude Code stdout may include ANSI escapes, model info preamble,
+ * and tool call output interleaved with text.
+ */
+export function normalizeClaudeOutput(
+  raw: string,
+  exitCode: number,
+  options?: { maxChars?: number }
+): ExecutorOutput {
+  const maxChars = options?.maxChars ?? DEFAULT_MAX_OUTPUT_CHARS
+  const cleaned = stripPreamble(stripAnsi(raw))
+  const text = truncate(cleaned, maxChars)
+
+  // Non-zero exit code = error, but stderr may have more detail
+  if (exitCode !== 0) {
+    return {
+      text: text || raw,
+      exitCode,
+      error: `Claude Code exited with code ${exitCode}`,
+    }
+  }
+
+  return { text, exitCode }
+}
+
+/**
+ * Normalize OpenCode stdout into ExecutorOutput.
+ *
+ * OpenCode exit codes:
+ *   0 = success
+ *   1 = general error
+ *
+ * OpenCode stdout is plain text (no ANSI escapes by default).
+ * Tool call output is interleaved with text in the run command output stream.
+ * OpenCode may emit permission prompts in non-headless mode, but
+ * we pass --dangerously-skip-permissions to suppress them.
+ */
+export function normalizeOpenCodeOutput(
+  raw: string,
+  exitCode: number,
+  options?: { maxChars?: number }
+): ExecutorOutput {
+  const maxChars = options?.maxChars ?? DEFAULT_MAX_OUTPUT_CHARS
+  const cleaned = stripPreamble(raw)
+  const text = truncate(cleaned, maxChars)
+
+  if (exitCode !== 0) {
+    return {
+      text: text || raw,
+      exitCode,
+      error: `OpenCode exited with code ${exitCode}`,
+    }
+  }
+
+  return { text, exitCode }
+}
+
+/**
+ * Normalize output from either backend.
+ * Call this after the spawn completes to get a consistent ExecutorOutput.
+ */
+export function normalizeOutput(
+  raw: string,
+  exitCode: number,
+  backend: 'claude' | 'opencode',
+  options?: { maxChars?: number }
+): ExecutorOutput {
+  if (backend === 'opencode') {
+    return normalizeOpenCodeOutput(raw, exitCode, options)
+  }
+  return normalizeClaudeOutput(raw, exitCode, options)
+}
+
+/**
+ * Attempt to parse JSON from executor output.
+ * Returns the parsed object or undefined if parse fails.
+ */
+export function parseJsonOutput(output: ExecutorOutput): unknown | undefined {
+  return extractJson(output.text)
+}

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -1,15 +1,17 @@
 /**
  * Headless Worker Executor
- * Enables workers to invoke Claude Code in headless mode with configurable sandbox profiles.
+ * Enables workers to invoke AI coding agents (Claude Code or OpenCode) in headless mode.
  *
  * ADR-020: Headless Worker Integration Architecture
  * - Integrates with CLAUDE_CODE_HEADLESS and CLAUDE_CODE_SANDBOX_MODE environment variables
+ * - Supports multiple backends: Claude Code (default) and OpenCode
  * - Provides process pool for concurrent execution
  * - Builds context from file glob patterns
  * - Supports prompt templates and output parsing
  * - Implements timeout and graceful error handling
  *
  * Key Features:
+ * - Multi-backend support (Claude Code / OpenCode)
  * - Process pool with configurable maxConcurrent
  * - Context building from file glob patterns with caching
  * - Prompt template system with context injection
@@ -24,6 +26,7 @@ import { EventEmitter } from 'events';
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
 import type { WorkerType } from './worker-daemon.js';
+import { normalizeOutput } from './executor-output.js';
 
 // ============================================
 // Type Definitions
@@ -66,6 +69,11 @@ export type OutputFormat = 'text' | 'json' | 'markdown';
  * Execution mode for workers
  */
 export type ExecutionMode = 'local' | 'headless';
+
+/**
+ * Coding agent backend for headless execution
+ */
+export type BackendType = 'claude' | 'opencode';
 
 /**
  * Worker priority levels
@@ -128,6 +136,9 @@ export interface HeadlessWorkerConfig extends WorkerConfig {
  * Executor configuration options
  */
 export interface HeadlessExecutorConfig {
+  /** Coding agent backend: claude (default) or opencode */
+  backend?: BackendType;
+
   /** Maximum concurrent headless processes */
   maxConcurrent?: number;
 
@@ -157,7 +168,7 @@ export interface HeadlessExecutionResult {
   /** Whether execution completed successfully */
   success: boolean;
 
-  /** Raw output from Claude Code */
+  /** Raw output from the coding agent */
   output: string;
 
   /** Parsed output (if outputFormat is json or markdown) */
@@ -186,6 +197,9 @@ export interface HeadlessExecutionResult {
 
   /** Execution ID for tracking */
   executionId: string;
+
+  /** Coding agent backend used */
+  backend: BackendType;
 }
 
 /**
@@ -586,9 +600,10 @@ export function getWorkerConfig(type: WorkerType): HeadlessWorkerConfig | undefi
 // ============================================
 
 /**
- * HeadlessWorkerExecutor - Executes workers using Claude Code in headless mode
+ * HeadlessWorkerExecutor - Executes workers using AI coding agents in headless mode
  *
  * Features:
+ * - Multi-backend support (Claude Code / OpenCode)
  * - Process pool with configurable concurrency limit
  * - Pending queue for overflow requests
  * - Context caching with configurable TTL
@@ -599,11 +614,14 @@ export function getWorkerConfig(type: WorkerType): HeadlessWorkerConfig | undefi
 export class HeadlessWorkerExecutor extends EventEmitter {
   private projectRoot: string;
   private config: Required<HeadlessExecutorConfig>;
+  private backend: BackendType;
   private processPool: Map<string, PoolEntry> = new Map();
   private pendingQueue: QueueEntry[] = [];
   private contextCache: Map<string, CacheEntry> = new Map();
   private claudeCodeAvailable: boolean | null = null;
   private claudeCodeVersion: string | null = null;
+  private openCodeAvailable: boolean | null = null;
+  private openCodeVersion: string | null = null;
 
   constructor(projectRoot: string, options?: HeadlessExecutorConfig) {
     super();
@@ -611,6 +629,7 @@ export class HeadlessWorkerExecutor extends EventEmitter {
 
     // Merge with defaults
     this.config = {
+      backend: options?.backend ?? 'claude',
       maxConcurrent: options?.maxConcurrent ?? 2,
       defaultTimeoutMs: options?.defaultTimeoutMs ?? 5 * 60 * 1000,
       maxContextFiles: options?.maxContextFiles ?? 20,
@@ -619,6 +638,8 @@ export class HeadlessWorkerExecutor extends EventEmitter {
       cacheContext: options?.cacheContext ?? true,
       cacheTtlMs: options?.cacheTtlMs ?? 60000, // 1 minute default
     };
+
+    this.backend = this.config.backend;
 
     // Ensure log directory exists
     this.ensureLogDir();
@@ -629,9 +650,34 @@ export class HeadlessWorkerExecutor extends EventEmitter {
   // ============================================
 
   /**
-   * Check if Claude Code CLI is available
+   * Get the current backend
+   */
+  getBackend(): BackendType {
+    return this.backend;
+  }
+
+  /**
+   * Set the backend dynamically
+   */
+  setBackend(backend: BackendType): void {
+    this.backend = backend;
+    this.emit('backendChange', { backend });
+  }
+
+  /**
+   * Check if the configured backend is available
    */
   async isAvailable(): Promise<boolean> {
+    if (this.backend === 'opencode') {
+      return this.isOpenCodeAvailable();
+    }
+    return this.isClaudeCodeAvailable();
+  }
+
+  /**
+   * Check if Claude Code CLI is available
+   */
+  async isClaudeCodeAvailable(): Promise<boolean> {
     if (this.claudeCodeAvailable !== null) {
       return this.claudeCodeAvailable;
     }
@@ -641,24 +687,53 @@ export class HeadlessWorkerExecutor extends EventEmitter {
         encoding: 'utf-8',
         stdio: 'pipe',
         timeout: 5000,
-        windowsHide: true, // Prevent phantom console windows on Windows
+        windowsHide: true,
       });
       this.claudeCodeAvailable = true;
       this.claudeCodeVersion = output.trim();
-      this.emit('status', { available: true, version: this.claudeCodeVersion });
+      this.emit('status', { backend: 'claude', available: true, version: this.claudeCodeVersion });
       return true;
     } catch {
       this.claudeCodeAvailable = false;
-      this.emit('status', { available: false });
+      this.emit('status', { backend: 'claude', available: false });
       return false;
     }
   }
 
   /**
-   * Get Claude Code version
+   * Check if OpenCode CLI is available
+   */
+  async isOpenCodeAvailable(): Promise<boolean> {
+    if (this.openCodeAvailable !== null) {
+      return this.openCodeAvailable;
+    }
+
+    try {
+      const output = execSync('opencode --version', {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 5000,
+        windowsHide: true,
+      });
+      this.openCodeAvailable = true;
+      this.openCodeVersion = output.trim();
+      this.emit('status', { backend: 'opencode', available: true, version: this.openCodeVersion });
+      return true;
+    } catch {
+      this.openCodeAvailable = false;
+      this.emit('status', { backend: 'opencode', available: false });
+      return false;
+    }
+  }
+
+  /**
+   * Get the version of the configured backend
    */
   async getVersion(): Promise<string | null> {
     await this.isAvailable();
+    if (this.backend === 'opencode') {
+      return this.openCodeVersion;
+    }
     return this.claudeCodeVersion;
   }
 
@@ -677,9 +752,15 @@ export class HeadlessWorkerExecutor extends EventEmitter {
     // Check availability
     const available = await this.isAvailable();
     if (!available) {
+      const message = this.backend === 'opencode'
+        ? 'OpenCode backend selected but opencode binary not found on PATH.\n' +
+          'Install it with: npm install -g opencode-ai\n' +
+          'Or switch to the Claude backend: ruflo agent --backend claude'
+        : 'Claude Code CLI not available. Install with: npm install -g @anthropic-ai/claude-code\n' +
+          'Or switch to the OpenCode backend: ruflo agent --backend opencode';
       const result = this.createErrorResult(
         workerType,
-        'Claude Code CLI not available. Install with: npm install -g @anthropic-ai/claude-code'
+        message
       );
       this.emit('error', result);
       return result;
@@ -847,7 +928,7 @@ export class HeadlessWorkerExecutor extends EventEmitter {
     const startTime = Date.now();
     const executionId = `${workerType}_${startTime}_${Math.random().toString(36).slice(2, 8)}`;
 
-    this.emit('start', { executionId, workerType, config: headless });
+    this.emit('start', { executionId, workerType, config: headless, backend: this.backend });
 
     try {
       // Build context from file patterns
@@ -859,14 +940,24 @@ export class HeadlessWorkerExecutor extends EventEmitter {
       // Log prompt for debugging
       this.logExecution(executionId, 'prompt', fullPrompt);
 
-      // Execute Claude Code headlessly
-      const result = await this.executeClaudeCode(fullPrompt, {
-        sandbox: headless.sandbox,
-        model: headless.model || 'sonnet',
-        timeoutMs: headless.timeoutMs || this.config.defaultTimeoutMs,
-        executionId,
-        workerType,
-      });
+      // Route to the correct backend
+      let result: { success: boolean; output: string; tokensUsed?: number; error?: string };
+      if (this.backend === 'opencode') {
+        result = await this.executeOpenCode(fullPrompt, {
+          model: headless.model || 'sonnet',
+          timeoutMs: headless.timeoutMs || this.config.defaultTimeoutMs,
+          executionId,
+          workerType,
+        });
+      } else {
+        result = await this.executeClaudeCode(fullPrompt, {
+          sandbox: headless.sandbox,
+          model: headless.model || 'sonnet',
+          timeoutMs: headless.timeoutMs || this.config.defaultTimeoutMs,
+          executionId,
+          workerType,
+        });
+      }
 
       // Parse output based on format
       let parsedOutput: unknown;
@@ -876,9 +967,12 @@ export class HeadlessWorkerExecutor extends EventEmitter {
         parsedOutput = this.parseMarkdownOutput(result.output);
       }
 
+      // Normalize output for consistent downstream consumption
+      const normalized = normalizeOutput(result.output, result.success ? 0 : 1, this.backend);
+
       const executionResult: HeadlessExecutionResult = {
         success: result.success,
-        output: result.output,
+        output: normalized.text,
         parsedOutput,
         durationMs: Date.now() - startTime,
         tokensUsed: result.tokensUsed,
@@ -887,7 +981,8 @@ export class HeadlessWorkerExecutor extends EventEmitter {
         workerType,
         timestamp: new Date(),
         executionId,
-        error: result.error,
+        error: result.error || normalized.error,
+        backend: this.backend,
       };
 
       // Log result
@@ -1245,6 +1340,153 @@ Analyze the above codebase context and provide your response following the forma
   }
 
   /**
+   * Execute OpenCode in headless mode via CLI
+   *
+   * Uses `opencode run` for one-shot non-interactive execution,
+   * similar to `claude --print`. Supports streaming output and timeout.
+   */
+  private executeOpenCode(
+    prompt: string,
+    options: {
+      model: ModelType;
+      timeoutMs: number;
+      executionId: string;
+      workerType: HeadlessWorkerType;
+    }
+  ): Promise<{ success: boolean; output: string; tokensUsed?: number; error?: string }> {
+    return new Promise((resolve) => {
+      const env: Record<string, string> = {
+        ...(process.env as Record<string, string>),
+      };
+      delete env.CLAUDE_SESSION_ID;
+      delete env.CLAUDE_PARENT_SESSION_ID;
+
+      // OpenCode needs provider-specific API keys in the environment.
+      // Pass through all known provider keys so the configured model can authenticate.
+      if (process.env.ANTHROPIC_API_KEY) env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+      if (process.env.OPENAI_API_KEY) env.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+      if (process.env.GOOGLE_API_KEY) env.GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
+      if (process.env.OPENROUTER_API_KEY) env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+      if (process.env.GROQ_API_KEY) env.GROQ_API_KEY = process.env.GROQ_API_KEY;
+      if (process.env.MISTRAL_API_KEY) env.MISTRAL_API_KEY = process.env.MISTRAL_API_KEY;
+      if (process.env.DEEPSEEK_API_KEY) env.DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY;
+
+      // OpenCode uses 'run' with --dangerously-skip-permissions
+      // for fully headless operation (no interactive permission prompts).
+      const args = [
+        'run',
+        '--dangerously-skip-permissions',
+        prompt,
+      ];
+
+      // If a specific model is configured, pass it (opencode uses provider/model format).
+      // Priority: OPENCODE_MODEL env var > opencode.json config file > default (opencode auto-detects)
+      const model = this.resolveOpenCodeModel();
+      if (model) {
+        args.unshift('--model', model);
+      }
+
+      const child = spawn('opencode', args, {
+        cwd: this.projectRoot,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+
+      // Setup timeout
+      const timeoutHandle = setTimeout(() => {
+        if (this.processPool.has(options.executionId)) {
+          child.kill('SIGTERM');
+          setTimeout(() => {
+            if (!child.killed) {
+              child.kill('SIGKILL');
+            }
+          }, 5000);
+        }
+      }, options.timeoutMs);
+
+      // Track in process pool
+      const poolEntry: PoolEntry = {
+        process: child,
+        executionId: options.executionId,
+        workerType: options.workerType,
+        startTime: new Date(),
+        timeout: timeoutHandle,
+      };
+      this.processPool.set(options.executionId, poolEntry);
+
+      let stdout = '';
+      let stderr = '';
+      let resolved = false;
+
+      const cleanup = () => {
+        clearTimeout(timeoutHandle);
+        this.processPool.delete(options.executionId);
+      };
+
+      child.stdout?.on('data', (data: Buffer) => {
+        const chunk = data.toString();
+        stdout += chunk;
+        this.emit('output', {
+          executionId: options.executionId,
+          type: 'stdout',
+          data: chunk,
+        });
+      });
+
+      child.stderr?.on('data', (data: Buffer) => {
+        const chunk = data.toString();
+        stderr += chunk;
+        this.emit('output', {
+          executionId: options.executionId,
+          type: 'stderr',
+          data: chunk,
+        });
+      });
+
+      child.on('close', (code: number | null) => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+
+        resolve({
+          success: code === 0,
+          output: stdout || stderr,
+          error: code !== 0 ? stderr || `Process exited with code ${code}` : undefined,
+        });
+      });
+
+      child.on('error', (error: Error) => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+
+        resolve({
+          success: false,
+          output: '',
+          error: error.message,
+        });
+      });
+
+      // Handle timeout
+      setTimeout(() => {
+        if (resolved) return;
+        if (!this.processPool.has(options.executionId)) return;
+
+        resolved = true;
+        child.kill('SIGTERM');
+        cleanup();
+
+        resolve({
+          success: false,
+          output: stdout || stderr,
+          error: `Execution timed out after ${options.timeoutMs}ms`,
+        });
+      }, options.timeoutMs + 100);
+    });
+  }
+
+  /**
    * Parse JSON output from Claude Code
    */
   private parseJsonOutput(output: string): unknown {
@@ -1320,6 +1562,45 @@ Analyze the above codebase context and provide your response following the forma
   }
 
   /**
+   * Resolve the OpenCode model to use.
+   *
+   * Priority:
+   *   1. OPENCODE_MODEL env var (explicit override)
+   *   2. opencode.json / .opencode/opencode.jsonc config file (project-level)
+   *   3. undefined (let opencode auto-detect from its own config)
+   */
+  private resolveOpenCodeModel(): string | undefined {
+    // 1. Explicit env var override
+    if (process.env.OPENCODE_MODEL) {
+      return process.env.OPENCODE_MODEL;
+    }
+
+    // 2. Try to read from opencode config file
+    try {
+      const configPaths = [
+        join(this.projectRoot, 'opencode.json'),
+        join(this.projectRoot, '.opencode', 'opencode.jsonc'),
+        join(this.projectRoot, '.opencode', 'opencode.json'),
+      ];
+      for (const configPath of configPaths) {
+        if (existsSync(configPath)) {
+          const raw = readFileSync(configPath, 'utf-8');
+          // jsonc may have comments — strip single-line // comments
+          const cleaned = raw.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+          const config = JSON.parse(cleaned);
+          if (config.model && typeof config.model === 'string') {
+            return config.model;
+          }
+        }
+      }
+    } catch {
+      // Config file missing or invalid — fall through to auto-detect
+    }
+
+    return undefined;
+  }
+
+  /**
    * Create an error result
    */
   private createErrorResult(
@@ -1336,6 +1617,7 @@ Analyze the above codebase context and provide your response following the forma
       timestamp: new Date(),
       executionId: `error_${Date.now()}`,
       error,
+      backend: this.backend,
     };
   }
 

--- a/v3/@claude-flow/cli/src/types/optional-modules.d.ts
+++ b/v3/@claude-flow/cli/src/types/optional-modules.d.ts
@@ -227,6 +227,12 @@ declare module '@ruvector/rvagent-wasm' {
   }
 }
 
+declare module '@ruvector/sona' {
+  const sona: any;
+  export default sona;
+  export const SonaEngine: any;
+}
+
 declare module '@ruvector/ruvllm-wasm' {
   export default function init(): Promise<void>;
 

--- a/v3/@claude-flow/integration/src/index.ts
+++ b/v3/@claude-flow/integration/src/index.ts
@@ -274,6 +274,21 @@ export {
   IntegrationError,
 } from './types.js';
 
+// ===== OpenCode Adapter =====
+export {
+  OpenCodeAdapter,
+  OPENCODE_MODEL_MAP,
+  OPENCODE_AGENT_MAP,
+  resolveOpenCodeModel,
+  resolveOpenCodeAgent,
+} from './opencode-adapter.js';
+
+export type {
+  BackendType as OpenCodeBackendType,
+  OpenCodeAgentConfig,
+  OpenCodeAdapterConfig,
+} from './opencode-adapter.js';
+
 // ===== Multi-Model Router (Cost Optimization) =====
 export {
   MultiModelRouter,
@@ -449,6 +464,7 @@ export const METADATA = {
     'Worker Pool (intelligent routing)',
     'Provider Adapter (multi-model support)',
     'Multi-Model Router (cost optimization)',
+    'OpenCode Adapter (multi-agent coding backend)',
   ],
   performance: {
     flashAttentionSpeedup: '2.49x-7.47x',

--- a/v3/@claude-flow/integration/src/opencode-adapter.ts
+++ b/v3/@claude-flow/integration/src/opencode-adapter.ts
@@ -1,0 +1,277 @@
+/**
+ * OpenCodeAdapter - Bridge between Claude Flow Agents and OpenCode
+ *
+ * Maps Ruflo agent types, configurations, and worker patterns
+ * to OpenCode's agent/session model. Enables Ruflo swarms to
+ * execute coding tasks via OpenCode instead of Claude Code.
+ *
+ * Key mappings:
+ * - Ruflo agent type → OpenCode session config
+ * - Ruflo worker type → OpenCode prompt template
+ * - Ruflo model type → OpenCode provider/model string
+ *
+ * @module v3/integration/opencode-adapter
+ * @version 3.0.0-beta.1
+ */
+
+import { EventEmitter } from 'events';
+
+// ============================================
+// Backend Type
+// ============================================
+
+export type BackendType = 'claude' | 'opencode';
+
+// ============================================
+// Model Mapping
+// ============================================
+
+/**
+ * Map Ruflo model types to OpenCode model IDs.
+ * OpenCode uses provider/model format (e.g., "anthropic/claude-sonnet-4-20250514").
+ */
+export const OPENCODE_MODEL_MAP: Record<string, string> = {
+  // Claude models via Anthropic provider
+  sonnet: 'anthropic/claude-sonnet-4-20250514',
+  opus: 'anthropic/claude-opus-4-20250514',
+  haiku: 'anthropic/claude-haiku-4-5-20251001',
+
+  // GPT models via OpenAI provider
+  'gpt-4o': 'openai/gpt-4o',
+  'gpt-4o-mini': 'openai/gpt-4o-mini',
+  'gpt-4-turbo': 'openai/gpt-4-turbo',
+  'gpt-3.5-turbo': 'openai/gpt-3.5-turbo',
+  'o1-preview': 'openai/o1-preview',
+  'o1-mini': 'openai/o1-mini',
+  'o3-mini': 'openai/o3-mini',
+
+  // Gemini models via Google provider
+  'gemini-2.0-flash': 'google/gemini-2.0-flash',
+  'gemini-1.5-pro': 'google/gemini-1.5-pro',
+  'gemini-1.5-flash': 'google/gemini-1.5-flash',
+  'gemini-pro': 'google/gemini-pro',
+
+  // Local models via Ollama provider
+  'llama3.2': 'ollama/llama3.2',
+  'llama3.1': 'ollama/llama3.1',
+  'mistral': 'ollama/mistral',
+  'mixtral': 'ollama/mixtral',
+  'codellama': 'ollama/codellama',
+  'deepseek-coder': 'ollama/deepseek-coder',
+};
+
+/**
+ * Resolve a Ruflo model type to an OpenCode model ID.
+ * Falls back to the raw model string if no mapping found
+ * (allows passing OpenCode model IDs directly).
+ */
+export function resolveOpenCodeModel(rufloModel: string): string {
+  return OPENCODE_MODEL_MAP[rufloModel] || rufloModel;
+}
+
+// ============================================
+// Agent Type Mapping
+// ============================================
+
+/**
+ * Map Ruflo agent types to OpenCode agent configurations.
+ * OpenCode agents have modes: "primary" (full access) or "subagent" (sandboxed).
+ * All Ruflo headless workers map to "primary" mode since they need full tool access.
+ */
+export interface OpenCodeAgentConfig {
+  /** OpenCode agent name */
+  name: string;
+  /** Agent mode: primary (full tools) or subagent (restricted) */
+  mode: 'primary' | 'subagent';
+  /** Model to use for this agent */
+  model?: string;
+  /** Custom instructions appended to system prompt */
+  instructions?: string;
+}
+
+export const OPENCODE_AGENT_MAP: Record<string, OpenCodeAgentConfig> = {
+  coder: {
+    name: 'ruflo-coder',
+    mode: 'primary',
+    instructions: 'You are a coding agent in a Ruflo swarm. Write clean, well-tested code following the project conventions.',
+  },
+  tester: {
+    name: 'ruflo-tester',
+    mode: 'primary',
+    instructions: 'You are a testing agent. Write comprehensive tests using the project testing framework. Focus on edge cases and error paths.',
+  },
+  reviewer: {
+    name: 'ruflo-reviewer',
+    mode: 'primary',
+    instructions: 'You are a code review agent. Review code for correctness, security, performance, and best practices.',
+  },
+  researcher: {
+    name: 'ruflo-researcher',
+    mode: 'primary',
+    instructions: 'You are a research agent. Analyze codebases, find patterns, and provide thorough analysis.',
+  },
+  architect: {
+    name: 'ruflo-architect',
+    mode: 'primary',
+    instructions: 'You are a system architect. Design scalable, maintainable architectures following domain-driven design.',
+  },
+  coordinator: {
+    name: 'ruflo-coordinator',
+    mode: 'primary',
+    instructions: 'You are a coordination agent. Orchestrate multi-agent workflows and track task progress.',
+  },
+  'security-architect': {
+    name: 'ruflo-security',
+    mode: 'primary',
+    instructions: 'You are a security architect. Audit code for vulnerabilities, review auth patterns, and ensure secure coding practices.',
+  },
+  'security-auditor': {
+    name: 'ruflo-security-auditor',
+    mode: 'primary',
+    instructions: 'You are a security auditor. Find CVEs, hardcoded secrets, injection risks, and insecure dependencies.',
+  },
+  'performance-engineer': {
+    name: 'ruflo-perf',
+    mode: 'primary',
+    instructions: 'You are a performance engineer. Identify bottlenecks, optimize queries, reduce memory usage, and improve rendering.',
+  },
+};
+
+/**
+ * Resolve OpenCode agent config for a Ruflo agent type.
+ * Falls back to a generic primary agent if no mapping found.
+ */
+export function resolveOpenCodeAgent(rufloAgentType: string): OpenCodeAgentConfig {
+  return OPENCODE_AGENT_MAP[rufloAgentType] || {
+    name: `ruflo-${rufloAgentType}`,
+    mode: 'primary',
+    instructions: `You are a ${rufloAgentType} agent in a Ruflo swarm. Complete your assigned task thoroughly.`,
+  };
+}
+
+// ============================================
+// Adapter Class
+// ============================================
+
+export interface OpenCodeAdapterConfig {
+  /** Default model for OpenCode sessions */
+  defaultModel?: string;
+  /** OpenCode serve port */
+  port?: number;
+  /** Timeout for OpenCode operations */
+  timeout?: number;
+}
+
+/**
+ * OpenCodeAdapter — Converts Ruflo agent requests to OpenCode-compatible formats.
+ *
+ * This adapter handles:
+ * - Model ID translation (Ruflo short names → OpenCode provider/model format)
+ * - Agent configuration mapping
+ * - Prompt template generation for headless execution
+ */
+export class OpenCodeAdapter extends EventEmitter {
+  private config: Required<OpenCodeAdapterConfig>;
+
+  constructor(config?: OpenCodeAdapterConfig) {
+    super();
+    this.config = {
+      defaultModel: config?.defaultModel || 'anthropic/claude-sonnet-4-20250514',
+      port: config?.port || 4096,
+      timeout: config?.timeout || 5 * 60 * 1000,
+    };
+  }
+
+  /**
+   * Get the OpenCode model ID for a Ruflo model name.
+   */
+  getModel(rufloModel?: string): string {
+    if (!rufloModel) return this.config.defaultModel;
+    return resolveOpenCodeModel(rufloModel);
+  }
+
+  /**
+   * Get OpenCode agent config for a given agent type.
+   */
+  getAgentConfig(agentType: string): OpenCodeAgentConfig {
+    return resolveOpenCodeAgent(agentType);
+  }
+
+  /**
+   * Build a headless execution command for `opencode run`.
+   */
+  buildRunCommand(prompt: string, model?: string): { cmd: string; args: string[] } {
+    const args: string[] = ['run', '--dangerously-skip-permissions'];
+    if (model) {
+      args.push('--model', this.getModel(model));
+    }
+    args.push(prompt);
+    return { cmd: 'opencode', args };
+  }
+
+  /**
+   * Build the environment variables for an OpenCode process.
+   */
+  buildEnv(): Record<string, string> {
+    const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+    delete env.CLAUDE_SESSION_ID;
+    delete env.CLAUDE_PARENT_SESSION_ID;
+    return env;
+  }
+
+  /**
+   * Check if OpenCode CLI is available on the system.
+   */
+  async checkAvailability(): Promise<{ available: boolean; version?: string }> {
+    try {
+      const { execSync } = await import('child_process');
+      const output = execSync('opencode --version', {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 5000,
+        windowsHide: true,
+      });
+      const versionMatch = output.trim().match(/v?(\d+\.\d+\.\d+)/);
+      return {
+        available: true,
+        version: versionMatch ? `v${versionMatch[1]}` : output.trim(),
+      };
+    } catch {
+      return { available: false };
+    }
+  }
+
+  /**
+   * Get the recommended OpenCode model for a given Ruflo worker type.
+   * Maps worker types to optimal model choices based on task complexity.
+   */
+  getRecommendedModel(workerType: string): string {
+    const modelMap: Record<string, string> = {
+      // Critical security work — use best model
+      audit: this.getModel('sonnet'),
+
+      // Performance analysis — balanced
+      optimize: this.getModel('sonnet'),
+
+      // Test gaps — balanced
+      testgaps: this.getModel('sonnet'),
+
+      // Documentation — cheap model OK
+      document: this.getModel('gpt-4o-mini'),
+
+      // Deep learning — best model
+      ultralearn: this.getModel('opus'),
+      deepdive: this.getModel('opus'),
+
+      // Refactoring — balanced
+      refactor: this.getModel('sonnet'),
+
+      // Predictive — cheap model OK
+      predict: this.getModel('gpt-4o-mini'),
+    };
+
+    return modelMap[workerType] || this.config.defaultModel;
+  }
+}
+
+export default OpenCodeAdapter;

--- a/v3/@claude-flow/providers/src/provider-manager.ts
+++ b/v3/@claude-flow/providers/src/provider-manager.ts
@@ -127,6 +127,16 @@ export class ProviderManager extends EventEmitter {
         return new OllamaProvider(options);
       case 'ruvector':
         return new RuVectorProvider(options);
+      case 'opencode':
+        // OpenCode is a coding agent backend, not a direct LLM provider.
+        // It delegates to underlying providers (Anthropic, OpenAI, Google, etc.)
+        // via its own provider system. Use the OpenCodeAdapter for agent-level
+        // integration instead.
+        throw new Error(
+          'OpenCode is a coding agent backend, not a direct LLM provider. ' +
+          'Use the HeadlessWorkerExecutor with backend="opencode" or the OpenCodeAdapter ' +
+          'from @claude-flow/integration for agent-level integration.'
+        );
       default:
         throw new Error(`Unknown provider: ${config.provider}`);
     }

--- a/v3/@claude-flow/providers/src/types.ts
+++ b/v3/@claude-flow/providers/src/types.ts
@@ -20,6 +20,7 @@ export type LLMProvider =
   | 'ruvector'
   | 'openrouter'
   | 'litellm'
+  | 'opencode'
   | 'custom';
 
 export type LLMModel =


### PR DESCRIPTION
## Ruflo with OpenCode: Alternative coding agent backend

Adds OpenCode as a second execution backend for Ruflo agents, alongside Claude Code.

### Why

Claude Code is free to install. The barrier isn't subscription — it's needing an **Anthropic API key** (separate signup at console.anthropic.com, per-token billing).

This creates a real gap: many developers pay for Claude.ai Pro ($20/mo) but haven't set up an Anthropic API billing account. They're locked out of Ruflo despite paying Anthropic money every month. Others have OpenAI or Google API keys from work but no Anthropic key at all.

This PR closes that gap by letting Ruflo use OpenCode as the executor. Users bring whatever API key they already have — OpenAI, Google, Groq, or local Ollama models.

| User has | Works today? | After this PR |
|----------|-------------|---------------|
| Anthropic API key | Yes (`claude`) | Yes (unchanged) |
| Claude.ai Pro, no API key | **No** | Yes via `--backend opencode` |
| OpenAI/Google API key only | **No** | Yes via `--backend opencode` |
| No API keys at all | **No** | Yes via local Ollama + OpenCode |

### What changed

| File | Change |
|------|--------|
| `cli/src/services/headless-worker-executor.ts` | `BackendType`, `isOpenCodeAvailable()`, `executeOpenCode()`, `resolveOpenCodeModel()`, backend-aware routing in `executeInternal()` |
| `cli/src/services/executor-output.ts` | **New** — normalizes stdout from both backends into consistent `ExecutorOutput` shape |
| `cli/src/services/container-worker-pool.ts` | Added `backend: 'claude'` to satisfy updated interface |
| `cli/src/commands/agent.ts` | `--backend claude|opencode` flag on `agent spawn` |
| `cli/src/commands/swarm.ts` | `--backend claude|opencode` flag on `swarm init` |
| `cli/src/commands/doctor.ts` | OpenCode health check + auto-install |
| `cli/src/types/optional-modules.d.ts` | `@ruvector/sona` ambient declaration (pre-existing build fix) |
| `providers/src/types.ts` | `'opencode'` added to `LLMProvider` union |
| `providers/src/provider-manager.ts` | `'opencode'` case with clear guidance |
| `integration/src/opencode-adapter.ts` | **New** — model mapping, agent config, build command helper |
| `integration/src/index.ts` | Export `OpenCodeAdapter` |
| `__tests__/open-code-integration.test.ts` | **New** — 13 unit tests |

### What this is NOT

- **Not a Claude Code replacement.** Ruflo remains a Claude Code plugin first. `claude` is still the default backend. This adds a fallback for when Claude Code can't authenticate.
- **Not a model routing change.** Ruflo's provider system (anthropic/openai/google/ollama) handles which LLM to call. This PR changes which binary runs the code.
- **Not opinionated about models.** OpenCode supports 18+ providers out of the box. Users configure models in their existing `opencode.json` — Ruflo doesn't need to know or care.

### Usage

```bash
ruflo agent spawn -t coder --name bot --backend opencode
ruflo swarm init --backend opencode --topology hierarchical
ruflo doctor opencode            # check availability
ruflo doctor --fix               # auto-install opencode if missing
```

Default backend remains `claude` for backward compatibility.

### Design decisions

1. **CLI-based approach** mirrors the existing `spawn('claude', ['--print', prompt])` pattern
2. **Output normalization layer** (`executor-output.ts`) makes downstream consumers (worker daemon, memory hooks) backend-agnostic
3. **Model resolution** reads from `opencode.json` config file, `OPENCODE_MODEL` env var, or falls back to opencode auto-detection
4. **Error messages** include install instructions AND switch-backend hints
5. **Env var passthrough** passes `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, etc. to the opencode process

### Testing

- 13 unit tests for output normalization, error handling, real-world format samples
- `pnpm build` passes on all 22 monorepo packages
- Backward compatible — omitting `--backend` defaults to `claude`
