### PR TITLE
fix(memory): persist sql.js data to disk after INSERT

### DIFF
--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -595,6 +595,11 @@ export async function bridgeStoreEntry(options: {
       ttl ? now + (ttl * 1000) : null
     );
 
+    // Flush sql.js in-memory data to disk (agentdb sql.js wrapper only saves on close())
+    if (ctx.db && typeof ctx.db.save === 'function') {
+      try { ctx.db.save(); } catch (_e) { /* ignore flush errors */ }
+    }
+
     // Phase 2: Write-through to TieredCache
     const safeNs = String(namespace).replace(/:/g, '_');
     const safeKey = String(key).replace(/:/g, '_');


### PR DESCRIPTION
## Bug Fix: Memory store entries lost on disk

### Problem
`bridgeStoreEntry()` in `memory-bridge.ts` uses the agentdb sql.js wrapper which operates in **in-memory mode**. After performing an `INSERT INTO memory_entries`, the data exists only in memory — the wrapper's `save()` method (which calls `db.export()` + `fs.writeFileSync`) is never invoked.

**Result**: `memory store` reports success but DB file on disk has 0 entries. All data is lost when the process exits. Semantic search finds nothing after restart.

### Fix
Added `db.save()` call after successful INSERT in `bridgeStoreEntry()`:
- Guards with type check — safe for better-sqlite3 (auto-persists, no `.save()`)
- Wrapped in try/catch to avoid breaking if flush fails

### Verification
```bash
# Before fix: entries = 0 on disk
ruflo memory store -k "test" --value "hello world"
# DB file mtime unchanged, sqlite3 query returns 0 rows

# After fix: entries persist
ruflo memory store -k "ai-research" --value "artificial intelligence research"
ruflo memory search -q "machine learning"
# → Found 1 result, score 0.31 (Xenova/all-MiniLM-L6-v2 384-dim embedding)
```

### Files Changed
- `v3/@claude-flow/cli/src/memory/memory-bridge.ts` — +5 lines

### Impact
- **Minimal**: Only affects the sql.js code path (WASM SQLite fallback)
- **No risk**: better-sqlite3 native path is unaffected (no `.save()` method)
- **Zero breaking changes**: Purely additive fix
