### PR TITLE
fix(hooks): NaN-safe coercion in metrics + pretrain output (#1686)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -11,6 +11,17 @@ import { storeCommand } from './transfer-store.js';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
+/**
+ * #1686 — `?? 0` only defaults null/undefined; NaN slips through and
+ * surfaces as `"NaN"` (or earlier crashed `.toFixed`) in the metrics
+ * dashboard and pretrain output. Coerce to a finite number, fall back
+ * to `fallback` when the input is null/undefined/non-numeric/NaN/Infinity.
+ */
+function safeNum(value: unknown, fallback = 0): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 // ============================================================================
 // Coverage Data Reader - reads Jest/Istanbul coverage files from disk
 // ============================================================================
@@ -1113,8 +1124,10 @@ const pretrainCommand: Command = {
       spinner.succeed('Pretraining completed');
 
       // Normalize shape: prefer `statistics`, fall back to `stats` for older tools.
+      // #1686 — coerce duration through safeNum so a NaN from the underlying
+      // pretrain pipeline surfaces as `0.0s` rather than `NaNs`.
       const stats = (rawResult.statistics ?? rawResult.stats ?? {}) as Record<string, number | undefined>;
-      const durationMs = rawResult.duration ?? (rawResult.statistics?.executionTime as number | undefined) ?? 0;
+      const durationMs = safeNum(rawResult.duration ?? rawResult.statistics?.executionTime);
       const result = { ...rawResult, stats, duration: durationMs };
 
       if (ctx.flags.format === 'json') {
@@ -1375,20 +1388,21 @@ const metricsCommand: Command = {
       });
 
       // Normalize across both shapes; default every numeric to 0 so toFixed
-      // never sees null/undefined.
-      const totalPatterns = rawMetrics.patterns?.total ?? rawMetrics.summary?.patternsLearned ?? 0;
-      const successfulPatterns = rawMetrics.patterns?.successful ?? Math.round((rawMetrics.summary?.successRate ?? 0) * totalPatterns);
-      const failedPatterns = rawMetrics.patterns?.failed ?? Math.max(0, totalPatterns - successfulPatterns);
-      const avgConfidence = rawMetrics.patterns?.avgConfidence ?? rawMetrics.summary?.avgQuality ?? 0;
+      // never sees null/undefined. #1686 — also coerce NaN through `safeNum`
+      // because `?? 0` only catches null/undefined; an upstream NaN would
+      // still land in `.toFixed(...)` and surface as `"NaN"`.
+      const totalPatterns = safeNum(rawMetrics.patterns?.total ?? rawMetrics.summary?.patternsLearned);
+      const successfulPatterns = safeNum(rawMetrics.patterns?.successful ?? Math.round(safeNum(rawMetrics.summary?.successRate) * totalPatterns));
+      const failedPatterns = Math.max(0, safeNum(rawMetrics.patterns?.failed ?? totalPatterns - successfulPatterns));
+      const avgConfidence = safeNum(rawMetrics.patterns?.avgConfidence ?? rawMetrics.summary?.avgQuality);
 
-      const routingAccuracy = rawMetrics.agents?.routingAccuracy
-        ?? (rawMetrics.routing?.avgConfidence ?? 0);
-      const totalRoutes = rawMetrics.agents?.totalRoutes ?? rawMetrics.routing?.totalRoutes ?? 0;
+      const routingAccuracy = safeNum(rawMetrics.agents?.routingAccuracy ?? rawMetrics.routing?.avgConfidence);
+      const totalRoutes = safeNum(rawMetrics.agents?.totalRoutes ?? rawMetrics.routing?.totalRoutes);
       const topAgent = rawMetrics.agents?.topAgent ?? rawMetrics.routing?.topAgents?.[0]?.agent ?? 'n/a';
 
-      const totalCommands = rawMetrics.commands?.totalExecuted ?? rawMetrics.commands?.totalCommands ?? 0;
-      const commandSuccessRate = rawMetrics.commands?.successRate ?? 0;
-      const avgRiskScore = rawMetrics.commands?.avgRiskScore ?? rawMetrics.commands?.avgExecutionTime ?? 0;
+      const totalCommands = safeNum(rawMetrics.commands?.totalExecuted ?? rawMetrics.commands?.totalCommands);
+      const commandSuccessRate = safeNum(rawMetrics.commands?.successRate);
+      const avgRiskScore = safeNum(rawMetrics.commands?.avgRiskScore ?? rawMetrics.commands?.avgExecutionTime);
 
       const result = {
         ...rawMetrics,


### PR DESCRIPTION
## Summary

Partially closes #1686 (display layer). \`?? 0\` defaults null/undefined but lets NaN through. When a counter came back as \`Number.NaN\` from the MCP tool, the metrics dashboard either rendered \`"NaN"\` (best case) or threw \`TypeError: Cannot read properties of null (reading 'toFixed')\` (worst case, before the May-1 nullish-coalesce work landed). Pretrain specifically reported \`Duration: NaNs\` because \`rawResult.duration === NaN\` survived the \`??\` chain.

## Fix

Tiny \`safeNum(value, fallback = 0)\` helper at the top of \`hooks.ts\` that coerces to a *finite* number — null / undefined / non-numeric / NaN / Infinity all collapse to \`fallback\`:

\`\`\`ts
function safeNum(value: unknown, fallback = 0): number {
  const n = typeof value === 'number' ? value : Number(value);
  return Number.isFinite(n) ? n : fallback;
}
\`\`\`

Use it for every numeric the metrics + pretrain commands feed into \`.toFixed(...)\`:
- \`metricsCommand\`: totalPatterns, successfulPatterns, failedPatterns, avgConfidence, routingAccuracy, totalRoutes, totalCommands, commandSuccessRate, avgRiskScore
- \`pretrainCommand\`: durationMs

## Out of scope (separate larger fix)

The user's issue describes an architectural disconnect: \`hooks post-*\` writes land in \`.swarm/memory.db\` but the dashboard reads \`.claude-flow/metrics/*.json\`. That bridge work is tracked for follow-up. This PR fixes the **display layer** so users at least see \`0.0s\` and \`0.0%\` instead of \`NaNs\` / TypeErrors. The numbers will still be zero until the persistence bridge lands; that's a separate problem.

## Test plan

- [x] Diff contained: 1 file, +27 / -13
- [ ] CI green
- [ ] Manual: \`ruflo hooks pretrain\` on a path with no timing data — should print \`Duration: 0.0s\`, not \`Duration: NaNs\`
- [ ] Manual: \`ruflo hooks metrics\` on a fresh project (no entries in memory.db yet) — should render the dashboard cleanly with all-zeros instead of crashing

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)