### PR TITLE
fix(agents): coder agents now read docs/adr/*.md alongside docs/SPEC.md (#1749)

### DIFF
--- a/.claude/agents/core/coder.md
+++ b/.claude/agents/core/coder.md
@@ -7,6 +7,17 @@ description: Implementation specialist for writing clean, efficient code
 
 You are a senior software engineer specialized in writing clean, maintainable, and efficient code following best practices and design patterns.
 
+## Authoritative project documents — read before implementing
+
+Before writing code that affects architecture, scope, or behavior, read **both**:
+
+1. **`docs/SPEC.md`** (and any sibling files under `docs/`) — describes **what** the system should do. Functional requirements, scope, acceptance criteria.
+2. **`docs/adr/*.md`** (Architecture Decision Records) — describes **how** decisions have been made. Tech stack choices, framework selection, auth strategy, integration patterns. Treat these as **binding** unless explicitly superseded by a newer ADR with `status: Accepted`.
+
+If both exist and conflict, the ADR wins on architectural decisions; SPEC wins on requirements scope. If an ADR contradicts your planned implementation, surface the conflict and propose either following the ADR or drafting a successor ADR — do not silently diverge.
+
+When neither file exists (greenfield work), you can proceed without — but if a sibling Architect agent generated ADRs in this session, those ADRs are authoritative for your work even before they land in `docs/adr/`. In multi-agent parallel development, ADRs are the contract that prevents drift between agents working on different bounded contexts.
+
 ## Core Responsibilities
 
 1. **Code Implementation**: Write production-quality code that meets requirements

--- a/.claude/agents/templates/implementer-sparc-coder.md
+++ b/.claude/agents/templates/implementer-sparc-coder.md
@@ -8,6 +8,18 @@ description: Transform specifications into working code with TDD practices
 ## Purpose
 This agent specializes in the implementation phases of SPARC methodology, focusing on transforming specifications and designs into high-quality, tested code.
 
+## Authoritative inputs
+
+The Refinement and Completion phases consume work from earlier SPARC phases. Read **all** of the following before implementing:
+
+1. **`docs/SPEC.md`** — Specification phase output (what to build)
+2. **`docs/pseudocode/*.md`** if present — Pseudocode phase output (algorithm shape)
+3. **`docs/adr/*.md`** — Architecture Decision Records from the Architecture phase (tech stack, framework choices, auth strategy, deployment shape). **Treat ADRs as binding** unless explicitly superseded by a newer `status: Accepted` ADR.
+
+ADRs describe **how** decisions were made; SPEC describes **what** the system does. In multi-agent parallel implementation, ADRs are the cross-agent contract — backend coders, frontend coders, and testers must all read the same ADRs or the bounded contexts will drift apart.
+
+If your planned implementation contradicts an ADR, surface the conflict and propose either following the ADR or drafting a successor — do not silently diverge.
+
 ## Core Implementation Principles
 
 ### 1. Test-Driven Development (TDD)

--- a/plugins/ruflo-core/agents/coder.md
+++ b/plugins/ruflo-core/agents/coder.md
@@ -5,6 +5,15 @@ model: sonnet
 ---
 You are a code implementation specialist working within a Ruflo-coordinated swarm. Write clean, typed, tested code. Prefer editing existing files. Follow TDD London School. Use `npx @claude-flow/cli@latest hooks pre-edit --file "$FILE"` before editing and `npx @claude-flow/cli@latest hooks post-edit --file "$FILE" --success true` after.
 
+## Authoritative project documents
+
+Before implementing anything that affects architecture or scope, read **both**:
+
+- **`docs/SPEC.md`** — what the system does (requirements, scope)
+- **`docs/adr/*.md`** — how decisions were made (tech stack, framework, auth, integration). Treat ADRs as **binding** unless superseded by a newer `status: Accepted` ADR.
+
+In a multi-agent swarm, ADRs are the cross-agent contract that prevents bounded-context drift. If your plan contradicts an ADR, surface the conflict — do not silently diverge.
+
 Guidelines:
 - Read files before editing. Never create unnecessary files.
 - Keep functions under 20 lines. Use typed interfaces for all public APIs.


### PR DESCRIPTION
## Summary

Fixes #1749 — coder agents (backend, frontend, generic) consult only `docs/SPEC.md` and ignore ADRs under `docs/adr/`, causing architectural drift in spec-driven multi-agent workflows.

### Three agent definitions updated

| File | Role |
|---|---|
| `.claude/agents/core/coder.md` | Task-tool default `coder` subagent — used when an agent calls `Task({subagent_type: "coder", ...})` |
| `.claude/agents/templates/implementer-sparc-coder.md` | SPARC Refinement / Completion phase coder template |
| `plugins/ruflo-core/agents/coder.md` | Plugin form invoked when ruflo-core is loaded |

Each now has an **"Authoritative project documents"** section with these contract clauses:

1. **Read BOTH `docs/SPEC.md` AND `docs/adr/*.md`** before architecture/scope-affecting work
2. **SPEC describes WHAT, ADRs describe HOW.** ADRs are *binding* unless superseded by a newer `status: Accepted` ADR
3. **Multi-agent case explicit:** ADRs are the cross-agent contract that prevents bounded-context drift between parallel backend / frontend / tester implementations
4. **Conflict path:** on disagreement with an ADR, surface it (propose either following the ADR or drafting a successor) — do not silently diverge

### Why this matters (per the issue's repro)

The reporter's prompt was:
> Build a full-stack application using a spec-driven development approach with a Python backend and React frontend. Define architecture using ADRs and structure the system with DDD bounded contexts to avoid implementation drift.

When the architect generates ADRs (e.g. "Auth: Auth0 OAuth 2.0", "DB: PostgreSQL with row-level security") and then backend / frontend coders are spawned without reading those ADRs, the resulting code can pick competing technologies — exactly the drift the prompt was trying to prevent.

This change makes the ADR contract explicit in every coder agent's prompt, so spawned agents read both documents.

## Test plan

- [x] All 3 files contain `docs/adr` reference
- [x] All 3 files contain `binding` or `authoritative` framing
- [x] No code-behavior changes — pure prompt content
- [ ] User verification — spawn a coder via Task tool with this branch loaded; confirm it reads `docs/adr/*.md` before implementing

## Out of scope

- The Architect agent's prompt (it already generates ADRs correctly per the issue — no fix needed there)
- Specialized coders (`backend-dev`, `mobile-dev`, `ml-developer`) — those use their own templates; could follow up if reports come in
- A smoke check enforcing ADR-mention in every coder template — could land in a separate PR

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)