### PR TITLE
fix(init): skip writing .mcp.json when ruflo MCP already registered (closes #1779)

### DIFF
--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -776,6 +776,49 @@ async function writeSettings(
 }
 
 /**
+ * #1779 — Walk parents of `targetDir` plus the user-global Claude Code
+ * config locations, looking for any `.mcp.json` (or `~/.claude.json`)
+ * that already declares a `ruflo`-keyed MCP server. We use this to skip
+ * writing our own `claude-flow`-keyed entry when the user has already
+ * registered the same binary under the new name — that's exactly the
+ * "same MCP server twice under two different prefixes" duplication the
+ * issue describes.
+ *
+ * Returns the path of the file that already declares `ruflo` (so we can
+ * surface it in the skipped-message), or null if none found.
+ */
+function detectExistingRufloMCP(targetDir: string): string | null {
+  const home = (process.env.HOME ?? process.env.USERPROFILE) ?? '';
+  const candidates = new Set<string>();
+  // User-global Claude Code config locations
+  if (home) {
+    candidates.add(path.join(home, '.claude.json'));
+    candidates.add(path.join(home, '.claude', 'mcp.json'));
+  }
+  // Walk parents of targetDir up to root, checking for .mcp.json at each
+  let dir = path.resolve(targetDir);
+  while (true) {
+    candidates.add(path.join(dir, '.mcp.json'));
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Skip the targetDir itself — that's the one we're about to write
+  candidates.delete(path.join(path.resolve(targetDir), '.mcp.json'));
+
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+        if ('ruflo' in parsed.mcpServers) return candidate;
+      }
+    } catch { /* malformed JSON — ignore */ }
+  }
+  return null;
+}
+
+/**
  * Write .mcp.json
  */
 async function writeMCPConfig(
@@ -788,6 +831,20 @@ async function writeMCPConfig(
   if (fs.existsSync(mcpPath) && !options.force) {
     result.skipped.push('.mcp.json');
     return;
+  }
+
+  // #1779 — Skip writing if the user already has a `ruflo`-keyed MCP
+  // server registered elsewhere (parent .mcp.json, ~/.claude.json, etc).
+  // Writing our `claude-flow`-keyed entry on top of that produces the
+  // duplicate-registration the issue describes (~250 duplicate tools).
+  // Force-mode (`--force`) bypasses this guard for users who actually
+  // want both registrations.
+  if (!options.force) {
+    const existingRufloPath = detectExistingRufloMCP(targetDir);
+    if (existingRufloPath) {
+      result.skipped.push(`.mcp.json (existing 'ruflo' MCP registration found at ${existingRufloPath} — would create duplicate; pass --force to write anyway)`);
+      return;
+    }
   }
 
   const content = generateMCPJson(options);


### PR DESCRIPTION
## Summary

Closes #1779. \`ruflo init\` always wrote \`.mcp.json\` with a hardcoded \`claude-flow\` top-level key. When users had ALSO registered the same binary under the new \`ruflo\` name (via \`claude mcp add ruflo ...\`, or via another project's \`.mcp.json\` in a parent directory), Claude Code ended up registering **the same MCP server twice under two prefixes** (\`mcp__claude-flow__*\` and \`mcp__ruflo__*\`), exposing ~250 duplicate tools and inflating the deferred-tools list.

## Fix (defensive, narrow)

\`v3/@claude-flow/cli/src/init/executor.ts\`:

1. **\`detectExistingRufloMCP(targetDir)\`** — walks parents of \`targetDir\` looking for \`.mcp.json\`, plus \`~/.claude.json\` and \`~/.claude/mcp.json\`. Returns the path of any file that already declares a \`ruflo\`-keyed MCP server.
2. **\`writeMCPConfig\`** — when that helper hits AND \`--force\` is not passed, skip writing \`.mcp.json\` with a clear message naming the existing file. The user keeps their single \`ruflo\` registration; init doesn't add the duplicate.
3. **\`--force\`** still bypasses the guard for users who genuinely want both.

## What this PR does NOT do

Rename \`claude-flow\` → \`ruflo\` as the canonical MCP key. That's a wider change because the codebase's existing tool references (\`mcp__claude-flow__*\` in agent prompts, CLAUDE.md docs, lots of skills) assume the legacy key. Leaving canonical-key migration for a follow-up design pass — this PR fixes the immediate duplicate-registration pain without breaking existing tool references.

## Test plan

- [x] Diff contained: 1 file, +57 / -0 (purely additive)
- [ ] CI green
- [ ] Manual: in a project where the user has run \`claude mcp add ruflo -- npx -y ruflo mcp start\` (so \`~/.claude.json\` has a \`ruflo\` entry), \`ruflo init\` should now skip \`.mcp.json\` writing with a message naming the existing config
- [ ] Manual: \`ruflo init --force\` overrides and writes anyway
- [ ] Manual: in a fresh env with no existing \`ruflo\` registration, init still writes \`.mcp.json\` as before

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)