### PR TITLE
Docs/verifiable action receipts

### DIFF
--- a/docs/roadmap/multilingual-embeddings.md
+++ b/docs/roadmap/multilingual-embeddings.md
@@ -1,0 +1,55 @@
+# Multilingual Embedding Models
+
+## Current Status
+
+Multilingual embedding models are a roadmap feature proposal, not a fully configurable shipped capability.
+
+Issue #1272 tracks support for configurable multilingual embedding backends for semantic search and retrieval workflows.
+
+Current releases primarily use the default embedding pipeline and do not expose full multilingual model selection through user-facing configuration.
+
+---
+
+## What Exists Today
+
+Current embedding support includes:
+
+- default embedding pipeline for semantic search
+- vector indexing for retrieval workflows
+- ONNX-based embedding execution
+- support for general semantic similarity across common text inputs
+
+This provides baseline embedding functionality, but not dedicated multilingual model configuration.
+
+---
+
+## Proposed Scope
+
+The proposed multilingual embedding feature would add:
+
+- configurable multilingual embedding backends
+- model selection via config
+- improved multilingual semantic retrieval
+- better non-English search and matching
+- support for alternate embedding providers
+
+This would improve retrieval quality across multilingual corpora.
+
+---
+
+## Not Yet Implemented
+
+The following are not currently shipped as stable user-facing features:
+
+- configurable multilingual embedding model selection
+- dedicated multilingual embedding presets
+- per-project multilingual model routing
+- language-aware embedding backend switching
+
+These remain roadmap items.
+
+---
+
+## Roadmap Reference
+
+Tracked in Issue #1272 as a future embedding and retrieval enhancement.

--- a/docs/roadmap/v3.6-roadmap.md
+++ b/docs/roadmap/v3.6-roadmap.md
@@ -1,0 +1,47 @@
+# v3.6 Roadmap
+
+This document is the maintained source of truth for the v3.6 roadmap.
+
+Issue tracking remains in GitHub:
+- Roadmap tracker: #1386
+
+ADR references are maintained separately in:
+- `docs/adr/README.md`
+
+---
+
+## Bugs (Fix Next)
+
+- #1122 — HNSW ghost vectors after memory_delete
+- #1117 — runWithTimeout orphan processes
+- #1276 — Edge Functions failing (semantic-search 500, ai-chat 401)
+
+---
+
+## UX Improvements
+
+- #1153 — Statusbar too wide on narrow terminals
+- #1330 — Excessive token consumption
+
+---
+
+## Feature Requests
+
+- #1272 — Multilingual embedding models
+- #1315 — Awake agent: message hive-mind by session ID
+- #1328 — Web visualization board
+- #1309 — Verifiable action receipts (AAR)
+
+---
+
+## Architecture Proposals
+
+- #1347 — GNAP: git-native coordination layer
+- #1273 — Context Optimization Engine (95–98% compression)
+
+---
+
+## Internal ADR Tracking
+
+See ADR index:
+- `docs/adr/README.md`

--- a/docs/roadmap/verifiable-action-receipts.md
+++ b/docs/roadmap/verifiable-action-receipts.md
@@ -1,0 +1,59 @@
+# Verifiable Action Receipts (AAR)
+
+## Current Status
+
+Verifiable Action Receipts (AAR) are a proposed roadmap feature for auditability in multi-agent workflows.
+
+Issue #1309 proposes cryptographically verifiable receipts for agent-to-agent handoffs, task execution, and audit trails.
+
+This is not a currently shipped feature.
+
+Current releases do not generate signed or cryptographically verifiable action receipts.
+
+---
+
+## What Exists Today
+
+Current releases provide operational visibility through:
+
+- task logs
+- execution traces
+- CLI output
+- task history
+- agent status inspection
+
+These features support observability and debugging, but they do not provide cryptographic verification or tamper-evident audit guarantees.
+
+---
+
+## Proposed Scope
+
+The proposed AAR system would add:
+
+- signed receipts for agent actions
+- verifiable execution records
+- append-only audit chains
+- tamper-evident action logs
+- stronger compliance and audit guarantees
+
+This is intended for high-trust, enterprise, and compliance-sensitive workflows.
+
+---
+
+## Not Yet Implemented
+
+The following are not currently available in released builds:
+
+- signed action receipts
+- cryptographic task attestations
+- tamper-evident receipt chains
+- verifiable receipt export
+- compliance-grade action proofs
+
+These remain roadmap items.
+
+---
+
+## Roadmap Reference
+
+Tracked in Issue #1309 as a future audit and compliance enhancement.


### PR DESCRIPTION
## Summary
Adds documentation clarifying current support and roadmap status for Verifiable Action Receipts (AAR).

## Changes
- add `docs/roadmap/verifiable-action-receipts.md`
- document current observability behavior
- clarify roadmap scope vs current support
- add README roadmap link

## Why
Issue #1309 proposes verifiable action receipts for multi-agent auditability.
This PR clarifies what exists today and what remains planned.