### PR TITLE
chore(release): 3.7.0-alpha.10 — 21 issue fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.9",
+  "version": "3.7.0-alpha.10",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.7.0-alpha.9",
+  "version": "3.7.0-alpha.10",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.7.0-alpha.1"
+    "@claude-flow/cli": "^3.7.0-alpha.10"
   },
   "overrides": {
     "@ruvector/rvf-wasm": "0.1.5",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.7.0-alpha.8",
+  "version": "3.7.0-alpha.10",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
@@ -108,7 +108,7 @@
     "@claude-flow/codex": "^3.0.0-alpha.8",
     "@claude-flow/embeddings": "^3.0.0-alpha.12",
     "@claude-flow/guidance": "^3.0.0-alpha.1",
-    "@claude-flow/memory": "^3.0.0-alpha.12",
+    "@claude-flow/memory": "workspace:3.0.0-alpha.14",
     "@claude-flow/plugin-gastown-bridge": "^0.1.3",
     "@claude-flow/security": "^3.0.0-alpha.1",
     "@ruvector/attention": "^0.1.32",
@@ -118,7 +118,7 @@
     "@ruvector/router": "^0.1.30",
     "@ruvector/ruvllm-wasm": "^2.0.2",
     "@ruvector/rvagent-wasm": "^0.1.0",
-    "@ruvector/sona": "^0.1.5",
+    "@ruvector/sona": "^0.1.6",
     "agentdb": "^3.0.0-alpha.13",
     "agentic-flow": "^3.0.0-alpha.1"
   },


### PR DESCRIPTION
Version bump to match published artifacts. Already on npm with `latest` / `alpha` / `v3alpha` dist-tags. Closes 17+ issues.