### PR TITLE
fix(embeddings): add default export for Node ESM compatibility

### DIFF
--- a/v3/@claude-flow/embeddings/package.json
+++ b/v3/@claude-flow/embeddings/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.js",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Summary

Adds an explicit default export to @claude-flow/embeddings for better Node ESM compatibility on Windows.

Problem

The embeddings package only exposed import, which can cause stricter ESM resolution failures in some Windows environments when resolving package entrypoints.

Fix

Added an explicit default export in the package export map:

"default": "./dist/index.js"
Result

Improves package resolution compatibility across Windows/Node ESM environments while keeping the package entrypoint behavior unchanged.

Note

Full workspace build is currently blocked by an unrelated invalid JSON parse issue in v2/examples/data-pipeline/package.json. This change is isolated to v3/@claude-flow/embeddings/package.json.