### PR TITLE
fix(hive-mind): spawned --claude worker now gets --mcp-config (#1748 Issue 2) (v3.6.29)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.6.28",
+  "version": "3.6.29",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.6.28",
+  "version": "3.6.29",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.6.28",
+  "version": "3.6.29",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -12,6 +12,7 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { spawn as childSpawn, execSync } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import { join } from 'path';
 
 // Worker type definitions for prompt generation
@@ -248,6 +249,36 @@ async function spawnClaudeCodeInstance(
     if (claudeAvailable && !dryRun) {
       // Build arguments - flags first, then prompt
       const claudeArgs: string[] = [];
+
+      // #1748 Issue 2 — pass --mcp-config so the spawned worker actually has
+      // mcp__ruflo__* tools registered. Before this, the coordination prompt
+      // referenced tools the worker didn't know about and exited silently.
+      // Resolution order:
+      //   1. explicit --mcp-config <path> flag passed by the caller
+      //   2. ./.mcp.json in cwd (project-local Ruflo MCP config)
+      //   3. ~/.claude.json or ~/.claude/mcp.json (user-global)
+      // If none found, we still spawn but warn — that's the pre-fix behavior
+      // and the user's debug log will surface the missing tools.
+      const explicitMcpConfig = flags['mcp-config'] as string | undefined;
+      let mcpConfigPath: string | undefined = explicitMcpConfig;
+      if (!mcpConfigPath) {
+        const candidates = [
+          join(process.cwd(), '.mcp.json'),
+          join(process.env.HOME || process.env.USERPROFILE || '', '.claude.json'),
+          join(process.env.HOME || process.env.USERPROFILE || '', '.claude', 'mcp.json'),
+        ];
+        for (const c of candidates) {
+          try {
+            if (c && existsSync(c)) { mcpConfigPath = c; break; }
+          } catch { /* continue */ }
+        }
+      }
+      if (mcpConfigPath) {
+        claudeArgs.push('--mcp-config', mcpConfigPath);
+        output.printInfo(`Spawned worker MCP config: ${mcpConfigPath}`);
+      } else {
+        output.printWarning('No .mcp.json or ~/.claude.json found — spawned worker will not have mcp__ruflo__* tools (#1748 Issue 2). Pass --mcp-config <path> or run "ruflo init" to generate one.');
+      }
 
       // Check for non-interactive mode
       const isNonInteractive = flags['non-interactive'] || flags.nonInteractive;
@@ -573,6 +604,11 @@ const spawnCommand: Command = {
       description: 'Run Claude Code in non-interactive mode',
       type: 'boolean',
       default: false
+    },
+    {
+      name: 'mcp-config',
+      description: 'Path to .mcp.json for the spawned worker (auto-detects ./.mcp.json or ~/.claude.json if omitted) — fixes #1748 Issue 2',
+      type: 'string'
     }
   ],
   examples: [


### PR DESCRIPTION
Closes #1748 Issue 2. `hive-mind spawn --claude` now passes `--mcp-config` to the spawned worker. Published as 3.6.29.

Resolution order: explicit flag → ./.mcp.json → ~/.claude.json → ~/.claude/mcp.json. Explicit warning if none found (was silent before).

Status of #1748: Issue 1 ✅ (PR #1754), Issue 2 ✅ (this PR + 3.6.29), Issue 3 ⏳, Issue 4 ⏳.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)