### PR TITLE
ci: publish container images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,171 @@
+name: Publish container images
+
+# Builds and publishes the deployable component images for Ruflo's stack to
+# GHCR. The Dockerfiles already live in-repo; this workflow just produces
+# multi-arch tagged images that downstream deployments (Coolify, Railway,
+# Fly, k8s) can pull without rebuilding.
+#
+# Images produced:
+#   ghcr.io/ruvnet/ruflo-cli         (v3/@claude-flow/cli/docker/Dockerfile)
+#   ghcr.io/ruvnet/ruflo-mcp-bridge  (ruflo/src/ruvocal/mcp-bridge/Dockerfile)
+#   ghcr.io/ruvnet/ruflo-nginx       (ruflo/src/nginx/Dockerfile)
+#   ghcr.io/ruvnet/ruflo-chat-ui     (ruflo/src/ruvocal/Dockerfile)
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - "v3/@claude-flow/cli/docker/Dockerfile"
+      - "ruflo/src/ruvocal/Dockerfile"
+      - "ruflo/src/ruvocal/mcp-bridge/Dockerfile"
+      - "ruflo/src/nginx/Dockerfile"
+      - ".github/workflows/docker-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.image.name }} (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+        image:
+          - name: ruflo-cli
+            context: .
+            dockerfile: v3/@claude-flow/cli/docker/Dockerfile
+          - name: ruflo-mcp-bridge
+            context: ruflo/src/ruvocal/mcp-bridge
+            dockerfile: ruflo/src/ruvocal/mcp-bridge/Dockerfile
+          - name: ruflo-nginx
+            context: ruflo/src/nginx
+            dockerfile: ruflo/src/nginx/Dockerfile
+          - name: ruflo-chat-ui
+            context: ruflo/src/ruvocal
+            dockerfile: ruflo/src/ruvocal/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # The chat-ui Dockerfile expects ruflo/src/ruvocal/.env (the
+      # SvelteKit app's baseline config) but that path is gitignored
+      # and never committed. The .dockerignore explicitly allows .env
+      # via `!.env`, so we drop in HF chat-ui's pinned baseline. Runtime
+      # DOTENV_LOCAL (set by Coolify) overrides everything that matters.
+      # Tracked as a follow-up upstream task: commit a .env.template
+      # and bake it into the Dockerfile so this step becomes a no-op.
+      - name: Prepare chat-ui build context
+        if: matrix.image.name == 'ruflo-chat-ui'
+        env:
+          HF_CHAT_UI_TAG: v0.9.5
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/huggingface/chat-ui/${HF_CHAT_UI_TAG}/.env" \
+            -o ruflo/src/ruvocal/.env
+          test -s ruflo/src/ruvocal/.env
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute platform pair
+        id: plat
+        run: |
+          echo "pair=${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ steps.plat.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-${{ steps.plat.outputs.pair }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests/${{ matrix.image.name }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${{ matrix.image.name }}/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image.name }}-${{ steps.plat.outputs.pair }}
+          path: /tmp/digests/${{ matrix.image.name }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests (${{ matrix.image }})
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ruflo-cli, ruflo-mcp-bridge, ruflo-nginx, ruflo-chat-ui]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=short
+
+      - name: Create manifest list & push
+        working-directory: /tmp/digests
+        run: |
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          digests=$(printf '${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}@sha256:%s ' *)
+          docker buildx imagetools create $tags $digests
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
# Publish container images to GHCR

## Why

Ruflo already ships four Dockerfiles and a working `ruflo/docker-compose.yml`,
but no images are published anywhere. Anyone deploying outside of `npx` —
Coolify, Railway, Fly, k8s, plain Docker — has to either build locally (slow
on small VPS targets) or pull a Git-context build (rebuilds on every deploy).

This PR adds a multi-arch publishing pipeline so the existing Dockerfiles
become pullable images at `ghcr.io/ruvnet/ruflo-*`. It does **not** add new
Dockerfiles — it just ships what's already in the tree.

## What this PR adds

| File | Purpose |
|---|---|
| `.github/workflows/docker-publish.yml` | On push to `main` and `v*` tags: builds `linux/amd64` + `linux/arm64` images for the four existing Dockerfiles, pushes to GHCR with semver / branch / sha tags. PR builds run without pushing. |

## Images produced

| Image | Source Dockerfile | Purpose |
|---|---|---|
| `ghcr.io/ruvnet/ruflo-cli` | `v3/@claude-flow/cli/docker/Dockerfile` | <100 MB Alpine CLI — `docker run --rm ruflo-cli claude-flow doctor` etc. |
| `ghcr.io/ruvnet/ruflo-mcp-bridge` | `ruflo/src/ruvocal/mcp-bridge/Dockerfile` | OpenAI-compatible bridge with the 11 `MCP_GROUP_*` toggles and `/health` endpoint on port 3001. |
| `ghcr.io/ruvnet/ruflo-nginx` | `ruflo/src/nginx/Dockerfile` | Brand-injecting reverse proxy that fronts chat-ui on port 3000. |
| `ghcr.io/ruvnet/ruflo-chat-ui` | `ruflo/src/ruvocal/Dockerfile` | The chat-ui SvelteKit fork that the user actually opens. |

Tags applied:
```
ghcr.io/ruvnet/ruflo-<name>:latest
ghcr.io/ruvnet/ruflo-<name>:<branch>
ghcr.io/ruvnet/ruflo-<name>:<version>      # e.g. 3.7.0-alpha.11
ghcr.io/ruvnet/ruflo-<name>:<major>.<minor>
ghcr.io/ruvnet/ruflo-<name>:<major>
ghcr.io/ruvnet/ruflo-<name>:sha-<short>
```

## Why this enables the Coolify ecosystem

A companion PR at
[`coollabsio/coolify`](https://github.com/coollabsio/coolify) ships a
one-click service template that pulls these images. Once this PR merges and
the workflow runs, that template Just Works — no build step, no submodules,
no large per-deploy clones of the monorepo.

## Verification

- `act -j build --matrix image:ruflo-mcp-bridge --matrix platform:linux/amd64`
  succeeds locally (Linux/amd64 only — arm64 needs CI's QEMU layer).
- `docker buildx build` against each Dockerfile in turn produces a runnable
  image; `docker run --rm ruflo-cli claude-flow --version` returns the
  expected version string.
- The workflow's PR-build path (no push) was exercised against this branch.

## Upstream gap discovered during validation

The chat-ui Dockerfile expects `ruflo/src/ruvocal/.env` (the SvelteKit
app's baseline config), but that path is gitignored and never committed.
A fresh clone cannot `docker build` the chat-ui image as-is — the entry
`COPY --chown=1000 .env /app/.env` fails. The runtime `entrypoint.sh`
also relies on `dotenv -e /app/.env -c -- node ...`, so even a manually
bind-mounted `.env.local` won't compensate.

This workflow works around it by curl-pulling HuggingFace chat-ui's
pinned `.env` from `v0.9.5` into the build context before the chat-ui
build step. The `.dockerignore` already allows `.env` via `!.env`, and
runtime `DOTENV_LOCAL` (injected by Coolify and the existing
`docker-compose.yml`) overrides the relevant values, so this is a safe
baseline.

**Follow-up I'd suggest** (separate PR if you'd like): commit
`ruflo/src/ruvocal/.env.template` plus a tiny `prepare-chat-ui.sh` (or
move the copy into the Dockerfile via a build arg). Once that lands,
the `Prepare chat-ui build context` step in this workflow becomes a
no-op and can be deleted. Happy to send that PR if it's preferred.

## Open questions for maintainers

1. **Image namespace** — happy with `ghcr.io/ruvnet/ruflo-*`? Alternative is
   a single multi-tag image, but the four Dockerfiles produce sufficiently
   different artifacts that separate repos makes pull bandwidth cheaper for
   downstream deployments that only need one or two.
2. **Tag policy** — the workflow tags `latest` only on the default branch.
   Tag pushes (`v*`) get full semver fan-out. Want a different cadence (e.g.
   no `latest`, only explicit semver)?
3. **CLI image variant** — the existing CLI Dockerfile is the "lite" build.
   Want a separate `:browser` variant that includes Playwright? Easy to add
   as another matrix row if useful for `MCP_GROUP_BROWSER=true` users.

## Out of scope

- No changes to existing Dockerfiles or compose
- No new deployment targets (Helm, k8s, etc.)
- No CI/test changes

## Downstream consumer note

The companion Coolify service template (PR at coollabsio/coolify) was
reworked from a 4-service to a 3-service architecture (drops nginx).
The template now uses HuggingFace's official chat-ui image directly
(specifically `huggingface/chat-ui:sha-999acc5` from DockerHub, since
HF stopped publishing semver tags after `0.8.4`). As a result, the
downstream consumer no longer needs two of the four images this PR
publishes:

- `ghcr.io/ruvnet/ruflo-cli` — still useful as a standalone CLI image
- `ghcr.io/ruvnet/ruflo-mcp-bridge` — required by the Coolify template
- `ghcr.io/ruvnet/ruflo-nginx` — no longer used by the Coolify template
- `ghcr.io/ruvnet/ruflo-chat-ui` — no longer used by the Coolify template

The workflow still publishes all four if you want to keep them as
upstream-snapshot mirrors of `ruflo/src/{ruvocal,nginx,...}`.
Maintainers may prefer to drop `ruflo-nginx` and `ruflo-chat-ui` from
the matrix to halve CI time; happy to send a follow-up that does so.
