### PR TITLE
docs(readme): add federation user-guide callout (docs/federation/)

### DIFF
--- a/ruflo/README.md
+++ b/ruflo/README.md
@@ -263,6 +263,8 @@ The difference: some channels are trusted, some aren't. [`@claude-flow/plugin-ag
 
 You don't configure handshakes or manage certificates. You `federation init`, `federation join`, and your agents start talking. The protocol handles identity, the PII pipeline handles data safety, and the audit trail handles compliance.
 
+> **📘 Full user guide:** [`docs/federation/`](./docs/federation/) — setup, MCP tools, trust levels, circuit breaker, and the (opt-in) WireGuard mesh layer that ties packet-layer reachability to federation trust. ADR-111 deep-dive at [`docs/federation/phase7-mesh-bringup.md`](./docs/federation/phase7-mesh-bringup.md).
+
 <details>
 <summary><strong>Federation capabilities</strong></summary>
 

--- a/v3/@claude-flow/cli/README.md
+++ b/v3/@claude-flow/cli/README.md
@@ -263,6 +263,8 @@ The difference: some channels are trusted, some aren't. [`@claude-flow/plugin-ag
 
 You don't configure handshakes or manage certificates. You `federation init`, `federation join`, and your agents start talking. The protocol handles identity, the PII pipeline handles data safety, and the audit trail handles compliance.
 
+> **📘 Full user guide:** [`docs/federation/`](./docs/federation/) — setup, MCP tools, trust levels, circuit breaker, and the (opt-in) WireGuard mesh layer that ties packet-layer reachability to federation trust. ADR-111 deep-dive at [`docs/federation/phase7-mesh-bringup.md`](./docs/federation/phase7-mesh-bringup.md).
+
 <details>
 <summary><strong>Federation capabilities</strong></summary>
 


### PR DESCRIPTION
Surfaces the existing `docs/federation/` user guide (setup, MCP tools, trust levels, circuit breaker, WireGuard mesh) and the ADR-111 deep dive (`docs/federation/phase7-mesh-bringup.md`) from both READMEs. Two-line addition; the linked docs already exist on disk. Was sitting uncommitted in the worktree.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)