### PR TITLE
fix(init): make RuFlo attribution trailer opt-in (closes #1670)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/commands-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/commands-deep.test.ts
@@ -1487,9 +1487,19 @@ describe('Init System', () => {
       expect(perms.deny).toBeDefined();
     });
 
-    it('should include attribution', () => {
+    it('should NOT include attribution by default (opt-in per #1670)', () => {
+      // #1670 — attribution (Co-Authored-By trailer) is now opt-in to avoid
+      // silently injecting a third-party co-author into user commits.
       const settings = generateSettings(DEFAULT_INIT_OPTIONS) as Record<string, unknown>;
+      expect(settings.attribution).toBeUndefined();
+    });
+
+    it('should include attribution when opted in', () => {
+      const settings = generateSettings({ ...DEFAULT_INIT_OPTIONS, attribution: true }) as Record<string, unknown>;
       expect(settings.attribution).toBeDefined();
+      const attribution = settings.attribution as Record<string, string>;
+      expect(attribution.commit).toContain('Co-Authored-By:');
+      expect(attribution.pr).toContain('Generated with');
     });
 
     it('should include env with agent teams enabled', () => {

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -41,11 +41,17 @@ export function generateSettings(options: InitOptions): object {
     ],
   };
 
-  // Add RuFlo attribution for git commits and PRs
-  settings.attribution = {
-    commit: 'Co-Authored-By: RuFlo <ruv@ruv.net>',
-    pr: '🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)',
-  };
+  // #1670 — RuFlo attribution (Co-Authored-By trailer + PR footer) is now
+  // OPT-IN. Default behavior no longer injects a third-party Co-Authored-By
+  // line into the user's commits — that pattern silently inflated GitHub
+  // contributor graphs and was hard to undo without rewriting history. Pass
+  // `--attribution` (or `attribution: true` in InitOptions) to enable.
+  if (options.attribution === true) {
+    settings.attribution = {
+      commit: 'Co-Authored-By: RuFlo <ruv@ruv.net>',
+      pr: '🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)',
+    };
+  }
 
   // Note: Claude Code expects 'model' to be a string, not an object
   // Model preferences are stored in claudeFlow settings instead

--- a/v3/@claude-flow/cli/src/init/types.ts
+++ b/v3/@claude-flow/cli/src/init/types.ts
@@ -316,6 +316,13 @@ export interface InitOptions {
    * Set true via --no-global to keep the global Claude rules file pristine (#1744).
    */
   skipGlobalClaudeMd?: boolean;
+  /**
+   * #1670 — opt in to writing the `attribution` block in `.claude/settings.json`
+   * (Co-Authored-By trailer + PR footer). Defaults to false: most users do not
+   * want a third-party Co-Authored-By line silently added to their commits and
+   * GitHub contributor graph. Pass `--attribution` to opt in.
+   */
+  attribution?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1670. \`ruflo init\` was silently writing this block into every project's \`.claude/settings.json\`:

\`\`\`json
"attribution": {
  "commit": "Co-Authored-By: RuFlo <ruv@ruv.net>",
  "pr":     "🤖 Generated with [RuFlo](...)"
}
\`\`\`

…which the assistant then dutifully appended to every commit it created during a session. The reporter flagged real consequences:

- **No consent** — trailer is injected without prompting
- **Misrepresents contribution** — implies direct human authorship from \`ruv@ruv.net\`
- **Pollutes GitHub contributor graphs** — Co-Authored-By trailers count toward the Contributors page, so \`ruvnet\` appeared on repos they never touched
- **Hard to undo** — removing the trailer needs \`git filter-branch\` + force-push, which disrupts anyone who cloned the repo

## Fix

Make it opt-in:

| File | Change |
|---|---|
| \`v3/@claude-flow/cli/src/init/types.ts\` | Add \`attribution?: boolean\` to \`InitOptions\` |
| \`v3/@claude-flow/cli/src/init/settings-generator.ts\` | Only emit \`settings.attribution\` when \`options.attribution === true\` |
| \`v3/@claude-flow/cli/__tests__/commands-deep.test.ts\` | Replace "should include attribution" with two tests: default = undefined, opt-in = present |

## Backward compat

- **Existing projects** keep their \`settings.attribution\` block as-is. This PR only changes what \`ruflo init\` *writes* on fresh setup.
- **Users who want the trailer** can pass \`--attribution\` (when surfaced as a CLI flag) or add the block to their \`.claude/settings.json\` manually.
- **No code reads \`attribution.commit\` directly** — verified via grep. The field is purely informational; the assistant follows it via CLAUDE.md / the system prompt's "create commits" instructions.

## Test plan

- [x] Diff contained: 3 files, +29 / -6
- [x] Test updated: default config no longer asserts attribution; opt-in path has explicit assertion
- [ ] CI green
- [ ] Manual: \`ruflo init\` in a fresh project — \`.claude/settings.json\` should NOT contain the \`attribution\` field
- [ ] Manual: \`ruflo init\` (when CLI surface lands) with \`--attribution\` — block IS present

## Note about this PR's own commit

For consistency with the issue, this PR's commit message itself still ends with the trailer (because the cron loop's commit-template instructions in CLAUDE.md include it). That's a separate change — merging this PR moves the fix forward; aligning the project's own commit conventions to match the new opt-in default is a follow-up.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)