### PR TITLE
fix: use configured local embeddings cache in MCP

### DIFF
--- a/v3/@claude-flow/cli/__tests__/embedding-runtime-config.test.ts
+++ b/v3/@claude-flow/cli/__tests__/embedding-runtime-config.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+import { resolveEmbeddingRuntimeOptions } from '../src/memory/memory-initializer.js';
+
+const originalCwd = process.cwd();
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const dir of tempDirs.splice(0)) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('embedding runtime config', () => {
+  it('uses the model and cache directory written by embeddings init', () => {
+    const cwd = mkdtempSync(join(process.cwd(), '.tmp-embedding-runtime-'));
+    tempDirs.push(cwd);
+    process.chdir(cwd);
+
+    mkdirSync('.claude-flow', { recursive: true });
+    writeFileSync(
+      join('.claude-flow', 'embeddings.json'),
+      JSON.stringify({
+        model: 'all-MiniLM-L6-v2',
+        modelPath: '.claude-flow/models',
+        dimension: 384,
+      }),
+    );
+
+    const runtime = resolveEmbeddingRuntimeOptions();
+
+    expect(runtime.modelName).toBe('Xenova/all-MiniLM-L6-v2');
+    expect(runtime.modelPath).toBe(resolve(cwd, '.claude-flow/models'));
+    expect(runtime.dimensions).toBe(384);
+  });
+
+  it('lets explicit load options override persisted config', () => {
+    const cwd = mkdtempSync(join(process.cwd(), '.tmp-embedding-runtime-'));
+    tempDirs.push(cwd);
+    process.chdir(cwd);
+
+    mkdirSync('.claude-flow', { recursive: true });
+    writeFileSync(
+      join('.claude-flow', 'embeddings.json'),
+      JSON.stringify({
+        model: 'Xenova/all-MiniLM-L6-v2',
+        modelPath: '.claude-flow/models',
+        dimension: 384,
+      }),
+    );
+
+    const runtime = resolveEmbeddingRuntimeOptions({
+      modelName: 'Xenova/all-mpnet-base-v2',
+      modelPath: 'custom-model-cache',
+    });
+
+    expect(runtime.modelName).toBe('Xenova/all-mpnet-base-v2');
+    expect(runtime.modelPath).toBe(resolve(cwd, 'custom-model-cache'));
+    expect(runtime.dimensions).toBe(768);
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/embeddings-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/embeddings-tools.ts
@@ -237,6 +237,12 @@ export const embeddingsTools: MCPTool[] = [
       };
 
       saveConfig(config);
+      try {
+        const { resetEmbeddingModelState } = await import('../memory/memory-initializer.js');
+        resetEmbeddingModelState();
+      } catch {
+        // Best-effort reset for long-running MCP processes.
+      }
 
       return {
         success: true,

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -1556,9 +1556,93 @@ interface EmbeddingModel {
   model: unknown;
   tokenizer: unknown;
   dimensions: number;
+  modelName: string;
+  modelPath?: string;
 }
 
 let embeddingModelState: EmbeddingModel | null = null;
+
+interface EmbeddingRuntimeOptions {
+  modelName: string;
+  modelPath?: string;
+  dimensions: number;
+}
+
+function normalizeEmbeddingModelName(model?: string): string {
+  const value = model?.trim() || 'Xenova/all-MiniLM-L6-v2';
+  return value.includes('/') ? value : `Xenova/${value}`;
+}
+
+function inferEmbeddingDimensions(modelName: string, configured?: unknown): number {
+  if (typeof configured === 'number' && configured > 0) return configured;
+  return modelName.toLowerCase().includes('mpnet') ? 768 : 384;
+}
+
+/**
+ * Load the embedding runtime configuration written by `embeddings init`.
+ * MCP tools also write the same file, so all embedding entry points must
+ * resolve model/cache options through this helper before touching ONNX.
+ */
+export function resolveEmbeddingRuntimeOptions(options?: {
+  modelPath?: string;
+  modelName?: string;
+  dimensions?: number;
+}): EmbeddingRuntimeOptions {
+  let config: Record<string, unknown> = {};
+  const configPath = path.resolve(process.cwd(), '.claude-flow', 'embeddings.json');
+
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      config = {};
+    }
+  }
+
+  const rawModel = options?.modelName
+    ?? (typeof config.model === 'string' ? config.model : undefined)
+    ?? 'Xenova/all-MiniLM-L6-v2';
+  const modelName = normalizeEmbeddingModelName(rawModel);
+
+  const rawPath = options?.modelPath
+    ?? (typeof config.modelPath === 'string' ? config.modelPath : undefined)
+    ?? process.env.CLAUDE_FLOW_EMBEDDING_MODEL_PATH
+    ?? process.env.TRANSFORMERS_CACHE;
+  const modelPath = rawPath && rawPath.trim().length > 0 ? path.resolve(rawPath) : undefined;
+
+  return {
+    modelName,
+    modelPath,
+    dimensions: inferEmbeddingDimensions(modelName, options?.dimensions ?? config.dimension),
+  };
+}
+
+/** Reset the lazily loaded model after embedding configuration changes. */
+export function resetEmbeddingModelState(): void {
+  embeddingModelState = null;
+}
+
+export const _resetEmbeddingModelStateForTests = resetEmbeddingModelState;
+
+function configureTransformersEnv(mod: Record<string, unknown>, modelPath?: string): void {
+  if (!modelPath) return;
+
+  const env = mod.env as Record<string, unknown> | undefined;
+  if (!env || typeof env !== 'object') return;
+
+  env.cacheDir = modelPath;
+  env.localModelPath = modelPath;
+  env.allowLocalModels = true;
+}
+
+function getTransformersPipelineOptions(modelPath?: string): Record<string, unknown> | undefined {
+  if (!modelPath) return undefined;
+
+  return {
+    cache_dir: modelPath,
+    local_files_only: process.env.CLAUDE_FLOW_EMBEDDINGS_LOCAL_ONLY === '1',
+  };
+}
 
 /**
  * Lazy load ONNX embedding model
@@ -1566,6 +1650,8 @@ let embeddingModelState: EmbeddingModel | null = null;
  */
 export async function loadEmbeddingModel(options?: {
   modelPath?: string;
+  modelName?: string;
+  dimensions?: number;
   verbose?: boolean;
 }): Promise<{
   success: boolean;
@@ -1575,31 +1661,43 @@ export async function loadEmbeddingModel(options?: {
   error?: string;
 }> {
   const { verbose = false } = options || {};
+  const runtime = resolveEmbeddingRuntimeOptions(options);
   const startTime = Date.now();
 
   // Already loaded
-  if (embeddingModelState?.loaded) {
+  if (
+    embeddingModelState?.loaded
+    && embeddingModelState.modelName === runtime.modelName
+    && embeddingModelState.modelPath === runtime.modelPath
+  ) {
     return {
       success: true,
       dimensions: embeddingModelState.dimensions,
-      modelName: 'cached',
+      modelName: embeddingModelState.modelName,
       loadTime: 0
     };
   }
 
-  // ADR-053: Try AgentDB v3 bridge first
-  const bridge = await getBridge();
-  if (bridge) {
-    const bridgeResult = await bridge.bridgeLoadEmbeddingModel();
-    if (bridgeResult && bridgeResult.success) {
-      // Mark local state as loaded too so subsequent calls use cache
-      embeddingModelState = {
-        loaded: true,
-        model: null, // Bridge handles embedding
-        tokenizer: null,
-        dimensions: bridgeResult.dimensions
-      };
-      return bridgeResult;
+  // ADR-053: Try AgentDB v3 bridge first only when the user has not
+  // initialized an explicit Transformers.js model cache. The bridge does not
+  // currently expose cache/modelPath wiring, so using it here can mask an
+  // AgentDB mock fallback as a successful real embedding provider.
+  if (!runtime.modelPath) {
+    const bridge = await getBridge();
+    if (bridge) {
+      const bridgeResult = await bridge.bridgeLoadEmbeddingModel();
+      if (bridgeResult && bridgeResult.success) {
+        // Mark local state as loaded too so subsequent calls use cache
+        embeddingModelState = {
+          loaded: true,
+          model: null, // Bridge handles embedding
+          tokenizer: null,
+          dimensions: bridgeResult.dimensions,
+          modelName: bridgeResult.modelName,
+          modelPath: runtime.modelPath,
+        };
+        return bridgeResult;
+      }
     }
   }
 
@@ -1610,7 +1708,7 @@ export async function loadEmbeddingModel(options?: {
     // avoid a circular optional-dep at install time; the logic mirrors
     // @claude-flow/embeddings/src/transformers-loader.ts.
     let transformersSource: '@huggingface/transformers' | '@xenova/transformers' | null = null;
-    let pipelineFn: ((task: string, model?: string) => Promise<unknown>) | null = null;
+    let pipelineFn: ((task: string, model?: string, options?: Record<string, unknown>) => Promise<unknown>) | null = null;
 
     {
       const tryLoad = async (specifier: string): Promise<Record<string, unknown> | null> => {
@@ -1619,34 +1717,43 @@ export async function loadEmbeddingModel(options?: {
       };
       const hf = await tryLoad('@huggingface/transformers');
       if (hf && typeof hf.pipeline === 'function') {
-        pipelineFn = hf.pipeline as (t: string, m?: string) => Promise<unknown>;
+        pipelineFn = hf.pipeline as (t: string, m?: string, o?: Record<string, unknown>) => Promise<unknown>;
         transformersSource = '@huggingface/transformers';
+        configureTransformersEnv(hf, runtime.modelPath);
       } else {
         const xen = await tryLoad('@xenova/transformers');
         if (xen && typeof xen.pipeline === 'function') {
-          pipelineFn = xen.pipeline as (t: string, m?: string) => Promise<unknown>;
+          pipelineFn = xen.pipeline as (t: string, m?: string, o?: Record<string, unknown>) => Promise<unknown>;
           transformersSource = '@xenova/transformers';
+          configureTransformersEnv(xen, runtime.modelPath);
         }
       }
     }
 
     if (pipelineFn && transformersSource) {
       if (verbose) {
-        console.log(`Loading ONNX embedding model via ${transformersSource} (all-MiniLM-L6-v2)...`);
+        const pathHint = runtime.modelPath ? ` from ${runtime.modelPath}` : '';
+        console.log(`Loading ONNX embedding model via ${transformersSource} (${runtime.modelName})${pathHint}...`);
       }
-      const embedder = await pipelineFn('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
+      const embedder = await pipelineFn(
+        'feature-extraction',
+        runtime.modelName,
+        getTransformersPipelineOptions(runtime.modelPath),
+      );
 
       embeddingModelState = {
         loaded: true,
         model: embedder,
         tokenizer: null,
-        dimensions: 384 // MiniLM-L6 produces 384-dim vectors
+        dimensions: runtime.dimensions,
+        modelName: runtime.modelName,
+        modelPath: runtime.modelPath,
       };
 
       return {
         success: true,
-        dimensions: 384,
-        modelName: 'Xenova/all-MiniLM-L6-v2',
+        dimensions: runtime.dimensions,
+        modelName: runtime.modelName,
         loadTime: Date.now() - startTime
       };
     }
@@ -1663,7 +1770,9 @@ export async function loadEmbeddingModel(options?: {
         loaded: true,
         model: { embed: reasoningBank.computeEmbedding },
         tokenizer: null,
-        dimensions: 768
+        dimensions: 768,
+        modelName: 'agentic-flow/reasoningbank',
+        modelPath: runtime.modelPath,
       };
 
       return {
@@ -1697,7 +1806,9 @@ export async function loadEmbeddingModel(options?: {
               loaded: true,
               model: (text: string) => onnxEmb.embed(text),
               tokenizer: null,
-              dimensions: probe.length || 384
+              dimensions: probe.length || 384,
+              modelName: 'ruvector/onnx',
+              modelPath: runtime.modelPath,
             };
             return {
               success: true,
@@ -1724,7 +1835,9 @@ export async function loadEmbeddingModel(options?: {
         loaded: true,
         model: (agenticFlow as any).embeddings,
         tokenizer: null,
-        dimensions: 768
+        dimensions: 768,
+        modelName: 'agentic-flow',
+        modelPath: runtime.modelPath,
       };
 
       return {
@@ -1740,7 +1853,9 @@ export async function loadEmbeddingModel(options?: {
       loaded: true,
       model: null, // Will use simple hash-based fallback
       tokenizer: null,
-      dimensions: 128 // Smaller fallback dimensions
+      dimensions: 128, // Smaller fallback dimensions
+      modelName: 'hash-fallback',
+      modelPath: runtime.modelPath,
     };
 
     return {
@@ -1768,16 +1883,29 @@ export async function generateEmbedding(text: string): Promise<{
   dimensions: number;
   model: string;
 }> {
-  // ADR-053: Try AgentDB v3 bridge first
-  const bridge = await getBridge();
-  if (bridge) {
-    const bridgeResult = await bridge.bridgeGenerateEmbedding(text);
-    if (bridgeResult) return bridgeResult;
+  const runtime = resolveEmbeddingRuntimeOptions();
+
+  // ADR-053: Try AgentDB v3 bridge first only when no explicit local model
+  // cache is configured; see the matching guard in loadEmbeddingModel().
+  if (!runtime.modelPath) {
+    const bridge = await getBridge();
+    if (bridge) {
+      const bridgeResult = await bridge.bridgeGenerateEmbedding(text);
+      if (bridgeResult) return bridgeResult;
+    }
   }
 
   // Ensure model is loaded
-  if (!embeddingModelState?.loaded) {
-    await loadEmbeddingModel();
+  if (
+    !embeddingModelState?.loaded
+    || embeddingModelState.modelName !== runtime.modelName
+    || embeddingModelState.modelPath !== runtime.modelPath
+  ) {
+    await loadEmbeddingModel({
+      modelName: runtime.modelName,
+      modelPath: runtime.modelPath,
+      dimensions: runtime.dimensions,
+    });
   }
 
   const state = embeddingModelState!;
@@ -1794,7 +1922,25 @@ export async function generateEmbedding(text: string): Promise<{
         return {
           embedding,
           dimensions: embedding.length,
-          model: 'onnx'
+          model: state.modelName
+        };
+      }
+    } catch {
+      // Fall through to fallback
+    }
+  }
+
+  if (state.model && typeof (state.model as any).embed === 'function') {
+    try {
+      const output = await (state.model as any).embed(text);
+      const embedding = Array.isArray(output)
+        ? output
+        : output instanceof Float32Array ? Array.from(output) : null;
+      if (embedding) {
+        return {
+          embedding,
+          dimensions: embedding.length,
+          model: state.modelName,
         };
       }
     } catch {
@@ -1807,7 +1953,7 @@ export async function generateEmbedding(text: string): Promise<{
   return {
     embedding,
     dimensions: state.dimensions,
-    model: 'hash-fallback'
+    model: state.modelName
   };
 }
 

--- a/v3/@claude-flow/embeddings/src/embedding-service.ts
+++ b/v3/@claude-flow/embeddings/src/embedding-service.ts
@@ -373,11 +373,15 @@ export class TransformersEmbeddingService extends BaseEmbeddingService {
   readonly provider: EmbeddingProvider = 'transformers';
   private pipeline: any = null;
   private readonly modelName: string;
+  private readonly modelPath?: string;
+  private readonly localFilesOnly: boolean;
   private initialized = false;
 
   constructor(config: TransformersEmbeddingConfig) {
     super(config);
     this.modelName = config.model ?? 'Xenova/all-MiniLM-L6-v2';
+    this.modelPath = config.modelPath;
+    this.localFilesOnly = config.localFilesOnly ?? false;
   }
 
   private async initialize(): Promise<void> {
@@ -395,7 +399,11 @@ export class TransformersEmbeddingService extends BaseEmbeddingService {
           'or @xenova/transformers to enable ONNX embeddings.',
         );
       }
-      this.pipeline = await handle.pipeline('feature-extraction', this.modelName);
+      const options = this.modelPath ? {
+        cache_dir: this.modelPath,
+        local_files_only: this.localFilesOnly,
+      } : undefined;
+      this.pipeline = await handle.pipeline('feature-extraction', this.modelName, options);
       this.initialized = true;
     } catch (error) {
       throw new Error(`Failed to initialize transformers pipeline: ${error}`);
@@ -910,6 +918,10 @@ export interface AutoEmbeddingConfig {
   modelId?: string;
   /** Model name for transformers */
   model?: string;
+  /** Transformers.js cache/model directory */
+  modelPath?: string;
+  /** Force local files only for transformers */
+  localFilesOnly?: boolean;
   /** Dimensions */
   dimensions?: number;
   /** Cache size */
@@ -983,6 +995,8 @@ export async function createEmbeddingServiceAsync(
       const service = new TransformersEmbeddingService({
         provider: 'transformers',
         model: rest.model ?? 'Xenova/all-MiniLM-L6-v2',
+        modelPath: rest.modelPath,
+        localFilesOnly: rest.localFilesOnly,
         cacheSize: rest.cacheSize,
       });
       // Validate it can initialize
@@ -1014,6 +1028,8 @@ export async function createEmbeddingServiceAsync(
         return new TransformersEmbeddingService({
           provider: 'transformers',
           model: rest.model ?? 'Xenova/all-MiniLM-L6-v2',
+          modelPath: rest.modelPath,
+          localFilesOnly: rest.localFilesOnly,
           cacheSize: rest.cacheSize,
         });
       case 'openai':

--- a/v3/@claude-flow/embeddings/src/neural-integration.ts
+++ b/v3/@claude-flow/embeddings/src/neural-integration.ts
@@ -297,6 +297,9 @@ export async function downloadEmbeddingModel(
   targetDir?: string,
   onProgress?: (progress: { percent: number; bytesDownloaded: number; totalBytes: number }) => void
 ): Promise<string> {
+  const modelDir = targetDir ?? '.models';
+  const modelName = modelId.includes('/') ? modelId : `Xenova/${modelId}`;
+
   try {
     const mod = await import('agentic-flow/embeddings').catch((err) => {
       throw err;
@@ -309,11 +312,11 @@ export async function downloadEmbeddingModel(
       // Treat as lazy-fetch path — @xenova/transformers will download on
       // first generate(). #1700 item 2 follow-up.
       console.warn('[embeddings] agentic-flow installed but does not expose downloadModel — ' +
-        'falling back to lazy fetch via @xenova/transformers on first generate.');
-      return targetDir ?? '.models';
+        'falling back to Transformers.js download.');
+      return await downloadWithTransformers(modelName, modelDir, onProgress);
     }
     return await (downloadFn as (id: string, dir: string, cb?: typeof onProgress) => Promise<string>)(
-      modelId, targetDir ?? '.models', onProgress
+      modelId, modelDir, onProgress
     );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -331,10 +334,36 @@ export async function downloadEmbeddingModel(
       || /ERR_PACKAGE_PATH_NOT_EXPORTED/.test(msg)
     ) {
       console.warn('[embeddings] agentic-flow neural extras unavailable — skipping eager model download. ' +
-        'Models will be fetched lazily by @xenova/transformers on first generate. ' +
+        'Using Transformers.js to populate the configured model cache. ' +
         `Reason: ${msg}`);
-      return targetDir ?? '.models';
+      return await downloadWithTransformers(modelName, modelDir, onProgress);
     }
     throw err;
   }
+}
+
+async function downloadWithTransformers(
+  modelName: string,
+  targetDir: string,
+  onProgress?: (progress: { percent: number; bytesDownloaded: number; totalBytes: number }) => void
+): Promise<string> {
+  const { loadTransformersPipeline } = await import('./transformers-loader.js');
+  const handle = await loadTransformersPipeline();
+  if (!handle) {
+    throw new Error(
+      'No transformers package available. Install @huggingface/transformers or @xenova/transformers to download ONNX embeddings.'
+    );
+  }
+
+  await handle.pipeline('feature-extraction', modelName, {
+    cache_dir: targetDir,
+    progress_callback: (progress: Record<string, unknown>) => {
+      const loaded = typeof progress.loaded === 'number' ? progress.loaded : 0;
+      const total = typeof progress.total === 'number' ? progress.total : 0;
+      const percent = total > 0 ? (loaded / total) * 100 : 0;
+      onProgress?.({ percent, bytesDownloaded: loaded, totalBytes: total });
+    },
+  });
+
+  return targetDir;
 }

--- a/v3/@claude-flow/embeddings/src/types.ts
+++ b/v3/@claude-flow/embeddings/src/types.ts
@@ -97,6 +97,12 @@ export interface TransformersEmbeddingConfig extends EmbeddingBaseConfig {
   /** Model name from Hugging Face */
   model?: string;
 
+  /** Transformers.js cache/model directory */
+  modelPath?: string;
+
+  /** Force local files only (no network fetch) */
+  localFilesOnly?: boolean;
+
   /** Quantization level */
   quantized?: boolean;
 


### PR DESCRIPTION
## Summary
- read `.claude-flow/embeddings.json` when loading embeddings so CLI and MCP reuse the downloaded local model cache
- pass the configured cache directory into Transformers.js and reset the lazy embedding state after `embeddings_init`
- skip the AgentDB bridge path when a local embedding cache is explicitly configured so the runtime uses the intended backend