### PR TITLE
fix(release): hotfix 3.7.0-alpha.11 — strip workspace: protocol leak (closes #1825)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.10",
+  "version": "3.7.0-alpha.11",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.7.0-alpha.10",
+  "version": "3.7.0-alpha.11",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.7.0-alpha.10"
+    "@claude-flow/cli": "^3.7.0-alpha.11"
   },
   "overrides": {
     "@ruvector/rvf-wasm": "0.1.5",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.7.0-alpha.10",
+  "version": "3.7.0-alpha.11",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
@@ -108,7 +108,7 @@
     "@claude-flow/codex": "^3.0.0-alpha.8",
     "@claude-flow/embeddings": "^3.0.0-alpha.12",
     "@claude-flow/guidance": "^3.0.0-alpha.1",
-    "@claude-flow/memory": "workspace:3.0.0-alpha.14",
+    "@claude-flow/memory": "^3.0.0-alpha.14",
     "@claude-flow/plugin-gastown-bridge": "^0.1.3",
     "@claude-flow/security": "^3.0.0-alpha.1",
     "@ruvector/attention": "^0.1.32",


### PR DESCRIPTION
## Summary

Closes #1825. \`@claude-flow/cli@3.7.0-alpha.10\` shipped with \`"@claude-flow/memory": "workspace:3.0.0-alpha.14"\` in \`optionalDependencies\`. The \`workspace:\` protocol is pnpm-internal — npm rejects it with \`EUNSUPPORTEDPROTOCOL\` before any packages download.

Reporter (@gnanendrart) on macOS / Node 22 + 25:
\`\`\`
npm install -g ruflo@latest
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:3.0.0-alpha.14
\`\`\`

## Cause

An earlier \`pnpm install\` rewrote the entry to \`workspace:\` form. \`npm publish\` (used in the alpha.10 publish flow) doesn't strip workspace: refs the way \`pnpm publish\` does, so the broken manifest shipped to npm.

## Fix

- Replace \`"workspace:3.0.0-alpha.14"\` with \`"^3.0.0-alpha.14"\` in \`v3/@claude-flow/cli/package.json\`
- Bump to \`3.7.0-alpha.11\` in cli, umbrella, ruflo
- **Already published** — \`latest\` / \`alpha\` / \`v3alpha\` all point to alpha.11

## End-to-end validation (the part #1825 specifically asked for)

\`\`\`
=== TEST: clean npm install (the previously-failing path) ===
$ npm init -y && npm install ruflo@latest
[...] added N packages
exit=0

$ npx ruflo@latest --version
ruflo v3.7.0-alpha.11

$ npx claude-flow@latest --version
ruflo v3.7.0-alpha.11
\`\`\`

No more \`EUNSUPPORTEDPROTOCOL\`.

## Process gap

The publish flow needs a pre-publish guard against \`workspace:\` protocol leaks. A \`prepublishOnly\` script that greps for \`"workspace:\` in the manifest and fails would have caught this. Tracking as follow-up.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)