### PR TITLE
docs: clarify Google CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Install Ruflo as a native Claude Code plugin -- adds skills, commands, agents, a
 <details>
 <summary><strong>All 32 plugins</strong></summary>
 
+Ruflo is CLI-agnostic and works with any compatible agent CLI, including Claude Code, OpenAI CLI, Gemini CLI, and Google CLI.
+
 #### Core & Orchestration
 
 | Plugin | What it does |


### PR DESCRIPTION
## Summary
Clarified that Ruflo is CLI-agnostic and works with Google CLI in addition to other supported agent CLIs.

## Changes
- Updated documentation to explicitly mention Google CLI support
- Clarified Ruflo works with any compatible agent CLI

Fixes #1690