### PR TITLE
fix(cli): load lazy commands before resolving subcommand short flags

### DIFF
--- a/v3/@claude-flow/cli/src/parser.ts
+++ b/v3/@claude-flow/cli/src/parser.ts
@@ -3,6 +3,7 @@
  * Advanced argument parsing with validation and type coercion
  */
 
+import { getCommandAsync } from './index.js';
 import type { Command, CommandOption, ParsedFlags, CommandContext, V3Config } from './types.js';
 
 export interface ParseResult {
@@ -137,7 +138,7 @@ export class CommandParser {
     });
   }
 
-  parse(args: string[]): ParseResult {
+  async parse(args: string[]): Promise<ParseResult> {
     const result: ParseResult = {
       command: [],
       flags: { _: [] },
@@ -165,7 +166,8 @@ export class CommandParser {
         // Lazy command: we know its name but not its subcommands. Stop the
         // walk here — we'll rely on Pass 2 to push it onto commandPath.
         if (this.lazyCommandNames.has(arg)) {
-          break;
+            resolvedCmd = await getCommandAsync(arg);
+            break;
         }
         // Unknown first positional — not a command. Stop walking.
         break;


### PR DESCRIPTION
## Summary
Fix lazy-registered command parsing so subcommand short flags (e.g. `-t`, `-c`) are resolved correctly.

## Problem
For lazy-registered commands like `guidance`, the parser exited early before loading subcommand metadata. As a result, subcommand-scoped short aliases were never registered and flags like `-t` / `-c` were treated as literals instead of aliases.

## Fix
Load the lazy command during parser pass 1 before breaking, so subcommand metadata and alias mappings are available during alias resolution.

## Result
Subcommand short flags now resolve correctly for lazy-registered commands.

Fixes #1651