### PR TITLE
docs: fix init/MCP drift surfaced in #1744 install study

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,11 @@ Install Ruflo as a native Claude Code plugin -- adds skills, commands, agents, a
 # One-line install
 curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/ruflo@main/scripts/install.sh | bash
 
-# Or via npx
-npx ruflo@latest init --wizard
+# Or via npx (interactive setup)
+npx ruflo@latest init wizard
+
+# Quick non-interactive init
+# npx ruflo@latest init
 
 # Or install globally
 npm install -g ruflo@latest
@@ -156,8 +159,8 @@ npm install -g ruflo@latest
 ### MCP Server
 
 ```bash
-# Add Ruflo as an MCP server in Claude Code
-claude mcp add ruflo -- npx -y @claude-flow/cli@latest
+# Add Ruflo as an MCP server in Claude Code (canonical form, matches USERGUIDE.md)
+claude mcp add ruflo -- npx ruflo@latest mcp start
 ```
 
 ---

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -153,7 +153,7 @@ curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/ruflo@main/scripts/install.sh | ba
 curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/ruflo@main/scripts/install.sh | bash -s -- --full
 
 # Or via npx
-npx ruflo@latest init --wizard
+npx ruflo@latest init wizard
 ```
 
 > **New to Ruflo?** You don't need to learn 310+ MCP tools or 26 CLI commands. After running `init`, just use Claude Code normally — the hooks system automatically routes tasks to the right agents, learns from successful patterns, and coordinates multi-agent work in the background. The advanced tools exist for fine-grained control when you need it.
@@ -2727,7 +2727,7 @@ Complete command-line interface for all Ruflo operations.
 
 ```bash
 # Initialize project with wizard
-npx ruflo@latest init --wizard
+npx ruflo@latest init wizard
 
 # Start daemon with background workers
 npx ruflo@latest daemon start
@@ -7281,7 +7281,7 @@ npx ruflo@latest config import --file my-config.json
 npx ruflo@latest config reset --key swarm
 
 # Initialize with wizard
-npx ruflo@latest init --wizard
+npx ruflo@latest init wizard
 ```
 
 </details>

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -7410,7 +7410,7 @@ npx ruflo@latest doctor --fix
 | V2 Command | V3 Command | Notes |
 |------------|------------|-------|
 | `ruflo start` | `ruflo mcp start` | MCP is explicit |
-| `ruflo init` | `ruflo init --wizard` | Interactive mode |
+| `ruflo init` | `ruflo init wizard` | Interactive setup (subcommand, not a flag) |
 | `ruflo spawn <type>` | `ruflo agent spawn -t <type>` | Nested under `agent` |
 | `ruflo swarm create` | `ruflo swarm init --topology mesh` | Explicit topology |
 | `--pattern-store path` | `--memory-backend agentdb` | Backend selection |


### PR DESCRIPTION
## Summary

Fixes two of the documentation papercuts logged in #1744:

### 1. `init --wizard` → `init wizard` (subcommand, not a flag)

Per `v3/@claude-flow/cli/src/commands/init.ts:445-447`:

```ts
const wizardCommand: Command = {
  name: 'wizard',
  description: 'Interactive setup wizard for comprehensive configuration',
  ...
};
// ...
subcommands: [wizardCommand, checkCommand, skillsCommand, hooksCommand, upgradeCommand],
```

`wizard` is registered as a subcommand under `init`, and `init --help` shows the canonical form as `claude-flow init wizard`. The flag form may parse but the docs were wrong about it being canonical.

Updated 5 occurrences across `README.md` (1) and `docs/USERGUIDE.md` (4).

### 2. README MCP add command — drop legacy package name

Before:
```bash
claude mcp add ruflo -- npx -y @claude-flow/cli@latest
```

After (matches `USERGUIDE.md` and `ruflo mcp --help`):
```bash
claude mcp add ruflo -- npx ruflo@latest mcp start
```

Both forms still work, but having two different commands across two docs was a friction point #1744 specifically called out.

## Test plan

- [x] `grep "init --wizard"` finds 0 occurrences in README and USERGUIDE
- [x] `grep "init wizard"` finds 5 (all the ones that used to say `--wizard`)
- [x] README MCP add line uses `npx ruflo@latest mcp start`
- [ ] CI green

No CLI behavior changes. Pure doc consistency. Closes part of #1744.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)