### PR TITLE
chore(witness): add 23 fix entries from 2026-05 issue-fix loop

### DIFF
--- a/verification.md.json
+++ b/verification.md.json
@@ -1,16 +1,16 @@
 {
   "manifest": {
     "schema": "ruflo-witness/v1",
-    "issuedAt": "2026-05-07T17:11:00.103Z",
-    "gitCommit": "02976fcb9dfd7f68872ddb65a84841fee33abf2c",
+    "issuedAt": "2026-05-07T17:14:17.612Z",
+    "gitCommit": "0666796a0f51681e7748f17fa23c4d5a0108f722",
     "branch": "fix/issues-may-1-3",
     "releases": {
       "ruflo": "3.7.0-alpha.11",
       "@claude-flow/cli": "3.7.0-alpha.11"
     },
     "summary": {
-      "totalFixes": 55,
-      "verified": 53,
+      "totalFixes": 78,
+      "verified": 76,
       "failed": 2
     },
     "fixes": [
@@ -453,15 +453,199 @@
         "sha256": "b562d739deb768e58bfd21d79cf30c7898a0c9a3d944d8fabebd218b4c4c305e",
         "marker": "workflow_cancel",
         "markerVerified": true
+      },
+      {
+        "id": "#1795",
+        "desc": "umbrella package missing cli-core dep (ERR_MODULE_NOT_FOUND)",
+        "file": "package.json",
+        "marker": "@claude-flow/cli-core",
+        "sha256": "e2a7dfbebc13fb805616a2ac562c928b8c8b74181bcff9a572c597da1a34e760",
+        "markerVerified": true
+      },
+      {
+        "id": "#1780",
+        "desc": "hive-mind --mcp-config variadic prompt slurp (ENAMETOOLONG)",
+        "file": "v3/@claude-flow/cli/dist/src/commands/hive-mind.js",
+        "marker": "--mcp-config=",
+        "sha256": "69da5c7bb7f2343d2b15ee218548af8b643778dfb8c1e240b96013888c0bea58",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.6",
+        "desc": "memory init idempotent when DB exists",
+        "file": "v3/@claude-flow/cli/dist/src/memory/memory-initializer.js",
+        "marker": "alreadyExists",
+        "sha256": "13383fa0ee5af878b29065e99835cd6d1abb045626fb04abcd750de9952fcdd4",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.7",
+        "desc": "doctor walk-up .git fallback",
+        "file": "v3/@claude-flow/cli/dist/src/commands/doctor.js",
+        "marker": "is-inside-work-tree",
+        "sha256": "edb1757106b8a9c1a64076d9dbd37044dc68c13b9af0dc70a9ac563f623de913",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.2",
+        "desc": "lazy-command pre-load for short flag scoping (also closes #1651)",
+        "file": "v3/@claude-flow/cli/dist/src/parser.js",
+        "marker": "isLazyOnly",
+        "sha256": "381b884d3902a998be261637c13ac4c890e07b165b16437b4eb064c2daaa0381",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.5",
+        "desc": "doctor --fix help text clarification",
+        "file": "v3/@claude-flow/cli/dist/src/commands/doctor.js",
+        "marker": "Print suggested fix commands",
+        "sha256": "edb1757106b8a9c1a64076d9dbd37044dc68c13b9af0dc70a9ac563f623de913",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.4",
+        "desc": "subcommand --help renders leaf, not parent",
+        "file": "v3/@claude-flow/cli/dist/src/index.js",
+        "marker": "commandPathOrName",
+        "sha256": "e1f741925c231b820354796790392b0eb94096fc206bc5f22eae9c2fb97bc58c",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.1",
+        "desc": "hive-mind task re-routed to task_create MCP tool",
+        "file": "v3/@claude-flow/cli/dist/src/commands/hive-mind.js",
+        "marker": "task_create",
+        "sha256": "69da5c7bb7f2343d2b15ee218548af8b643778dfb8c1e240b96013888c0bea58",
+        "markerVerified": true
+      },
+      {
+        "id": "#1791.8",
+        "desc": "content-hash dedupe in memory_import_claude --allProjects",
+        "file": "v3/@claude-flow/cli/dist/src/mcp-tools/memory-tools.js",
+        "marker": "duplicatesSkipped",
+        "sha256": "187272b14867473d5dac78d88600e5750c51195008e300e79f1f3d8d63622bb9",
+        "markerVerified": true
+      },
+      {
+        "id": "#1799",
+        "desc": "orphan-swarm reconcile on swarm-state.json load (PID + TTL)",
+        "file": "v3/@claude-flow/cli/dist/src/mcp-tools/swarm-tools.js",
+        "marker": "reconcileOrphanSwarms",
+        "sha256": "fc88476d365dff10b99a1feca048df5aa411b1cc908bd6032dd64a02f7b70a16",
+        "markerVerified": true
+      },
+      {
+        "id": "#1798",
+        "desc": "doctor surfaces config collision (legacy JSON + v3 YAML)",
+        "file": "v3/@claude-flow/cli/dist/src/commands/doctor.js",
+        "marker": "Config collision",
+        "sha256": "edb1757106b8a9c1a64076d9dbd37044dc68c13b9af0dc70a9ac563f623de913",
+        "markerVerified": true
+      },
+      {
+        "id": "#1810",
+        "desc": "WASM gallery default Sonnet bumped 20250514 → 4-6",
+        "file": "v3/@claude-flow/cli/dist/src/ruvector/agent-wasm.js",
+        "marker": "claude-sonnet-4-6",
+        "sha256": "12fce07f6458aff5db210b0ba50104fa9b2dd52c85b5e9071b48c2899451c631",
+        "markerVerified": true
+      },
+      {
+        "id": "#1807",
+        "desc": "aidefence load: retry plain import + actionable error",
+        "file": "v3/@claude-flow/cli/dist/src/mcp-tools/security-tools.js",
+        "marker": "resolver path",
+        "sha256": "991a2de4462b8a7b29ae26006977fd7b1942bc56fa0e891422d0f28a7e9fff06",
+        "markerVerified": true
+      },
+      {
+        "id": "#1686",
+        "desc": "NaN-safe coercion in hooks metrics + pretrain (safeNum)",
+        "file": "v3/@claude-flow/cli/dist/src/commands/hooks.js",
+        "marker": "safeNum",
+        "sha256": "470ce75647e31af44bc1805bdebb431f6dfd4c0c01a74af6df7576104cc42fd3",
+        "markerVerified": true
+      },
+      {
+        "id": "#1670",
+        "desc": "RuFlo Co-Authored-By trailer made opt-in",
+        "file": "v3/@claude-flow/cli/dist/src/init/settings-generator.js",
+        "marker": "options.attribution === true",
+        "sha256": "bba78d719e47c4cd3d56bb08112fde37624432711c02baf9b356bfd480bd837e",
+        "markerVerified": true
+      },
+      {
+        "id": "#1622",
+        "desc": "memory stats shows embedding provider + HNSW status",
+        "file": "v3/@claude-flow/cli/dist/src/commands/memory.js",
+        "marker": "Semantic Search",
+        "sha256": "30348d91675739610f4ebd67602c3aace2ac9ad29ebdfd3792bea69575ba0b50",
+        "markerVerified": true
+      },
+      {
+        "id": "#1574",
+        "desc": "github-project-management skill: Security Considerations section",
+        "file": ".claude/skills/github-project-management/SKILL.md",
+        "marker": "Security Considerations (read first)",
+        "sha256": "b92f8ccb2307f791ef06b47b2dad1cdbfe75abba88a77ceb63a2703ac9c40101",
+        "markerVerified": true
+      },
+      {
+        "id": "#1608",
+        "desc": "bcrypt → bcryptjs (drops 6 HIGH tar CVEs)",
+        "file": "v3/@claude-flow/security/dist/password-hasher.js",
+        "marker": "bcryptjs",
+        "sha256": "96b46dd1849fcae990c955dc81703aca8269b2a5d2c69f18003ba9b15bc3f1cf",
+        "markerVerified": true
+      },
+      {
+        "id": "#1609",
+        "desc": "vitest bumped to ^4.0.16 (drops 4 moderate esbuild CVEs)",
+        "file": "v3/@claude-flow/aidefence/package.json",
+        "marker": "\"vitest\": \"^4.0.16\"",
+        "sha256": "2d0cb744b2392b3bfa8ca1e1967f96607444828d43e8f43b060aa33040181eb8",
+        "markerVerified": true
+      },
+      {
+        "id": "#1779",
+        "desc": "init detect-and-skip when ruflo MCP already registered",
+        "file": "v3/@claude-flow/cli/dist/src/init/executor.js",
+        "marker": "detectExistingRufloMCP",
+        "sha256": "737e42db019fb8eec7a4b0d5cd04524335d9853181f046076caf4a8357d7a6b0",
+        "markerVerified": true
+      },
+      {
+        "id": "#1463",
+        "desc": "statusline detects Python test_*.py / spec_*.py",
+        "file": ".claude/helpers/statusline.cjs",
+        "marker": "startsWith('test_')",
+        "sha256": "8310c729d0dfdaf69da124c3410e836b164e4ae9c1e3144d16fdf42c6adfe34d",
+        "markerVerified": true
+      },
+      {
+        "id": "#1825",
+        "desc": "hotfix: workspace: protocol leak in cli optionalDependencies",
+        "file": "v3/@claude-flow/cli/package.json",
+        "marker": "\"@claude-flow/memory\": \"^3.0.0-alpha.14\"",
+        "sha256": "4e2f7b144ce0db3a38a39ec265f23094bbac7bef92eb5b34fc02585a76d07c87",
+        "markerVerified": true
+      },
+      {
+        "id": "#1834",
+        "desc": "skill listing budget bumped + duplicates pruned",
+        "file": ".claude/settings.json",
+        "marker": "skillListingBudgetFraction",
+        "sha256": "d95faa7672d8f96ef656ff2c1d0ef0a29003702e4b5ca08544e92594c7c2eb1c",
+        "markerVerified": true
       }
     ]
   },
   "integrity": {
     "manifestHashAlgo": "sha256",
-    "manifestHash": "213fbb1eb0ef7af901f5e62d0bf83678cbab575afd7ab1f0c2f297f8a8c6a7e3",
+    "manifestHash": "5278b8aadbfa06840c123cd15a5436c05a86fb2a7b34784284c7d3304fdd3114",
     "signatureAlgo": "ed25519",
-    "publicKey": "170fb40aa09ef3f787e4d9e6981d4379b7045b587b1d730119e54ce5f600ed76",
-    "signature": "be6f92bff201cecb1b15558bf79b6cd8e89a38d853ae663c78a31a53fe9e9862aa10f4aa589d2ed4b2789ad90dd89a948e1d80a2039685ad3c5ccf9a15c76d0e",
+    "publicKey": "e3939874a798011fbdfa5f54c81dd054bc12257f14c2960a4f5496798f6d765f",
+    "signature": "16813898834b298facee4e8de8be1458ae1c5337a700949905ac2836df4f3b033af9830273bf647bf09c426f78f6202174f69e6d6def505eccffb0c96bfb2903",
     "seedDerivation": "sha256(gitCommit + ':ruflo-witness/v1')"
   }
 }


### PR DESCRIPTION
Adds witness entries for the 22 fixes from the 2026-05-06 issue-fix loop plus the earlier cli-core dep fix (#1795). Manifest now signs over 78 fix corpus (76/78 verified — same 2 pre-existing FILE_MISSING). Re-derived gitCommit + Ed25519 signature.