### PR TITLE
docs: clarify Claude Code plugin install limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ User --> Ruflo (CLI/MCP) --> Router --> Swarm --> Agents --> Memory --> LLM Prov
 Install Ruflo as a native Claude Code plugin -- adds skills, commands, agents, and MCP tools directly:
 
 ```bash
-# Add the marketplace
-/plugin marketplace add ruvnet/ruflo
+> Note: Claude Code cannot install RuFlo plugins directly from the raw `ruvnet/ruflo` GitHub repository.
+> Claude Code expects either a valid published marketplace manifest or a local checkout of the repository.
 
-# Install core + any plugins you need
-/plugin install ruflo-core@ruflo
-/plugin install ruflo-swarm@ruflo
-/plugin install ruflo-autopilot@ruflo
-/plugin install ruflo-federation@ruflo
+```bash
+# Clone RuFlo locally
+git clone https://github.com/ruvnet/ruflo.git
+cd ruflo
+
+# Then install RuFlo plugins from a supported local or published source
+```
 ```
 
 <details>


### PR DESCRIPTION
Summary

Fixes misleading Claude Code plugin installation instructions in the README.

The previous docs suggested users could install RuFlo directly from:

/plugin marketplace add ruvnet/ruflo

That flow does not work reliably in Claude Code when using the raw GitHub repo directly, because Claude Code expects either:

a valid published marketplace manifest, or
a local checkout of the repository

This PR updates the Quick Start section to clarify that limitation and replaces the broken direct install flow with a safer local clone workflow.

Changes made
Removed misleading direct marketplace install instructions
Added clarification about Claude Code marketplace expectations
Replaced broken install flow with local clone guidance
Prevents users from following a setup path that currently fails in Claude Code
Why this fixes the issue

Users were following the documented install steps and hitting plugin installation failures because Claude Code could not resolve the marketplace manifest from the raw GitHub repo.

The updated docs now reflect the actual supported workflow and prevent false setup expectations.