### PR TITLE
fix(doctor): surface config collision between legacy JSON and v3 YAML (closes #1798)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -73,36 +73,60 @@ async function checkNpmVersion(): Promise<HealthCheck> {
 
 // Check config file
 async function checkConfigFile(): Promise<HealthCheck> {
-  // JSON configs (parse-validated)
+  // JSON configs (parse-validated). The first three are LEGACY shapes from
+  // pre-v3 init flows; v3 init writes only `.claude-flow/config.yaml`.
   const jsonPaths = [
     '.claude-flow/config.json',
     'claude-flow.config.json',
     '.claude-flow.json'
   ];
-
-  for (const configPath of jsonPaths) {
-    if (existsSync(configPath)) {
-      try {
-        const content = readFileSync(configPath, 'utf8');
-        JSON.parse(content);
-        return { name: 'Config File', status: 'pass', message: `Found: ${configPath}` };
-      } catch (e) {
-        return { name: 'Config File', status: 'fail', message: `Invalid JSON: ${configPath}`, fix: 'Fix JSON syntax in config file' };
-      }
-    }
-  }
-
-  // YAML configs (existence-checked only — no heavy yaml parser dependency)
+  // YAML configs (existence-checked only — no heavy yaml parser dependency).
   const yamlPaths = [
     '.claude-flow/config.yaml',
     '.claude-flow/config.yml',
     'claude-flow.config.yaml'
   ];
 
-  for (const configPath of yamlPaths) {
-    if (existsSync(configPath)) {
-      return { name: 'Config File', status: 'pass', message: `Found: ${configPath}` };
+  // #1798 — collect ALL configs that exist instead of returning at the first
+  // hit. The previous early-return masked silent collisions: if both a v2
+  // JSON and a v3 YAML existed, doctor reported only the JSON while the
+  // daemon was actually reading from the YAML. Surfacing both lets the user
+  // see and resolve the disagreement.
+  const foundJson: string[] = [];
+  const invalidJson: string[] = [];
+  for (const configPath of jsonPaths) {
+    if (!existsSync(configPath)) continue;
+    try {
+      JSON.parse(readFileSync(configPath, 'utf8'));
+      foundJson.push(configPath);
+    } catch {
+      invalidJson.push(configPath);
     }
+  }
+  const foundYaml = yamlPaths.filter(p => existsSync(p));
+
+  // Hard failures first: malformed JSON wins.
+  if (invalidJson.length > 0) {
+    return { name: 'Config File', status: 'fail', message: `Invalid JSON: ${invalidJson.join(', ')}`, fix: 'Fix JSON syntax in config file' };
+  }
+
+  // #1798 — collision: legacy JSON + new YAML both present. Subsystems can
+  // disagree on which to read; surface this as a warn with the recommended
+  // resolution (keep the YAML, archive the JSON).
+  if (foundJson.length > 0 && foundYaml.length > 0) {
+    return {
+      name: 'Config File',
+      status: 'warn',
+      message: `Config collision: legacy ${foundJson.join(', ')} + ${foundYaml.join(', ')} — subsystems may disagree silently`,
+      fix: `Archive the legacy JSON (mv ${foundJson[0]} ${foundJson[0]}.bak) and keep ${foundYaml[0]} as the canonical config`,
+    };
+  }
+
+  if (foundYaml.length > 0) {
+    return { name: 'Config File', status: 'pass', message: `Found: ${foundYaml[0]}` };
+  }
+  if (foundJson.length > 0) {
+    return { name: 'Config File', status: 'pass', message: `Found: ${foundJson[0]}` };
   }
 
   return { name: 'Config File', status: 'warn', message: 'No config file (using defaults)', fix: 'claude-flow config init' };


### PR DESCRIPTION
## Summary

Closes #1798. Previously \`ruflo doctor\` reported only the FIRST config file it found (checking JSON before YAML), which masked the silent disagreement #1798 describes: a project with both a leftover v2 \`claude-flow.config.json\` AND a v3 \`.claude-flow/config.yaml\` would see doctor pass with the JSON listed as "active" while the daemon was actually reading from the YAML — causing swarms to spin up with config A while doctor confirms config B.

## Reproduction (from issue)

> \`claude-flow doctor\` reports the JSON as the active config: \`✓ Config File: Found: claude-flow.config.json\`.
> Swarms spawned by the daemon used the YAML values (\`hierarchical-mesh, maxAgents: 15\`) — confirmed in \`swarm-state.json\` entries.

## Root cause

\`v3 init\` writes only \`.claude-flow/config.yaml\`. The JSON variants are leftover from pre-v3 init flows. The two files survive upgrades and silently disagree.

## Fix

\`v3/@claude-flow/cli/src/commands/doctor.ts\` — \`checkConfigFile()\`:

- Collect ALL configs that exist instead of early-returning at the first hit.
- Hard failure on malformed JSON (unchanged behavior).
- **New collision case**: if both a legacy JSON and a v3 YAML exist, emit \`warn\` with \`Config collision: ... — subsystems may disagree silently\` and a \`fix\` suggesting \`mv <legacy>.json <legacy>.json.bak\`, keeping the YAML canonical.
- Otherwise prefer YAML (v3 canonical) over a lone JSON.

## Out of scope

The actual subsystem-side unification (a single config loader that all subsystems use) is a larger change tracked separately. This PR makes the collision **detectable** so users can resolve it manually until that lands. Doctor stops being silent.

## Test plan

- [x] Diff contained: 1 file, +42 / -18
- [ ] CI green
- [ ] Manual: project with both \`claude-flow.config.json\` and \`.claude-flow/config.yaml\` — \`ruflo doctor\` should now report the collision warning instead of silently passing
- [ ] Manual: project with only the YAML — doctor should pass with the YAML listed
- [ ] Manual: project with only a JSON — doctor should pass with the JSON listed

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)