### PR TITLE
docs: clarify multilingual embeddings roadmap status

### DIFF
--- a/docs/roadmap/multilingual-embeddings.md
+++ b/docs/roadmap/multilingual-embeddings.md
@@ -1,0 +1,55 @@
+# Multilingual Embedding Models
+
+## Current Status
+
+Multilingual embedding models are a roadmap feature proposal, not a fully configurable shipped capability.
+
+Issue #1272 tracks support for configurable multilingual embedding backends for semantic search and retrieval workflows.
+
+Current releases primarily use the default embedding pipeline and do not expose full multilingual model selection through user-facing configuration.
+
+---
+
+## What Exists Today
+
+Current embedding support includes:
+
+- default embedding pipeline for semantic search
+- vector indexing for retrieval workflows
+- ONNX-based embedding execution
+- support for general semantic similarity across common text inputs
+
+This provides baseline embedding functionality, but not dedicated multilingual model configuration.
+
+---
+
+## Proposed Scope
+
+The proposed multilingual embedding feature would add:
+
+- configurable multilingual embedding backends
+- model selection via config
+- improved multilingual semantic retrieval
+- better non-English search and matching
+- support for alternate embedding providers
+
+This would improve retrieval quality across multilingual corpora.
+
+---
+
+## Not Yet Implemented
+
+The following are not currently shipped as stable user-facing features:
+
+- configurable multilingual embedding model selection
+- dedicated multilingual embedding presets
+- per-project multilingual model routing
+- language-aware embedding backend switching
+
+These remain roadmap items.
+
+---
+
+## Roadmap Reference
+
+Tracked in Issue #1272 as a future embedding and retrieval enhancement.

--- a/docs/roadmap/v3.6-roadmap.md
+++ b/docs/roadmap/v3.6-roadmap.md
@@ -1,0 +1,47 @@
+# v3.6 Roadmap
+
+This document is the maintained source of truth for the v3.6 roadmap.
+
+Issue tracking remains in GitHub:
+- Roadmap tracker: #1386
+
+ADR references are maintained separately in:
+- `docs/adr/README.md`
+
+---
+
+## Bugs (Fix Next)
+
+- #1122 — HNSW ghost vectors after memory_delete
+- #1117 — runWithTimeout orphan processes
+- #1276 — Edge Functions failing (semantic-search 500, ai-chat 401)
+
+---
+
+## UX Improvements
+
+- #1153 — Statusbar too wide on narrow terminals
+- #1330 — Excessive token consumption
+
+---
+
+## Feature Requests
+
+- #1272 — Multilingual embedding models
+- #1315 — Awake agent: message hive-mind by session ID
+- #1328 — Web visualization board
+- #1309 — Verifiable action receipts (AAR)
+
+---
+
+## Architecture Proposals
+
+- #1347 — GNAP: git-native coordination layer
+- #1273 — Context Optimization Engine (95–98% compression)
+
+---
+
+## Internal ADR Tracking
+
+See ADR index:
+- `docs/adr/README.md`


### PR DESCRIPTION
## Summary
Adds documentation clarifying current multilingual embedding support and roadmap status.

## Changes
- add `docs/roadmap/multilingual-embeddings.md`
- document current embedding behavior
- clarify current support vs roadmap
- add README roadmap link

## Why
Issue #1272 describes multilingual embedding support as a roadmap feature.
This PR clarifies what exists today and what remains planned.