### PR TITLE
fix(cli): make co-author trailer opt-in

### DIFF
--- a/v3/@claude-flow/shared/src/hooks/safety/git-commit.ts
+++ b/v3/@claude-flow/shared/src/hooks/safety/git-commit.ts
@@ -198,7 +198,7 @@ const DEFAULT_CONFIG: CommitConfig = {
   maxSubjectLength: 72,
   maxBodyLength: 100,
   requireConventional: true,
-  addCoAuthor: true,
+  addCoAuthor: false,
   coAuthor: DEFAULT_CO_AUTHOR,
   addClaudeReference: true,
 };


### PR DESCRIPTION
## Summary
Stops Claude Flow from silently appending a `Co-Authored-By` trailer to commit messages by default.

## Changes
- removed unconditional `Co-Authored-By` injection in `simple-commands/hooks.js`
- changed commit hook default config to `addCoAuthor: false`
- preserved explicit opt-in support for users who want co-author trailers

## Result
Commit messages are no longer modified with co-author attribution unless the user explicitly enables it.