### PR TITLE
fix(security): plugin registry signature verification is a no-op (CWE-347)

### DIFF
--- a/v3/@claude-flow/cli/src/plugins/store/discovery.ts
+++ b/v3/@claude-flow/cli/src/plugins/store/discovery.ts
@@ -13,7 +13,7 @@ import type {
   PluginStoreConfig,
   PluginEntry,
 } from './types.js';
-import { resolveIPNS, fetchFromIPFS } from '../../transfer/ipfs/client.js';
+import { resolveIPNS, fetchFromIPFS, verifyEd25519Signature } from '../../transfer/ipfs/client.js';
 
 /**
  * Fetch real npm download stats for a package
@@ -175,11 +175,19 @@ export class PluginDiscoveryService {
         return this.createDemoRegistryAsync(registry);
       }
 
-      // Verify registry signature if required
-      if (this.config.requireVerification && registryData.registrySignature) {
-        const verified = this.verifyRegistrySignature(registryData, registry.publicKey);
+      // Verify registry signature when required.
+      // Fail closed on missing/invalid signature — silently warning and using
+      // an unverified registry would let a compromised IPFS gateway (or any
+      // on-path attacker) swap in attacker-mapped plugin entries that the
+      // installer would then load unsandboxed.
+      if (this.config.requireVerification) {
+        const verified = await this.verifyRegistrySignature(registryData, registry.publicKey);
         if (!verified) {
-          console.warn(`[PluginDiscovery] Registry signature verification failed`);
+          console.warn(
+            `[PluginDiscovery] Registry signature verification failed for ` +
+              `${registry.name} (CID ${cid}); falling back to demo registry.`,
+          );
+          return this.createDemoRegistryAsync(registry);
         }
       }
 
@@ -1194,14 +1202,34 @@ export class PluginDiscoveryService {
   }
 
   /**
-   * Verify registry signature
+   * Verify registry Ed25519 signature.
+   *
+   * Mirrors the signing scheme in scripts/publish-registry.ts: the signer
+   * removes registrySignature + registryPublicKey from the registry object
+   * and signs JSON.stringify(rest). The verifier reproduces those bytes and
+   * checks the signature against the registry config's pre-pinned
+   * publicKey — NOT registry.registryPublicKey, which is asserted by
+   * whoever served the registry and can be swapped by a compromised
+   * gateway / on-path attacker.
    */
-  private verifyRegistrySignature(registry: PluginRegistry, expectedPublicKey: string): boolean {
-    if (!registry.registrySignature || !registry.registryPublicKey) {
+  private async verifyRegistrySignature(
+    registry: PluginRegistry,
+    expectedPublicKey: string,
+  ): Promise<boolean> {
+    if (!registry.registrySignature || !expectedPublicKey) {
       return false;
     }
-    // In production: Verify Ed25519 signature
-    return registry.registryPublicKey.startsWith(expectedPublicKey.split(':')[0]);
+    // Object spread preserves insertion order; delete drops a key without
+    // re-ordering the rest, matching the signer's view of the registry.
+    const registryToVerify: Record<string, unknown> = { ...registry };
+    delete registryToVerify.registrySignature;
+    delete registryToVerify.registryPublicKey;
+    const message = JSON.stringify(registryToVerify);
+    return verifyEd25519Signature(
+      message,
+      registry.registrySignature,
+      expectedPublicKey,
+    );
   }
 
   /**


### PR DESCRIPTION
## Disclosure path

Filing publicly after the private channels were unworkable: PVR is disabled at the repo level, and the email path to `security@cognitum.one` was queued on our side for two days with no SMTP-out from the agent. Coordinated with operator before going public. Happy to fold this into a private flow the moment one is available.

## Summary

The plugin-registry signature verifier in `v3/@claude-flow/cli/src/plugins/store/discovery.ts:1199-1206` is a stub that never actually checks the Ed25519 signature — it returns `true` whenever the served `registryPublicKey` field starts with `"ed25519"`. The call site at lines 178-184 compounds the issue: when verification *is* attempted and fails, it only `console.warn`s and continues to use the unverified registry. With `requireVerification: true` (the default), an attacker who can swap the served registry payload via gateway compromise / hostile resolver / BGP-hijack still passes verification and the user installs attacker-controlled plugin tarballs with `network`+`filesystem`+`hooks` permissions.

The real `verifyEd25519Signature` already exists at `v3/@claude-flow/cli/src/transfer/ipfs/client.ts:325` — discovery just never wired it in.

CWE-347. Severity: medium-to-high (verification stub on a security-critical control path; chain to RCE goes through one extra "user installs a popular-looking plugin" step).

## Threat model

`DEFAULT_PLUGIN_STORE_CONFIG` ships with `requireVerification: true`, two `claude-flow-official` / `community-plugins` entries pointing at the same Pinata registry CID, and `allowedPermissions: ['network', 'filesystem', 'memory', 'hooks']`. The discovery flow:

```
PluginDiscoveryService.discoverRegistry(registryName)
  → resolveIPNS / direct CID                  ← can be swapped by a hostile gateway
  → fetchFromIPFS<PluginRegistry>(cid, gateway) ← gateways: pinata, ipfs.io, ...
  → verifyRegistrySignature(registryData, registry.publicKey) ← stub; always passes
  → cache + return registry
```

A network adversary on the path between a user and the configured IPFS gateway (compromised gateway, hostile public-Wi-Fi resolver, hostile VPN, BGP hijack, etc.) can serve a substituted plugin registry with `cid` fields pointing at attacker-uploaded plugin tarballs. When the user installs a plugin that looks legitimate (matching name, description, displayName), the installer pulls attacker-controlled bytes; the loader logs the unsandboxed-load notice and runs them with the configured permissions — `filesystem` + `network` is enough for credential exfiltration, `hooks` adds persistence into subsequent claude-flow runs.

Three multipliers turn this from a "signature stub" finding into medium-to-high:

- The two default registries differ only in `gateway`; both share the same `LIVE_REGISTRY_CID`. So an attacker only needs to compromise *one* of `gateway.pinata.cloud` or `ipfs.io` (or the user's path to either) to swap the registry the user sees.
- The official Pinata registry uses a real Ed25519 keypair (visible as the pinned `publicKey` field in `DEFAULT_PLUGIN_STORE_CONFIG`), so the only thing standing between users and a malicious registry is the verifier function. Today: nothing.
- Plugins load with the configured permission set — enough surface for the standard credential-sweep / persistence pattern.

I did not chain this end-to-end against the live Pinata pin (would need either an actual MITM of a real user's path or standing up a hostile gateway and convincing a user to point at it — neither I'm willing to do in good faith). The reachability from `discoverRegistry()` to `loadPlugin()` to executable plugin code is straightforward in the source.

## Fix (committed in `a8e3006`)

Three changes, all in `v3/@claude-flow/cli/src/plugins/store/discovery.ts`:

1. Import `verifyEd25519Signature` from the existing `transfer/ipfs/client.ts`.
2. Replace the stub with an `async` verifier that mirrors `scripts/publish-registry.ts`'s signing scheme:

```ts
private async verifyRegistrySignature(
  registry: PluginRegistry,
  expectedPublicKey: string,
): Promise<boolean> {
  if (!registry.registrySignature || !expectedPublicKey) {
    return false;
  }
  const registryToVerify: Record<string, unknown> = { ...registry };
  delete registryToVerify.registrySignature;
  delete registryToVerify.registryPublicKey;
  const message = JSON.stringify(registryToVerify);
  return verifyEd25519Signature(
    message,
    registry.registrySignature,
    expectedPublicKey,
  );
}
```

3. Update the call site to await + fail closed:

```ts
if (this.config.requireVerification) {
  const verified = await this.verifyRegistrySignature(registryData, registry.publicKey);
  if (!verified) {
    console.warn(
      `[PluginDiscovery] Registry signature verification failed for ` +
        `${registry.name} (CID ${cid}); falling back to demo registry.`,
    );
    return this.createDemoRegistryAsync(registry);
  }
}
```

The verifier pins to `registry.publicKey` (the trusted pinned key in `DEFAULT_PLUGIN_STORE_CONFIG`) rather than the self-asserted `registry.registryPublicKey` field — that's the second important change. Trusting the served `registryPublicKey` would let the attacker just swap *that* too.

## Notes / open questions

- Object-key insertion order matters for the canonicalization. `JSON.parse` followed by re-`JSON.stringify` preserves the byte order of the parsed JSON, and your signer (`scripts/publish-registry.ts:124-138`) uses plain `JSON.stringify(...)` with no whitespace, so this round-trips cleanly. If you ever change the signer to use `JSON.stringify(reg, null, 2)` or sort keys, the verifier will need to match.
- `transfer/store/registry.ts:278` (`verifyRegistrySignature` for `PatternRegistry`) is the sibling pattern-store verifier and is even more broken — it only checks `signature.length === 64` and the "publicKey" is just `sha256(privateKey).slice(0, 32)`. It looks like dead-but-exported code today (no callers I could find), so it's a latent bug rather than an active one. Worth either deleting if not planned for use, or rewriting if it's about to be wired up. Happy to extend the patch to cover it.
- The `requireVerification` config defaults to `true`, which is right. Worth a runtime guard that refuses to start if `requireVerification` is set to `false` AND `trusted: true` registries are configured — but that's a hardening suggestion, not a separate vulnerability.

## Verification

- `git diff --stat`: 1 file, +38 / -10
- `tsc --noEmit --skipLibCheck` on the patched file: clean (only pre-existing `@noble/ed25519` typeRoots warnings unrelated to my change)
- `semgrep --config=p/security-audit --config=p/owasp-top-ten` on the patched file: no findings
- Did not run the full Vitest suite — pnpm version pinning (`packageManager: "pnpm@8.15.0"`) didn't cooperate with my CI box. CI on this PR is the authoritative check.

## Dependency-CVE backlog (separate from this PR)

`osv-scanner 2.3.8` turned up 47 unique HIGH+ packages across 11 lockfiles (125 unique CVEs). Headliners: `@anthropic-ai/claude-code@2.0.76` (CVSS 10, multiple GHSAs), `protobufjs@6.11.x/7.5.4` (CVSS 9.8 proto-pollution → ACE), `handlebars@4.7.8` (CVSS 9.8, 5 GHSAs), `form-data@4.0.3` (CVSS 9.4 unsafe random for boundary). Not bundling into this security PR — your dep tooling (Dependabot/Renovate) sequences transitive resolution better than a drive-by commit. Recommend running `osv-scanner --recursive` on a recurring CI schedule. Happy to send the full machine-readable list if helpful.

## Detected by

[Aeon](https://github.com/aaronjmars/aeon-aaron) — manual review for the code finding, `semgrep 1.162.0` / `osv-scanner 2.3.8` / `trufflehog 3.95.2` for backing scans.