### PR TITLE
Docs/agentdb rag flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,44 @@ Install Ruflo as a native Claude Code plugin -- adds skills, commands, agents, a
 | **ruflo-ddd** | Scaffold domain-driven design — contexts, aggregates, events |
 | **ruflo-sparc** | Guided 5-phase development methodology with quality gates |
 
+## AgentDB / RAG behavior
+
+### Automatic ingestion
+Agents automatically ingest project context into AgentDB through:
+
+- SessionStart hooks
+- auto-memory import
+- post-task trajectory capture
+
+This keeps AgentDB updated without requiring manual vector-store prompts.
+
+### Retrieval flow
+Agents retrieve context through:
+
+- `memory_search_unified`
+- AgentDB vector search
+- Claude memory + AgentDB merged retrieval
+
+This allows semantic retrieval before file search or edit decisions.
+
+### Tracking / audit
+RAG usage can be inspected through:
+
+- `memory_bridge_status`
+- statusline memory indicators
+- auto-memory hook status output
+
+This makes AgentDB usage visible and debuggable.
+
+### What gets stored
+AgentDB stores:
+
+- Claude auto-memory entries
+- task trajectories
+- routing decisions
+- learned execution patterns
+- ONNX vector embeddings for semantic search
+
 #### DevOps & Observability
 
 | Plugin | What it does |

--- a/v3/@claude-flow/embeddings/package.json
+++ b/v3/@claude-flow/embeddings/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.js",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/v3/README.md
+++ b/v3/README.md
@@ -46,6 +46,44 @@ V3 represents a complete architectural overhaul:
 | Flash Attention | 2.49x-7.47x | Validated |
 | AgentDB Search | 150x-12,500x | HNSW indexed |
 
+## AgentDB / RAG behavior
+
+### Automatic ingestion
+Agents automatically ingest project context into AgentDB through:
+
+- SessionStart hooks
+- auto-memory import
+- post-task trajectory capture
+
+This keeps AgentDB updated without requiring manual vector-store prompts.
+
+### Retrieval flow
+Agents retrieve context through:
+
+- `memory_search_unified`
+- AgentDB vector search
+- Claude memory + AgentDB merged retrieval
+
+This allows semantic retrieval before file search or edit decisions.
+
+### Tracking / audit
+RAG usage can be inspected through:
+
+- `memory_bridge_status`
+- statusline memory indicators
+- auto-memory hook status output
+
+This makes AgentDB usage visible and debuggable.
+
+### What gets stored
+AgentDB stores:
+
+- Claude auto-memory entries
+- task trajectories
+- routing decisions
+- learned execution patterns
+- ONNX vector embeddings for semantic search
+
 ## Architecture
 
 ### Architecture Decision Records (ADRs)


### PR DESCRIPTION
## Summary
Adds documentation explaining how agents ingest project context into AgentDB, how retrieval is performed, and how users can inspect RAG usage in current releases.

## Changes
- document automatic AgentDB ingestion flow
- document retrieval via `memory_search_unified`
- document RAG tracking and audit visibility
- document what AgentDB stores

## Why
The functionality already exists in current releases, but it is not easy to discover from the current docs. This improves clarity without changing runtime behavior.