### PR TITLE
feat(init): --no-attribution / RUFLO_NO_ATTRIBUTION suppresses settings.json attribution

### DIFF
--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -188,6 +188,7 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
   const skipClaude = ctx.flags['skip-claude'] as boolean;
   const onlyClaude = ctx.flags['only-claude'] as boolean;
   const noGlobal = ctx.flags['no-global'] as boolean;
+  const noAttribution = ctx.flags['no-attribution'] as boolean;
   const codexMode = ctx.flags.codex as boolean;
   const dualMode = ctx.flags.dual as boolean;
   const cwd = ctx.cwd;
@@ -257,6 +258,18 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
   // who rely on it; opting in via --no-global keeps the global file pristine.
   if (noGlobal) {
     options.skipGlobalClaudeMd = true;
+  }
+
+  // #1670 — opt-out of the RuFlo Co-Authored-By trailer and PR-body footer
+  // that get written into the project's .claude/settings.json. CLI flag is
+  // primary; RUFLO_NO_ATTRIBUTION env var is a convenience for CI/scripted
+  // runs that don't want to thread the flag through every invocation.
+  if (
+    noAttribution ||
+    process.env.RUFLO_NO_ATTRIBUTION === '1' ||
+    process.env.RUFLO_NO_ATTRIBUTION === 'true'
+  ) {
+    options.noAttribution = true;
   }
 
   // Create spinner
@@ -1074,6 +1087,13 @@ export const initCommand: Command = {
     {
       name: 'no-global',
       description: 'Skip the ~/.claude/CLAUDE.md "Ruflo Integration" pointer block (#1744)',
+      type: 'boolean',
+      default: false,
+    },
+    {
+      name: 'no-attribution',
+      description:
+        'Suppress the RuFlo Co-Authored-By commit trailer and PR-body footer in .claude/settings.json (#1670). Also honors RUFLO_NO_ATTRIBUTION=1 in the env.',
       type: 'boolean',
       default: false,
     },

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -41,11 +41,23 @@ export function generateSettings(options: InitOptions): object {
     ],
   };
 
-  // Add RuFlo attribution for git commits and PRs
-  settings.attribution = {
-    commit: 'Co-Authored-By: RuFlo <ruv@ruv.net>',
-    pr: '🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)',
-  };
+  // RuFlo attribution for git commits and PRs.
+  // Suppressed when --no-attribution / RUFLO_NO_ATTRIBUTION is set (#1670).
+  // The Claude Code settings schema treats empty strings as "hide
+  // attribution" for both fields, so writing "" is the documented
+  // off-switch. Companion to PR #1713 which addresses the hook-based
+  // commit-trailer path; this covers the settings-based path that
+  // Claude Code itself reads when building commit messages and PR bodies.
+  const suppressAttribution =
+    options.noAttribution === true ||
+    process.env.RUFLO_NO_ATTRIBUTION === '1' ||
+    process.env.RUFLO_NO_ATTRIBUTION === 'true';
+  settings.attribution = suppressAttribution
+    ? { commit: '', pr: '' }
+    : {
+        commit: 'Co-Authored-By: RuFlo <ruv@ruv.net>',
+        pr: '🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)',
+      };
 
   // Note: Claude Code expects 'model' to be a string, not an object
   // Model preferences are stored in claudeFlow settings instead

--- a/v3/@claude-flow/cli/src/init/types.ts
+++ b/v3/@claude-flow/cli/src/init/types.ts
@@ -316,6 +316,16 @@ export interface InitOptions {
    * Set true via --no-global to keep the global Claude rules file pristine (#1744).
    */
   skipGlobalClaudeMd?: boolean;
+  /**
+   * Suppress the RuFlo `Co-Authored-By` commit trailer and `🤖 Generated
+   * with [RuFlo]` PR-body footer in the generated `.claude/settings.json`.
+   * When true, `attribution.commit` and `attribution.pr` are written as
+   * empty strings — the schema-documented way to disable both lines.
+   * Set via `--no-attribution` or env `RUFLO_NO_ATTRIBUTION=1`. Companion
+   * to PR #1713 which addressed the hook-based commit-trailer path; this
+   * covers the settings-based path (#1670).
+   */
+  noAttribution?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes the second half of #1670. Companion to #1713.

## Background

#1713 made the hook-based commit trailer opt-in by flipping `addCoAuthor: false` as the default in `git-commit.ts`. That fixes commits the safety hook builds itself. But Claude Code also reads `attribution.commit` and `attribution.pr` from `.claude/settings.json` and appends them to commit messages and PR bodies on its own — and `init/settings-generator.ts` hardcodes the RuFlo strings into every newly initialized project regardless of the user's preference. So even after #1713 lands, a fresh `ruflo init` writes:

```json
\"attribution\": {
  \"commit\": \"Co-Authored-By: RuFlo <ruv@ruv.net>\",
  \"pr\": \"🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)\"
}
```

…which the user then has to edit by hand in every project, or accept the trailers they reported in #1670.

## Change

Add an opt-out for the settings-generator path:

- New `--no-attribution` flag on `ruflo init`. Also honored when `RUFLO_NO_ATTRIBUTION=1` (or `=true`) is in the environment, so CI/scripted runs don't have to thread the flag through every invocation.
- New `InitOptions.noAttribution?: boolean` field, plumbed from the CLI parser to `generateSettings`.
- When the option is set, `settings-generator.ts` writes `attribution: { commit: \"\", pr: \"\" }` instead of the RuFlo strings. Empty string is the documented off-switch in the [claude-code-settings JSON schema](https://json.schemastore.org/claude-code-settings.json) — it explicitly hides both the Co-Authored-By trailer and the PR-body footer.

Default behaviour is unchanged: existing users who want the attribution keep getting it. The flag is purely additive — three small files (47 insertions, 5 deletions).

## Diff scope

\`\`\`
v3/@claude-flow/cli/src/commands/init.ts           | 20 ++++++++++++++++++++
v3/@claude-flow/cli/src/init/settings-generator.ts | 22 +++++++++++++++++-----
v3/@claude-flow/cli/src/init/types.ts              | 10 ++++++++++
3 files changed, 47 insertions(+), 5 deletions(-)
\`\`\`

## Why both a flag and an env var

Following the precedent of \`--no-global\` (#1744): the flag is the discoverable, documented form. The env var is for shells / CI / dotfiles where re-typing the flag for every \`ruflo init\` would be tedious.

## Test plan

- [ ] \`ruflo init\` (no flag, no env) → \`.claude/settings.json\` contains the existing \`attribution.commit: 'Co-Authored-By: RuFlo …'\` and \`attribution.pr: '🤖 Generated with [RuFlo]…'\`. Default behaviour preserved.
- [ ] \`ruflo init --no-attribution\` → both fields are \`\"\"\` instead.
- [ ] \`RUFLO_NO_ATTRIBUTION=1 ruflo init\` → same result as \`--no-attribution\`.
- [ ] \`RUFLO_NO_ATTRIBUTION=1 ruflo init --no-attribution\` (both set) → same as either alone (idempotent).
- [ ] \`ruflo init --help\` → lists the new flag with the description referencing the env var alternative.

## Relationship to #1713

Both PRs are needed to fully close #1670:
- #1713: stops the safety hook from injecting Co-Authored-By when it builds a commit message.
- This PR: stops a fresh \`ruflo init\` from baking the attribution into the project's settings.json (which Claude Code itself reads).

They touch different files and don't conflict.