### PR TITLE
fix(plugins): hooks per-plugin layout — ruflo-core install loads hooks (#1748 Issue 1)

### DIFF
--- a/plugins/ruflo-core/README.md
+++ b/plugins/ruflo-core/README.md
@@ -15,7 +15,7 @@ Foundation plugin. Registers the `ruflo` MCP server (300+ tools), provides three
 - **CLI Commands**: 26 commands with 140+ subcommands for agent orchestration
 - **3-Tier Model Routing**: Agent Booster (WASM), Haiku, Sonnet/Opus with automatic cost optimization
 - **Session Management**: Persistent sessions with cross-conversation learning
-- **Hooks System**: 17 hooks + 12 background workers for self-learning automation
+- **Hooks**: PreToolUse / PostToolUse / PreCompact / Stop wired to claude-flow's auto-routing + learning loop. Defined at `plugins/ruflo-core/hooks/hooks.json` so the per-plugin loader picks them up on `/plugin install ruflo-core@ruflo` (per-plugin layout — fixes #1748 Issue 1; the marketplace-root copy at `.claude-plugin/hooks/hooks.json` is preserved for `claude --plugin-dir <repo-root>` users).
 
 ## Configuration
 

--- a/plugins/ruflo-core/hooks/hooks.json
+++ b/plugins/ruflo-core/hooks/hooks.json
@@ -1,0 +1,74 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | npx claude-flow@alpha hooks modify-bash"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | npx claude-flow@alpha hooks modify-file"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | jq -r '.tool_input.command // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-command --command '{}' --track-metrics true --store-results true"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-edit --file '{}' --format true --update-memory true"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "manual",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/bash -c 'INPUT=$(cat); CUSTOM=$(echo \"$INPUT\" | jq -r \".custom_instructions // \\\"\\\"\"); echo \"🔄 PreCompact Guidance:\"; echo \"📋 IMPORTANT: Review CLAUDE.md in project root for:\"; echo \"   • 54 available agents and concurrent usage patterns\"; echo \"   • Swarm coordination strategies (hierarchical, mesh, adaptive)\"; echo \"   • SPARC methodology workflows with batchtools optimization\"; echo \"   • Critical concurrent execution rules (GOLDEN RULE: 1 MESSAGE = ALL OPERATIONS)\"; if [ -n \"$CUSTOM\" ]; then echo \"🎯 Custom compact instructions: $CUSTOM\"; fi; echo \"✅ Ready for compact operation\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/bash -c 'echo \"🔄 Auto-Compact Guidance (Context Window Full):\"; echo \"📋 CRITICAL: Before compacting, ensure you understand:\"; echo \"   • All 54 agents available in .claude/agents/ directory\"; echo \"   • Concurrent execution patterns from CLAUDE.md\"; echo \"   • Batchtools optimization for 300% performance gains\"; echo \"   • Swarm coordination strategies for complex tasks\"; echo \"⚡ Apply GOLDEN RULE: Always batch operations in single messages\"; echo \"✅ Auto-compact proceeding with full agent context\"'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow@alpha hooks session-end --generate-summary true --persist-state true --export-metrics true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes the most load-bearing finding in #1748 — the methodical eval from the Liberation of Bajor team. With `/plugin install ruflo-core@ruflo`, Claude Code's plugin loader looks for hooks at `<plugin>/hooks/hooks.json` (per-plugin) but ruflo's hooks lived only at marketplace root (`.claude-plugin/hooks/hooks.json`). Result: **zero hooks loaded** for plugin-install users.

The team cross-checked against `hookify` (a working positive control) — its hooks live inside the plugin directory and load correctly. We weren't matching that layout.

## Why this matters more than anything else in #1748

> **From #1748:** Your README's value proposition is "After init, just use Claude Code normally — the hooks system automatically routes tasks, learns from successful patterns, and coordinates agents in the background." The hooks ARE the value. Without them, Ruflo is a pile of MCP tools the model demonstrably doesn't call.

Across four independent experiments (slices 282, 284, 285, 289), the team observed **zero Ruflo MCP tool invocations**. With hooks not loading, the auto-routing pitch is a no-op for plugin-install users.

## Fix

Copy the existing `.claude-plugin/hooks/hooks.json` to `plugins/ruflo-core/hooks/hooks.json` — same content, second location. Both layouts are now functional:

| Install path | Hooks loaded from |
|---|---|
| `/plugin install ruflo-core@ruflo` | `plugins/ruflo-core/hooks/hooks.json` ← **new** |
| `claude --plugin-dir <repo-root>` | `.claude-plugin/hooks/hooks.json` ← preserved |
| `npx ruflo init` (full CLI install) | written to `.claude/settings.json` by `init.ts` |

Hook definitions (PreToolUse, PostToolUse, PreCompact, Stop) are unchanged.

## Validation

```bash
# Both files are byte-identical (single source of truth, dual discovery)
sha256sum .claude-plugin/hooks/hooks.json plugins/ruflo-core/hooks/hooks.json
# → f53a98d0...d270a51 (same hash)

# Per-plugin file parses, has the 4 documented hook types
node -e "const j=JSON.parse(require('fs').readFileSync('plugins/ruflo-core/hooks/hooks.json'));
         console.log(Object.keys(j.hooks).length, Object.keys(j.hooks).join(','))"
# → 4 PreToolUse,PostToolUse,PreCompact,Stop
```

## Test plan

- [x] File created at `plugins/ruflo-core/hooks/hooks.json` with byte-identical content
- [x] JSON parses; 4 hook types present
- [x] Marketplace-root file unchanged (no regression for `claude --plugin-dir` users)
- [ ] **External validation** — would welcome a re-run from the #1748 reporters: install with `/plugin install ruflo-core@ruflo`, confirm hooks now load via debug log

## Out of scope (deferred to follow-up PRs)

- **#1748 Issue 2** — `ruflo hive-mind spawn --claude` doesn't pass `--mcp-config` to the spawned worker, so worker tool registry is empty for `mcp__ruflo__*`. Needs CLI source change.
- **#1748 Issue 3** — Package size (1.8 MB / 999 files) racing the 30s MCP-startup timeout. Needs both a footprint reduction AND README documentation of the pre-warm mitigation.
- **#1748 Issue 4** — 237 MCP tool descriptions don't differentiate from native tools; model picks `Read`/`Grep`/`Edit` every time. Needs description sharpening + a "lite" default surface.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)