### PR TITLE
chore(gitignore): ignore media-optimizer `optimised/` dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ hive-mind-prompt-*.txt
 .env.*
 !.env.example
 !.env.*.example
+
+# Media-optimizer output dirs (third-party tools drop these next to source media)
+optimised/


### PR DESCRIPTION
## Summary

Adds `optimised/` to `.gitignore`. Some macOS media-optimizer tools drop an `optimised/` subdirectory next to the source media they compress, leaving 8 nested untracked directories across the working tree (`archive/v2/assets/`, `ruflo/assets/`, `ruflo/src/chat-ui/static/chatui/`, `ruflo/src/ruvocal/static/chatui/`, `ruflo/src/ruvocal/static/huggingchat/`, `v3/docs/assets/`, `v3/goal_ui/public/`, and the repo root).

## Changes

- One line in `.gitignore`: `optimised/` (matches the dir name anywhere in the tree).

## Test plan

- [x] `git status` clean after change (no untracked `optimised/` dirs surfaced)
- [x] No existing tracked `optimised/` paths in the repo