### PR TITLE
fix(doctor): walk-up .git fallback for git-repo health check (#1791.7)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -186,11 +186,32 @@ async function checkGit(): Promise<HealthCheck> {
 }
 
 // Check if in git repo (async with proper env inheritance)
+//
+// #1791.7 — `git rev-parse` was reported as failing on hosts where `.git`
+// clearly exists in cwd (linux-arm64 daemon contexts). Treat the git binary
+// as authoritative when it succeeds, but fall back to a `.git` walk-up so a
+// present repository is recognized even when the git invocation fails for
+// environment reasons (PATH, broken global config, EBADCWD, etc.).
 async function checkGitRepo(): Promise<HealthCheck> {
   try {
-    await runCommand('git rev-parse --git-dir');
+    await runCommand('git rev-parse --is-inside-work-tree');
     return { name: 'Git Repository', status: 'pass', message: 'In a git repository' };
   } catch {
+    // Walk parents of cwd for a .git directory before reporting "not a repo"
+    let dir = process.cwd();
+    while (true) {
+      if (existsSync(join(dir, '.git'))) {
+        return {
+          name: 'Git Repository',
+          status: 'warn',
+          message: `Repo detected on disk (${join(dir, '.git')}) but \`git rev-parse\` failed — check git installation and PATH`,
+          fix: 'Verify git is on PATH (try `git --version`) and that the working tree is not corrupted',
+        };
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
     return { name: 'Git Repository', status: 'warn', message: 'Not a git repository', fix: 'git init' };
   }
 }


### PR DESCRIPTION
## Summary

Fixes sub-bug 7 of #1791 — \`ruflo doctor\` reports "Not a git repository" even when \`.git/\` clearly exists in cwd:

\`\`\`text
\$ ls -la .git    # exists
\$ ruflo doctor
⚠ Git Repository: Not a git repository
\`\`\`

## Root cause

\`checkGitRepo()\` only consulted \`git rev-parse --git-dir\`. When that command failed for environment reasons (PATH inheritance, daemon-launched contexts, broken global git config, EBADCWD, etc.) the doctor concluded "no repository" rather than "git is broken".

## Fix

\`v3/@claude-flow/cli/src/commands/doctor.ts\`:

1. Switch the probe to \`git rev-parse --is-inside-work-tree\` (slightly more robust; matches what other tools do).
2. On failure, walk parents of cwd looking for a \`.git\` directory. If found, surface a useful warning ("repo detected on disk but \`git rev-parse\` failed — check git PATH") instead of "not a repository". Only return the original "Not a git repository" message when neither git succeeds nor a \`.git\` is found anywhere on the path.

\`pass\` semantics unchanged — still requires git to be working. The change only improves the failure messaging.

## Test plan

- [x] Diff contained: 1 file, +22 / -1
- [ ] CI green
- [ ] Manual: \`ruflo doctor\` in a repo where \`git rev-parse\` deliberately fails (e.g. with a broken \`gitdir:\` pointer) shows the new "repo detected on disk but git failed" message instead of "Not a git repository"

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)