### PR TITLE
fix(settings): raise skillListingBudgetFraction to clear truncation warning (refs #1834)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,7 @@
 {
   "model": "claude-opus-4-7",
+  "_comment_skillListingBudgetFraction": "#1834 — repo has 367 SKILL.md files (5x duplicates of common skills) across .agents/skills, .claude/skills, archive/v2/.claude/skills, v3/@claude-flow/{cli,mcp}/.claude/skills. With Claude Code's default 1% budget, ~378 descriptions get truncated. Bumping to 6% covers the actual usage (5.5%). Long-term fix is to prune the duplicates and archive paths (see #1834).",
+  "skillListingBudgetFraction": 0.06,
   "customInstructions": "Follow the project's CLAUDE.md guidelines. Use concurrent execution for all operations. Prioritize v3 implementation with security-first development, 15-agent swarm coordination, phased performance optimization, and cross-platform helper automation.",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary

Refs #1834. Band-aid for the 378-skill-description truncation warning Claude Code surfaces on every session start in this repo. Bumps `skillListingBudgetFraction` from the default 1% to 6% (5.5% is the actual usage at the current SKILL.md count).

The structural fix — pruning the 367 SKILL.md files across 5 locations (5x duplicates of common skills) — is tracked in #1834.

## Trade-off

| | Before (1%) | After (6%) |
|---|---|---|
| Skill descriptions full | ~2 / 380 | All |
| Tokens / session | baseline | +~11k |
| Skill resolution accuracy | low (descriptions truncated) | high |

For a project with 367 SKILL.md files, the higher accuracy is worth the token cost. The real fix is reducing that count.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)