### PR TITLE
fix(statusline): detect Python test_*.py / spec_*.py files (closes #1463)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -533,7 +533,17 @@ function getTestStats() {
           countTestFiles(path.join(dir, entry.name), depth + 1);
         } else if (entry.isFile()) {
           const n = entry.name;
-          if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.')) {
+          // #1463 — also detect Python pytest's `test_*.py` convention
+          // (and the rarer `*_test.py` / `*_test.py` already covered by
+          // _test. above; spec_*.py mirrors test_*.py for unittest naming).
+          if (
+            n.includes('.test.') ||
+            n.includes('.spec.') ||
+            n.includes('_test.') ||
+            n.includes('_spec.') ||
+            n.startsWith('test_') ||
+            n.startsWith('spec_')
+          ) {
             testFiles++;
           }
         }


### PR DESCRIPTION
## Summary

Closes #1463. \`getTestStats()\` in \`.claude/helpers/statusline.cjs\` only matched JS/TS conventions (\`*.test.*\`, \`*.spec.*\`) and Go/Rust-style \`*_test.*\` / \`*_spec.*\`. It missed pytest's standard \`test_*.py\` naming, so a Python project with \`tests/test_app.py\`, \`tests/test_export.py\`, etc. showed up as \`Tests ●0 (~0 cases)\` in the statusline.

## Fix

Add \`startsWith('test_')\` and \`startsWith('spec_')\` to the existing matcher. Both apply to any extension (\`.py\`, \`.ts\`, \`.js\`, \`.rb\`, ...) so pytest, unittest, and similar conventions count correctly.

\`\`\`diff
- if (n.includes('.test.') || n.includes('.spec.') || n.includes('_test.') || n.includes('_spec.')) {
+ if (
+   n.includes('.test.') ||
+   n.includes('.spec.') ||
+   n.includes('_test.') ||
+   n.includes('_spec.') ||
+   n.startsWith('test_') ||
+   n.startsWith('spec_')
+ ) {
\`\`\`

## Scope

The two other \`statusline.cjs\` copies under \`v3/@claude-flow/{cli,mcp}/\` have a different, older layout that doesn't define \`getTestStats()\` at all — no change needed there.

## Test plan

- [x] Diff contained: 1 file, +11 / -1
- [ ] CI green
- [ ] Manual: Python project with \`tests/test_*.py\` files now shows non-zero \`Tests ●N\` in the statusline

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)