### PR TITLE
feat(cli): support custom Anthropic-compatible endpoints via ANTHROPIC_BASE_URL

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
@@ -91,6 +91,12 @@ export interface AnthropicCallResult {
  * RUFLO_PROVIDER=ollama is explicitly set. Response shape is normalized
  * to the Anthropic-flavored AnthropicCallResult so existing callers
  * don't need to know which provider answered.
+ *
+ * Custom Anthropic-compatible endpoints (e.g. Kimi-for-coding, AWS Bedrock
+ * proxies) are supported via ANTHROPIC_BASE_URL. When set, requests are
+ * routed to ${ANTHROPIC_BASE_URL}/v1/messages instead of the official
+ * api.anthropic.com endpoint, while keeping the same Messages API wire
+ * format and x-api-key auth scheme.
  */
 export async function callAnthropicMessages(input: AnthropicCallInput): Promise<AnthropicCallResult> {
   const explicitProvider = (process.env.RUFLO_PROVIDER || '').toLowerCase();
@@ -110,11 +116,12 @@ export async function callAnthropicMessages(input: AnthropicCallInput): Promise<
     };
   }
   const model = input.model || 'claude-3-5-sonnet-latest';
+  const baseUrl = (process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/+$/, '');
   const startedAt = Date.now();
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), input.timeoutMs || 60000);
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
+    const res = await fetch(`${baseUrl}/v1/messages`, {
       method: 'POST',
       headers: {
         'x-api-key': anthropicKey,
@@ -310,16 +317,6 @@ export interface AgentExecuteResult {
 }
 
 export async function executeAgentTask(input: AgentExecuteInput): Promise<AgentExecuteResult> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return {
-      success: false,
-      agentId: input.agentId,
-      error: 'ANTHROPIC_API_KEY not set in environment',
-      remediation: 'Set the env var and re-run. The key is read at call time.',
-    };
-  }
-
   const store = loadAgentStore();
   const agent = store.agents[input.agentId];
   if (!agent) return { success: false, agentId: input.agentId, error: 'Agent not found' };
@@ -337,84 +334,46 @@ export async function executeAgentTask(input: AgentExecuteInput): Promise<AgentE
 
   const startedAt = Date.now();
 
-  try {
-    const controller = new AbortController();
-    const timeoutMs = input.timeoutMs || 60000;
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const llmResult = await callAnthropicMessages({
+    prompt: input.prompt,
+    systemPrompt,
+    model: anthropicModel,
+    maxTokens: input.maxTokens,
+    temperature: input.temperature,
+    timeoutMs: input.timeoutMs,
+  });
 
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: anthropicModel,
-        max_tokens: input.maxTokens || 1024,
-        temperature: typeof input.temperature === 'number' ? input.temperature : 0.7,
-        system: systemPrompt,
-        messages: [{ role: 'user', content: input.prompt }],
-      }),
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
+  const durationMs = Date.now() - startedAt;
 
-    if (!res.ok) {
-      const errText = await res.text().catch(() => '<unreadable error body>');
-      agent.status = 'idle';
-      saveAgentStore(store);
-      return {
-        success: false,
-        agentId: input.agentId,
-        model: anthropicModel,
-        error: `Anthropic API error ${res.status}: ${errText.slice(0, 400)}`,
-      };
-    }
-
-    const data = await res.json() as {
-      id: string;
-      model: string;
-      content: Array<{ type: string; text?: string }>;
-      stop_reason: string;
-      usage: { input_tokens: number; output_tokens: number };
-    };
-
-    const textOut = data.content
-      .filter(c => c.type === 'text' && typeof c.text === 'string')
-      .map(c => c.text as string)
-      .join('');
-
-    const result: AgentExecuteResult = {
-      success: true,
-      agentId: input.agentId,
-      messageId: data.id,
-      model: data.model,
-      stopReason: data.stop_reason,
-      output: textOut,
-      usage: {
-        inputTokens: data.usage.input_tokens,
-        outputTokens: data.usage.output_tokens,
-        totalTokens: data.usage.input_tokens + data.usage.output_tokens,
-      },
-      durationMs: Date.now() - startedAt,
-    };
-
-    agent.status = 'idle';
-    agent.lastResult = result as unknown as Record<string, unknown>;
-    saveAgentStore(store);
-
-    return result;
-  } catch (err) {
+  if (!llmResult.success) {
     agent.status = 'idle';
     saveAgentStore(store);
-    const msg = err instanceof Error ? err.message : String(err);
     return {
       success: false,
       agentId: input.agentId,
       model: anthropicModel,
-      error: `agent_execute failed: ${msg}`,
-      durationMs: Date.now() - startedAt,
+      error: llmResult.error,
+      durationMs,
+      remediation: llmResult.error?.includes('No LLM provider configured')
+        ? 'Set ANTHROPIC_API_KEY (Tier-3), OLLAMA_API_KEY (Tier-2), or ANTHROPIC_BASE_URL with a compatible key.'
+        : undefined,
     };
   }
+
+  const result: AgentExecuteResult = {
+    success: true,
+    agentId: input.agentId,
+    messageId: llmResult.messageId,
+    model: llmResult.model,
+    stopReason: llmResult.stopReason,
+    output: llmResult.output,
+    usage: llmResult.usage,
+    durationMs,
+  };
+
+  agent.status = 'idle';
+  agent.lastResult = result as unknown as Record<string, unknown>;
+  saveAgentStore(store);
+
+  return result;
 }


### PR DESCRIPTION
## Summary

Enable `callAnthropicMessages()` and `executeAgentTask()` to route requests to any Anthropic Messages API-compatible endpoint by reading `ANTHROPIC_BASE_URL`. When the variable is unset, behavior is identical to today (official `api.anthropic.com`).

This unlocks Kimi-for-coding, AWS Bedrock Claude proxies, Google Vertex AI Claude gateways, and other enterprise-compatible endpoints without adding provider-specific branching logic.

**For existing users:** This change is purely additive. If you do not set `ANTHROPIC_BASE_URL`, everything behaves exactly as before — same endpoint, same auth, same defaults. No configuration changes are required.

## Motivation

Ruflo's README advertises "Multi-Provider" support (Claude, GPT, Gemini, Cohere, Ollama), but the agent execution core hard-codes `https://api.anthropic.com/v1/messages` in two places:

- `callAnthropicMessages()` — used by the WASM runtime and direct callers.
- `executeAgentTask()` — used by the MCP agent execute tool and workflow runtime.

This means users who have access to **Kimi-for-coding** (which speaks the Anthropic Messages API wire format on `api.kimi.com/coding/v1/messages`) cannot point Ruflo at it, even though the protocol is byte-for-byte compatible.

Issue #1725 tracks missing Ollama support; this PR addresses the broader "any Anthropic-compatible endpoint" gap while keeping the code provider-agnostic.

## Changes

### 1. `callAnthropicMessages()` — dynamic endpoint

- Reads `ANTHROPIC_BASE_URL` from the environment.
- Strips trailing slashes to avoid double-slash URLs.
- Defaults to `https://api.anthropic.com` when unset.
- Updated JSDoc to document the new capability.

```typescript
const baseUrl = (process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/+$/, '');
const res = await fetch(`${baseUrl}/v1/messages`, { ... });
```

### 2. `executeAgentTask()` — DRY + automatic endpoint support

Previously, `executeAgentTask()` duplicated the entire fetch logic verbatim. It:
- Only checked `ANTHROPIC_API_KEY` (ignoring `OLLAMA_API_KEY`).
- Hard-coded the Anthropic URL again.
- Could not benefit from future fixes in `callAnthropicMessages()`.

Now it **delegates to `callAnthropicMessages()`**, gaining:
- Custom endpoint support for free.
- Ollama fallback support for free (closing a latent gap).
- Single source of truth for the Messages API wire protocol.

Agent store state management (busy → idle, `lastResult`, `taskCount`) is preserved exactly as before.

### 3. Improved remediation hint

When no provider key is configured, the error now mentions all three options:

> Set `ANTHROPIC_API_KEY` (Tier-3), `OLLAMA_API_KEY` (Tier-2), or `ANTHROPIC_BASE_URL` with a compatible key.

## Backward Compatibility

| Scenario | Before | After |
|---|---|---|
| `ANTHROPIC_BASE_URL` unset | `api.anthropic.com` | `api.anthropic.com` — no change |
| `ANTHROPIC_API_KEY` + official Claude | Works | Works — no change |
| `OLLAMA_API_KEY` only (Ollama Cloud) | `callAnthropicMessages()` worked, `executeAgentTask()` failed | Both work — bugfix |
| `ANTHROPIC_BASE_URL=https://api.kimi.com/coding/` + `ANTHROPIC_API_KEY=sk-kimi-...` | Failed (403 / wrong endpoint) | Works — new feature |

## Test Plan

- Base-URL logic verified with edge-case script (trailing slashes, empty env).
- Integration test: mock server on `localhost:9999/v1/messages` responds with Anthropic shape; verify `callAnthropicMessages` routes there when `ANTHROPIC_BASE_URL` is set.
- Kimi-for-coding smoke test (requires live key).
- Ollama-only key smoke test (verifies `executeAgentTask` now supports Ollama).

## Related Issues

- #1725 — Ollama provider missing (this PR fixes the `executeAgentTask` part of that gap)
- #794 — EPIC: Multi-Provider Agent Execution Engine

## Environment Example

```bash
# Kimi-for-coding
export ANTHROPIC_BASE_URL=https://api.kimi.com/coding/
export ANTHROPIC_API_KEY=sk-kimi-xxxxxxxx

# AWS Bedrock Claude proxy (hypothetical)
export ANTHROPIC_BASE_URL=https://bedrock-proxy.internal.company
export ANTHROPIC_API_KEY=aws-secret-key
```

## Notes

- **Kimi-for-coding** is the specific Kimi product line that exposes an Anthropic Messages API-compatible surface. The standard Kimi consumer API (`api.moonshot.cn`) remains OpenAI-compatible and should continue to be used via the existing OpenAI provider path, not this one.
- No new dependencies.
- No breaking changes to public interfaces (`AnthropicCallInput`, `AgentExecuteInput`, `AgentExecuteResult` shapes are untouched).
