### PR TITLE
fix(cli): verify Claude process before reporting launch success

### DIFF
--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -322,6 +322,13 @@ async function spawnClaudeCodeInstance(
         }
       });
 
+
+      if (!claudeProcess || claudeProcess.killed || claudeProcess.exitCode !== null) {
+      output.writeLine();
+      output.printError('Failed to launch Claude Code');
+      return { success: false, promptFile };
+      }
+
       output.writeln();
       output.printSuccess('Claude Code launched with Hive Mind coordination');
       output.printInfo('The Queen coordinator will orchestrate all worker agents');


### PR DESCRIPTION
## Summary
Fix false-positive success output in the Hive Mind Claude launch flow by verifying the Claude process is still alive before reporting launch success.

## Changes
- added a validation check for `claudeProcess` before printing launch success
- return failure when Claude process is missing, killed, or already exited
- prevent RuFlo from reporting successful Claude launch when the process failed immediately

## Why
Issue #1677 reports that RuFlo prints:

`Claude Code launched with Hive Mind coordination`

even when Claude does not actually launch successfully.

This change ensures success is only reported when the Claude process is still alive after spawn.