### PR TITLE
fix(memory): show active embedding provider + HNSW status in stats (closes #1622)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -701,6 +701,69 @@ const statsCommand: Command = {
         ]
       });
 
+      // #1622 — Surface the active embedding provider in `memory stats` so
+      // users can tell which backend resolved at runtime (the 6-level
+      // fallback chain in loadEmbeddingModel ranges from full ONNX to a
+      // 128-dim hash that has no semantic understanding). Calling
+      // loadEmbeddingModel() is cheap when the model is already cached;
+      // a fresh call still resolves quickly because we only need the
+      // metadata, not a real embedding.
+      try {
+        const { loadEmbeddingModel, getHNSWStatus } = await import('../memory/memory-initializer.js');
+        const embedding = await loadEmbeddingModel({ verbose: false });
+        const hnsw = getHNSWStatus();
+        // Map model name → semantic capability so users can spot the
+        // hash-fallback case without reading docs.
+        const semanticProviders = new Set([
+          'Xenova/all-MiniLM-L6-v2',
+          'Xenova/all-mpnet-base-v2',
+          'Xenova/bge-small-en-v1.5',
+          'agentic-flow',
+          'agentic-flow/reasoningbank',
+          'ruvector/onnx',
+          'cached',
+        ]);
+        const isSemantic = embedding.success && semanticProviders.has(embedding.modelName);
+
+        output.writeln();
+        output.writeln(output.bold('Embedding'));
+        output.printTable({
+          columns: [
+            { key: 'metric', header: 'Metric', width: 20 },
+            { key: 'value', header: 'Value', width: 30, align: 'right' }
+          ],
+          data: [
+            {
+              metric: 'Provider',
+              value: embedding.success
+                ? embedding.modelName
+                : output.warning(`unavailable: ${embedding.error || 'unknown'}`),
+            },
+            { metric: 'Dimensions', value: String(embedding.dimensions) },
+            {
+              metric: 'Semantic Search',
+              value: isSemantic
+                ? output.success('yes')
+                : output.warning('no — using hash fallback'),
+            },
+            {
+              metric: 'HNSW Index',
+              value: hnsw.available && hnsw.initialized
+                ? output.success(`active (${hnsw.entryCount.toLocaleString()} entries)`)
+                : hnsw.available
+                  ? output.warning('available but not initialized')
+                  : output.dim('not active'),
+            },
+          ]
+        });
+      } catch (e) {
+        // Don't fail the whole stats command if introspection breaks —
+        // the rest of the dashboard is still useful.
+        output.writeln();
+        output.writeln(output.bold('Embedding'));
+        output.printInfo(`Provider info unavailable: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
       output.writeln();
       output.printInfo('V3 Performance: 150x-12,500x faster search with HNSW indexing');
 


### PR DESCRIPTION
## Summary

Closes #1622. \`ruflo memory stats\` previously didn't surface which embedding backend the runtime fallback chain in \`loadEmbeddingModel()\` actually picked. That matters because the chain ranges from full 384-dim ONNX semantic search down to a 128-dim hash fallback with **no semantic understanding** — and users couldn't tell which one they had without re-running \`memory init --verbose --force\` (destructive: reinitializes the DB).

The reporter noted three concrete consequences: (1) search returns poor results on the hash fallback with no indication why, (2) entries stored under different providers have incompatible dimensions, (3) debugging "memory search doesn't find expected results" always starts with "which embedder is active?" with no command to answer it.

## Fix

Add an "Embedding" section to \`memory stats\` (\`v3/@claude-flow/cli/src/commands/memory.ts\`):

| Field | Source | Notes |
|---|---|---|
| Provider | \`loadEmbeddingModel().modelName\` | e.g. \`Xenova/all-MiniLM-L6-v2\`, \`ruvector/onnx\`, \`hash-fallback\` |
| Dimensions | \`loadEmbeddingModel().dimensions\` | 384 / 768 / 128 |
| Semantic Search | derived from known-providers Set | surfaces the hash-fallback degradation explicitly so users see WHY results are poor |
| HNSW Index | \`getHNSWStatus()\` | active (with entry count) / available-not-init / not-active |

Wrapped in try/catch so a broken introspection path doesn't fail the whole stats dashboard.

## Notes

- \`loadEmbeddingModel()\` is cached after the first call so subsequent \`memory stats\` invocations are essentially free.
- This is the same scope as the in-flight #1623 PR (which was also referenced from the issue body); landing either one closes #1622. This branch is independent of #1623 and can replace it.

## Test plan

- [x] Diff contained: 1 file, +63 / -0
- [ ] CI green
- [ ] Manual: \`ruflo memory stats\` should render a new "Embedding" table with provider/dim/semantic/HNSW rows
- [ ] Manual: in an env where ONNX is unavailable, the Provider row should show \`hash-fallback\` and Semantic Search should show the warning

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)