### PR TITLE
fix(statusline): prevent Claude Buddy render misalignment

### DIFF
--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -623,6 +623,31 @@ function progressBar(current, total) {
   return '[' + '\\u25CF'.repeat(filled) + '\\u25CB'.repeat(width - filled) + ']';
 }
 
+function isBuddyMode() {
+  const args = process.argv.join(' ').toLowerCase();
+  const envBuddy =
+    process.env.CLAUDE_BUDDY === '1' ||
+    process.env.CLAUDE_CODE_BUDDY === '1';
+
+  return args.includes('buddy') || envBuddy;
+}
+
+function generateBuddyStatusline() {
+  const git = getGitInfo();
+  const modelName = getModelFromStdin() || getModelName();
+
+  let line = c.bold + c.brightPurple + '▊ RuFlo ' + c.reset;
+  line += c.brightCyan + git.name + c.reset;
+
+  if (git.gitBranch) {
+    line += ' ' + c.dim + '|' + c.reset + ' ' + c.brightBlue + git.gitBranch + c.reset;
+  }
+
+  line += ' ' + c.dim + '|' + c.reset + ' ' + c.purple + modelName + c.reset;
+
+  return line;
+}
+
 function generateStatusline() {
   const git = getGitInfo();
   // Prefer model name from Claude Code stdin data, fallback to file-based detection
@@ -857,7 +882,7 @@ if (process.argv.includes('--json')) {
 } else if (process.argv.includes('--compact')) {
   console.log(JSON.stringify(generateJSON()));
 } else {
-  console.log(generateStatusline());
+  console.log(isBuddyMode() ? generateBuddyStatusline() : generateStatusline());
 }
 `;
 }


### PR DESCRIPTION
## Summary
Prevent Ruflo’s multiline statusline from interfering with Claude Buddy terminal rendering.

## Changes
- added Buddy mode detection to the generated statusline script
- introduced a compact single-line statusline for Buddy mode
- preserved the full multiline statusline for normal usage
- prevented ANSI / multiline redraw conflicts with Claude Buddy output

## Why
Claude Buddy output could appear visually shifted or misaligned because Ruflo rendered a multiline ANSI status block while Claude Buddy was also drawing its own structured terminal UI.

This change switches Ruflo to a compact single-line statusline during Buddy mode, preventing terminal rendering overlap.