### PR TITLE
feat(agentdb): hierarchical + causal-edge + causal-node delete MCP tools (#1784)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/agentdb-delete-tools.test.ts
+++ b/v3/@claude-flow/cli/__tests__/agentdb-delete-tools.test.ts
@@ -1,0 +1,121 @@
+/**
+ * agentdb_*-delete MCP tool surface tests (#1784).
+ *
+ * Verifies the three new delete tools exist, validate inputs, and surface
+ * the right shapes for both supported (SQL fallback) and unsupported
+ * (native graph-node / HierarchicalMemory) backends.
+ *
+ * Behavioral integration tests (actually deleting rows from a live
+ * AgentDB) are out of scope here — they require a sqlite + agentdb
+ * instance which the cli's existing test scaffolding doesn't spin up
+ * for unit tests. The MCP-level shape tests below cover the contract
+ * the importer (plugins/ruflo-adr/scripts/import.mjs) depends on.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  agentdbHierarchicalDelete,
+  agentdbCausalEdgeDelete,
+  agentdbCausalNodeDelete,
+  agentdbTools,
+} from '../src/mcp-tools/agentdb-tools.js';
+
+describe('agentdb delete tools — surface (#1784)', () => {
+  it('exposes agentdb_hierarchical-delete in the tool registry', () => {
+    const names = agentdbTools.map((t) => t.name);
+    expect(names).toContain('agentdb_hierarchical-delete');
+  });
+
+  it('exposes agentdb_causal-edge-delete in the tool registry', () => {
+    const names = agentdbTools.map((t) => t.name);
+    expect(names).toContain('agentdb_causal-edge-delete');
+  });
+
+  it('exposes agentdb_causal-node-delete in the tool registry', () => {
+    const names = agentdbTools.map((t) => t.name);
+    expect(names).toContain('agentdb_causal-node-delete');
+  });
+
+  it('hierarchical-delete validates required key parameter', async () => {
+    const r = await agentdbHierarchicalDelete.handler({});
+    expect(r.success).toBe(false);
+    expect(r.deleted).toBe(false);
+    expect(typeof r.error).toBe('string');
+  });
+
+  it('hierarchical-delete rejects invalid tier', async () => {
+    const r = await agentdbHierarchicalDelete.handler({
+      key: 'test-key',
+      tier: 'not-a-real-tier',
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/tier|Invalid|disallowed/i);
+  });
+
+  it('hierarchical-delete accepts valid tiers', async () => {
+    for (const tier of ['working', 'episodic', 'semantic']) {
+      const r = await agentdbHierarchicalDelete.handler({ key: 'test-key', tier });
+      // Either it works (success) or it surfaces a controller status — both are fine
+      expect(r).toBeDefined();
+      expect(typeof r.success).toBe('boolean');
+    }
+  });
+
+  it('causal-edge-delete validates required sourceId / targetId', async () => {
+    const r1 = await agentdbCausalEdgeDelete.handler({ targetId: 'B' });
+    expect(r1.success).toBe(false);
+    const r2 = await agentdbCausalEdgeDelete.handler({ sourceId: 'A' });
+    expect(r2.success).toBe(false);
+  });
+
+  it('causal-edge-delete handles a missing edge cleanly (returns native-unsupported or not-found)', async () => {
+    const r = await agentdbCausalEdgeDelete.handler({
+      sourceId: 'nonexistent-source',
+      targetId: 'nonexistent-target',
+    });
+    expect(r).toBeDefined();
+    expect(typeof r.success).toBe('boolean');
+    // If the bridge isn't available at all, the tool surfaces an error;
+    // if it is, controller will be 'native-unsupported' or 'sql-error'.
+    if (r.controller) {
+      expect(['native-unsupported', 'bridge-fallback', 'sql-error', 'guard']).toContain(r.controller);
+    }
+  });
+
+  it('causal-node-delete validates required nodeId', async () => {
+    const r = await agentdbCausalNodeDelete.handler({});
+    expect(r.success).toBe(false);
+    expect(r.deletedNode).toBe(false);
+    expect(r.deletedEdges).toBe(0);
+  });
+
+  it('causal-node-delete returns the cascade contract shape', async () => {
+    const r = await agentdbCausalNodeDelete.handler({ nodeId: 'nonexistent-node' });
+    expect(r).toBeDefined();
+    expect(typeof r.success).toBe('boolean');
+    expect(typeof r.deletedNode).toBe('boolean');
+    expect(typeof r.deletedEdges).toBe('number');
+    // nodeId is echoed back when the bridge returns a real result. When the
+    // bridge isn't available (test env without AgentDB), the handler returns
+    // its no-bridge fallback shape without nodeId — both are valid.
+    if (r.nodeId !== undefined) {
+      expect(r.nodeId).toBe('nonexistent-node');
+    } else {
+      expect(r.error).toMatch(/bridge not available/i);
+    }
+  });
+
+  it('all three delete tools have an inputSchema with required fields', () => {
+    for (const tool of [agentdbHierarchicalDelete, agentdbCausalEdgeDelete, agentdbCausalNodeDelete]) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+      expect((tool.inputSchema.required as string[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all three delete tools return useful descriptions surfacing the native-backend caveat', () => {
+    expect(agentdbHierarchicalDelete.description).toMatch(/native|backend|delete/i);
+    expect(agentdbCausalEdgeDelete.description).toMatch(/native|backend|delete/i);
+    expect(agentdbCausalNodeDelete.description).toMatch(/cascade|delete/i);
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -119,7 +119,7 @@
     "@ruvector/ruvllm-wasm": "^2.0.2",
     "@ruvector/rvagent-wasm": "^0.1.0",
     "@ruvector/sona": "^0.1.5",
-    "agentdb": "^3.0.0-alpha.11",
+    "agentdb": "^3.0.0-alpha.13",
     "agentic-flow": "^3.0.0-alpha.1"
   },
   "publishConfig": {

--- a/v3/@claude-flow/cli/src/mcp-tools/agentdb-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agentdb-tools.ts
@@ -624,6 +624,100 @@ export const agentdbSemanticRoute: MCPTool = {
   },
 };
 
+// ===== #1784: Delete tools — symmetry for hierarchical-store + causal-edge =====
+
+export const agentdbHierarchicalDelete: MCPTool = {
+  name: 'agentdb_hierarchical-delete',
+  description: 'Delete a hierarchical-memory entry by key. Returns controller="native-unsupported" when the entry is in a backend without a public delete API.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      key: { type: 'string', description: 'Memory entry key to delete' },
+      tier: {
+        type: 'string',
+        description: 'Optional tier filter (working, episodic, semantic)',
+        enum: ['working', 'episodic', 'semantic'],
+      },
+    },
+    required: ['key'],
+  },
+  handler: async (params: Record<string, unknown>) => {
+    try {
+      const vKey = validateIdentifier(params.key, 'key');
+      if (!vKey.valid) return { success: false, deleted: false, error: vKey.error };
+      if (params.tier) { const vTier = validateIdentifier(params.tier, 'tier'); if (!vTier.valid) return { success: false, deleted: false, error: vTier.error }; }
+      const key = validateString(params.key, 'key', 1000);
+      if (!key) return { success: false, deleted: false, error: 'key is required (non-empty string, max 1KB)' };
+      const tier = validateString(params.tier, 'tier', 20);
+      if (tier && !['working', 'episodic', 'semantic'].includes(tier)) {
+        return { success: false, deleted: false, error: `Invalid tier: ${tier}. Must be working, episodic, or semantic` };
+      }
+      const bridge = await getBridge();
+      const result = await bridge.bridgeDeleteHierarchical({ key, tier: tier ?? undefined });
+      return result ?? { success: false, deleted: false, error: 'AgentDB bridge not available' };
+    } catch (error) {
+      return { success: false, deleted: false, error: sanitizeError(error) };
+    }
+  },
+};
+
+export const agentdbCausalEdgeDelete: MCPTool = {
+  name: 'agentdb_causal-edge-delete',
+  description: 'Delete a causal edge between two memory entries. Returns controller="native-unsupported" when the edge lives in graph-node native storage (no public delete API).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      sourceId: { type: 'string', description: 'Source entry ID' },
+      targetId: { type: 'string', description: 'Target entry ID' },
+      relation: { type: 'string', description: 'Optional relationship type filter' },
+    },
+    required: ['sourceId', 'targetId'],
+  },
+  handler: async (params: Record<string, unknown>) => {
+    try {
+      const vSourceId = validateIdentifier(params.sourceId, 'sourceId');
+      if (!vSourceId.valid) return { success: false, deleted: false, error: vSourceId.error };
+      const vTargetId = validateIdentifier(params.targetId, 'targetId');
+      if (!vTargetId.valid) return { success: false, deleted: false, error: vTargetId.error };
+      const sourceId = validateString(params.sourceId, 'sourceId', 500);
+      const targetId = validateString(params.targetId, 'targetId', 500);
+      if (!sourceId) return { success: false, deleted: false, error: 'sourceId is required (non-empty string)' };
+      if (!targetId) return { success: false, deleted: false, error: 'targetId is required (non-empty string)' };
+      const relation = validateString(params.relation, 'relation', 200) ?? undefined;
+      const bridge = await getBridge();
+      const result = await bridge.bridgeDeleteCausalEdge({ sourceId, targetId, relation });
+      return result ?? { success: false, deleted: false, error: 'AgentDB bridge not available' };
+    } catch (error) {
+      return { success: false, deleted: false, error: sanitizeError(error) };
+    }
+  },
+};
+
+export const agentdbCausalNodeDelete: MCPTool = {
+  name: 'agentdb_causal-node-delete',
+  description: 'Cascade-delete a causal node and all its incident edges from the SQL fallback. Native graph-node entries are unaffected (no delete API in the binding).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      nodeId: { type: 'string', description: 'Node ID to delete (cascades to all incident edges)' },
+    },
+    required: ['nodeId'],
+  },
+  handler: async (params: Record<string, unknown>) => {
+    try {
+      const vNodeId = validateIdentifier(params.nodeId, 'nodeId');
+      if (!vNodeId.valid) return { success: false, deletedNode: false, deletedEdges: 0, error: vNodeId.error };
+      const nodeId = validateString(params.nodeId, 'nodeId', 500);
+      if (!nodeId) return { success: false, deletedNode: false, deletedEdges: 0, error: 'nodeId is required (non-empty string)' };
+      const bridge = await getBridge();
+      const result = await bridge.bridgeDeleteCausalNode({ nodeId });
+      return result ?? { success: false, deletedNode: false, deletedEdges: 0, error: 'AgentDB bridge not available' };
+    } catch (error) {
+      return { success: false, deletedNode: false, deletedEdges: 0, error: sanitizeError(error) };
+    }
+  },
+};
+
 // ===== Export all tools =====
 
 export const agentdbTools: MCPTool[] = [
@@ -633,11 +727,14 @@ export const agentdbTools: MCPTool[] = [
   agentdbPatternSearch,
   agentdbFeedback,
   agentdbCausalEdge,
+  agentdbCausalEdgeDelete,
+  agentdbCausalNodeDelete,
   agentdbRoute,
   agentdbSessionStart,
   agentdbSessionEnd,
   agentdbHierarchicalStore,
   agentdbHierarchicalRecall,
+  agentdbHierarchicalDelete,
   agentdbConsolidate,
   agentdbBatch,
   agentdbContextSynthesize,

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -1576,6 +1576,245 @@ export async function bridgeRecordCausalEdge(options: {
   }
 }
 
+// ===== #1784: Delete tools for hierarchical + causal-graph =====
+
+/**
+ * Delete a hierarchical-memory entry by key (#1784).
+ *
+ * Reality check: agentdb's HierarchicalMemory class doesn't expose a public
+ * delete API today, so the real-backend path falls back to direct SQL on
+ * the underlying SQLite tables (status flip to 'deleted' + AttestationLog
+ * audit). The bridge-fallback path that bridgeHierarchicalStore uses when
+ * HierarchicalMemory isn't loaded writes plain memory_entries rows that
+ * `bridgeDeleteEntry` already handles.
+ *
+ * Returns { controller: 'native-unsupported' } when the real HM is loaded
+ * and the SQL fallback can't reach its private tables — surfacing the
+ * limitation honestly instead of silently returning success.
+ */
+export async function bridgeDeleteHierarchical(options: {
+  key: string;
+  tier?: string;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  deleted: boolean;
+  key: string;
+  tier?: string;
+  controller: string;
+  guarded?: boolean;
+  error?: string;
+} | null> {
+  const registry = await getRegistry(options.dbPath);
+  if (!registry) return null;
+  try {
+    const { key, tier } = options;
+
+    // MutationGuard validation
+    const guardResult = await guardValidate(registry, 'delete', { key, namespace: 'hierarchical' });
+    if (!guardResult.allowed) {
+      return { success: false, deleted: false, key, tier, controller: 'guard', error: `MutationGuard rejected: ${guardResult.reason}` };
+    }
+
+    const hm = registry.get('hierarchicalMemory');
+    // 1. Try HierarchicalMemory's own delete API if it ever ships one.
+    if (hm && typeof hm.delete === 'function') {
+      try {
+        await hm.delete(key);
+        await logAttestation(registry, 'delete', key, { namespace: 'hierarchical', tier });
+        return { success: true, deleted: true, key, tier, controller: 'hierarchicalMemory', guarded: true };
+      } catch (err) {
+        // Fall through to SQL fallback
+      }
+    }
+
+    // 2. Stub HierarchicalMemory may expose `remove` or `forget`
+    if (hm && typeof hm.remove === 'function') {
+      try {
+        await hm.remove(key);
+        await logAttestation(registry, 'delete', key, { namespace: 'hierarchical', tier });
+        return { success: true, deleted: true, key, tier, controller: 'hierarchicalMemory-stub', guarded: true };
+      } catch { /* fall through */ }
+    }
+
+    // 3. Bridge-fallback: HM stored to memory_entries with namespace prefix
+    //    (used when the real controller isn't loaded). Soft-delete via SQL.
+    const ctx = getDb(registry);
+    if (ctx) {
+      try {
+        const result = ctx.db.prepare(`
+          UPDATE memory_entries
+          SET status = 'deleted', updated_at = ?
+          WHERE key = ? AND namespace LIKE 'hierarchical%' AND status = 'active'
+        `).run(Date.now(), key);
+        const changes = result?.changes ?? 0;
+        if (changes > 0) {
+          await logAttestation(registry, 'delete', key, { namespace: 'hierarchical', tier });
+          return { success: true, deleted: true, key, tier, controller: 'bridge-fallback', guarded: true };
+        }
+        // Nothing to delete in SQL fallback — and no real-HM delete API.
+        // Surface the situation honestly.
+        return {
+          success: false, deleted: false, key, tier,
+          controller: hm ? 'native-unsupported' : 'not-found',
+          error: hm
+            ? 'HierarchicalMemory has no public delete API; entry remains in native storage'
+            : 'No hierarchical entry found with this key',
+        };
+      } catch (err) {
+        return { success: false, deleted: false, key, tier, controller: 'sql-error', error: (err as Error).message };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete a causal edge between two memory entries (#1784).
+ *
+ * The bridge stores fallback edges in namespace='causal-edges' with key
+ * '{sourceId}→{targetId}'. Those CAN be soft-deleted. The native graph-node
+ * backend has no delete API (createNode/createEdge/createHyperedge only),
+ * so an edge that landed in graph-node native storage stays there. We
+ * surface that explicitly via controller: 'native-unsupported'.
+ */
+export async function bridgeDeleteCausalEdge(options: {
+  sourceId: string;
+  targetId: string;
+  relation?: string;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  deleted: boolean;
+  sourceId: string;
+  targetId: string;
+  controller: string;
+  guarded?: boolean;
+  error?: string;
+} | null> {
+  const registry = await getRegistry(options.dbPath);
+  if (!registry) return null;
+  try {
+    const { sourceId, targetId, relation } = options;
+    const edgeKey = `${sourceId}→${targetId}`;
+
+    const guardResult = await guardValidate(registry, 'delete', { key: edgeKey, namespace: 'causal-edges' });
+    if (!guardResult.allowed) {
+      return { success: false, deleted: false, sourceId, targetId, controller: 'guard', error: `MutationGuard rejected: ${guardResult.reason}` };
+    }
+
+    // 1. Try CausalMemoryGraph's own delete API if it appears in a future agentdb version.
+    const causalGraph = registry.get('causalGraph');
+    if (causalGraph && typeof causalGraph.removeEdge === 'function') {
+      try {
+        await causalGraph.removeEdge(sourceId, targetId, relation);
+        await logAttestation(registry, 'delete', edgeKey, { namespace: 'causal-edges', relation });
+        return { success: true, deleted: true, sourceId, targetId, controller: 'causalGraph', guarded: true };
+      } catch { /* fall through */ }
+    }
+
+    // 2. Bridge-fallback: soft-delete the memory_entries row.
+    const ctx = getDb(registry);
+    if (ctx) {
+      try {
+        const result = ctx.db.prepare(`
+          UPDATE memory_entries
+          SET status = 'deleted', updated_at = ?
+          WHERE key = ? AND namespace = 'causal-edges' AND status = 'active'
+        `).run(Date.now(), edgeKey);
+        const changes = result?.changes ?? 0;
+        if (changes > 0) {
+          await logAttestation(registry, 'delete', edgeKey, { namespace: 'causal-edges', relation });
+          return { success: true, deleted: true, sourceId, targetId, controller: 'bridge-fallback', guarded: true };
+        }
+        return {
+          success: false, deleted: false, sourceId, targetId,
+          controller: 'native-unsupported',
+          error: 'graph-node native backend has no delete API; edge cannot be removed from native storage. SQL fallback found no matching row.',
+        };
+      } catch (err) {
+        return { success: false, deleted: false, sourceId, targetId, controller: 'sql-error', error: (err as Error).message };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cascade-delete a causal node and all its incident edges (#1784).
+ *
+ * Same constraint as bridgeDeleteCausalEdge — native graph-node lacks a
+ * delete API. SQL fallback path soft-deletes the node (if stored as a
+ * memory_entries row) and every edge whose key contains the nodeId.
+ */
+export async function bridgeDeleteCausalNode(options: {
+  nodeId: string;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  deletedNode: boolean;
+  deletedEdges: number;
+  nodeId: string;
+  controller: string;
+  guarded?: boolean;
+  error?: string;
+} | null> {
+  const registry = await getRegistry(options.dbPath);
+  if (!registry) return null;
+  try {
+    const { nodeId } = options;
+
+    const guardResult = await guardValidate(registry, 'delete', { key: nodeId, namespace: 'causal-nodes' });
+    if (!guardResult.allowed) {
+      return { success: false, deletedNode: false, deletedEdges: 0, nodeId, controller: 'guard', error: `MutationGuard rejected: ${guardResult.reason}` };
+    }
+
+    const ctx = getDb(registry);
+    if (!ctx) return null;
+
+    let deletedEdges = 0;
+    let deletedNode = false;
+    try {
+      // Soft-delete every edge whose key contains nodeId on either side.
+      const edgeResult = ctx.db.prepare(`
+        UPDATE memory_entries
+        SET status = 'deleted', updated_at = ?
+        WHERE namespace = 'causal-edges'
+          AND status = 'active'
+          AND (key LIKE ? OR key LIKE ?)
+      `).run(Date.now(), `${nodeId}→%`, `%→${nodeId}`);
+      deletedEdges = edgeResult?.changes ?? 0;
+
+      // Soft-delete the node row if it exists in memory_entries.
+      const nodeResult = ctx.db.prepare(`
+        UPDATE memory_entries
+        SET status = 'deleted', updated_at = ?
+        WHERE key = ? AND status = 'active'
+      `).run(Date.now(), nodeId);
+      deletedNode = (nodeResult?.changes ?? 0) > 0;
+
+      await logAttestation(registry, 'delete', nodeId, { namespace: 'causal-nodes', deletedEdges });
+    } catch (err) {
+      return { success: false, deletedNode: false, deletedEdges: 0, nodeId, controller: 'sql-error', error: (err as Error).message };
+    }
+
+    return {
+      success: true,
+      deletedNode,
+      deletedEdges,
+      nodeId,
+      controller: 'bridge-fallback',
+      guarded: true,
+    };
+  } catch {
+    return null;
+  }
+}
+
 // ===== Phase 5: ReflexionMemory session lifecycle =====
 
 /**

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -1617,7 +1617,23 @@ export async function bridgeDeleteHierarchical(options: {
     }
 
     const hm = registry.get('hierarchicalMemory');
-    // 1. Try HierarchicalMemory's own delete API if it ever ships one.
+
+    // 1. agentdb@3.0.0-alpha.13+: ReflexionMemory.deleteEpisode propagates through
+    //    graph adapter / generic graph backend / vector backend AND purges SQL
+    //    episodes + episode_embeddings rows. Single call, durably consistent.
+    //    See agentic-flow#150/#151 (closes ruvnet/RuVector#427 the cli-visible way).
+    const reflexion = registry.get('reflexionMemory');
+    if (reflexion && typeof reflexion.deleteEpisode === 'function') {
+      try {
+        const removed = await reflexion.deleteEpisode(key);
+        if (removed) {
+          await logAttestation(registry, 'delete', key, { namespace: 'hierarchical', tier });
+          return { success: true, deleted: true, key, tier, controller: 'reflexionMemory', guarded: true };
+        }
+      } catch { /* fall through */ }
+    }
+
+    // 2. Try HierarchicalMemory's own delete API if it ever ships one.
     if (hm && typeof hm.delete === 'function') {
       try {
         await hm.delete(key);
@@ -1628,7 +1644,7 @@ export async function bridgeDeleteHierarchical(options: {
       }
     }
 
-    // 2. Stub HierarchicalMemory may expose `remove` or `forget`
+    // 3. Stub HierarchicalMemory may expose `remove` or `forget`
     if (hm && typeof hm.remove === 'function') {
       try {
         await hm.remove(key);
@@ -1705,8 +1721,24 @@ export async function bridgeDeleteCausalEdge(options: {
       return { success: false, deleted: false, sourceId, targetId, controller: 'guard', error: `MutationGuard rejected: ${guardResult.reason}` };
     }
 
-    // 1. Try CausalMemoryGraph's own delete API if it appears in a future agentdb version.
     const causalGraph = registry.get('causalGraph');
+
+    // 1. agentdb@3.0.0-alpha.13+: GraphDatabaseAdapter.deleteEdgesByEndpoints
+    //    handles the (sourceId, targetId, relation?) tuple case directly via
+    //    Cypher MATCH … DETACH DELETE. Cypher-injection-safe (label validated
+    //    against /^[A-Za-z_][A-Za-z0-9_]*$/ upstream).
+    if (causalGraph && typeof causalGraph.deleteEdgesByEndpoints === 'function') {
+      try {
+        const r = await causalGraph.deleteEdgesByEndpoints(sourceId, targetId, relation);
+        const deletedCount = typeof r === 'object' && r ? (r.deleted ?? 0) : (r ? 1 : 0);
+        if (deletedCount > 0) {
+          await logAttestation(registry, 'delete', edgeKey, { namespace: 'causal-edges', relation, count: deletedCount });
+          return { success: true, deleted: true, sourceId, targetId, controller: 'causalGraph-cypher', guarded: true };
+        }
+      } catch { /* fall through */ }
+    }
+
+    // 2. Pre-alpha.13 / different controller: try removeEdge() if exposed.
     if (causalGraph && typeof causalGraph.removeEdge === 'function') {
       try {
         await causalGraph.removeEdge(sourceId, targetId, relation);
@@ -1773,13 +1805,38 @@ export async function bridgeDeleteCausalNode(options: {
       return { success: false, deletedNode: false, deletedEdges: 0, nodeId, controller: 'guard', error: `MutationGuard rejected: ${guardResult.reason}` };
     }
 
+    // 1. agentdb@3.0.0-alpha.13+: GraphDatabaseAdapter.deleteNode(id, {cascade})
+    //    counts incident edges before delete so we get accurate audit numbers
+    //    regardless of binding stats. Cypher MATCH (n {id}) DETACH DELETE n.
+    const causalGraph = registry.get('causalGraph');
+    if (causalGraph && typeof causalGraph.deleteNode === 'function') {
+      try {
+        const r = await causalGraph.deleteNode(nodeId, { cascade: true });
+        if (r && typeof r === 'object') {
+          const deletedNodeNative = !!r.deletedNode;
+          const deletedEdgesNative = typeof r.deletedEdges === 'number' ? r.deletedEdges : 0;
+          await logAttestation(registry, 'delete', nodeId, { namespace: 'causal-nodes', deletedEdges: deletedEdgesNative });
+          return {
+            success: true,
+            deletedNode: deletedNodeNative,
+            deletedEdges: deletedEdgesNative,
+            nodeId,
+            controller: 'causalGraph-cypher',
+            guarded: true,
+          };
+        }
+      } catch { /* fall through to SQL */ }
+    }
+
+    // 2. SQL fallback: soft-delete the node row + every causal-edges row whose
+    //    key contains nodeId on either side. Used when agentdb pre-alpha.13 OR
+    //    when the entry was stored via the bridge's SQL fallback path.
     const ctx = getDb(registry);
     if (!ctx) return null;
 
     let deletedEdges = 0;
     let deletedNode = false;
     try {
-      // Soft-delete every edge whose key contains nodeId on either side.
       const edgeResult = ctx.db.prepare(`
         UPDATE memory_entries
         SET status = 'deleted', updated_at = ?
@@ -1789,7 +1846,6 @@ export async function bridgeDeleteCausalNode(options: {
       `).run(Date.now(), `${nodeId}→%`, `%→${nodeId}`);
       deletedEdges = edgeResult?.changes ?? 0;
 
-      // Soft-delete the node row if it exists in memory_entries.
       const nodeResult = ctx.db.prepare(`
         UPDATE memory_entries
         SET status = 'deleted', updated_at = ?

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/aidefence':
     dependencies:
@@ -58,7 +58,7 @@ importers:
         version: 0.6.0
       agentic-flow:
         specifier: ^2.0.3
-        version: 2.0.3(@types/node@20.19.27)(hono@4.12.11)(marked@11.2.0)
+        version: 2.0.3(@types/node@20.19.27)(marked@11.2.0)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -96,7 +96,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/cli':
     dependencies:
@@ -168,8 +168,8 @@ importers:
         specifier: ^0.1.5
         version: 0.1.6
       agentdb:
-        specifier: ^3.0.0-alpha.11
-        version: 3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76)
+        specifier: ^3.0.0-alpha.13
+        version: 3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76)
       agentic-flow:
         specifier: ^3.0.0-alpha.1
         version: 3.0.0-alpha.2
@@ -237,7 +237,7 @@ importers:
         version: 25.0.2(typescript@5.9.3)
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/embeddings':
     dependencies:
@@ -249,7 +249,7 @@ importers:
         version: 2.17.2
       agentic-flow:
         specifier: ^2.0.0
-        version: 2.0.3(@types/node@20.19.27)(hono@4.12.11)(marked@11.2.0)
+        version: 2.0.3(@types/node@20.19.27)(marked@11.2.0)
       sql.js:
         specifier: ^1.13.0
         version: 1.13.0
@@ -288,7 +288,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/hooks':
     dependencies:
@@ -320,13 +320,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/integration':
     dependencies:
       agentic-flow:
         specifier: ^2.0.0-alpha
-        version: 2.0.0-alpha(@types/node@20.19.27)(hono@4.12.11)(marked@11.2.0)(typescript@5.9.3)
+        version: 2.0.0-alpha(@types/node@20.19.27)(marked@11.2.0)(typescript@5.9.3)
     optionalDependencies:
       agent-booster:
         specifier: ^0.2.2
@@ -334,7 +334,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/mcp':
     dependencies:
@@ -365,7 +365,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/memory':
     dependencies:
@@ -387,7 +387,7 @@ importers:
         version: 1.4.9
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/neural':
     dependencies:
@@ -400,7 +400,7 @@ importers:
     optionalDependencies:
       agentdb:
         specifier: ^2.0.0 || ^3.0.0-alpha.1
-        version: 3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76)
+        version: 3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76)
 
   '@claude-flow/performance':
     dependencies:
@@ -413,7 +413,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/plugin-agent-federation':
     dependencies:
@@ -479,7 +479,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/providers':
     dependencies:
@@ -520,7 +520,7 @@ importers:
         version: 5.0.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/shared':
     dependencies:
@@ -554,7 +554,7 @@ importers:
         version: 7.2.0
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
       ws:
         specifier: ^8.16.0
         version: 8.19.0
@@ -566,7 +566,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
   '@claude-flow/testing':
     devDependencies:
@@ -584,7 +584,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
 
 packages:
 
@@ -737,7 +737,7 @@ packages:
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
     dev: false
 
-  /@claude-flow/aidefence@3.0.2(agentdb@3.0.0-alpha.11):
+  /@claude-flow/aidefence@3.0.2(agentdb@3.0.0-alpha.13):
     resolution: {integrity: sha512-jyZa1axjjqtYyS1AbnW0fPuzKBUqRH4SnTOTJZLm5Q6E7qX7A/IG7JcZVEeyipHSl9rFfc6Tj91bC1EoV4GMQg==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
@@ -747,7 +747,7 @@ packages:
       agentdb:
         optional: true
     dependencies:
-      agentdb: 3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76)
     dev: false
     optional: true
 
@@ -762,7 +762,7 @@ packages:
       '@ruvector/rabitq-wasm': 0.1.0
       semver: 7.7.4
     optionalDependencies:
-      '@claude-flow/aidefence': 3.0.2(agentdb@3.0.0-alpha.11)
+      '@claude-flow/aidefence': 3.0.2(agentdb@3.0.0-alpha.13)
       '@claude-flow/codex': 3.0.0-alpha.9(@claude-flow/cli@3.6.30)(@types/node@20.19.27)
       '@claude-flow/embeddings': 3.0.0-alpha.15(@claude-flow/shared@3.0.0-alpha.7)(agentic-flow@3.0.0-alpha.2)
       '@claude-flow/guidance': 3.0.0-alpha.2(@types/node@20.19.27)(zod@3.25.76)
@@ -777,7 +777,7 @@ packages:
       '@ruvector/ruvllm-wasm': 2.0.2
       '@ruvector/rvagent-wasm': 0.1.0
       '@ruvector/sona': 0.1.6
-      agentdb: 3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76)
       agentic-flow: 3.0.0-alpha.2
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -912,7 +912,7 @@ packages:
     os: [darwin, linux, win32]
     requiresBuild: true
     dependencies:
-      agentdb: 3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76)
       better-sqlite3: 11.10.0
       sql.js: 1.14.1
     transitivePeerDependencies:
@@ -933,7 +933,7 @@ packages:
       '@claude-flow/memory': 3.0.0-alpha.14(@types/node@20.19.27)(zod@3.25.76)
       '@ruvector/sona': 0.1.6
     optionalDependencies:
-      agentdb: 3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@types/node'
@@ -2487,7 +2487,6 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
     requiresBuild: true
-    dev: false
 
   /@opentelemetry/api@1.9.1:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -2548,6 +2547,66 @@ packages:
       '@opentelemetry/resource-detector-gcp': 0.29.13(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/auto-instrumentations-node@0.47.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-W7Iz4SZhj6z5iqYTu4zZXr2woP/zD4dA6zFAz9PQEx21/SGn6+y6plcJTA08KnPVMbRff60D1IBdl547TyGy9A==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.4.1
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.38.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-lambda': 0.42.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-sdk': 0.42.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-bunyan': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cassandra-driver': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cucumber': 0.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dns': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.40.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fastify': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.13.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.41.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-grpc': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.41.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.41.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.38.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-memcached': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.45.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-nestjs-core': 0.38.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-net': 0.37.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.42.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pino': 0.40.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.40.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis-4': 0.40.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-restify': 0.39.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-router': 0.38.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-socket.io': 0.40.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.3.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-winston': 0.38.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-alibaba-cloud': 0.28.10(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-aws': 1.12.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-azure': 0.2.12(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-container': 0.3.11(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-gcp': 0.29.13(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -2640,6 +2699,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/exporter-metrics-otlp-http@0.52.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-oAHPOy1sZi58bwqXaucd19F/v7+qE2EuVslQOEeLQT94CDuZJJ4tbWzx8DpYBTrOSzKqqrMtx9+PMxkrcbxOyQ==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.25.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.1)
+    dev: false
+    optional: true
+
   /@opentelemetry/exporter-prometheus@0.52.1(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-hwK0QnjtqAxGpQAXMNUY+kTT5CnHyz1I0lBA8SFySvaFtExZm7yQg/Ua/i+RBqgun7WkUbkUVJzEi3lKpJ7WdA==}
     engines: {node: '>=14'}
@@ -2651,6 +2726,20 @@ packages:
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
+    dev: false
+    optional: true
+
+  /@opentelemetry/exporter-prometheus@0.52.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-hwK0QnjtqAxGpQAXMNUY+kTT5CnHyz1I0lBA8SFySvaFtExZm7yQg/Ua/i+RBqgun7WkUbkUVJzEi3lKpJ7WdA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.25.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.1)
     dev: false
     optional: true
 
@@ -2798,6 +2887,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-amqplib@0.38.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-6i1sZl2B329NoOeCFm0R6H/u0DLex7L3NVLEQGSujfM6ztNxEZGmrFhV57eFkzwIHVHUqq9pfmpAAYVkGgrO1w==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-aws-lambda@0.42.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-GhV3s62W8gWXDuCdPkWj60W3giHGadHoGBPGW5Wud2fUK9lY6FiYxv6AmCokzugTaiRfB2RjsaJWd9xTtYttVA==}
     engines: {node: '>=14'}
@@ -2809,6 +2914,24 @@ packages:
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-aws-xray': 1.26.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/aws-lambda': 8.10.122
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-aws-lambda@0.42.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-GhV3s62W8gWXDuCdPkWj60W3giHGadHoGBPGW5Wud2fUK9lY6FiYxv6AmCokzugTaiRfB2RjsaJWd9xTtYttVA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-aws-xray': 1.26.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/aws-lambda': 8.10.122
     transitivePeerDependencies:
@@ -2833,6 +2956,23 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-aws-sdk@0.42.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-6b4LQAeBSKU5RhKEP9rH+wMcKswlllIT9J65uREmnWQQJo5zogD6cWa2sJ814o9K25/aDi+zheVHDFDuA7iVCQ==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagation-utils': 0.30.16(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-bunyan@0.39.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-AQ845Wh5Yhd7S0argkCd1vrThNo4q/p6LJePC4OlFifPa9i5O2MzfLNh4mo8YWa0rYvcc+jbhodkGNa+1YJk/A==}
     engines: {node: '>=14'}
@@ -2849,6 +2989,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-bunyan@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-AQ845Wh5Yhd7S0argkCd1vrThNo4q/p6LJePC4OlFifPa9i5O2MzfLNh4mo8YWa0rYvcc+jbhodkGNa+1YJk/A==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.52.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@types/bunyan': 1.8.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-cassandra-driver@0.39.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-D1p7zNNHQYI6/d0ulAFXe+71oDAgzxctfB0EICT8GpBhOCRlCW0U4rxRWrnZW6T5sJaBJqSsY4QF5CPqvCc00w==}
     engines: {node: '>=14'}
@@ -2858,6 +3014,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-cassandra-driver@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-D1p7zNNHQYI6/d0ulAFXe+71oDAgzxctfB0EICT8GpBhOCRlCW0U4rxRWrnZW6T5sJaBJqSsY4QF5CPqvCc00w==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -2881,6 +3052,23 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-connect@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-SeQktDIH5rNzjiEiazWiJAIXkmnLOnNV7wwHpahrqE0Ph+Z3heqMfxRtoMtbdJSIYLfcNZYO51AjxZ00IXufdw==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.36
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-cucumber@0.7.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-bF9gpkUsDbg5Ii47PrhOzgCJKKrT0Tn0wfowOOgcW8PruqfuXgnQ9q1B6GGdSqtIaFnX3xFxGCyWcmf5emt64w==}
     engines: {node: '>=14'}
@@ -2890,6 +3078,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-cucumber@0.7.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-bF9gpkUsDbg5Ii47PrhOzgCJKKrT0Tn0wfowOOgcW8PruqfuXgnQ9q1B6GGdSqtIaFnX3xFxGCyWcmf5emt64w==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -2910,6 +3113,20 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-dataloader@0.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-yoAHGsgXx0YNFJ5XgCAgPo2Wr7Hy4IQX7YTcCulnKuxdfFXybsM9Yz7wiF9X2X2eB6HRLRJRufXT0sujbHaq1g==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-dns@0.37.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-vhIOqqUGq1qwSKS6mF9tpXP7GmVQpQK4zm7bn2UYModpm+YYQzghtf/D8JH6lxXyUMP40zA37xUd2HO6uze/dw==}
     engines: {node: '>=14'}
@@ -2919,6 +3136,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-dns@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-vhIOqqUGq1qwSKS6mF9tpXP7GmVQpQK4zm7bn2UYModpm+YYQzghtf/D8JH6lxXyUMP40zA37xUd2HO6uze/dw==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
@@ -2941,6 +3173,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-express@0.40.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-+RKMvVe2zw3kIXRup9c1jFu3T4d0fs5aKy015TpiMyoCKX1UMu3Z0lfgYtuyiSTANvg5hZnDbWmQmqSPj9VTvg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-fastify@0.37.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-WRjwzNZgupSzbEYvo9s+QuHJRqZJjVdNxSEpGBwWK8RKLlHGwGVAu0gcc2gPamJWUJsGqPGvahAPWM18ZkWj6A==}
     engines: {node: '>=14'}
@@ -2951,6 +3199,22 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-fastify@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-WRjwzNZgupSzbEYvo9s+QuHJRqZJjVdNxSEpGBwWK8RKLlHGwGVAu0gcc2gPamJWUJsGqPGvahAPWM18ZkWj6A==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -2972,6 +3236,21 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-fs@0.13.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-sZxofhMkul95/Rb4R/Q1eP8mIpgWX8dXNCAOk1jMzl/I8xPJ5tnPgT+PIInPSiDh3kgZDTxK5Up1zMnUh0XqSg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-generic-pool@0.37.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-l3VivYfu+FRw0/hHu2jlFLz4mfxZrOg4r96usDF5dJgDRQrRUmjtq6xssYGuFKn1FXAfN8Rcn1Tdk/c40PNYEA==}
     engines: {node: '>=14'}
@@ -2986,6 +3265,20 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-generic-pool@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-l3VivYfu+FRw0/hHu2jlFLz4mfxZrOg4r96usDF5dJgDRQrRUmjtq6xssYGuFKn1FXAfN8Rcn1Tdk/c40PNYEA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-graphql@0.41.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-R/gXeljgIhaRDKquVkKYT5QHPnFouM8ooyePZEP0kqyaVAedtR1V7NfAUJbxfTG5fBQa5wdmLjvu63+tzRXZCA==}
     engines: {node: '>=14'}
@@ -2995,6 +3288,20 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-graphql@0.41.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-R/gXeljgIhaRDKquVkKYT5QHPnFouM8ooyePZEP0kqyaVAedtR1V7NfAUJbxfTG5fBQa5wdmLjvu63+tzRXZCA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3015,6 +3322,21 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-grpc@0.52.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-EdSDiDSAO+XRXk/ZN128qQpBo1I51+Uay/LUPcPQhSRGf7fBPIEUBeOLQiItguGsug5MGOYjql2w/1wCQF3fdQ==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.25.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-hapi@0.39.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-ik2nA9Yj2s2ay+aNY+tJsKCsEx6Tsc2g/MK0iWBW5tibwrWKTy1pdVt5sB3kd5Gkimqj23UV5+FH2JFcQLeKug==}
     engines: {node: '>=14'}
@@ -3025,6 +3347,22 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-hapi@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-ik2nA9Yj2s2ay+aNY+tJsKCsEx6Tsc2g/MK0iWBW5tibwrWKTy1pdVt5sB3kd5Gkimqj23UV5+FH2JFcQLeKug==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -3048,6 +3386,23 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-http@0.52.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-dG/aevWhaP+7OLv4BQQSEKMJv8GyeOp3Wxl31NHqE8xo9/fYMfEljiZphUHIfyg4gnZ9swMyWjfOQs5GUQe54Q==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.25.1
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-ioredis@0.41.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-rxiLloU8VyeJGm5j2fZS8ShVdB82n7VNP8wTwfUQqDwRfHCnkzGr+buKoxuhGD91gtwJ91RHkjHA1Eg6RqsUTg==}
     engines: {node: '>=14'}
@@ -3064,6 +3419,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-ioredis@0.41.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-rxiLloU8VyeJGm5j2fZS8ShVdB82n7VNP8wTwfUQqDwRfHCnkzGr+buKoxuhGD91gtwJ91RHkjHA1Eg6RqsUTg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-knex@0.37.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-NyXHezcUYiWnzhiY4gJE/ZMABnaC7ZQUCyx7zNB4J9Snmc4YCsRbLpTkJmCLft3ey/8Qg1Un+6efZcpgthQqbg==}
     engines: {node: '>=14'}
@@ -3073,6 +3444,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-knex@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-NyXHezcUYiWnzhiY4gJE/ZMABnaC7ZQUCyx7zNB4J9Snmc4YCsRbLpTkJmCLft3ey/8Qg1Un+6efZcpgthQqbg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -3097,6 +3483,24 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-koa@0.41.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-mbPnDt7ELvpM2S0vixYUsde7122lgegLOJQxx8iJQbB8YHal/xnTh9v7IfArSVzIDo+E+080hxZyUZD4boOWkw==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/koa': 2.14.0
+      '@types/koa__router': 12.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-lru-memoizer@0.38.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-x41JPoCbltEeOXlHHVxHU6Xcd/91UkaXHNIqj8ejfp9nVQe0lFHBJ8wkUaVJlasu60oEPmiz6VksU3Wa42BrGw==}
     engines: {node: '>=14'}
@@ -3111,6 +3515,20 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-lru-memoizer@0.38.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-x41JPoCbltEeOXlHHVxHU6Xcd/91UkaXHNIqj8ejfp9nVQe0lFHBJ8wkUaVJlasu60oEPmiz6VksU3Wa42BrGw==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-memcached@0.37.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-30mEfl+JdeuA6m7GRRwO6XYkk7dj4dp0YB70vMQ4MS2qBMVQvkEu3Gb+WFhSHukTYv753zyBeohDkeXw7DEsvw==}
     engines: {node: '>=14'}
@@ -3120,6 +3538,22 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/memcached': 2.2.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-memcached@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-30mEfl+JdeuA6m7GRRwO6XYkk7dj4dp0YB70vMQ4MS2qBMVQvkEu3Gb+WFhSHukTYv753zyBeohDkeXw7DEsvw==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/memcached': 2.2.10
     transitivePeerDependencies:
@@ -3143,6 +3577,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-mongodb@0.45.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-xnZP9+ayeB1JJyNE9cIiwhOJTzNEsRhXVdLgfzmrs48Chhhk026mQdM5CITfyXSCfN73FGAIB8d91+pflJEfWQ==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-mongoose@0.39.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-J1r66A7zJklPPhMtrFOO7/Ud2p0Pv5u8+r23Cd1JUH6fYPmftNJVsLp2urAt6PHK4jVqpP/YegN8wzjJ2mZNPQ==}
     engines: {node: '>=14'}
@@ -3153,6 +3603,22 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-mongoose@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-J1r66A7zJklPPhMtrFOO7/Ud2p0Pv5u8+r23Cd1JUH6fYPmftNJVsLp2urAt6PHK4jVqpP/YegN8wzjJ2mZNPQ==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -3175,6 +3641,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-mysql2@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Iypuq2z6TCfriAXCIZjRq8GTFCKhQv5SpXbmI+e60rYdXw8NHtMH4NXcGF0eKTuoCsC59IYSTUvDQYDKReaszA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-mysql@0.39.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-8snHPh83rhrDf31v9Kq0Nf+ts8hdr7NguuszRqZomZBHgE0+UyXZSkXHAAFZoBPPRMGyM68uaFE5hVtFl+wOcA==}
     engines: {node: '>=14'}
@@ -3184,6 +3666,22 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.22
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-mysql@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-8snHPh83rhrDf31v9Kq0Nf+ts8hdr7NguuszRqZomZBHgE0+UyXZSkXHAAFZoBPPRMGyM68uaFE5hVtFl+wOcA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/mysql': 2.15.22
     transitivePeerDependencies:
@@ -3206,6 +3704,21 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-nestjs-core@0.38.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-M381Df1dM8aqihZz2yK+ugvMFK5vlHG/835dc67Sx2hH4pQEQYDA2PpFPTgc9AYYOydQaj7ClFQunESimjXDgg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-net@0.37.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-kLTnWs4R/FtNDvJC7clS7/tBzK7I8DH5IV1I8abog4/1fHh/CFiwWeTRlPlREwcGfVJyL95pDX2Utjviybr5Dg==}
     engines: {node: '>=14'}
@@ -3215,6 +3728,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-net@0.37.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-kLTnWs4R/FtNDvJC7clS7/tBzK7I8DH5IV1I8abog4/1fHh/CFiwWeTRlPlREwcGfVJyL95pDX2Utjviybr5Dg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -3239,6 +3767,24 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-pg@0.42.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-sjgcM8CswYy8zxHgXv4RAZ09DlYhQ+9TdlourUs63Df/ek5RrB1ZbjznqW7PB6c3TyJJmX6AVtPTjAsROovEjA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.6.1
+      '@types/pg-pool': 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-pino@0.40.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-29B7mpabiB5m9YeVuUpWNceKv2E2semh44Y0EngFn7Z/Dwg13j+jsD3h6RaLPLUmUynWKSa160jZm0XrWbx40w==}
     engines: {node: '>=14'}
@@ -3253,6 +3799,20 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-pino@0.40.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-29B7mpabiB5m9YeVuUpWNceKv2E2semh44Y0EngFn7Z/Dwg13j+jsD3h6RaLPLUmUynWKSa160jZm0XrWbx40w==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-redis-4@0.40.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-0ieQYJb6yl35kXA75LQUPhHtGjtQU9L85KlWa7d4ohBbk/iQKZ3X3CFl5jC5vNMq/GGPB3+w3IxNvALlHtrp7A==}
     engines: {node: '>=14'}
@@ -3262,6 +3822,22 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-redis-4@0.40.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-0ieQYJb6yl35kXA75LQUPhHtGjtQU9L85KlWa7d4ohBbk/iQKZ3X3CFl5jC5vNMq/GGPB3+w3IxNvALlHtrp7A==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/redis-common': 0.36.2
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -3285,6 +3861,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-redis@0.40.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-vf2EwBrb979ztLMbf8ew+65ECP3yMxeFwpMLu9KjX6+hFf1Ng776jlM2H9GeP1YePbvoBB5Jbo0MBU6Y0HEgzA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-restify@0.39.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-+KDpaGvJLW28LYoT3AZAEVnywzy8dGS+wTWirXU6edKXu4w5mwdxui3UB3Vy/+FV7gbMWidzedaihTDlQvZXRA==}
     engines: {node: '>=14'}
@@ -3295,6 +3887,22 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-restify@0.39.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-+KDpaGvJLW28LYoT3AZAEVnywzy8dGS+wTWirXU6edKXu4w5mwdxui3UB3Vy/+FV7gbMWidzedaihTDlQvZXRA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -3316,6 +3924,21 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-router@0.38.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-HMeeBva/rqIqg/KHzmKcvutK4JS90Sk59i4qCnLhHW57CMVruj18aXEpBT+QMVJRjmzrvhkJnIpNcPu5vglmRg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-socket.io@0.40.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-BJFMytiHnvKM7n6n67pT9eTBGpZetY+LHic8UKrIQ313uBp+MBbRyqiJY6dT4bcN1B6sl47JzCyKmVprSuSnBA==}
     engines: {node: '>=14'}
@@ -3325,6 +3948,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-socket.io@0.40.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-BJFMytiHnvKM7n6n67pT9eTBGpZetY+LHic8UKrIQ313uBp+MBbRyqiJY6dT4bcN1B6sl47JzCyKmVprSuSnBA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -3347,6 +3985,22 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-tedious@0.11.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Dh93CyaR7vldKf0oXwtYlSEdqvMGUTv270N0YGBQtODPKtgIMr9816vIA7cJPCZ4SbbREgLNQJfbh0qeadAM4Q==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-undici@0.3.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-LMbOE4ofjpQyZ3266Ah6XL9JIBaShebLN0aaZPvqXozKPu41rHmggO3qk0H+Unv8wbiUnHgYZDvq8yxXyKAadg==}
     engines: {node: '>=14'}
@@ -3362,6 +4016,21 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/instrumentation-undici@0.3.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-LMbOE4ofjpQyZ3266Ah6XL9JIBaShebLN0aaZPvqXozKPu41rHmggO3qk0H+Unv8wbiUnHgYZDvq8yxXyKAadg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
   /@opentelemetry/instrumentation-winston@0.38.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-rBAoVkv5HGyKFIpM3Xy5raPNJ/Le1JsAFPbxwbfOZUxpLT2YBB99h/jJYsHm+eNueJ7EBwz2ftqY8rEpVlk3XA==}
     engines: {node: '>=14'}
@@ -3372,6 +4041,21 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/instrumentation-winston@0.38.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-rBAoVkv5HGyKFIpM3Xy5raPNJ/Le1JsAFPbxwbfOZUxpLT2YBB99h/jJYsHm+eNueJ7EBwz2ftqY8rEpVlk3XA==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.52.1
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3518,6 +4202,17 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/propagation-utils@0.30.16(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+    dev: false
+    optional: true
+
   /@opentelemetry/propagator-aws-xray@1.26.2(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-k43wxTjKYvwfce9L4eT8fFYy/ATmCfPHZPZsyT/6ABimf2KE1HafoOsIcxLOtmNSZt6dCvBIYCrXaOWta20xJg==}
     engines: {node: '>=14'}
@@ -3526,6 +4221,17 @@ packages:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
     dependencies:
       '@opentelemetry/api': 1.9.0
+    dev: false
+    optional: true
+
+  /@opentelemetry/propagator-aws-xray@1.26.2(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-k43wxTjKYvwfce9L4eT8fFYy/ATmCfPHZPZsyT/6ABimf2KE1HafoOsIcxLOtmNSZt6dCvBIYCrXaOWta20xJg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
     dev: false
     optional: true
 
@@ -3597,6 +4303,19 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/resource-detector-alibaba-cloud@0.28.10(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-TZv/1Y2QCL6sJ+X9SsPPBXe4786bc/Qsw0hQXFsNTbJzDTGGUmOAlSZ2qPiuqAd4ZheUYfD+QA20IvAjUz9Hhg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    dev: false
+    optional: true
+
   /@opentelemetry/resource-detector-aws@1.12.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==}
     engines: {node: '>=14'}
@@ -3607,6 +4326,20 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    dev: false
+    optional: true
+
+  /@opentelemetry/resource-detector-aws@1.12.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     dev: false
     optional: true
@@ -3625,6 +4358,20 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/resource-detector-azure@0.2.12(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-iIarQu6MiCjEEp8dOzmBvCSlRITPFTinFB2oNKAjU6xhx8d7eUcjNOKhBGQTvuCriZrxrEvDaEEY9NfrPQ6uYQ==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    dev: false
+    optional: true
+
   /@opentelemetry/resource-detector-container@0.3.11(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-22ndMDakxX+nuhAYwqsciexV8/w26JozRUV0FN9kJiqSWtA1b5dCVtlp3J6JivG5t8kDN9UF5efatNnVbqRT9Q==}
     engines: {node: '>=14'}
@@ -3634,6 +4381,19 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    dev: false
+    optional: true
+
+  /@opentelemetry/resource-detector-container@0.3.11(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-22ndMDakxX+nuhAYwqsciexV8/w26JozRUV0FN9kJiqSWtA1b5dCVtlp3J6JivG5t8kDN9UF5efatNnVbqRT9Q==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     dev: false
     optional: true
@@ -3648,6 +4408,24 @@ packages:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      gcp-metadata: 6.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+    optional: true
+
+  /@opentelemetry/resource-detector-gcp@0.29.13(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-vdotx+l3Q+89PeyXMgKEGnZ/CwzwMtuMi/ddgD9/5tKZ08DfDGB2Npz9m2oXPHRCjc4Ro6ifMqFlRyzIvgOjhg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       gcp-metadata: 6.1.1
     transitivePeerDependencies:
@@ -3777,6 +4555,19 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+    dev: false
+    optional: true
+
   /@opentelemetry/sdk-node@0.52.1(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-uEG+gtEr6eKd8CVWeKMhH2olcCHM9dEK68pe0qE0be32BcCRsvYURhHaD1Srngh1SQcnQzZ4TP324euxqtBOJA==}
     engines: {node: '>=14'}
@@ -3871,6 +4662,20 @@ packages:
     dev: false
     optional: true
 
+  /@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    dev: false
+    optional: true
+
   /@opentelemetry/sdk-trace-node@1.25.1(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==}
     engines: {node: '>=14'}
@@ -3935,6 +4740,18 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+    dev: false
+    optional: true
+
+  /@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
     dev: false
     optional: true
 
@@ -5765,7 +6582,7 @@ packages:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6132,21 +6949,21 @@ packages:
       - supports-color
     dev: false
 
-  /agentdb@2.0.0-alpha.3.7(@types/node@20.19.27)(express@5.2.1)(hono@4.12.11)(marked@11.2.0):
+  /agentdb@2.0.0-alpha.3.7(@types/node@20.19.27)(express@5.2.1)(marked@11.2.0):
     resolution: {integrity: sha512-03CUdFgrqw8Mplkvlz66YCKQBSD+l+r8ox4hTZmx56nvkJU8ltKMQJ9h9nz7kvxEbDz2PeZO+SqT45qHNEWRcg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@modelcontextprotocol/sdk': 1.25.1(hono@4.12.11)(zod@3.25.76)
-      '@opentelemetry/api': 1.9.0
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
       '@ruvector/attention': 0.1.32
       '@ruvector/gnn': 0.1.25
       '@ruvector/graph-node': 0.1.26
       '@ruvector/router': 0.1.30
       '@ruvector/ruvllm': 0.2.4
       '@ruvector/sona': 0.1.6
-      ajv: 8.17.1
+      ajv: 8.18.0
       chalk: 5.6.2
       cli-table3: 0.6.5
       commander: 12.1.0
@@ -6155,19 +6972,19 @@ packages:
       jsonwebtoken: 9.0.3
       marked-terminal: 6.2.0(marked@11.2.0)
       ora: 7.0.1
-      ruvector: 0.1.95(zod@3.25.76)
-      ruvector-attention-wasm: 0.1.0
-      sql.js: 1.13.0
+      ruvector: 0.1.100(zod@3.25.76)
+      ruvector-attention-wasm: 0.1.32
+      sql.js: 1.14.1
       zod: 3.25.76
     optionalDependencies:
-      '@opentelemetry/auto-instrumentations-node': 0.47.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.52.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-prometheus': 0.52.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.52.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/auto-instrumentations-node': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@xenova/transformers': 2.17.2
       argon2: 0.44.0
@@ -6184,7 +7001,6 @@ packages:
       - bare-buffer
       - encoding
       - express
-      - hono
       - marked
       - react-native-b4a
       - supports-color
@@ -6238,8 +7054,8 @@ packages:
       - supports-color
     dev: false
 
-  /agentdb@3.0.0-alpha.11(@types/node@20.19.27)(zod@3.25.76):
-    resolution: {integrity: sha512-MMxq0/Pxv6+aUlImK6bLOxNV1f9duajRWAt4aZXUtwMMfCUkiOvpO/DyJp4AIM+EwerVjkSwipGOAfTvyH28Cg==}
+  /agentdb@3.0.0-alpha.13(@types/node@20.19.27)(zod@3.25.76):
+    resolution: {integrity: sha512-KSYyPE3am0q+RBwDfZ5Z7N0n0I9K5adsqw+8FKgBCkWFy0piupVxWfMMw8ACC/+HJ7PRHlnfCk3VBhj7jPRbMw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     requiresBuild: true
@@ -6326,7 +7142,7 @@ packages:
     dev: false
     optional: true
 
-  /agentic-flow@2.0.0-alpha(@types/node@20.19.27)(hono@4.12.11)(marked@11.2.0)(typescript@5.9.3):
+  /agentic-flow@2.0.0-alpha(@types/node@20.19.27)(marked@11.2.0)(typescript@5.9.3):
     resolution: {integrity: sha512-lbBEr7LiOq0lcBFnxrTZEGfXp9KzPsiNtIkWDIve0y+LMW+ZUKl8FNraT0Lwcc7zcKMQoqCfvZksvyEFG+E0Fg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
@@ -6351,7 +7167,7 @@ packages:
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react-swc': 4.2.2(vite@7.3.0)
       '@xenova/transformers': 2.17.2
-      agentdb: 2.0.0-alpha.3.7(@types/node@20.19.27)(express@5.2.1)(hono@4.12.11)(marked@11.2.0)
+      agentdb: 2.0.0-alpha.3.7(@types/node@20.19.27)(express@5.2.1)(marked@11.2.0)
       agentic-payments: 0.1.13(typescript@5.9.3)
       autoprefixer: 10.4.23(postcss@8.5.6)
       axios: 1.13.2
@@ -6386,7 +7202,6 @@ packages:
       - debug
       - effect
       - encoding
-      - hono
       - jiti
       - jose
       - less
@@ -6405,7 +7220,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /agentic-flow@2.0.3(@types/node@20.19.27)(hono@4.12.11)(marked@11.2.0):
+  /agentic-flow@2.0.3(@types/node@20.19.27)(marked@11.2.0):
     resolution: {integrity: sha512-yqrcwWG+RztVKx4w9bvIiAymXEZn93GiTsF6qhYv2gOTQyhIl+VKwY9MLuQKz+Nr5wibTJ4EPm1Cib43usvNNA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -6438,7 +7253,7 @@ packages:
     optionalDependencies:
       '@ruvector/attention': 0.1.32
       '@ruvector/sona': 0.1.6
-      agentdb: 2.0.0-alpha.3.7(@types/node@20.19.27)(express@5.2.1)(hono@4.12.11)(marked@11.2.0)
+      agentdb: 2.0.0-alpha.3.7(@types/node@20.19.27)(express@5.2.1)(marked@11.2.0)
       better-sqlite3: 11.10.0
       onnxruntime-node: 1.24.3
       sharp: 0.32.6
@@ -6455,7 +7270,6 @@ packages:
       - debug
       - effect
       - encoding
-      - hono
       - jose
       - marked
       - react-native-b4a
@@ -8854,7 +9668,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      node-addon-api: 8.5.0
+      node-addon-api: 8.7.0
     dev: false
     optional: true
 
@@ -11235,7 +12049,6 @@ packages:
     engines: {node: '>=16.0.0'}
     requiresBuild: true
     dev: false
-    optional: true
 
   /ruvector-core-darwin-arm64@0.1.29:
     resolution: {integrity: sha512-gjZ1/J/0Nh9Mn74VdifIIkPLP/M4FqD/g+QVxWcfWcNFWhHVz+zHyxGjc6gJgrfYBquiMyP5jLfvyR3TffLanQ==}
@@ -12730,6 +13543,76 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27):
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.19.27
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.3.0)
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0(@types/node@20.19.27)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
     dev: true
 
   /vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@20.19.27):


### PR DESCRIPTION
## Summary

Closes #1784. The reporter (@Tovli) flagged that \`agentdb_hierarchical-store\` and \`agentdb_causal-edge\` had no delete counterparts — net effect \`/adr-index\` can't do a full re-index because deleted ADR files leave stale nodes + dangling edges in \`adr-patterns\` / \`adr-edges\` forever.

This PR adds three new MCP tools + the bridge functions behind them.

## Architectural finding during scoping

The reporter's proposed \`deleteNode(id)\` / \`deleteEdge(id)\` wrappers around \`@ruvector/graph-node\` native APIs assumed primitives that don't exist:

\`\`\`
> GraphDatabase prototype methods:
[ 'createEdge', 'createHyperedge', 'createNode', 'searchHyperedges' ]
\`\`\`

Likewise agentdb's \`HierarchicalMemory\` and \`CausalMemoryGraph\` controllers expose store/recall but no public delete. So delete genuinely cannot be propagated to the underlying graph storage.

**Honest fix:** surface delete for the **SQL fallback path** that bridge stores already use (\`memory_entries\` soft-delete via \`status='deleted'\` + AttestationLog audit), and explicitly report \`controller: "native-unsupported"\` when an entry lives in a backend without delete. No silent black holes.

## What ships

### Bridge functions (`v3/@claude-flow/cli/src/memory/memory-bridge.ts`)

- **\`bridgeDeleteHierarchical({ key, tier? })\`**
  1. Try \`hm.delete()\` if HierarchicalMemory ever ships one
  2. Try \`hm.remove()\` for stub HMs
  3. SQL fallback: soft-delete on \`memory_entries WHERE namespace LIKE 'hierarchical%'\`
  4. Returns \`controller: 'native-unsupported'\` when neither matches and real HM is loaded
- **\`bridgeDeleteCausalEdge({ sourceId, targetId, relation? })\`**
  1. Try \`causalGraph.removeEdge()\` if it ever exists
  2. SQL fallback: soft-delete \`causal-edges\` row keyed \`{sourceId}→{targetId}\`
  3. \`native-unsupported\` when graph-node native is the canonical store
- **\`bridgeDeleteCausalNode({ nodeId })\` — cascade**
  Soft-deletes the node row + every edge whose key matches \`nodeId→%\` or \`%→nodeId\`. Returns \`deletedEdges\` count.

All three flow through **MutationGuard** (fail-closed) and **AttestationLog** (audit), mirroring \`bridgeDeleteEntry\`.

### MCP tools (`v3/@claude-flow/cli/src/mcp-tools/agentdb-tools.ts`)

| Tool | Required | Purpose |
|---|---|---|
| \`agentdb_hierarchical-delete\` | \`key\` (+ optional \`tier\`) | Delete a hierarchical entry |
| \`agentdb_causal-edge-delete\` | \`sourceId\`, \`targetId\` (+ optional \`relation\`) | Delete a causal edge |
| \`agentdb_causal-node-delete\` | \`nodeId\` | Cascade-delete a node + all incident edges |

Each tool's description surfaces the native-backend caveat so callers can tell at a glance.

### Tests (`__tests__/agentdb-delete-tools.test.ts`)

12 surface tests covering registry presence, required-field validation, tier-enum rejection, cascade contract shape, inputSchema completeness, and description content.

## Validation

| Check | Result |
|---|---|
| \`npm run build\` (cli) | ✅ clean |
| **12 new delete-tool tests pass** | ✅ |
| **781 baseline cli tests still pass** — parser, output, validate-input ×2, mcp-tools-deep, commands, cli, commands-deep, config-adapter ×2, p1-commands, router-bandit, neural-package-bridge | ✅ |
| Total: **793 cli tests green** | ✅ |

## Out of scope (queued)

- **Tombstone tables for native graph-node storage** — would let recall paths filter against a shadow table so even native-stored edges can be hidden after delete. Bigger architectural change; #1784 follow-up.
- **Updating `plugins/ruflo-adr/scripts/import.mjs`** to invoke the new delete tools during \`/adr-index\` re-index. Needs sync-semantics design (which side of \`disk vs graph\` is authoritative, etc).

## Test plan

- [x] tsc build clean
- [x] All 3 new MCP tools registered in \`agentdbTools\`
- [x] Required-field validation works
- [x] Tier enum rejected when invalid
- [x] No regressions in 781-test baseline

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)