### PR TITLE
fix(hive-mind): pass --mcp-config=<path> to stop variadic prompt slurp (closes #1780)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -274,7 +274,12 @@ async function spawnClaudeCodeInstance(
         }
       }
       if (mcpConfigPath) {
-        claudeArgs.push('--mcp-config', mcpConfigPath);
+        // #1780 — Claude Code's `--mcp-config` is variadic; passing it as two
+        // argv tokens (`--mcp-config`, `<path>`) lets a later positional (the
+        // hive-mind prompt) be slurped as a second config file, producing
+        // `ENAMETOOLONG: name too long, open` once the prompt exceeds PATH_MAX.
+        // Use `=`-syntax so the flag stays attached to its single value.
+        claudeArgs.push(`--mcp-config=${mcpConfigPath}`);
         output.printInfo(`Spawned worker MCP config: ${mcpConfigPath}`);
       } else {
         output.printWarning('No .mcp.json or ~/.claude.json found — spawned worker will not have mcp__ruflo__* tools (#1748 Issue 2). Pass --mcp-config <path> or run "ruflo init" to generate one.');


### PR DESCRIPTION
## Summary

Fixes #1780. `ruflo hive-mind spawn --claude` was unconditionally failing with:

```
Error: Invalid MCP configuration:
Failed to read file: Error: ENAMETOOLONG: name too long, open ...
```

## Root cause

Claude Code's `--mcp-config <configs...>` flag is variadic — it slurps all subsequent positional args as config paths. We were passing it as two separate argv tokens, then pushing the (4000+-char) hive-mind prompt as the next positional. Claude Code treated the prompt as a second `--mcp-config` file path, called `open(prompt)`, and crashed with `ENAMETOOLONG`.

```js
// Before — variadic flag eats the prompt:
claudeArgs.push('--mcp-config', mcpConfigPath);
// ...
claudeArgs.push(hiveMindPrompt); // ← interpreted as a second config file
```

## Fix

Use `=`-syntax so the flag stays attached to its single value:

```js
claudeArgs.push(\`--mcp-config=\${mcpConfigPath}\`);
```

Single line change in `v3/@claude-flow/cli/src/commands/hive-mind.ts:277`. The exact pattern was identified and proposed by the issue reporter (@Sheriff702).

## Out of scope (filed separately)

- **#1779** (init writes legacy `claude-flow` MCP key) was on the original quick-fix list but isn't a one-liner. The codebase's MCP tool surface (`mcp__claude-flow__*` tool prefixes in agent prompts, CLAUDE.md docs, etc.) currently assumes the `claude-flow` key. Renaming the init template to `ruflo` without migrating those references would silently break tool resolution. Needs a design call on which key is canonical going forward — leaving for a follow-up PR.

## Test plan

- [x] Verified the only call site of the buggy pattern in `src/`; one occurrence, fixed
- [ ] CI green (vitest, build, cross-OS)
- [ ] Manual repro from issue body (4000+-char prompt) no longer triggers `ENAMETOOLONG`

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)