### PR TITLE
fix(mcp): sharpen high-overlap tool descriptions (#1748 Issue 4 — first batch) (v3.6.30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.6.29",
+  "version": "3.6.30",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.6.29",
+  "version": "3.6.30",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.6.29",
+  "version": "3.6.30",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -180,7 +180,7 @@ async function determineAgentModel(
 export const agentTools: MCPTool[] = [
   {
     name: 'agent_spawn',
-    description: 'Spawn a new agent with intelligent model selection',
+    description: 'Spawn a Ruflo-tracked agent with cost attribution + memory persistence + swarm coordination. Use when native Task tool is wrong because you need (a) cost tracking per agent in the cost-tracking namespace, (b) cross-session learning via the patterns namespace, or (c) coordination with other agents in a swarm topology (hierarchical / mesh / consensus). For one-shot subtasks with no learning loop, native Task is fine. Pair with hooks_route to pick the right model first.',
     category: 'agent',
     inputSchema: {
       type: 'object',

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -882,7 +882,7 @@ export const hooksPostCommand: MCPTool = {
 
 export const hooksRoute: MCPTool = {
   name: 'hooks_route',
-  description: 'Route task to optimal agent using semantic similarity (native HNSW or pure JS)',
+  description: 'Get a 3-tier routing recommendation for a task: Tier 1 (Agent Booster, 0ms / $0 — for var-to-const, add-types, etc.), Tier 2 (Haiku — simple), Tier 3 (Sonnet/Opus — complex). Use this BEFORE spawning an agent to avoid sending simple transforms to Sonnet. Native tools have no equivalent — Claude Code does not introspect its own model-selection cost. Returns the recommended model + a `[AGENT_BOOSTER_AVAILABLE]` literal when the WASM bypass applies.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -192,7 +192,7 @@ async function ensureInitialized(): Promise<void> {
 export const memoryTools: MCPTool[] = [
   {
     name: 'memory_store',
-    description: 'Store a value in memory with vector embedding for semantic search (sql.js + HNSW backend). Use upsert=true to update existing keys.',
+    description: 'Persistent key-value store with vector embedding — survives across sessions and is searchable by meaning, not just by file path. Use when native Write is wrong because the data is not a file (e.g. a learned pattern, a decision, a budget config) AND you need to recall it later by semantic query, not by path. Defaults to namespace="default"; pass --upsert=true to update an existing key.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -272,7 +272,7 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_retrieve',
-    description: 'Retrieve a value from memory by key',
+    description: 'Read back a value previously stored via memory_store, by exact (namespace, key) — lossless, includes metadata. Use when native Read is wrong because the value is not a file (it lives in the .swarm/memory.db SQLite store) AND you know the exact key. For semantic lookup by meaning, use memory_search.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -336,7 +336,7 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_search',
-    description: 'Semantic vector search using HNSW index (150x-12,500x faster than keyword search)',
+    description: 'Find stored memories by meaning (vector similarity), not by literal text — finds "JWT auth pattern" when you query "token-based login flow". Use when native Grep is wrong because Grep matches characters and you need to find conceptually-related entries across past sessions. Backed by HNSW index over ONNX embeddings; returns top-k with similarity scores. Pair with smart=true for query expansion + MMR diversity.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -462,7 +462,7 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_delete',
-    description: 'Delete a memory entry by key',
+    description: 'Remove a stored memory entry by exact (namespace, key). Use when a previously stored decision is invalidated or contains stale data. No native equivalent — Write to a file does not affect the .swarm/memory.db SQLite store.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -505,7 +505,7 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_list',
-    description: 'List memory entries with optional filtering',
+    description: 'Enumerate stored memory entries (optionally filtered by namespace/tags) without semantic search. Use when native Glob is wrong because the entries are not files (they live in .swarm/memory.db). For inspection / audit / "what is in my memory" — pair with memory_search for retrieval-by-meaning.',
     category: 'memory',
     inputSchema: {
       type: 'object',


### PR DESCRIPTION
Closes the first batch of #1748 Issue 4. 7 of 237 tool descriptions sharpened — the highest-overlap ones where the model has a native equivalent and the differentiation was unclear.

**Memory family (competes with Read/Write/Grep/Glob):**
- memory_store/retrieve/search/delete/list — each now leads with 'Use when native X is wrong because Y'

**Hooks family:**
- hooks_route — '3-tier routing BEFORE spawning' framing; explicit 'Native tools have no equivalent — Claude Code does not introspect its own model-selection cost'

**Agent family:**
- agent_spawn — 'Use when native Task is wrong because you need cost tracking / cross-session learning / swarm coordination'

**Published as 3.6.30:** `npx @claude-flow/cli@3.6.30`, `claude-flow@3.6.30`, `ruflo@3.6.30` — all dist-tags consistent.

**Status of #1748:**
- ✅ Issue 1 (per-plugin hooks layout) — PR #1754
- ✅ Issue 2 (spawn --mcp-config) — PR #1755 / 3.6.29
- ⏳ Issue 3 (package size / 30s timeout) — follow-up PR
- 🔁 Issue 4 — **first batch sharpened (this PR / 3.6.30)**; pattern established; further families land incrementally

The smoke test: re-run #1748's G3 cross-file rename against 3.6.30 — does the model now invoke memory_search, or still fall through to Grep? That measurement is the validation we'd love to see from the reporters.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)