### PR TITLE
chore(gitignore): ignore Clop media-optimizer `optimised/` dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ hive-mind-prompt-*.txt
 .env.*
 !.env.example
 !.env.*.example
+
+# Clop media-optimizer output (sits next to source media)
+optimised/


### PR DESCRIPTION
## Summary

Adds `optimised/` to `.gitignore`. The [Clop](https://clop.lol/) macOS media-optimizer drops an `optimised/` subdirectory next to source media after compressing — this was leaving 8 nested untracked directories in the working tree (`archive/v2/assets/`, `ruflo/assets/`, `ruflo/src/chat-ui/static/chatui/`, `ruflo/src/ruvocal/static/chatui/`, `ruflo/src/ruvocal/static/huggingchat/`, `v3/docs/assets/`, `v3/goal_ui/public/`, and the repo root).

## Changes

- One line in `.gitignore`: `optimised/` (matches the dir name anywhere in the tree).

## Test plan

- [x] `git status` is clean after change (no untracked `optimised/` dirs surfaced)
- [x] No existing tracked `optimised/` paths in the repo (verified — none of the 8 dirs were under git control)