### PR TITLE
fix(cli): use shell for Claude handoff on Windows

### DIFF
--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -278,8 +278,8 @@ async function spawnClaudeCodeInstance(
 
       // Spawn claude with properly ordered arguments
       const claudeProcess = childSpawn('claude', claudeArgs, {
-        stdio: 'inherit',
-        shell: false,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
       });
 
       // Set up SIGINT handler for session management


### PR DESCRIPTION
## Summary
Fixes Windows Claude handoff in `hive-mind spawn` by enabling shell resolution when spawning the Claude process.

## Problem
After recent updates, `hive-mind spawn ... --claude --auto-spawn` successfully created workers and generated the Hive Mind prompt, but failed to properly hand off into the Claude interactive session on Windows.

The issue was caused by spawning `claude` with `shell: false`, which can fail to resolve the executable correctly on Windows.

## Fix
Use shell resolution only on Windows when spawning the Claude process:

- keep Linux/macOS behavior unchanged
- enable Windows command resolution for `claude`
- preserve interactive stdio handoff

## Changes
- updated Claude process spawn in `v3/@claude-flow/cli/src/commands/hive-mind.ts`
- changed `shell: false` to `shell: process.platform === 'win32'`

## Result
`hive-mind spawn ... --claude --auto-spawn` now correctly hands off into the Claude interactive session on Windows.