### PR TITLE
fix(cli): pre-load lazy commands so subcommand short flags scope correctly (#1791.2)

### DIFF
--- a/v3/@claude-flow/cli/src/index.ts
+++ b/v3/@claude-flow/cli/src/index.ts
@@ -83,6 +83,22 @@ export class CLI {
    */
   async run(args: string[] = process.argv.slice(2)): Promise<void> {
     try {
+      // #1791.2 — If the user invoked a lazy command (e.g. `hive-mind task`),
+      // pre-load it BEFORE parsing so the parser can build scoped flag
+      // aliases for its subcommands. Without this, short flags defined on
+      // the lazy command's subcommand options (`-d` for description, etc.)
+      // never get into the alias map and silently fall through to global
+      // resolution — the user sees `[ERROR] Task description is required`
+      // even though they passed `-d "smoke"`.
+      for (const arg of args) {
+        if (arg.startsWith('-')) continue;
+        if (this.parser.isLazyOnly(arg)) {
+          const cmd = await getCommandAsync(arg);
+          if (cmd) this.parser.registerCommand(cmd);
+        }
+        break; // only the first non-flag positional is the command name
+      }
+
       // Parse arguments
       const parseResult = this.parser.parse(args);
       const { command: commandPath, flags, positional } = parseResult;

--- a/v3/@claude-flow/cli/src/parser.ts
+++ b/v3/@claude-flow/cli/src/parser.ts
@@ -119,6 +119,18 @@ export class CommandParser {
     this.lazyCommandNames.add(name);
   }
 
+  /**
+   * #1791.2 — true when `name` is a lazy command that hasn't been promoted
+   * to a fully registered Command yet. The CLI uses this to eagerly load
+   * the module before parsing so its subcommand flags (e.g. `-d` for
+   * `hive-mind task --description`) are scoped into the alias map. Without
+   * this, lazy commands' short flags silently fall through to global
+   * resolution and the action handler sees an empty `flags.description`.
+   */
+  isLazyOnly(name: string): boolean {
+    return this.lazyCommandNames.has(name) && !this.commands.has(name);
+  }
+
   private isKnownCommandName(name: string): boolean {
     return this.commands.has(name) || this.lazyCommandNames.has(name);
   }


### PR DESCRIPTION
## Summary

Fixes sub-bug 2 of #1791 — `ruflo hive-mind task -d "smoke"` silently rejects the short flag and exits with `[ERROR] Task description is required`, even though `taskCommand` defines `{ name: 'description', short: 'd' }`.

This is not a hive-mind bug — it's a parser limitation that affects every lazy-loaded command (`hive-mind`, `neural`, `performance`, `security`, `ruvector`, etc.).

## Root cause

The parser's pass-1 walk (`parser.ts:148–176`) treats lazy commands as a "name we recognize but can't resolve subcommands for." When it sees one, it `break`s out without descending into subcommand resolution. Then `buildScopedAliases()` only ever sees the parent's options, so the subcommand's short flags never make it into the alias map.

Result: `-d` falls through to global resolution, gets stored as `flags.d = "smoke"`, and the action handler reading `flags.description` sees `undefined`.

## Fix

Two small changes:

1. **`parser.ts`** — add `isLazyOnly(name)` helper that returns true when a name is registered as lazy but hasn't been promoted to a full Command yet.
2. **`index.ts`** — in `CLI.run()`, before calling `parser.parse()`, walk the first non-flag arg; if it's lazy-only, `await getCommandAsync(arg)` and `registerCommand()` it. Parse then sees the full subcommand tree and scopes flags correctly.

## Behavior change / cost

- Lazy commands load on first invocation rather than mid-parse — but they would have loaded moments later anyway. Wall-clock impact essentially zero.
- Commands the user doesn't invoke still don't load (lazy benefit preserved).

Fix is global — every lazy command gets correct flag scoping for free, not just `hive-mind`.

## Test plan

- [x] Diff contained: 2 files, +28 / -0
- [ ] CI green
- [ ] Manual: `ruflo hive-mind task -d "smoke" --hive-id <id>` should accept the description (vs the previous `[ERROR] Task description is required`)
- [ ] Manual: spot-check other lazy commands (neural, security, performance) also accept their subcommand short flags now

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)