### PR TITLE
fix(memory): content-hash dedupe in memory_import_claude --allProjects (#1791.8)

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -13,6 +13,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, resolve } from 'path';
+import { createHash } from 'crypto';
 import type { MCPTool } from './types.js';
 import { validateIdentifier } from './validate-input.js';
 
@@ -711,12 +712,31 @@ export const memoryTools: MCPTool[] = [
 
       let imported = 0;
       let skipped = 0;
+      // #1791.8 — Claude Code's `~/.claude/projects/` accumulates historical
+      // project_id directories (truncated forms, sandbox cwds, renamed
+      // workspaces) that all contain copies of the same memory files. The
+      // previous import indexed each copy under a different `project_id`
+      // prefix, producing 5–8x duplication on long-lived homes. Dedupe by
+      // file content hash so the same memory is imported once even if it
+      // appears under several project directories.
+      const seenContentHashes = new Set<string>();
+      let duplicatesSkipped = 0;
       const projects = new Set<string>();
 
       for (const memFile of memoryFiles) {
         projects.add(memFile.project);
         try {
           const content = readFileSync(memFile.path, 'utf-8');
+
+          // #1791.8 — Skip if we've already imported this exact content under
+          // a different project_id directory.
+          const contentHash = createHash('sha256').update(content).digest('hex').slice(0, 16);
+          if (seenContentHashes.has(contentHash)) {
+            duplicatesSkipped++;
+            continue;
+          }
+          seenContentHashes.add(contentHash);
+
           const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
           let name = memFile.file.replace('.md', '');
           let body = content;
@@ -753,6 +773,7 @@ export const memoryTools: MCPTool[] = [
         success: true,
         imported,
         skipped,
+        duplicatesSkipped,
         files: memoryFiles.length,
         projects: projects.size,
         namespace: ns,


### PR DESCRIPTION
## Summary

Fixes sub-bug 8 of #1791 — \`memory_import_claude --allProjects=true\` was indexing the same memory file content under multiple \`project_id\` prefixes, producing 5–8x duplication on long-lived homes. Reporter measured 2648 entries from 456 files on an 8-project home (vs 331 entries from 57 files with \`--allProjects=false\` — natural 8x reduction).

## Root cause

Claude Code's \`~/.claude/projects/\` directory accumulates historical project_id directories: truncated forms (\`claude:-home-matheus:\` vs \`claude:-home-mathe:\`), sandbox cwds, renamed workspaces, etc. Each contains its own copy of the same memory files. The previous import walked all of them and stored every copy under a different \`claude:<project_id>:<name>:<section>\` key.

## Fix

Add content-hash dedupe to the \`allProjects\` walk:

\`\`\`ts
const seenContentHashes = new Set<string>();
// ...
const contentHash = createHash('sha256').update(content).digest('hex').slice(0, 16);
if (seenContentHashes.has(contentHash)) { duplicatesSkipped++; continue; }
seenContentHashes.add(contentHash);
\`\`\`

Surface \`duplicatesSkipped\` in the response so users can see how much dedupe happened on their home.

## Behavior preserved

- The FIRST project_id seen for each unique content keeps the import (deterministic given readdir's sort order)
- Real behavioral differences between projects' versions of "the same" memory file hash differently and import normally
- Per-project import (\`--allProjects=false\`) is unchanged — still indexes everything in the current project's directory

## Test plan

- [x] Diff contained: 1 file, +21 / -0 (purely additive)
- [ ] CI green
- [ ] Manual: \`memory_import_claude\` with \`allProjects: true\` should report a non-zero \`duplicatesSkipped\` on a multi-project home, and \`imported\` count drops to roughly the per-project number times the count of unique projects

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)