### PR TITLE
fix(hive-mind): re-route task submission to existing task_create MCP tool (#1791.1)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -986,19 +986,33 @@ const taskCommand: Command = {
     output.printInfo('Submitting task to hive...');
 
     try {
+      // #1791.1 — `hive-mind_task` was never registered in the bundled MCP
+      // server (the `mcp__ruflo__hive-mind_*` surface only exposes init,
+      // spawn, status, broadcast, consensus, memory, shutdown, leave). The
+      // CLI was dispatching to a tool that doesn't exist, producing
+      // `MCP tool not found: hive-mind_task` and aborting.
+      //
+      // Re-route to the existing `task_create` tool. Hive-specific options
+      // (consensus requirement, timeout) are preserved as tags so a future
+      // hive-mind worker / consensus tool can pick them up — the data is
+      // not lost just because the dedicated hive-mind tool isn't there yet.
+      const consensusTag = `consensus:${requireConsensus ? 'required' : 'none'}`;
+      const timeoutTag = `timeout:${timeout}s`;
+
       const result = await callMCPTool<{
         taskId: string;
+        type: string;
         description: string;
+        priority: string;
         status: string;
         assignedTo: string[];
-        priority: string;
-        requiresConsensus: boolean;
-        estimatedTime: string;
-      }>('hive-mind_task', {
+        tags: string[];
+        createdAt: string;
+      }>('task_create', {
+        type: 'hive-mind',
         description,
         priority,
-        requireConsensus,
-        timeout,
+        tags: ['hive-mind', consensusTag, timeoutTag],
       });
 
       if (ctx.flags.format === 'json') {
@@ -1012,9 +1026,10 @@ const taskCommand: Command = {
           `Task ID: ${result.taskId}`,
           `Status: ${formatAgentStatus(result.status)}`,
           `Priority: ${formatPriority(priority)}`,
-          `Assigned: ${result.assignedTo.join(', ')}`,
-          `Consensus: ${result.requiresConsensus ? 'Yes' : 'No'}`,
-          `Est. Time: ${result.estimatedTime}`
+          `Assigned: ${result.assignedTo.length > 0 ? result.assignedTo.join(', ') : 'pending dispatch'}`,
+          `Consensus: ${requireConsensus ? 'Yes' : 'No'}`,
+          `Timeout: ${timeout}s`,
+          `Tags: ${result.tags.join(', ')}`
         ].join('\n'),
         'Task Submitted'
       );


### PR DESCRIPTION
## Summary

Fixes sub-bug 1 of #1791 — \`ruflo hive-mind task ...\` was unconditionally failing because the CLI dispatched to a non-existent MCP tool:

\`\`\`text
$ ruflo hive-mind task --description "smoke" --hive-id <id>
[INFO] Submitting task to hive...
[ERROR] Task submission error: MCP tool not found: hive-mind_task
\`\`\`

The bundled MCP server's \`mcp__ruflo__hive-mind_*\` surface exposes init / spawn / status / broadcast / consensus / memory / shutdown / leave — but no \`task\` tool. The CLI was calling a name that was never registered.

## Fix

Re-route the CLI to the existing \`task_create\` tool. Hive-specific options that don't have a home in \`task_create\`'s schema are preserved as tags so a future hive-mind worker can pick them up:

- \`consensus:required\` / \`consensus:none\`
- \`timeout:<n>s\`
- \`hive-mind\` (general bucket tag)

Display values for priority / consensus / timeout come from local flags (since \`task_create\` doesn't echo them all). \`assignedTo\` shows "pending dispatch" when \`task_create\` returns the empty array (the expected state right after creation, before workers pick it up).

This is the lower-risk option vs. registering a new \`hive-mind_task\` tool, which would need a hive-mind-specific backing implementation and a corresponding schema decision (consensus quorum, timeout enforcement, etc.).

## Test plan

- [x] Diff contained: 1 file, +24 / -9
- [ ] CI green
- [ ] Manual: \`ruflo hive-mind task -d "smoke" --hive-id <id>\` should succeed and print a Task Submitted box (vs the previous \`MCP tool not found\` error)
- [ ] Verify tags appear in the output: \`Tags: hive-mind, consensus:required, timeout:300s\` (or similar based on flags passed)

## Out of scope

A real hive-mind-specific task tool (with consensus enforcement, hive-aware dispatch) is tracked separately. This PR keeps the CLI working today.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)