### PR TITLE
fix(init): use 'ruflo' as MCP server key instead of legacy 'claude-flow'

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -221,7 +221,7 @@ async function checkMcpServers(): Promise<HealthCheck> {
     }
   }
 
-  return { name: 'MCP Servers', status: 'warn', message: 'No MCP config found', fix: 'claude mcp add claude-flow npx @claude-flow/cli@v3alpha mcp start' };
+  return { name: 'MCP Servers', status: 'warn', message: 'No MCP config found', fix: 'claude mcp add ruflo -- npx -y ruflo@latest mcp start' };
 }
 
 // Check disk space (async with proper env inheritance)

--- a/v3/@claude-flow/cli/src/commands/swarm.ts
+++ b/v3/@claude-flow/cli/src/commands/swarm.ts
@@ -511,7 +511,7 @@ const startCommand: Command = {
     } catch (err) {
       spinner.fail('MCP swarm_init failed — swarm metadata saved locally only');
       output.writeln(output.dim(`  Error: ${err instanceof Error ? err.message : String(err)}`));
-      output.writeln(output.dim('  The MCP server may not be running. Start it with: claude mcp add claude-flow npx claude-flow@v3alpha mcp start'));
+      output.writeln(output.dim('  The MCP server may not be running. Start it with: claude mcp add ruflo -- npx -y ruflo@latest mcp start'));
     }
 
     // Persist swarm state to disk so `swarm status` can read it

--- a/v3/@claude-flow/cli/src/init/mcp-generator.ts
+++ b/v3/@claude-flow/cli/src/init/mcp-generator.ts
@@ -52,9 +52,11 @@ export function generateMCPConfig(options: InitOptions): object {
     npm_config_update_notifier: 'false',
   };
 
-  // Claude Flow MCP server (core) — uses ruflo wrapper for portable npm-resolved invocation
+  // Ruflo MCP server (core) — formerly registered as 'claude-flow' before the package rename.
+  // The `claude-flow` key was retained after the rename, which caused duplicate MCP registrations
+  // for users who also added the server under the new name (see issue #1779).
   if (config.claudeFlow) {
-    mcpServers['claude-flow'] = createMCPServerEntry(
+    mcpServers['ruflo'] = createMCPServerEntry(
       ['ruflo@latest', 'mcp', 'start'],
       {
         ...npmEnv,
@@ -106,7 +108,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
 
   if (isWindows()) {
     if (config.claudeFlow) {
-      commands.push('claude mcp add claude-flow -- cmd /c npx -y ruflo@latest mcp start');
+      commands.push('claude mcp add ruflo -- cmd /c npx -y ruflo@latest mcp start');
     }
     if (config.ruvSwarm) {
       commands.push('claude mcp add ruv-swarm -- cmd /c npx -y ruv-swarm mcp start');
@@ -116,7 +118,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
     }
   } else {
     if (config.claudeFlow) {
-      commands.push("claude mcp add claude-flow -- npx -y ruflo@latest mcp start");
+      commands.push("claude mcp add ruflo -- npx -y ruflo@latest mcp start");
     }
     if (config.ruvSwarm) {
       commands.push("claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start");


### PR DESCRIPTION
## Summary

- `ruflo init` now writes `.mcp.json` with `mcpServers.ruflo` instead of `mcpServers['claude-flow']`
- Updated the printed `claude mcp add ...` instructions in `mcp-generator`, `doctor`, and `swarm` so they register the server under the new name (consistent with `scripts/install.sh:333`)

Fixes #1779.

## Why

The init generator was hardcoding the **legacy** package name as the `.mcp.json` top-level key, even though the binary it points to is the renamed `ruflo`. When a user also registered the server under the new name — for example via `claude mcp add ruflo ...`, which is exactly what `scripts/install.sh` does, or via a separate project-level `.mcp.json` — Claude Code happily loaded both files and registered **the same MCP server twice**, exposing ~250 duplicate tools under two prefixes (`mcp__claude-flow__*` and `mcp__ruflo__*`).

This was particularly easy to hit by accident: any user who ran `ruflo init` from `\$HOME` ended up with `~/.mcp.json` containing the legacy key, which Claude Code picks up as a parent-project config from anywhere under `\$HOME`. `claude mcp list` then reports both as `Project config (shared via .mcp.json)` and the duplicate becomes globally active.

## Changes

| File | Change |
|---|---|
| `v3/@claude-flow/cli/src/init/mcp-generator.ts` | `mcpServers['claude-flow']` → `mcpServers['ruflo']`; updated printed `claude mcp add ...` strings (Unix + Windows) |
| `v3/@claude-flow/cli/src/commands/doctor.ts` | Updated MCP-missing fix hint to use `ruflo` as the registration name |
| `v3/@claude-flow/cli/src/commands/swarm.ts` | Updated 'MCP server may not be running' hint to use `ruflo` |

Diff is +8 / −6 across 3 files.

## Backward compatibility

- Existing `.mcp.json` files that already contain `mcpServers['claude-flow']` are **not modified** — they continue to work as before.
- Only fresh `init` runs (or `init --force`) write the new key.
- Users who currently have **both** registrations (the duplicate this PR is preventing) can clean up by either:
  - removing `mcpServers['claude-flow']` from their `.mcp.json`, or
  - running `claude mcp remove claude-flow -s project`.

## Out of scope (follow-ups)

These docs / templates still reference the old name and should be updated separately to avoid bloating this PR:

- `CLAUDE.md` (root), `AGENTS.md`
- `v3/@claude-flow/codex/**` (Codex CLI integration)
- `v3/@claude-flow/cli/src/init/claudemd-generator.ts` (the CLAUDE.md template the init writes)
- `.claude/skills/swarm-advanced/SKILL.md`, `.agents/skills/swarm-advanced/SKILL.md`
- `.claude-plugin/README.md`, `.claude-plugin/docs/QUICKSTART.md`
- `archive/v2/**` — legacy, probably not worth touching

I'm happy to send a follow-up PR for the docs sweep if useful — kept this PR scoped to behavioural code so it's easy to review.

## Test plan

- [ ] CI passes
- [ ] `ruflo init` in a clean directory writes `.mcp.json` with key `ruflo` (was: `claude-flow`)
- [ ] `ruflo init --force` overwrites a previous `claude-flow`-keyed file with the new key
- [ ] `ruflo doctor` prints `claude mcp add ruflo -- ...` (was: `... claude-flow ...`) when no MCP config is found
- [ ] `ruflo swarm start` failure path prints `claude mcp add ruflo -- ...` (was: `... claude-flow ...`)
- [ ] `claude mcp list` after a fresh init shows only one `ruflo` entry, no `claude-flow` duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)