### PR TITLE
fix(doctor): clarify --fix prints commands rather than auto-applying (#1791.5)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -546,7 +546,10 @@ export const doctorCommand: Command = {
     {
       name: 'fix',
       short: 'f',
-      description: 'Show fix commands for issues',
+      // #1791.5 — flag name was misleading: it does NOT auto-apply fixes,
+      // it only prints the suggested commands so the user can run them
+      // themselves. Make that explicit in the help output.
+      description: 'Print suggested fix commands (does not auto-apply — copy/paste them yourself)',
       type: 'boolean',
       default: false
     },
@@ -573,7 +576,7 @@ export const doctorCommand: Command = {
   ],
   examples: [
     { command: 'claude-flow doctor', description: 'Run full health check' },
-    { command: 'claude-flow doctor --fix', description: 'Show fixes for issues' },
+    { command: 'claude-flow doctor --fix', description: 'Print suggested fix commands (does not auto-apply)' },
     { command: 'claude-flow doctor --install', description: 'Auto-install missing dependencies' },
     { command: 'claude-flow doctor -c version', description: 'Check for stale npx cache' },
     { command: 'claude-flow doctor -c claude', description: 'Check Claude Code CLI only' }
@@ -707,17 +710,18 @@ export const doctorCommand: Command = {
 
     output.writeln(`Summary: ${summaryParts.join(', ')}`);
 
-    // Show fixes
+    // Show fixes — #1791.5: header makes it explicit these are commands you
+    // run yourself, not actions doctor took.
     if (showFix && fixes.length > 0) {
       output.writeln();
-      output.writeln(output.bold('Suggested Fixes:'));
+      output.writeln(output.bold('Suggested commands (run them yourself):'));
       output.writeln();
       for (const fix of fixes) {
         output.writeln(output.dim(`  ${fix}`));
       }
     } else if (fixes.length > 0 && !showFix) {
       output.writeln();
-      output.writeln(output.dim(`Run with --fix to see ${fixes.length} suggested fix${fixes.length > 1 ? 'es' : ''}`));
+      output.writeln(output.dim(`Run with --fix to see ${fixes.length} suggested command${fixes.length > 1 ? 's' : ''} (does not auto-apply)`));
     }
 
     // Overall result


### PR DESCRIPTION
## Summary

Fixes sub-bug 5 of #1791. \`ruflo doctor --fix\` was reported as misleading: the flag name reads as "automatically fix issues" but the implementation only PRINTS suggested shell commands. The pre-existing help text ("Show fix commands for issues") was buried and ambiguous.

## Changes

Three small wording updates in \`v3/@claude-flow/cli/src/commands/doctor.ts\`:

- Option description: \`Print suggested fix commands (does not auto-apply — copy/paste them yourself)\`
- Example description matches.
- Output header changes from \`Suggested Fixes:\` to \`Suggested commands (run them yourself):\`, and the "use --fix" hint mentions that it doesn't auto-apply.

No behavior change. Backward compatible (same flag name, same output structure).

## Out of scope

A real auto-apply mode (proposed \`--apply\` in #1791) is intentionally out of scope — that needs design work on which fix recipes are safe enough to run without user confirmation.

## Test plan

- [x] Diff contained: 1 file, +9 / -5
- [ ] CI green
- [ ] Manual: \`ruflo doctor --help\` now shows the unambiguous description; \`ruflo doctor --fix\` prints the new "Suggested commands (run them yourself):" header

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)