### PR TITLE
fix(#1910): keep stdio MCP server stdout JSON-RPC-only (hook-tool diagnostics corrupted the transport)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/mcp-stdio-protocol.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-stdio-protocol.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MCP_SERVER = join(__dirname, '..', 'bin', 'mcp-server.js');
+const CLI = join(__dirname, '..', 'bin', 'cli.js');
+
+let server: ChildProcessWithoutNullStreams | null = null;
+
+afterEach(async () => {
+  if (!server || server.killed) return;
+  server.kill('SIGTERM');
+  await Promise.race([
+    once(server, 'exit'),
+    new Promise(resolve => setTimeout(resolve, 1000)),
+  ]);
+  server = null;
+});
+
+function readJsonLine(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs = 10000
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for JSON-RPC stdout line. Buffer: ${buffer}`));
+    }, timeoutMs);
+
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const newline = buffer.indexOf('\n');
+      if (newline === -1) return;
+
+      const line = buffer.slice(0, newline);
+      cleanup();
+      try {
+        resolve(JSON.parse(line));
+      } catch (error) {
+        reject(new Error(`Non-JSON stdout line: ${line}`));
+      }
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`MCP server exited before response: code=${code} signal=${signal}`));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout.off('data', onData);
+      child.off('exit', onExit);
+    };
+
+    child.stdout.on('data', onData);
+    child.once('exit', onExit);
+  });
+}
+
+function send(child: ChildProcessWithoutNullStreams, message: Record<string, unknown>) {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+describe('stdio MCP protocol', () => {
+  it.each([
+    ['direct MCP server bin', MCP_SERVER, []],
+    ['CLI mcp start auto-detect path', CLI, ['mcp', 'start']],
+  ])('keeps stdout JSON-RPC-only for %s when hook tools log diagnostics', async (_name, bin, args) => {
+    server = spawn(process.execPath, [bin, ...args], {
+      cwd: join(__dirname, '..'),
+      env: { ...process.env, CLAUDE_FLOW_CWD: join(__dirname, '..') },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    send(server, { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+    const init = await readJsonLine(server);
+    expect(init).toMatchObject({ jsonrpc: '2.0', id: 1 });
+
+    send(server, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'hooks_route',
+        arguments: {
+          task: 'MCP stdio smoke route validation',
+          context: 'protocol stdout must remain JSON only',
+          useSemanticRouter: true,
+        },
+      },
+    });
+
+    const route = await readJsonLine(server);
+    expect(route).toMatchObject({ jsonrpc: '2.0', id: 2 });
+    expect(route).toHaveProperty('result');
+
+    send(server, { jsonrpc: '2.0', id: 3, method: 'ping' });
+    const ping = await readJsonLine(server);
+    expect(ping).toEqual({ jsonrpc: '2.0', id: 3, result: {} });
+  });
+});

--- a/v3/@claude-flow/cli/bin/cli.js
+++ b/v3/@claude-flow/cli/bin/cli.js
@@ -57,6 +57,20 @@ const isMCPMode = !process.stdin.isTTY
   && (process.argv.length === 2 || isExplicitMCP);
 
 if (isMCPMode) {
+  // In stdio MCP mode, stdout is reserved exclusively for JSON-RPC frames.
+  // Redirect diagnostic console output to stderr so tool-level console.log calls
+  // cannot corrupt the MCP stream and make clients close the transport.
+  console.log = (...args) => {
+    if (_isCosmeticAgentdbPatchNoise(String(args[0] ?? ''))) return;
+    console.error(...args);
+  };
+  console.info = (...args) => console.error(...args);
+  console.debug = (...args) => console.error(...args);
+
+  const writeProtocolMessage = (message) => {
+    process.stdout.write(`${JSON.stringify(message)}\n`);
+  };
+
   // Run MCP server mode
   const { listMCPTools, callMCPTool, hasTool } = await import('../dist/src/mcp-client.js');
 
@@ -81,14 +95,14 @@ if (isMCPMode) {
     if (buffer.length > MCP_MAX_BUFFER_BYTES) {
       // Drop the buffer + emit a protocol-level error so the client
       // sees the rejection rather than a silent OOM.
-      console.log(JSON.stringify({
+      writeProtocolMessage({
         jsonrpc: '2.0',
         id: null,
         error: {
           code: -32700,
           message: `Buffered stdin exceeds ${MCP_MAX_BUFFER_BYTES} bytes without newline; resetting`,
         },
-      }));
+      });
       buffer = '';
       return;
     }
@@ -101,25 +115,25 @@ if (isMCPMode) {
         try {
           message = JSON.parse(line);
         } catch {
-          console.log(JSON.stringify({
+          writeProtocolMessage({
             jsonrpc: '2.0',
             id: null,
             error: { code: -32700, message: 'Parse error' },
-          }));
+          });
           continue;
         }
         try {
           const response = await handleMessage(message);
           if (response) {
-            console.log(JSON.stringify(response));
+            writeProtocolMessage(response);
           }
         } catch (error) {
           // #1606: Return proper internal error instead of parse error
-          console.log(JSON.stringify({
+          writeProtocolMessage({
             jsonrpc: '2.0',
             id: message.id ?? null,
             error: { code: -32603, message: error instanceof Error ? error.message : 'Internal error' },
-          }));
+          });
         }
       }
     }

--- a/v3/@claude-flow/cli/bin/mcp-server.js
+++ b/v3/@claude-flow/cli/bin/mcp-server.js
@@ -9,13 +9,13 @@
 
 import { randomUUID } from 'crypto';
 
-// Suppress the SPECIFIC cosmetic "[AgentDB Patch] Controller index not found"
-// noise. Tight match (both prefix AND "Controller index not found") so other
-// [AgentDB Patch] warnings about real issues still flow through. Also patch
-// console.log because the underlying call site uses it. See bin/cli.js for
-// the same rationale.
+// In stdio MCP mode, stdout is reserved exclusively for JSON-RPC frames.
+// Redirect diagnostic console output to stderr so tool-level console.log calls
+// cannot corrupt the MCP stream and make clients close the transport.
+// Also suppress the SPECIFIC cosmetic "[AgentDB Patch] Controller index not
+// found" noise. Tight match (both prefix AND "Controller index not found") so
+// other [AgentDB Patch] warnings about real issues still flow through.
 const _origWarn = console.warn;
-const _origLog = console.log;
 const _isCosmeticAgentdbPatchNoise = (msg) =>
   msg.includes('[AgentDB Patch]') && msg.includes('Controller index not found');
 console.warn = (...args) => {
@@ -24,8 +24,10 @@ console.warn = (...args) => {
 };
 console.log = (...args) => {
   if (_isCosmeticAgentdbPatchNoise(String(args[0] ?? ''))) return;
-  _origLog.apply(console, args);
+  console.error(...args);
 };
+console.info = (...args) => console.error(...args);
+console.debug = (...args) => console.error(...args);
 
 import { listMCPTools, callMCPTool, hasTool } from '../dist/src/mcp-client.js';
 
@@ -47,6 +49,10 @@ console.error(JSON.stringify({
   version: VERSION,
 }));
 
+function writeProtocolMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
 // Handle stdin messages
 // Audit-flagged DoS protection (audit_1776483149979): cap stdin buffer
 // to 10MB. See bin/cli.js for the same protection on the auto-detect path.
@@ -58,14 +64,14 @@ process.stdin.on('data', async (chunk) => {
   buffer += chunk;
 
   if (buffer.length > MCP_MAX_BUFFER_BYTES) {
-    console.log(JSON.stringify({
+    writeProtocolMessage({
       jsonrpc: '2.0',
       id: null,
       error: {
         code: -32700,
         message: `Buffered stdin exceeds ${MCP_MAX_BUFFER_BYTES} bytes without newline; resetting`,
       },
-    }));
+    });
     buffer = '';
     return;
   }
@@ -80,7 +86,7 @@ process.stdin.on('data', async (chunk) => {
         const message = JSON.parse(line);
         const response = await handleMessage(message);
         if (response) {
-          console.log(JSON.stringify(response));
+          writeProtocolMessage(response);
         }
       } catch (error) {
         console.error(
@@ -88,11 +94,11 @@ process.stdin.on('data', async (chunk) => {
           error instanceof Error ? error.message : String(error)
         );
         // Send parse error response
-        console.log(JSON.stringify({
+        writeProtocolMessage({
           jsonrpc: '2.0',
           id: null,
           error: { code: -32700, message: 'Parse error' },
-        }));
+        });
       }
     }
   }

--- a/v3/@claude-flow/cli/src/mcp-server.ts
+++ b/v3/@claude-flow/cli/src/mcp-server.ts
@@ -32,6 +32,23 @@ import { trackRequest } from './mcp-tools/request-tracker.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+function writeStdioProtocolMessage(message: unknown): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function redirectConsoleStdoutForMCPStdio(): void {
+  const consoleWithFlag = console as Console & { __claudeFlowMcpStdioRedirected?: boolean };
+  if (consoleWithFlag.__claudeFlowMcpStdioRedirected) {
+    return;
+  }
+
+  const writeToStderr = (...args: unknown[]) => console.error(...args);
+  console.log = writeToStderr;
+  console.info = writeToStderr;
+  console.debug = writeToStderr;
+  consoleWithFlag.__claudeFlowMcpStdioRedirected = true;
+}
+
 /**
  * MCP Server configuration
  */
@@ -309,6 +326,8 @@ export class MCPServerManager extends EventEmitter {
    * Handles stdin/stdout directly like V2 implementation
    */
   private async startStdioServer(): Promise<void> {
+    redirectConsoleStdoutForMCPStdio();
+
     // Import the tool registry
     const { listMCPTools, callMCPTool, hasTool } = await import('./mcp-client.js');
 
@@ -364,7 +383,7 @@ export class MCPServerManager extends EventEmitter {
     }));
 
     // Send server initialization notification
-    console.log(JSON.stringify({
+    writeStdioProtocolMessage({
       jsonrpc: '2.0',
       method: 'server.initialized',
       params: {
@@ -377,7 +396,7 @@ export class MCPServerManager extends EventEmitter {
           },
         },
       },
-    }));
+    });
 
     // Handle stdin messages (S-5: bounded buffer to prevent OOM)
     const MAX_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
@@ -391,10 +410,10 @@ export class MCPServerManager extends EventEmitter {
           `[${new Date().toISOString()}] ERROR [claude-flow-mcp] Buffer exceeded ${MAX_BUFFER_SIZE} bytes, rejecting`
         );
         buffer = '';
-        console.log(JSON.stringify({
+        writeStdioProtocolMessage({
           jsonrpc: '2.0',
           error: { code: -32600, message: 'Request too large' },
-        }));
+        });
         return;
       }
 
@@ -408,7 +427,7 @@ export class MCPServerManager extends EventEmitter {
             const message = JSON.parse(line);
             const response = await this.handleMCPMessage(message, sessionId);
             if (response) {
-              console.log(JSON.stringify(response));
+              writeStdioProtocolMessage(response);
             }
           } catch (error) {
             console.error(


### PR DESCRIPTION
Closes #1910.

## Root cause
The `claude-flow` stdio MCP server closed its transport mid-session during a broad smoke test: the first `hooks_route` / `hooks_model_route` / `hooks_explain` call runs `getSemanticRouter()`, which `console.log`s `[hooks] Semantic router initialized: …` — directly onto **fd 1**, which a stdio MCP server reserves for JSON-RPC framing. The client sees garbage, drops the transport, and every subsequent call (incl. `mcp_status`) fails with `Transport closed`. (Full analysis: [#1910 comment](https://github.com/ruvnet/ruflo/issues/1910#issuecomment-4422054655).)

## Fix
Guard **at the transport boundary** so it covers every stdio entry point, not just the one offending `console.log`:
- `v3/@claude-flow/cli/bin/mcp-server.js` — diagnostics → stderr; JSON-RPC responses written via `process.stdout.write`
- `v3/@claude-flow/cli/bin/cli.js` — same protection on the `mcp start` auto-detect path
- `v3/@claude-flow/cli/src/mcp-server.ts` — same fix in the TS server-manager path
- `v3/@claude-flow/cli/__tests__/mcp-stdio-protocol.test.ts` — regression test: drives both stdio entry points through a `hooks_*` batch and asserts every stdout line parses as JSON-RPC and the transport stays up

## Verification
- `npx vitest run __tests__/mcp-stdio-protocol.test.ts` → **2/2 pass**
- `npx tsc --noEmit` (`@claude-flow/cli`) → clean

## Follow-ups (not in this PR)
- `hooks-tools.ts:347/372/376` still has the literal `console.log('[hooks] Semantic router initialized: …')` — harmless now that the transport guards fd 1, but worth a `→ console.error` cleanup.
- The other "ambiguous/suspicious" items from the smoke test report (`config_get` `source:default`, `agentdb_feedback` `success:true/controller:none`, `hive_mind_status` truncated ID / stale state) — separate issues.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)