### PR TITLE
fix(statusline): detect Python test_*.py files in test counter

### DIFF
--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -554,8 +554,14 @@ function getTestStats() {
           countTestFiles(path.join(dir, entry.name), depth + 1);
         } else if (entry.isFile()) {
           const n = entry.name;
-          if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.')) {
-            testFiles++;
+          if (
+            n.includes('.test.') ||
+            n.includes('.spec.') ||
+            n.includes('_test.') ||
+            n.includes('_spec.') ||
+            (n.startsWith('test_') && n.endsWith('.py'))
+          )
+  testFiles++;
           }
         }
       }


### PR DESCRIPTION
## Summary
Update the statusline test counter to detect Python pytest files using the standard `test_*.py` naming convention.

## Changes
- updated test file detection in `getTestStats()` within `statusline-generator.ts`
- preserved existing JS/TS and Go/Rust test file matching
- added support for Python pytest-style `test_*.py` files

## Why
The statusline test counter previously detected:
- `*.test.*`
- `*.spec.*`
- `*_test.*`
- `*_spec.*`

But it missed Python’s standard pytest naming convention:
- `test_*.py`

This caused Python test files to be excluded from the statusline test count.