### PR TITLE
fix(daemon): persist headless worker results to .claude-flow/metrics/

### DIFF
--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -753,10 +753,18 @@ export class WorkerDaemon extends EventEmitter {
       try {
         this.log('info', `Running ${workerConfig.type} in headless mode (Claude Code AI)`);
         const result = await this.headlessExecutor.execute(workerConfig.type as HeadlessWorkerType);
-        return {
-          mode: 'headless',
+        const headlessOutput = {
+          mode: 'headless' as const,
+          timestamp: new Date().toISOString(),
           ...result,
         };
+        // Persist headless result to the same metrics file the local-fallback
+        // worker would have written (#1793). Without this, AI-driven runs leave
+        // no observable artifact beyond the raw prompt/result logs in
+        // .claude-flow/logs/headless/, so consumers (statusline, memory store,
+        // self-learning hooks) never see the structured findings.
+        this.persistHeadlessResult(workerConfig.type, headlessOutput);
+        return headlessOutput;
       } catch (error) {
         this.log('warn', `Headless execution failed for ${workerConfig.type}, falling back to local mode`);
         this.emit('headless:fallback', {
@@ -795,6 +803,47 @@ export class WorkerDaemon extends EventEmitter {
         return this.runPreloadWorkerLocal();
       default:
         return { status: 'unknown worker type', mode: 'local' };
+    }
+  }
+
+  /**
+   * Persist a headless worker's output to the same .claude-flow/metrics/<file>.json
+   * that the corresponding local-fallback worker writes. Mirrors the per-worker
+   * filename convention used by runMapWorker / runAuditWorkerLocal / etc., so
+   * downstream consumers (statusline, memory store, self-learning hooks) get the
+   * structured AI findings instead of stale local-mode placeholders. Failures
+   * are logged but never propagated — the worker run itself stays a success.
+   * See #1793.
+   */
+  private persistHeadlessResult(type: string, output: unknown): void {
+    const filenameByType: Record<string, string> = {
+      audit: 'security-audit.json',
+      optimize: 'performance.json',
+      testgaps: 'test-gaps.json',
+      document: 'documentation.json',
+      ultralearn: 'ultralearn.json',
+      refactor: 'refactor.json',
+      deepdive: 'deepdive.json',
+      predict: 'predictions.json',
+    };
+    const filename = filenameByType[type];
+    if (!filename) {
+      // Unknown headless worker — skip rather than guess a path.
+      return;
+    }
+
+    try {
+      const metricsDir = join(this.projectRoot, '.claude-flow', 'metrics');
+      if (!existsSync(metricsDir)) {
+        mkdirSync(metricsDir, { recursive: true });
+      }
+      const metricsFile = join(metricsDir, filename);
+      writeFileSync(metricsFile, JSON.stringify(output, null, 2));
+    } catch (error) {
+      this.log(
+        'warn',
+        `Failed to persist headless ${type} metric file: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- After a headless (AI) worker (`audit`, `optimize`, `testgaps`, `document`, `refactor`, `deepdive`, `predict`, `ultralearn`) succeeds, write its output to `.claude-flow/metrics/<file>.json` using the same per-worker filename map the local-fallback workers already use.
- Add a `timestamp` field to the headless output so the persisted artifact is self-describing.
- Wrap the write in try/catch and log a warning on failure — the worker run itself stays a success even if persistence fails.

Fixes #1793.

## Why

The headless branch of `runWorkerLogic` was returning the result and exiting:

```ts
if (isHeadlessWorker(...) && this.headlessAvailable && this.headlessExecutor) {
  const result = await this.headlessExecutor.execute(...);
  return { mode: 'headless', ...result };          // ← never persisted anywhere
}
```

Meanwhile every local-fallback worker (`runMapWorker`, `runAuditWorkerLocal`, `runOptimizeWorkerLocal`, …) explicitly does:

```ts
writeFileSync(metricsFile, JSON.stringify(map, null, 2));
```

Result: with Claude Code in PATH and `Claude Code headless mode available - AI workers enabled` logged at startup, the daemon was running real AI analyses (3 min for optimize, 90 s–4 min for audit, ~4 min for testgaps each, dumped to ~12–44 KB of structured findings per call), but `metrics/security-audit.json`, `metrics/performance.json`, `metrics/test-gaps.json` were stale or absent, `npx ruflo memory stats` reported `Total Entries: 0`, and the statusline pattern count was driven entirely by a fallback heuristic. The findings were sitting in `logs/headless/*_result.log` with no consumer ever reading them.

The audit worker's last run on my local checkout independently surfaced a real CRITICAL CWE-798 (hardcoded Google OAuth credentials) plus 9 other findings — precisely the kind of signal "self-learning memory" is supposed to retain. Without this PR, none of that reaches anywhere a user or downstream feature would look.

## Approach

Mirror the local-mode persistence pattern as closely as possible to keep behaviour consistent:

| Worker | Metric filename | Matches local-mode? |
|---|---|---|
| `audit` | `security-audit.json` | ✓ same as `runAuditWorkerLocal` |
| `optimize` | `performance.json` | ✓ same as `runOptimizeWorkerLocal` |
| `testgaps` | `test-gaps.json` | ✓ same as `runTestGapsWorkerLocal` |
| `document` | `documentation.json` | new — local equivalent doesn't yet write a file |
| `refactor` | `refactor.json` | new |
| `deepdive` | `deepdive.json` | new |
| `predict` | `predictions.json` | new |
| `ultralearn` | `ultralearn.json` | new |

Per-type filename map is intentionally explicit (no derived-from-type fallback) so an unknown worker doesn't silently land at a guessed path.

## Out of scope (follow-ups)

- **Ingest `result.parsedOutput` into `memory.db` / `auto-memory-store.json`**. That would close the rest of the gap (statusline pattern count, ReasoningBank corpus, self-learning hooks all become non-empty), but it's a behaviour change with broader implications and deserves a separate PR.
- **`worker:complete` listener** that emits `[INTELLIGENCE]` style summaries to the daemon log, so users running interactively see findings without grepping `metrics/`.
- **Backfill from `logs/headless/*_result.log`** so users with months of unread results get the latest one materialised. One-time script, not core daemon code.

Happy to pick any of these up if you'd like.

## Test plan

- [x] Manual: ran a daemon with a synthetic headless executor that returns a fake result, confirmed `metrics/security-audit.json` (and friends) are written with the expected payload.
- [x] `tsc --noEmit` reports the same error count on this file before and after the patch (only pre-existing missing-`@types/node` noise remains; zero new diagnostics from the change).
- [ ] CI passes.

## Diff

+51 / -2 across one file: `v3/@claude-flow/cli/src/services/worker-daemon.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)