### PR TITLE
chore(witness): regenerate verification.md.json for 3.7.0-alpha.11

### DIFF
--- a/verification.md.json
+++ b/verification.md.json
@@ -1,24 +1,24 @@
 {
   "manifest": {
     "schema": "ruflo-witness/v1",
-    "issuedAt": "2026-05-05T12:48:24.960Z",
-    "gitCommit": "63b9ac35d1d33d01e877fee88f9da5664ccdfe31",
+    "issuedAt": "2026-05-07T17:11:00.103Z",
+    "gitCommit": "02976fcb9dfd7f68872ddb65a84841fee33abf2c",
     "branch": "fix/issues-may-1-3",
     "releases": {
-      "ruflo": "3.6.28",
-      "@claude-flow/cli": "3.6.28"
+      "ruflo": "3.7.0-alpha.11",
+      "@claude-flow/cli": "3.7.0-alpha.11"
     },
     "summary": {
       "totalFixes": 55,
-      "verified": 0,
-      "failed": 0
+      "verified": 53,
+      "failed": 2
     },
     "fixes": [
       {
         "id": "F1",
         "desc": "hooks_metrics persistence",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/hooks-tools.js",
-        "sha256": "11a78ae628c5e1fa6a998294e3a0398bcaf40291a5aca103a3596e556aeabfc5",
+        "sha256": "38bb332bcc6eac84ddbc5a15777baf71a6b82974fa94a224c55a8b28364d3863",
         "marker": "getIntelligenceStatsFromMemory",
         "markerVerified": true
       },
@@ -26,7 +26,7 @@
         "id": "F2",
         "desc": "worker-dispatch honesty",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/hooks-tools.js",
-        "sha256": "11a78ae628c5e1fa6a998294e3a0398bcaf40291a5aca103a3596e556aeabfc5",
+        "sha256": "38bb332bcc6eac84ddbc5a15777baf71a6b82974fa94a224c55a8b28364d3863",
         "marker": "'no-daemon'",
         "markerVerified": true
       },
@@ -42,7 +42,7 @@
         "id": "F4",
         "desc": "agentdb_pattern-store memory-store fallback",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/agentdb-tools.js",
-        "sha256": "68d7257df63e72a441c444df7f5ed697117d31802c220a2234ff9e6d678d57ac",
+        "sha256": "6ca2c3b6d17e39378a6d95b9ef104a4c7e01c321687a4e21fc5ddc599589f91f",
         "marker": "memory-store-fallback",
         "markerVerified": true
       },
@@ -82,7 +82,7 @@
         "id": "F9",
         "desc": "F9 router probe + actionable error",
         "file": "v3/@claude-flow/cli/dist/src/memory/memory-bridge.js",
-        "sha256": "9a0c99e44636ce46ceecebad87e704ef57fea085246f87b9de1e9a6bc16644af",
+        "sha256": "cd6e967ede383bd6453384519d2cf263b0e5c0b462e2b7c0f777a8e5bfd7ff39",
         "marker": "IntentRouter",
         "markerVerified": true
       },
@@ -90,7 +90,7 @@
         "id": "F10",
         "desc": "intelligence_attention real patterns",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/hooks-tools.js",
-        "sha256": "11a78ae628c5e1fa6a998294e3a0398bcaf40291a5aca103a3596e556aeabfc5",
+        "sha256": "38bb332bcc6eac84ddbc5a15777baf71a6b82974fa94a224c55a8b28364d3863",
         "marker": "real-flash-attention+memory",
         "markerVerified": true
       },
@@ -98,7 +98,7 @@
         "id": "F11",
         "desc": "neural_predict classifier head",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/neural-tools.js",
-        "sha256": "047f521d7a53aeae37a93494f2c5d183f202f381172b6fe9d7544423a094bc43",
+        "sha256": "7e08b72ac68774af172107f93aba27c5e7254bdb52ba6a8a686da7917fe81e9b",
         "marker": "knn-cosine+softmax",
         "markerVerified": true
       },
@@ -114,7 +114,7 @@
         "id": "#1697",
         "desc": "rvf-wasm overrides",
         "file": "package.json",
-        "sha256": "7e0f17bd65b69454a587dfa321a1622d9de672a47c111a4aa6b4a074c8e2e4c0",
+        "sha256": "e2a7dfbebc13fb805616a2ac562c928b8c8b74181bcff9a572c597da1a34e760",
         "marker": "@ruvector/rvf-wasm",
         "markerVerified": true
       },
@@ -122,7 +122,7 @@
         "id": "#1698",
         "desc": "HNSW init fix in CLI command",
         "file": "v3/@claude-flow/cli/dist/src/commands/embeddings.js",
-        "sha256": "2cb57b6fb38bb4722eebd169f4b6056f1b6f69ba0adde9978bcd9e03f83d43ab",
+        "sha256": "168ae7d5d542117129340b09879b5df6f46543e2cf97549811d7ff0ed2f98a70",
         "marker": "getHNSWIndex",
         "markerVerified": true
       },
@@ -130,7 +130,7 @@
         "id": "#1691",
         "desc": "Windows daemon fork()",
         "file": "v3/@claude-flow/cli/dist/src/commands/daemon.js",
-        "sha256": "8272eafbfcd0010166d44797461e2730e85d44ce6bb09e54bacce4affefdd179",
+        "sha256": "f09d153c3339f3bb341df93bdf2e351a3f911f5478028baefa1c3171a4925c2f",
         "marker": "fork(cliPath",
         "markerVerified": true
       },
@@ -138,7 +138,7 @@
         "id": "#1721",
         "desc": "postinstall copies all dist/src/* siblings",
         "file": "v3/@claude-flow/cli/package.json",
-        "sha256": "bb8a4fb7975460547d68eb8c6fecd4551b82abcfd7e657ce5da52854152435c1",
+        "sha256": "4e2f7b144ce0db3a38a39ec265f23094bbac7bef92eb5b34fc02585a76d07c87",
         "marker": "postinstall.cjs",
         "markerVerified": true
       },
@@ -148,7 +148,7 @@
         "file": "v3/@claude-flow/embeddings/dist/transformers-loader.js",
         "sha256": "1d2225e7422f8a2d47d39100324d5e4ac2d29c55e8e72b02f5e4a7a113d45be2",
         "marker": "@huggingface/transformers",
-        "markerVerified": true
+        "markerVerified": false
       },
       {
         "id": "G1",
@@ -170,7 +170,7 @@
         "id": "G4",
         "desc": "WASM agent prompt routes to Anthropic",
         "file": "v3/@claude-flow/cli/dist/src/ruvector/agent-wasm.js",
-        "sha256": "36915b20914ed3ab3a050b78c8e2169c01b293ef2ec0cc78e3484bc26131f1d5",
+        "sha256": "12fce07f6458aff5db210b0ba50104fa9b2dd52c85b5e9071b48c2899451c631",
         "marker": "isEchoStub",
         "markerVerified": true
       },
@@ -178,7 +178,7 @@
         "id": "G6",
         "desc": "auto-memory content-hash dedup",
         "file": "v3/@claude-flow/cli/.claude/helpers/intelligence.cjs",
-        "sha256": "84a6159b384b8118f0beaa1089c417cab6d1116cd77d3882a607715ef7679ea8",
+        "sha256": "ca717a606b03e5922f4a51c0b67deb7a8cd80ff81a50006457a27d12b417a2a8",
         "marker": "deduplicateByContent",
         "markerVerified": true
       },
@@ -186,7 +186,7 @@
         "id": "G7-gnn",
         "desc": "gnnService activated",
         "file": "v3/@claude-flow/cli/dist/src/memory/memory-bridge.js",
-        "sha256": "9a0c99e44636ce46ceecebad87e704ef57fea085246f87b9de1e9a6bc16644af",
+        "sha256": "cd6e967ede383bd6453384519d2cf263b0e5c0b462e2b7c0f777a8e5bfd7ff39",
         "marker": "GNNService",
         "markerVerified": true
       },
@@ -194,7 +194,7 @@
         "id": "G7-rvf",
         "desc": "rvfOptimizer activated",
         "file": "v3/@claude-flow/cli/dist/src/memory/memory-bridge.js",
-        "sha256": "9a0c99e44636ce46ceecebad87e704ef57fea085246f87b9de1e9a6bc16644af",
+        "sha256": "cd6e967ede383bd6453384519d2cf263b0e5c0b462e2b7c0f777a8e5bfd7ff39",
         "marker": "RVFOptimizer",
         "markerVerified": true
       },
@@ -202,7 +202,7 @@
         "id": "G7-mut",
         "desc": "mutationGuard activated",
         "file": "v3/@claude-flow/cli/dist/src/memory/memory-bridge.js",
-        "sha256": "9a0c99e44636ce46ceecebad87e704ef57fea085246f87b9de1e9a6bc16644af",
+        "sha256": "cd6e967ede383bd6453384519d2cf263b0e5c0b462e2b7c0f777a8e5bfd7ff39",
         "marker": "MutationGuard",
         "markerVerified": true
       },
@@ -210,7 +210,7 @@
         "id": "G7-att",
         "desc": "attestationLog activated with sqlite db",
         "file": "v3/@claude-flow/cli/dist/src/memory/memory-bridge.js",
-        "sha256": "9a0c99e44636ce46ceecebad87e704ef57fea085246f87b9de1e9a6bc16644af",
+        "sha256": "cd6e967ede383bd6453384519d2cf263b0e5c0b462e2b7c0f777a8e5bfd7ff39",
         "marker": "attestation.db",
         "markerVerified": true
       },
@@ -218,7 +218,7 @@
         "id": "G7-gvb",
         "desc": "GuardedVectorBackend wraps mutationGuard+log",
         "file": "v3/@claude-flow/cli/dist/src/memory/memory-bridge.js",
-        "sha256": "9a0c99e44636ce46ceecebad87e704ef57fea085246f87b9de1e9a6bc16644af",
+        "sha256": "cd6e967ede383bd6453384519d2cf263b0e5c0b462e2b7c0f777a8e5bfd7ff39",
         "marker": "GuardedVectorBackend",
         "markerVerified": true
       },
@@ -228,240 +228,240 @@
         "file": "v3/@claude-flow/plugin-agent-federation/dist/plugin.js",
         "sha256": "881dad4fa9dc19a539c1a46dfe27c77984596cdd05759937909aacf028378acc",
         "marker": "@noble/ed25519",
-        "markerVerified": true
+        "markerVerified": false
       },
       {
         "id": "CAP-MCP-agent-tools",
         "desc": "MCP tools (8): agent_execute, agent_health, agent_list, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/agent-tools.js",
-        "sha256": "",
+        "sha256": "fc907ef704fdb0ab2df56019a8956c230cf270c2b8ef00038914d87b9abf4936",
         "marker": "agent_execute",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-agentdb-tools",
         "desc": "MCP tools (15): agentdb_batch, agentdb_causal-edge, agentdb_consolidate, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/agentdb-tools.js",
-        "sha256": "",
+        "sha256": "6ca2c3b6d17e39378a6d95b9ef104a4c7e01c321687a4e21fc5ddc599589f91f",
         "marker": "agentdb_batch",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-analyze-tools",
         "desc": "MCP tools (6): analyze_diff, analyze_diff-classify, analyze_diff-reviewers, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/analyze-tools.js",
-        "sha256": "",
+        "sha256": "34c78f417c395ca9df13e53c35c4d47153818f9d10a019e3e299da150c7329c4",
         "marker": "analyze_diff",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-autopilot-tools",
         "desc": "MCP tools (10): autopilot_config, autopilot_disable, autopilot_enable, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/autopilot-tools.js",
-        "sha256": "",
+        "sha256": "927df07df0cbe27e8ce0a77ec99529beb62e222649854ef2d1e6d21ad2f446c9",
         "marker": "autopilot_config",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-browser-tools",
         "desc": "MCP tools (23): browser_back, browser_check, browser_click, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/browser-tools.js",
-        "sha256": "",
+        "sha256": "2c075877030bba617709030487675296a9bfddcfc15ea4c30beedbd7d83cf94a",
         "marker": "browser_back",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-claims-tools",
         "desc": "MCP tools (12): claims_accept-handoff, claims_board, claims_claim, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/claims-tools.js",
-        "sha256": "",
+        "sha256": "2a00b654e87dd75b9cbb36a0d32e41443c275f5bdf939136c6a397c355f83aa7",
         "marker": "claims_accept-handoff",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-config-tools",
         "desc": "MCP tools (6): config_export, config_get, config_import, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/config-tools.js",
-        "sha256": "",
+        "sha256": "811ac1297fea330f0e497523a234eb97339a4e1c009b2c33be14915b662b7dec",
         "marker": "config_export",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-coordination-tools",
         "desc": "MCP tools (7): coordination_consensus, coordination_load_balance, coordination_metrics, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/coordination-tools.js",
-        "sha256": "",
+        "sha256": "5d9b47750015c4626b044453494ef9905ccda9cbb35a06f56215783b6251cef0",
         "marker": "coordination_consensus",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-daa-tools",
         "desc": "MCP tools (8): daa_agent_adapt, daa_agent_create, daa_cognitive_pattern, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/daa-tools.js",
-        "sha256": "",
+        "sha256": "90828f0744e1769212a079ef01c13c4a7d2f0d77d6036978a18b94134beef14a",
         "marker": "daa_agent_adapt",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-embeddings-tools",
         "desc": "MCP tools (10): embeddings_compare, embeddings_generate, embeddings_hyperbolic, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/embeddings-tools.js",
-        "sha256": "",
+        "sha256": "6f0f172840b7db1a491356bed5f7b6b6f6e8760633cd38e1bc968f4aa22bc946",
         "marker": "embeddings_compare",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-github-tools",
         "desc": "MCP tools (5): github_issue_track, github_metrics, github_pr_manage, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/github-tools.js",
-        "sha256": "",
+        "sha256": "5987990581843350f1e01490648dd7b85d8e02bbbce8d9551438219e23bef5ec",
         "marker": "github_issue_track",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-guidance-tools",
         "desc": "MCP tools (5): guidance_capabilities, guidance_discover, guidance_quickref, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/guidance-tools.js",
-        "sha256": "",
+        "sha256": "c6e4b76e3ea97b9689a8ab7c72f286e653c46e95b59f1f49fe3615f960c1214e",
         "marker": "guidance_capabilities",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-hive-mind-tools",
         "desc": "MCP tools (9): hive-mind_broadcast, hive-mind_consensus, hive-mind_init, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/hive-mind-tools.js",
-        "sha256": "",
+        "sha256": "6987df2e11f6c5fe7cb2a4f5b2ba8c883a6705b447b3c0d0f237a2187e5e28a4",
         "marker": "hive-mind_broadcast",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-hooks-tools",
         "desc": "MCP tools (62): build-agents, explain, hooks_build-agents, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/hooks-tools.js",
-        "sha256": "",
+        "sha256": "38bb332bcc6eac84ddbc5a15777baf71a6b82974fa94a224c55a8b28364d3863",
         "marker": "build-agents",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-memory-tools",
         "desc": "MCP tools (10): memory_bridge_status, memory_delete, memory_import_claude, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/memory-tools.js",
-        "sha256": "",
+        "sha256": "187272b14867473d5dac78d88600e5750c51195008e300e79f1f3d8d63622bb9",
         "marker": "memory_bridge_status",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-neural-tools",
         "desc": "MCP tools (6): neural_compress, neural_optimize, neural_patterns, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/neural-tools.js",
-        "sha256": "",
+        "sha256": "7e08b72ac68774af172107f93aba27c5e7254bdb52ba6a8a686da7917fe81e9b",
         "marker": "neural_compress",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-performance-tools",
         "desc": "MCP tools (6): performance_benchmark, performance_bottleneck, performance_metrics, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/performance-tools.js",
-        "sha256": "",
+        "sha256": "d612f3c006c7c1bf3283c0c257bc24557feff65f8b1f3dbb32c4b9a33478767c",
         "marker": "performance_benchmark",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-progress-tools",
         "desc": "MCP tools (4): progress_check, progress_summary, progress_sync, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/progress-tools.js",
-        "sha256": "",
+        "sha256": "6b9c5c1b27687cfaa1f6b47b245a8b25d98d16418221b0a462f1a11b5b090710",
         "marker": "progress_check",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-ruvllm-tools",
         "desc": "MCP tools (10): ruvllm_chat_format, ruvllm_generate_config, ruvllm_hnsw_add, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/ruvllm-tools.js",
-        "sha256": "",
+        "sha256": "31eb7e4ee42c506685a85008740e83aee2b1d12df6189d4f9bf3f450e0223b37",
         "marker": "ruvllm_chat_format",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-security-tools",
         "desc": "MCP tools (6): aidefence_analyze, aidefence_has_pii, aidefence_is_safe, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/security-tools.js",
-        "sha256": "",
+        "sha256": "991a2de4462b8a7b29ae26006977fd7b1942bc56fa0e891422d0f28a7e9fff06",
         "marker": "aidefence_analyze",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-session-tools",
         "desc": "MCP tools (5): session_delete, session_info, session_list, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/session-tools.js",
-        "sha256": "",
+        "sha256": "f623493c80bd305bbf9bf426563db5a9ad745817972bc5690c84a1d1b33e92b9",
         "marker": "session_delete",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-swarm-tools",
         "desc": "MCP tools (9): agents, coordinator, persistence, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/swarm-tools.js",
-        "sha256": "",
+        "sha256": "fc88476d365dff10b99a1feca048df5aa411b1cc908bd6032dd64a02f7b70a16",
         "marker": "agents",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-system-tools",
         "desc": "MCP tools (15): config, database, disk, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/system-tools.js",
-        "sha256": "",
+        "sha256": "1f50f3378e0ffa77a70e1ad55ee3f8ac3144314715105d3ee8bb824b1d02643b",
         "marker": "config",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-task-tools",
         "desc": "MCP tools (7): task_assign, task_cancel, task_complete, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/task-tools.js",
-        "sha256": "",
+        "sha256": "da3443945cfe91c4f253ead1b26c7c7995c1e89c0a6de3afa063b282de4416c8",
         "marker": "task_assign",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-terminal-tools",
         "desc": "MCP tools (5): terminal_close, terminal_create, terminal_execute, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/terminal-tools.js",
-        "sha256": "",
+        "sha256": "ee54c3dc39f88da154722e1955ed88814e54e653f3b30848e4217eedf2352183",
         "marker": "terminal_close",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-transfer-tools",
         "desc": "MCP tools (11): transfer_detect-pii, transfer_ipfs-resolve, transfer_plugin-featured, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/transfer-tools.js",
-        "sha256": "",
+        "sha256": "a58b95f7e702f72d1f142511bdf530116586138b90aca0e2833b8817799ed27f",
         "marker": "transfer_detect-pii",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-wasm-agent-tools",
         "desc": "MCP tools (10): wasm_agent_create, wasm_agent_export, wasm_agent_files, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/wasm-agent-tools.js",
-        "sha256": "",
+        "sha256": "114a996d08963a3524447d80eb4c693a1d235eccd877d8b7163caa8f86bcaafa",
         "marker": "wasm_agent_create",
-        "markerVerified": false
+        "markerVerified": true
       },
       {
         "id": "CAP-MCP-workflow-tools",
         "desc": "MCP tools (10): workflow_cancel, workflow_create, workflow_delete, …",
         "file": "v3/@claude-flow/cli/dist/src/mcp-tools/workflow-tools.js",
-        "sha256": "",
+        "sha256": "b562d739deb768e58bfd21d79cf30c7898a0c9a3d944d8fabebd218b4c4c305e",
         "marker": "workflow_cancel",
-        "markerVerified": false
+        "markerVerified": true
       }
     ]
   },
   "integrity": {
     "manifestHashAlgo": "sha256",
-    "manifestHash": "3682335387ba54b427e80e4f13d470ea1ef5a82f08c11c1285e7ee39d454541a",
+    "manifestHash": "213fbb1eb0ef7af901f5e62d0bf83678cbab575afd7ab1f0c2f297f8a8c6a7e3",
     "signatureAlgo": "ed25519",
-    "publicKey": "e786342c844b22e018a07ef848c7d0d35a185a2c701f8036e0f7ed27abfa961c",
-    "signature": "3b7198344f6593d2e58a096f741a96b4954871cdd3f0175dcc8dce988f595b866ea5c461a18f3579584f048e361750de86e51760f8a1f0158c512c21604eb906",
+    "publicKey": "170fb40aa09ef3f787e4d9e6981d4379b7045b587b1d730119e54ce5f600ed76",
+    "signature": "be6f92bff201cecb1b15558bf79b6cd8e89a38d853ae663c78a31a53fe9e9862aa10f4aa589d2ed4b2789ad90dd89a948e1d80a2039685ad3c5ccf9a15c76d0e",
     "seedDerivation": "sha256(gitCommit + ':ruflo-witness/v1')"
   }
 }


### PR DESCRIPTION
Refreshes the witness manifest's gitCommit, releases, and per-fix sha256/marker against current main HEAD. 53/55 fixes still verified; 2 FILE_MISSING entries are unbuilt-dist artifacts (markers present in source — see verification-results.md). The 22 fixes from this session aren't yet catalogued in the manifest; that's a separate inventory pass.