### PR TITLE
fix(memory): make memory init idempotent when DB already exists (#1791 sub-bug 6)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -1338,6 +1338,13 @@ const initMemoryCommand: Command = {
         return { success: false, exitCode: 1 };
       }
 
+      // #1791.6 — DB already initialized and --force not passed: friendly no-op.
+      if (result.alreadyExists) {
+        spinner.succeed(`Memory database already initialized at ${result.dbPath}`);
+        output.printInfo('Use `--force` to reinitialize from scratch (destructive).');
+        return { success: true, exitCode: 0 };
+      }
+
       spinner.succeed('Schema initialized');
 
       // Lazy load or pre-load embedding model

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -940,6 +940,11 @@ INSERT OR IGNORE INTO vector_indexes (id, name, dimensions) VALUES
  */
 export interface MemoryInitResult {
   success: boolean;
+  /**
+   * #1791.6 — set when an existing database was found and `force` was not
+   * passed. The call is treated as a successful no-op rather than an error.
+   */
+  alreadyExists?: boolean;
   backend: string;
   dbPath: string;
   schemaVersion: string;
@@ -1186,9 +1191,16 @@ export async function initializeMemoryDatabase(options: {
     }
 
     // Check existing database
+    // #1791.6 — Idempotent re-init: if the database already exists and the
+    // caller did not pass --force, treat it as a successful no-op instead of
+    // an error. Callers (CLI, MCP tools, embeddings) can branch on
+    // `alreadyExists` if they want a different message; previous behavior
+    // surfaced an `[ERROR]` and a "Initialization failed" spinner even when
+    // the existing DB was perfectly healthy.
     if (fs.existsSync(dbPath) && !force) {
       return {
-        success: false,
+        success: true,
+        alreadyExists: true,
         backend,
         dbPath,
         schemaVersion: '3.0.0',
@@ -1200,8 +1212,7 @@ export async function initializeMemoryDatabase(options: {
           temporalDecay: false,
           hnswIndexing: false,
           migrationTracking: false
-        },
-        error: 'Database already exists. Use --force to reinitialize.'
+        }
       };
     }
 


### PR DESCRIPTION
## Summary

Fixes sub-bug 6 of #1791 — \`ruflo memory init\` was non-idempotent: when \`.swarm/memory.db\` already existed and \`--force\` was not passed, it emitted a fake \`[ERROR]\` and a "Initialization failed" spinner even though the existing DB was healthy and there was nothing to fail.

## Reproduction (from #1791)

\`\`\`text
$ ruflo memory init
... Initializing schema...
[ERROR] Database already exists. Use --force to reinitialize.
\`\`\`

## Fix

Treat the "DB exists, no --force" path as a **successful no-op**:

- \`MemoryInitResult\` gains an optional \`alreadyExists?: boolean\` flag
- The early-return branch now returns \`success: true, alreadyExists: true\` (no \`error\`)
- The \`memory init\` CLI prints \`Memory database already initialized at <path>\` with a friendly hint, exits 0

## Backward compatibility

Other call sites that go through \`initializeMemoryDatabase({ force: false })\` and then check \`result.success\` get **better** behavior:

- \`v3/@claude-flow/cli/src/mcp-server.ts:333\` — previously saw existing DB as failure; now correctly sees it as ready
- \`v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts:158\` — already gates on \`checkMemoryInitialization()\` first, so this path is unreachable; behavior unchanged

No public API removed. \`error\` field is still set on real errors. \`success\` semantics are now monotonic ("DB usable after this call returns") instead of mixing "DB usable" with "DB existed already".

## Out of scope (filed separately)

Other sub-bugs in #1791 are tracked as follow-ups; this PR is intentionally surgical:
- 1, 2 — \`hive-mind task\` MCP routing + short-flag parsing
- 3 — \`hive-mind spawn --claude\` ENAMETOOLONG → fixed in #1800
- 4 — subcommand \`--help\` returns parent help (parser change)
- 5 — \`doctor --fix\` is text-only (rename or implement)
- 7 — \`doctor\` git false-negative
- 8 — \`memory_import_claude --allProjects\` triplicates entries (dedupe at import)

## Test plan

- [x] Diff is contained: 2 files, 21 insertions, 3 deletions
- [ ] CI green (vitest, build, cross-OS)
- [ ] Manual: \`ruflo memory init && ruflo memory init\` — second call should succeed silently with friendly message

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)