### PR TITLE
fix(alpha-12): MCP naming, smartSearch fallback, real worker dispatch, health score

### DIFF
--- a/v3/@claude-flow/cli/bin/cli.js
+++ b/v3/@claude-flow/cli/bin/cli.js
@@ -134,7 +134,7 @@ if (isMCPMode) {
           id: message.id,
           result: {
             protocolVersion: '2024-11-05',
-            serverInfo: { name: 'claude-flow', version: VERSION },
+            serverInfo: { name: 'ruflo', version: VERSION },
             capabilities: {
               tools: { listChanged: true },
               resources: { subscribe: true, listChanged: true },

--- a/v3/@claude-flow/cli/bin/mcp-server.js
+++ b/v3/@claude-flow/cli/bin/mcp-server.js
@@ -138,7 +138,7 @@ async function handleMessage(message) {
           id: message.id,
           result: {
             protocolVersion: '2024-11-05',
-            serverInfo: { name: 'claude-flow', version: VERSION },
+            serverInfo: { name: 'ruflo', version: VERSION },
             capabilities: {
               tools: { listChanged: true },
               resources: { subscribe: true, listChanged: true },

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -108,7 +108,7 @@
     "@claude-flow/codex": "^3.0.0-alpha.8",
     "@claude-flow/embeddings": "^3.0.0-alpha.12",
     "@claude-flow/guidance": "^3.0.0-alpha.1",
-    "@claude-flow/memory": "^3.0.0-alpha.14",
+    "@claude-flow/memory": "^3.0.0-alpha.15",
     "@claude-flow/plugin-gastown-bridge": "^0.1.3",
     "@claude-flow/security": "^3.0.0-alpha.1",
     "@ruvector/attention": "^0.1.32",

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -9,6 +9,7 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join, dirname } from 'path';
+import { findExistingMCPRegistration } from '../init/mcp-detection.js';
 import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { execSync, exec } from 'child_process';
@@ -270,33 +271,26 @@ async function checkAIDefence(): Promise<HealthCheck> {
   }
 }
 
-// Check MCP servers
+// Check MCP servers — covers Claude Code project-scoped registrations,
+// global ~/.claude.json, Claude Desktop configs, and parent .mcp.json.
 async function checkMcpServers(): Promise<HealthCheck> {
-  const mcpConfigPaths = [
-    join(process.env.HOME || '', '.claude/claude_desktop_config.json'),
-    join(process.env.HOME || '', '.config/claude/mcp.json'),
-    '.mcp.json'
-  ];
-
-  for (const configPath of mcpConfigPaths) {
-    if (existsSync(configPath)) {
-      try {
-        const content = JSON.parse(readFileSync(configPath, 'utf8'));
-        const servers = content.mcpServers || content.servers || {};
-        const count = Object.keys(servers).length;
-        const hasClaudeFlow = 'claude-flow' in servers || 'claude-flow_alpha' in servers || 'ruflo' in servers || 'ruflo_alpha' in servers;
-        if (hasClaudeFlow) {
-          return { name: 'MCP Servers', status: 'pass', message: `${count} servers (ruflo configured)` };
-        } else {
-          return { name: 'MCP Servers', status: 'warn', message: `${count} servers (ruflo not found)`, fix: 'claude mcp add ruflo -- npx -y ruflo@latest mcp start' };
-        }
-      } catch {
-        // continue to next path
-      }
-    }
+  const match = findExistingMCPRegistration(process.cwd());
+  if (match) {
+    const scope = match.projectKey ? ` [project-scoped: ${match.projectKey}]` : '';
+    const aliasNote = match.key === 'claude-flow' ? ' (legacy alias)' : '';
+    return {
+      name: 'MCP Servers',
+      status: 'pass',
+      message: `ruflo MCP configured at ${match.configPath}${scope}${aliasNote}`,
+    };
   }
 
-  return { name: 'MCP Servers', status: 'warn', message: 'No MCP config found', fix: 'claude mcp add claude-flow npx @claude-flow/cli@v3alpha mcp start' };
+  return {
+    name: 'MCP Servers',
+    status: 'warn',
+    message: 'No ruflo MCP registration found',
+    fix: 'claude mcp add ruflo -- npx -y ruflo@latest mcp start',
+  };
 }
 
 // Check disk space (async with proper env inheritance)

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -339,16 +339,29 @@ const searchCommand: Command = {
     // Use direct sql.js search with vector similarity
     try {
       const { searchEntries } = await import('../memory/memory-initializer.js');
-      const useSmart = (ctx.flags.smart || ctx.flags.s) as boolean;
+      const requestedSmart = (ctx.flags.smart || ctx.flags.s) as boolean;
+      let useSmart = requestedSmart;
 
       let results: { key: string; score: number; namespace: string; preview: string }[];
       let searchTimeMs: number;
       let smartStats: Record<string, unknown> | undefined;
       let backendLabel = 'HNSW + sql.js';
 
+      // Probe smartSearch availability before committing to the smart path. The published
+      // @claude-flow/memory package may be older than this CLI and not yet export smartSearch.
+      let smartSearchFn: ((fn: unknown, opts: unknown) => Promise<{ results: Array<{ key: string; content: string; score: number; namespace: string }>; stats: { durationMs: number } & Record<string, unknown> }>) | undefined;
       if (useSmart) {
-        const { smartSearch } = await import('@claude-flow/memory');
+        const memoryMod = await import('@claude-flow/memory');
+        const candidate = (memoryMod as { smartSearch?: unknown }).smartSearch;
+        if (typeof candidate === 'function') {
+          smartSearchFn = candidate as typeof smartSearchFn;
+        } else {
+          output.printWarning('--smart: smartSearch is not exported by the installed @claude-flow/memory — falling back to standard HNSW semantic search.');
+          useSmart = false;
+        }
+      }
 
+      if (useSmart && smartSearchFn) {
         // Adapt searchEntries to the SearchFn interface
         const rawSearch = async (req: { query: string; namespace?: string; limit?: number; threshold?: number }) => {
           const r = await searchEntries({
@@ -368,7 +381,7 @@ const searchCommand: Command = {
           };
         };
 
-        const smartResult = await smartSearch(rawSearch, {
+        const smartResult = await smartSearchFn(rawSearch, {
           query,
           namespace,
           limit,

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -16,6 +16,7 @@ import type { InitOptions, InitResult, PlatformInfo } from './types.js';
 import { detectPlatform, DEFAULT_INIT_OPTIONS } from './types.js';
 import { generateSettingsJson, generateSettings } from './settings-generator.js';
 import { generateMCPJson } from './mcp-generator.js';
+import { findExistingMCPRegistration } from './mcp-detection.js';
 import { generateStatuslineScript, generateStatuslineHook } from './statusline-generator.js';
 import {
   generatePreCommitHook,
@@ -776,49 +777,6 @@ async function writeSettings(
 }
 
 /**
- * #1779 — Walk parents of `targetDir` plus the user-global Claude Code
- * config locations, looking for any `.mcp.json` (or `~/.claude.json`)
- * that already declares a `ruflo`-keyed MCP server. We use this to skip
- * writing our own `claude-flow`-keyed entry when the user has already
- * registered the same binary under the new name — that's exactly the
- * "same MCP server twice under two different prefixes" duplication the
- * issue describes.
- *
- * Returns the path of the file that already declares `ruflo` (so we can
- * surface it in the skipped-message), or null if none found.
- */
-function detectExistingRufloMCP(targetDir: string): string | null {
-  const home = (process.env.HOME ?? process.env.USERPROFILE) ?? '';
-  const candidates = new Set<string>();
-  // User-global Claude Code config locations
-  if (home) {
-    candidates.add(path.join(home, '.claude.json'));
-    candidates.add(path.join(home, '.claude', 'mcp.json'));
-  }
-  // Walk parents of targetDir up to root, checking for .mcp.json at each
-  let dir = path.resolve(targetDir);
-  while (true) {
-    candidates.add(path.join(dir, '.mcp.json'));
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  // Skip the targetDir itself — that's the one we're about to write
-  candidates.delete(path.join(path.resolve(targetDir), '.mcp.json'));
-
-  for (const candidate of candidates) {
-    if (!fs.existsSync(candidate)) continue;
-    try {
-      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf-8'));
-      if (parsed && typeof parsed === 'object' && parsed.mcpServers && typeof parsed.mcpServers === 'object') {
-        if ('ruflo' in parsed.mcpServers) return candidate;
-      }
-    } catch { /* malformed JSON — ignore */ }
-  }
-  return null;
-}
-
-/**
  * Write .mcp.json
  */
 async function writeMCPConfig(
@@ -833,16 +791,18 @@ async function writeMCPConfig(
     return;
   }
 
-  // #1779 — Skip writing if the user already has a `ruflo`-keyed MCP
-  // server registered elsewhere (parent .mcp.json, ~/.claude.json, etc).
-  // Writing our `claude-flow`-keyed entry on top of that produces the
-  // duplicate-registration the issue describes (~250 duplicate tools).
-  // Force-mode (`--force`) bypasses this guard for users who actually
-  // want both registrations.
+  // #1779 / #1840 — Skip writing if the user already has a ruflo (or its
+  // legacy `claude-flow` alias) MCP server registered elsewhere: parent
+  // `.mcp.json`, top-level or project-scoped `~/.claude.json`, or one of the
+  // Claude Desktop config locations. Writing on top of that would produce
+  // duplicate tool registrations. `--force` bypasses this guard.
   if (!options.force) {
-    const existingRufloPath = detectExistingRufloMCP(targetDir);
-    if (existingRufloPath) {
-      result.skipped.push(`.mcp.json (existing 'ruflo' MCP registration found at ${existingRufloPath} — would create duplicate; pass --force to write anyway)`);
+    const existing = findExistingMCPRegistration(targetDir);
+    if (existing) {
+      const projectScope = existing.projectKey ? ` [project ${existing.projectKey}]` : '';
+      result.skipped.push(
+        `.mcp.json (existing '${existing.key}' MCP registration found at ${existing.configPath}${projectScope} — would create duplicate; pass --force to write anyway)`,
+      );
       return;
     }
   }

--- a/v3/@claude-flow/cli/src/init/mcp-detection.ts
+++ b/v3/@claude-flow/cli/src/init/mcp-detection.ts
@@ -1,0 +1,136 @@
+/**
+ * MCP detection helpers — shared between `init` (skip duplicate registration)
+ * and `doctor` (report whether ruflo MCP is configured).
+ *
+ * Looks for both the canonical `ruflo` key and the legacy `claude-flow` key,
+ * across:
+ *   - parent directories' `.mcp.json` (project-local config)
+ *   - `~/.claude.json` top-level `mcpServers` (Claude Code user-global)
+ *   - `~/.claude.json` `projects[*].mcpServers` (Claude Code project-scoped)
+ *   - `~/.claude/mcp.json`, `~/.config/claude/mcp.json`,
+ *     `~/.claude/claude_desktop_config.json`
+ *
+ * Project keys in `~/.claude.json.projects` are matched case-insensitively
+ * after normalizing path separators, because Claude stores them with forward
+ * slashes while Node `path.resolve()` on Windows emits backslashes.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export type MCPRegistrationKey = 'ruflo' | 'claude-flow';
+
+export interface MCPRegistrationMatch {
+  /** Path of the file where the registration was found. */
+  configPath: string;
+  /** Which key the registration used. */
+  key: MCPRegistrationKey;
+  /**
+   * If found inside `~/.claude.json.projects[<projectKey>]`, the project key
+   * that matched. Undefined for top-level / parent `.mcp.json` matches.
+   */
+  projectKey?: string;
+}
+
+const KEYS: MCPRegistrationKey[] = ['ruflo', 'claude-flow'];
+
+function normalizeProjectKey(p: string): string {
+  return path.resolve(p).replace(/\\/g, '/').toLowerCase();
+}
+
+function findInMcpServers(
+  obj: unknown,
+): MCPRegistrationKey | undefined {
+  if (!obj || typeof obj !== 'object') return undefined;
+  const servers = (obj as { mcpServers?: unknown }).mcpServers;
+  if (!servers || typeof servers !== 'object') return undefined;
+  for (const key of KEYS) {
+    if (key in (servers as Record<string, unknown>)) return key;
+  }
+  return undefined;
+}
+
+function readJsonSafe(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find an existing MCP registration for ruflo (or its legacy `claude-flow`
+ * alias) in any of the known config locations.
+ *
+ * @param targetDir - Directory we're about to write `.mcp.json` to. Its own
+ *   `.mcp.json` is excluded so init can detect prior parent-level / global
+ *   registrations without matching the file it's about to overwrite.
+ * @returns Match details, or null if no registration found.
+ */
+export function findExistingMCPRegistration(
+  targetDir: string,
+): MCPRegistrationMatch | null {
+  const home = (process.env.HOME ?? process.env.USERPROFILE) ?? '';
+  const resolvedTarget = path.resolve(targetDir);
+  const targetMcpPath = path.join(resolvedTarget, '.mcp.json');
+  const normalizedTarget = normalizeProjectKey(resolvedTarget);
+
+  // 1) ~/.claude.json — top-level + project-scoped
+  if (home) {
+    const claudeJsonPath = path.join(home, '.claude.json');
+    if (fs.existsSync(claudeJsonPath)) {
+      const parsed = readJsonSafe(claudeJsonPath);
+      if (parsed && typeof parsed === 'object') {
+        // Top-level
+        const topKey = findInMcpServers(parsed);
+        if (topKey) return { configPath: claudeJsonPath, key: topKey };
+
+        // Project-scoped: parsed.projects[<resolvedKey>].mcpServers
+        const projects = (parsed as { projects?: Record<string, unknown> }).projects;
+        if (projects && typeof projects === 'object') {
+          for (const [projKey, projVal] of Object.entries(projects)) {
+            if (normalizeProjectKey(projKey) !== normalizedTarget) continue;
+            const matchedKey = findInMcpServers(projVal);
+            if (matchedKey) {
+              return {
+                configPath: claudeJsonPath,
+                key: matchedKey,
+                projectKey: projKey,
+              };
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 2) Other Claude Code / Desktop config files
+  const otherCandidates: string[] = [];
+  if (home) {
+    otherCandidates.push(path.join(home, '.claude', 'mcp.json'));
+    otherCandidates.push(path.join(home, '.config', 'claude', 'mcp.json'));
+    otherCandidates.push(path.join(home, '.claude', 'claude_desktop_config.json'));
+  }
+  for (const candidate of otherCandidates) {
+    if (!fs.existsSync(candidate)) continue;
+    const parsed = readJsonSafe(candidate);
+    const matchedKey = findInMcpServers(parsed);
+    if (matchedKey) return { configPath: candidate, key: matchedKey };
+  }
+
+  // 3) Walk parents of targetDir looking for .mcp.json
+  let dir = resolvedTarget;
+  while (true) {
+    const candidate = path.join(dir, '.mcp.json');
+    if (candidate !== targetMcpPath && fs.existsSync(candidate)) {
+      const parsed = readJsonSafe(candidate);
+      const matchedKey = findInMcpServers(parsed);
+      if (matchedKey) return { configPath: candidate, key: matchedKey };
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
+}

--- a/v3/@claude-flow/cli/src/init/mcp-generator.ts
+++ b/v3/@claude-flow/cli/src/init/mcp-generator.ts
@@ -52,9 +52,11 @@ export function generateMCPConfig(options: InitOptions): object {
     npm_config_update_notifier: 'false',
   };
 
-  // Claude Flow MCP server (core) — uses ruflo wrapper for portable npm-resolved invocation
+  // Ruflo MCP server (core) — uses ruflo wrapper for portable npm-resolved invocation.
+  // Key is `ruflo` (canonical, see #1841). Detector accepts the legacy `claude-flow`
+  // alias for compatibility with installations created before this change.
   if (config.claudeFlow) {
-    mcpServers['claude-flow'] = createMCPServerEntry(
+    mcpServers['ruflo'] = createMCPServerEntry(
       ['ruflo@latest', 'mcp', 'start'],
       {
         ...npmEnv,

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -3612,24 +3612,62 @@ export const hooksWorkerDispatch: MCPTool = {
     activeWorkers.set(workerId, worker);
 
     // Determine honest status
-    let reportedStatus: 'queued' | 'no-daemon' | 'synthetic-completed';
+    let reportedStatus: 'dispatched' | 'completed' | 'failed' | 'no-daemon' | 'synthetic-completed';
     let note: string;
+    let executionDurationMs: number | undefined;
+    let executionError: string | undefined;
+
     if (!daemonAlive) {
       reportedStatus = 'no-daemon';
       note = 'No worker daemon detected. Run `claude-flow daemon start` to enable real worker execution. The dispatch was recorded in-process but no actual work will run.';
-    } else if (background) {
-      // Daemon is alive — record the queued worker. The daemon polls activeWorkers
-      // via its own state file, so this constitutes a real queue entry.
-      reportedStatus = 'queued';
-      note = `Worker queued for daemon (pid ${daemonPid}). Poll hooks_worker-status to track progression — do not assume completion until status === "completed".`;
     } else {
-      // Synchronous mode without a runner — be honest about it
-      reportedStatus = 'synthetic-completed';
-      worker.progress = 100;
-      worker.phase = 'completed';
-      worker.status = 'completed';
-      worker.completedAt = new Date();
-      note = 'Synchronous mode: worker record marked completed but no real work executed (no in-process runner). Use background:true with the daemon for real execution.';
+      // #1845 — actually run the worker. We mirror the `daemon trigger -w` CLI
+      // pattern: instantiate a WorkerDaemon in-process and call triggerWorker().
+      // Both this process and the running daemon (pid ${daemonPid}) share state
+      // via the atomically-written state file, so success/run counters update
+      // for either caller. This replaces the previous "queued" lie where the
+      // request never reached the daemon.
+      const { getDaemon } = await import('../services/worker-daemon.js');
+
+      const runWorker = async (): Promise<void> => {
+        worker.status = 'running';
+        worker.phase = 'executing';
+        try {
+          const daemon = getDaemon(cwd);
+          const result = await daemon.triggerWorker(trigger as never);
+          if (result.success) {
+            worker.status = 'completed';
+            worker.phase = 'completed';
+            worker.progress = 100;
+          } else {
+            worker.status = 'failed';
+            worker.phase = 'failed';
+            executionError = result.error;
+          }
+          executionDurationMs = result.durationMs;
+        } catch (err) {
+          worker.status = 'failed';
+          worker.phase = 'failed';
+          executionError = err instanceof Error ? err.message : String(err);
+        } finally {
+          worker.completedAt = new Date();
+        }
+      };
+
+      if (background) {
+        // Fire-and-forget. Caller polls hooks_worker-status for completion.
+        void runWorker();
+        reportedStatus = 'dispatched';
+        note = `Worker dispatched in-process (pid ${process.pid}); state syncs with the running daemon (pid ${daemonPid}) via .claude-flow/daemon-state.json. Poll hooks_worker-status to track progression — do not assume completion until status === "completed".`;
+      } else {
+        // Synchronous: await the worker completion before responding.
+        await runWorker();
+        reportedStatus = worker.status === 'completed' ? 'completed' : 'failed';
+        note =
+          worker.status === 'completed'
+            ? `Worker completed in ${executionDurationMs ?? 0}ms; state synced with daemon (pid ${daemonPid}).`
+            : `Worker failed${executionError ? `: ${executionError}` : ''}.`;
+      }
     }
 
     return {
@@ -3648,6 +3686,8 @@ export const hooksWorkerDispatch: MCPTool = {
       daemonPid: daemonAlive ? daemonPid : null,
       background,
       note,
+      ...(executionDurationMs !== undefined ? { durationMs: executionDurationMs } : {}),
+      ...(executionError ? { error: executionError } : {}),
       timestamp: new Date().toISOString(),
     };
   },

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -364,60 +364,68 @@ export const memoryTools: MCPTool[] = [
       const startTime = performance.now();
 
       try {
+        let smartFallbackReason: string | undefined;
         if (input.smart) {
           // SmartRetrieval pipeline (ADR-090)
-          const { smartSearch } = await import('@claude-flow/memory');
+          const memoryMod = await import('@claude-flow/memory');
+          const smartSearch = (memoryMod as { smartSearch?: unknown }).smartSearch;
 
-          // Adapt searchEntries to the SearchFn interface
-          const rawSearch = async (req: { query: string; namespace?: string; limit?: number; threshold?: number }) => {
-            const r = await searchEntries({
-              query: req.query,
-              namespace: req.namespace || namespace,
-              limit: req.limit || limit * 3,
-              threshold: req.threshold ?? threshold,
+          if (typeof smartSearch !== 'function') {
+            // Older published @claude-flow/memory may not export smartSearch — fall through to standard HNSW path.
+            smartFallbackReason = 'smartSearch is not exported by the installed @claude-flow/memory; falling back to standard HNSW semantic search';
+          } else {
+            // Adapt searchEntries to the SearchFn interface
+            const rawSearch = async (req: { query: string; namespace?: string; limit?: number; threshold?: number }) => {
+              const r = await searchEntries({
+                query: req.query,
+                namespace: req.namespace || namespace,
+                limit: req.limit || limit * 3,
+                threshold: req.threshold ?? threshold,
+              });
+              return {
+                results: r.results.map(e => ({
+                  id: e.id,
+                  key: e.key,
+                  content: e.content,
+                  score: e.score,
+                  namespace: e.namespace,
+                })),
+              };
+            };
+
+            const smartResult = await (smartSearch as (
+              fn: typeof rawSearch,
+              opts: { query: string; namespace: string; limit: number; threshold: number }
+            ) => Promise<{ results: Array<{ key: string; content: string; score: number; namespace: string }>; stats: unknown }>)(
+              rawSearch,
+              { query, namespace, limit, threshold }
+            );
+
+            const duration = performance.now() - startTime;
+
+            const results = smartResult.results.map(r => {
+              let value: unknown = r.content;
+              try { value = JSON.parse(r.content); } catch { /* keep as string */ }
+              return {
+                key: r.key,
+                namespace: r.namespace,
+                value,
+                similarity: r.score,
+              };
             });
+
             return {
-              results: r.results.map(e => ({
-                id: e.id,
-                key: e.key,
-                content: e.content,
-                score: e.score,
-                namespace: e.namespace,
-              })),
+              query,
+              results,
+              total: results.length,
+              searchTime: `${duration.toFixed(2)}ms`,
+              backend: 'SmartRetrieval (RRF + MMR + Recency)',
+              stats: smartResult.stats,
             };
-          };
-
-          const smartResult = await smartSearch(rawSearch, {
-            query,
-            namespace,
-            limit,
-            threshold,
-          });
-
-          const duration = performance.now() - startTime;
-
-          const results = smartResult.results.map(r => {
-            let value: unknown = r.content;
-            try { value = JSON.parse(r.content); } catch { /* keep as string */ }
-            return {
-              key: r.key,
-              namespace: r.namespace,
-              value,
-              similarity: r.score,
-            };
-          });
-
-          return {
-            query,
-            results,
-            total: results.length,
-            searchTime: `${duration.toFixed(2)}ms`,
-            backend: 'SmartRetrieval (RRF + MMR + Recency)',
-            stats: smartResult.stats,
-          };
+          }
         }
 
-        // Original non-smart path (unchanged)
+        // Standard non-smart path (also used as fallback when smartSearch is unavailable)
         const result = await searchEntries({
           query,
           namespace,
@@ -450,6 +458,7 @@ export const memoryTools: MCPTool[] = [
           total: results.length,
           searchTime: `${duration.toFixed(2)}ms`,
           backend: 'HNSW + sql.js',
+          ...(smartFallbackReason ? { smartFallback: smartFallbackReason } : {}),
         };
       } catch (error) {
         return {

--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -319,7 +319,17 @@ export const systemTools: MCPTool[] = [
         const legacyPath = join(projectCwd, '.claude-flow', 'memory', 'store.json');
         const agentDbPath = join(projectCwd, '.claude-flow', 'memory', 'agentdb.sqlite');
         const rvfPath = join(projectCwd, '.claude-flow', 'memory', 'store.rvf');
-        const memoryExists = existsSync(legacyPath) || existsSync(agentDbPath) || existsSync(rvfPath);
+        // #1843 — current sql.js / HNSW / RuVector memory paths used by alpha runtime
+        const sqljsPath = join(projectCwd, '.claude-flow', 'memory', 'claude-flow.db');
+        const swarmDbPath = join(projectCwd, '.swarm', 'memory.db');
+        const ruvectorDbPath = join(projectCwd, 'ruvector.db');
+        const memoryExists =
+          existsSync(legacyPath) ||
+          existsSync(agentDbPath) ||
+          existsSync(rvfPath) ||
+          existsSync(sqljsPath) ||
+          existsSync(swarmDbPath) ||
+          existsSync(ruvectorDbPath);
         const elapsed = performance.now() - t0;
         checks.push({
           name: 'memory',
@@ -329,12 +339,18 @@ export const systemTools: MCPTool[] = [
         });
       }
 
-      // Config check — verify config file exists
+      // Config check — verify config file exists. #1843: also accept YAML.
       {
         const t0 = performance.now();
         const configPath = join(projectCwd, '.claude-flow', 'config.json');
+        const yamlConfigPath = join(projectCwd, '.claude-flow', 'config.yaml');
         const altConfigPath = join(projectCwd, 'claude-flow.config.json');
-        const configExists = existsSync(configPath) || existsSync(altConfigPath);
+        const altYamlConfigPath = join(projectCwd, 'claude-flow.config.yaml');
+        const configExists =
+          existsSync(configPath) ||
+          existsSync(yamlConfigPath) ||
+          existsSync(altConfigPath) ||
+          existsSync(altYamlConfigPath);
         const elapsed = performance.now() - t0;
         checks.push({
           name: 'config',
@@ -438,9 +454,13 @@ export const systemTools: MCPTool[] = [
         }
       }
 
+      // #1843 — `unknown` checks are advisory (we couldn't verify, not failures);
+      // exclude them from the denominator so the score reflects actionable state.
       const healthy = checks.filter(c => c.status === 'healthy').length;
+      const unknown = checks.filter(c => c.status === 'unknown').length;
       const total = checks.length;
-      const overallHealth = healthy / total;
+      const actionable = total - unknown;
+      const overallHealth = actionable === 0 ? 1 : healthy / actionable;
 
       // Update metrics
       metrics.health = overallHealth;
@@ -452,6 +472,7 @@ export const systemTools: MCPTool[] = [
         checks,
         healthy,
         total,
+        unknown,
         timestamp: new Date().toISOString(),
         issues: checks.filter(c => c.status !== 'healthy').map(c => ({
           component: c.name,

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -280,11 +280,19 @@ export class WorkerDaemon extends EventEmitter {
   } {
     const configPath = join(claudeFlowDir, 'config.json');
     if (!existsSync(configPath)) {
-      // Warn if config.yaml exists but config.json does not (#1395 Bug 4)
+      // #1395 / #1844 — daemon settings live in `.claude-flow/config.json` with
+      // dot-notation keys; the structured `.claude-flow/config.yaml` written by
+      // `ruflo init` does not contain daemon settings. Make that explicit in the
+      // warning so users don't quietly run with defaults.
       const yamlPath = join(claudeFlowDir, 'config.yaml');
       const ymlPath = join(claudeFlowDir, 'config.yml');
       if (existsSync(yamlPath) || existsSync(ymlPath)) {
-        this.log('warn', `Found ${existsSync(yamlPath) ? 'config.yaml' : 'config.yml'} but daemon reads only config.json — YAML config is being ignored. Convert to JSON or create config.json.`);
+        this.log(
+          'warn',
+          `Daemon settings are read from .claude-flow/config.json (dot-notation), not from ${existsSync(yamlPath) ? 'config.yaml' : 'config.yml'}. ` +
+            `Running with defaults. To customize, create .claude-flow/config.json with keys like ` +
+            `{"daemon.maxConcurrent":4,"daemon.workerTimeoutMs":960000,"daemon.resourceThresholds.maxCpuLoad":16}.`,
+        );
       }
       return {};
     }

--- a/v3/@claude-flow/memory/package.json
+++ b/v3/@claude-flow/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/memory",
-  "version": "3.0.0-alpha.14",
+  "version": "3.0.0-alpha.15",
   "type": "module",
   "description": "Memory module - AgentDB unification, HNSW indexing, vector search, hybrid SQLite+AgentDB backend (ADR-009)",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "bench": "vitest bench",
     "build": "tsc",
     "prebuild": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepublishOnly": "npm run build && node -e \"const m = await import('./dist/index.js'); const required = ['ControllerRegistry','HnswLite','PersistentSonaCoordinator','RvfBackend','RvfLearningStore','RvfMigrator']; const missing = required.filter(k => !m[k]); if (missing.length) { console.error('Missing exports:', missing); process.exit(1); } console.log('All required exports present');\""
+    "prepublishOnly": "npm run build && node -e \"const m = await import('./dist/index.js'); const required = ['ControllerRegistry','HnswLite','PersistentSonaCoordinator','RvfBackend','RvfLearningStore','RvfMigrator','smartSearch','defaultQueryExpansions']; const missing = required.filter(k => !m[k]); if (missing.length) { console.error('Missing exports:', missing); process.exit(1); } console.log('All required exports present');\""
   },
   "dependencies": {
     "agentdb": "^3.0.0-alpha.10",

--- a/v3/@claude-flow/memory/src/smart-retrieval.test.ts
+++ b/v3/@claude-flow/memory/src/smart-retrieval.test.ts
@@ -72,7 +72,7 @@ describe('smartSearch — multi-query fan-out', () => {
   });
 
   it('falls back to a single raw call when multiQuery=false', async () => {
-    const search = vi.fn<SearchFn>(async () => ({
+    const search = vi.fn<Parameters<SearchFn>, ReturnType<SearchFn>>(async () => ({
       results: [makeCandidate({ id: 'x', content: 'only one' })],
     }));
 


### PR DESCRIPTION
## Summary

Bundles four buckets of fixes for the alpha.11 regressions reported in #1839–#1846 (8 issues closed). Each bucket is a separate commit so reviewers can split or revert.

## Closed issues

| Bucket | Issues | One-line |
|---|---|---|
| C — memory smartSearch | #1846 | published `@claude-flow/memory@alpha.14` lacks `smartSearch`; CLI imports it → `smartSearch is not a function`. Republish + defensive fallback. |
| A — MCP naming drift | #1839, #1840, #1841, #1842 | `serverInfo.name`, `.mcp.json` key, init detector, doctor — all four were the same drift. Canonical name = `ruflo`. |
| D — system_health | #1843 | `unknown` checks dragged the score down; YAML config + sql.js paths weren't recognized. |
| B — worker dispatch | #1844, #1845 | `hooks_worker-dispatch` reported "queued" but stored work in a process-local Map the daemon never sees; YAML-vs-JSON config guidance was unclear. |

## Per-bucket detail

### C — memory `smartSearch` ([fa34bdb](https://github.com/ruvnet/ruflo/pull/.../commits/fa34bdb86))
Two stacked bugs:
1. `@claude-flow/memory@alpha.14` was published 2026-04-11; `smart-retrieval.ts` was wired in 19 days later (commit d66358149). The published dist therefore lacks the export the CLI imports.
2. `tsc` could not rebuild memory because `vi.fn<SearchFn>(...)` violates vitest 1.x's `vi.fn<TArgs extends any[], R>` signature; `prebuild` deletes `dist`, `tsc` errors → any republish would have shipped without smart-retrieval anyway.

Fixes: typing fix in the test, memory bumped to `alpha.15`, `prepublishOnly` guard now also requires `smartSearch` + `defaultQueryExpansions`. CLI defensively probes `typeof smartSearch === 'function'` and falls back to standard HNSW semantic search with a warning if missing — so future drift degrades gracefully.

### A — MCP naming on `ruflo` ([6281be5d](https://github.com/ruvnet/ruflo/pull/.../commits/6281be5d9))
Canonical name = `ruflo`. The legacy `claude-flow` key is still **detected** so existing installations don't get duplicate registrations after init.

- `bin/cli.js`, `bin/mcp-server.js`: wire `serverInfo.name` "claude-flow" → "ruflo".
- `init/mcp-generator.ts`: `.mcp.json` key "claude-flow" → "ruflo".
- `init/mcp-detection.ts` (new): single helper used by init + doctor. Walks parent `.mcp.json` and `~/.claude.json`'s top-level + project-scoped `mcpServers` (with case-insensitive Windows path normalization), plus `~/.claude/mcp.json`, `~/.config/claude/mcp.json`, and Claude Desktop config. Returns whichever key matched (`ruflo` or `claude-flow`) so callers can show "(legacy alias)" notes.
- `init/executor.ts`: replaces local `detectExistingRufloMCP` — old code only checked top-level `mcpServers` and missed Claude Code's project-scoped registrations under `projects[<path>].mcpServers`.
- `commands/doctor.ts`: `checkMcpServers` also goes through the helper, so doctor stops reporting "No MCP config found" on machines where Claude Code stored a working ruflo registration project-scoped.

### D — `system_health` honesty ([0800554f](https://github.com/ruvnet/ruflo/pull/.../commits/0800554f9))
- `actionable = total - unknown`; `overallHealth = healthy / actionable`. Unknown count surfaced separately.
- Config check recognizes `.claude-flow/config.yaml` (the file `ruflo init` actually writes) and `claude-flow.config.yaml`.
- Memory check recognizes current sql.js / HNSW / RuVector paths: `.claude-flow/memory/claude-flow.db`, `.swarm/memory.db`, `ruvector.db`.

### B — real worker dispatch ([54a23de](https://github.com/ruvnet/ruflo/pull/.../commits/54a23de39))
`hooks_worker-dispatch` mirrors the proven `ruflo daemon trigger -w <worker>` pattern: instantiate a `WorkerDaemon` in-process via `getDaemon(cwd)` and call `daemon.triggerWorker(trigger)`. State syncs with the running daemon (pid X) via the atomically-written state file (`renameSync` in `saveState`), so success/run counters update for either caller. Replaces the prior "queued" lie where the request never reached the daemon.

- `background:true` → fire-and-forget `runWorker()`; `status="dispatched"`; `hooks_worker-status` reflects pending → running → completed/failed.
- `background:false` → await `runWorker()`; `status="completed"` or `"failed"` with actual `durationMs`/error.
- Daemon dead → keep `"no-daemon"` with original guidance.

YAML/JSON daemon-config warning now explicitly states daemon settings live in `.claude-flow/config.json` with dot-notation keys, including a working example.

## Test plan

- [x] `@claude-flow/memory` builds clean (`tsc` exits 0)
- [x] `smart-retrieval.test.ts` — 11/11 passing
- [x] `mcp-detection.ts` smoke tests — 4/4 passing (project-scoped ruflo, legacy top-level claude-flow, no registration, Windows-style case-insensitive path normalization)
- [x] All 9 changed/new TS files type-check clean
- [ ] **Reviewer:** verify `ruflo init` in a fresh dir writes `.mcp.json` with `ruflo` key (was `claude-flow`)
- [ ] **Reviewer:** verify `ruflo doctor` recognizes a project-scoped `~/.claude.json` registration (was warning "No MCP config found")
- [ ] **Reviewer:** verify `mcp__ruflo__hooks_worker-dispatch` actually runs work and updates daemon state counters
- [ ] **Reviewer:** verify `mcp__ruflo__memory_search` with `smart=true` works after publishing `@claude-flow/memory@alpha.15`
- [ ] **Reviewer:** verify MCP `initialize` returns `serverInfo.name="ruflo"` (was `"claude-flow"`)

## Publishing notes

This PR depends on republishing `@claude-flow/memory` as `3.0.0-alpha.15`. The CLI's dependency pin is bumped accordingly. Per CLAUDE.md publishing protocol:
1. `@claude-flow/memory@alpha.15` (memory package, dist now includes `smartSearch`)
2. `@claude-flow/cli@alpha.12` (consuming the new memory)
3. `claude-flow@alpha.12` umbrella + dist-tags (`alpha`, `latest`, `v3alpha`)
4. `ruflo@alpha.12` umbrella + dist-tags (`alpha`, `latest`)

## Out of scope

- #1847 (hooks_pretrain markdown clarity) and #1850 (MiniMax provider) are documentation/feature requests, not regressions; left for a follow-up.
- Pre-existing CLI build errors (`@ruvector/learning-wasm` not installed, `index.ts` strict-null on `command`, swarm-deps not built) are unrelated and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)