### PR TITLE
docs(adr-117): neural-trader heavy jobs on the Managed Agent cloud runtime

### DIFF
--- a/plugins/ruflo-neural-trader/README.md
+++ b/plugins/ruflo-neural-trader/README.md
@@ -4,7 +4,9 @@ Neural trading strategies powered by [`neural-trader`](https://www.npmjs.com/pac
 
 ## Overview
 
-Wraps the `neural-trader` npm package as a Ruflo plugin with 4 specialized agents, 6 skills, and comprehensive CLI commands. Adds AgentDB memory persistence, SONA trajectory learning, and swarm-coordinated execution on top of neural-trader's Rust/NAPI engine.
+Wraps the `neural-trader` npm package as a Ruflo plugin with 4 specialized agents, 7 skills, and comprehensive CLI commands. Adds AgentDB memory persistence, SONA trajectory learning, and swarm-coordinated execution on top of neural-trader's Rust/NAPI engine.
+
+Heavy jobs — multi-year walk-forward backtests, large Monte-Carlo runs, parameter sweeps, LSTM/Transformer/N-BEATS training — can be dispatched to an Anthropic Managed Agent **cloud container** instead of running locally: see the `trader-cloud-backtest` skill, the `/trader cloud <backtest|train|sweep>` command, and [ADR-117](../../v3/docs/adr/ADR-117-neural-trader-managed-agent-backtests.md) (built on the `managed_agent_*` runtime from the `ruflo-agent` plugin / [ADR-115](../../v3/docs/adr/ADR-115-managed-agents-rvagent-backend.md); needs `ANTHROPIC_API_KEY` + Managed Agents beta — degrades to the local `trader-backtest` skill without it).
 
 ## Prerequisites
 
@@ -45,6 +47,7 @@ claude mcp add neural-trader -- npx neural-trader mcp start
 | `trader-regime` | `/trader-regime [--symbol SPY]` | Market regime detection and classification |
 | `trader-train` | `/trader-train lstm --symbol TSLA` | Train neural prediction models |
 | `trader-risk` | `/trader-risk [--symbol AAPL]` | VaR, position sizing, circuit breaker status |
+| `trader-cloud-backtest` | `/trader cloud backtest <strategy> --symbol SPY` | Dispatch a heavy backtest / training / sweep to an Anthropic Managed Agent cloud container ([ADR-117](../../v3/docs/adr/ADR-117-neural-trader-managed-agent-backtests.md)) |
 
 ## Commands
 
@@ -182,9 +185,12 @@ bash plugins/ruflo-neural-trader/scripts/smoke.sh
 ## Architecture Decisions
 
 - [`ADR-0001` — ruflo-neural-trader plugin contract (already-compliant namespaces, 4-namespace claim, smoke as contract)](./docs/adrs/0001-neural-trader-contract.md)
+- [`ADR-117`](../../v3/docs/adr/ADR-117-neural-trader-managed-agent-backtests.md) — run heavy jobs (walk-forward / Monte-Carlo / sweep / training) on the Managed Agent cloud runtime (the `trader-cloud-backtest` skill + `/trader cloud` command), with cost-optimization rules
+- [`ADR-115`](../../v3/docs/adr/ADR-115-managed-agents-rvagent-backend.md) — the `managed_agent_*` cloud runtime that ADR-117 builds on (lives in the `ruflo-agent` plugin)
 
 ## Related Plugins
 
+- `ruflo-agent` — the `managed_agent_*` cloud agent runtime used by the `trader-cloud-backtest` skill (ADR-115 / ADR-117)
 - `ruflo-agentdb` — namespace convention owner; backing store
 - `ruflo-market-data` — OHLCV data ingestion and candlestick pattern detection (feeds `trading-strategies`)
 - `ruflo-ruvector` — HNSW indexing for strategy pattern similarity search

--- a/plugins/ruflo-neural-trader/commands/trader.md
+++ b/plugins/ruflo-neural-trader/commands/trader.md
@@ -16,6 +16,7 @@ Subcommands:
 - `portfolio optimize [--risk-target <number>]` -- Optimize allocation via mean-variance
 - `live --broker <name> [--swarm enabled]` -- Start live trading with optional swarm coordination
 - `history` -- View trade history and performance summary
+- `cloud <backtest|train|sweep> <strategy-or-model> --symbol <TICKER> [--period 2020-2024] [--mc-paths 1000]` -- Run a HEAVY job (long walk-forward, big Monte-Carlo, parameter sweep, model training) on an Anthropic Managed Agent cloud container instead of locally. Needs `ANTHROPIC_API_KEY`. See the `trader-cloud-backtest` skill + ADR-117. (Cost: a cloud session bills container time + tokens until terminated — the skill installs neural-trader once, reuses the env, pre-flights cheap, terminates eagerly.)
 
 Steps by subcommand:
 

--- a/plugins/ruflo-neural-trader/scripts/smoke.sh
+++ b/plugins/ruflo-neural-trader/scripts/smoke.sh
@@ -17,15 +17,18 @@ if [[ "$v" != "0.2.0" ]]; then bad "expected 0.2.0, got '$v'"; else
   [[ -z "$miss" ]] && ok || bad "missing keywords:$miss"
 fi
 
-step "2. all 6 skills present with valid frontmatter"
+step "2. all 7 skills present with valid frontmatter (6 base + trader-cloud-backtest, ADR-117)"
 miss=""
-for s in trader-backtest trader-portfolio trader-regime trader-risk trader-signal trader-train; do
+for s in trader-backtest trader-portfolio trader-regime trader-risk trader-signal trader-train trader-cloud-backtest; do
   f="$ROOT/skills/$s/SKILL.md"
   [[ -f "$f" ]] || { miss="$miss missing-$s"; continue; }
   for k in 'name:' 'description:' 'allowed-tools:'; do
     grep -q "^$k" "$f" || miss="$miss $s-no-$k"
   done
 done
+# the cloud-backtest skill must reference the managed_agent_* tools + offer the local fallback
+grep -q 'managed_agent_create' "$ROOT/skills/trader-cloud-backtest/SKILL.md" 2>/dev/null || miss="$miss cloud-no-managed-tool-ref"
+grep -q 'trader-backtest' "$ROOT/skills/trader-cloud-backtest/SKILL.md" 2>/dev/null || miss="$miss cloud-no-local-fallback-ref"
 [[ -z "$miss" ]] && ok || bad "$miss"
 
 step "3. all 4 agents present"
@@ -67,10 +70,10 @@ grep -q "Monte Carlo\|monte-carlo" "$F" || miss="$miss monte-carlo"
 grep -q "Parameter optimization\|parameter optimization\|param-optimize" "$F" || miss="$miss param-opt"
 [[ -z "$miss" ]] && ok || bad "$miss"
 
-step "10. ADR-0001 exists with status Proposed"
+step "10. ADR-0001 exists with status Accepted"
 ADR="$ROOT/docs/adrs/0001-neural-trader-contract.md"
-[[ -f "$ADR" ]] && grep -qE "^status:[[:space:]]*Proposed" "$ADR" \
-  && ok || bad "ADR missing or status != Proposed"
+[[ -f "$ADR" ]] && grep -qE "^status:[[:space:]]*Accepted" "$ADR" \
+  && ok || bad "ADR missing or status != Accepted"
 
 step "11. no wildcard tool grants in skills"
 bad_skills=""

--- a/plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: trader-cloud-backtest
+description: Run a heavy neural-trader job (long walk-forward, big Monte-Carlo, parameter sweep, model training) on the Anthropic Managed Agent cloud runtime instead of locally
+allowed-tools: mcp__claude-flow__managed_agent_create mcp__claude-flow__managed_agent_prompt mcp__claude-flow__managed_agent_events mcp__claude-flow__managed_agent_status mcp__claude-flow__managed_agent_terminate mcp__claude-flow__memory_store mcp__claude-flow__memory_retrieve mcp__claude-flow__memory_search mcp__claude-flow__agentdb_pattern-store Bash Read
+argument-hint: "<backtest|train|sweep> <strategy-or-model> --symbol <TICKER> [--period 2020-2024] [--mc-paths 1000]"
+---
+
+# Cloud backtest / train (neural-trader on a Managed Agent)
+
+Dispatch a **heavy** `neural-trader` job to an Anthropic Claude Managed Agent (cloud container) instead of running it locally. See project ADR-117 (recipe + cost rules) and ADR-115 (the `managed_agent_*` runtime).
+
+## When to use this vs `trader-backtest` (local)
+
+| Job | Runtime |
+|---|---|
+| Quick sanity check; one short backtest (< ~1 min) | local — use the `trader-backtest` skill |
+| Multi-year **walk-forward**, big **Monte-Carlo** count, **parameter sweep** over a grid, or **model training** (LSTM/Transformer/N-BEATS) | **cloud — this skill** |
+
+Prereq: `ANTHROPIC_API_KEY` (or `CLAUDE_API_KEY`) + Managed Agents beta access. If `managed_agent_*` returns "needs ANTHROPIC_API_KEY", fall back to the local `trader-backtest` skill.
+
+## Steps
+
+1. **Estimate first.** From the job size, print an estimated cost (≈ container-minutes × rate + tokens) — a long sweep is a deliberate choice, not a default.
+
+2. **Provision (or reuse) the container** — install neural-trader at container start so the agent doesn't reinstall mid-run:
+   ```
+   managed_agent_create({
+     name: "nt-cloud",
+     model: "claude-haiku-4-5-20251001",            // orchestration only — the compute is the Rust engine, not the LM (ADR-026)
+     system: "You operate the `neural-trader` CLI in this container. Run exactly the commands asked, report the metrics, write requested artifacts, then stop.",
+     networking: "unrestricted",                     // or "restricted" pinned to your data host
+     packages: { npm: ["neural-trader"] },           // add apt:["build-essential"] ONLY if there's no prebuilt NAPI binary for the arch (neural-trader ships prebuilds → usually omit)
+     initScript: "npm install -g neural-trader >/dev/null 2>&1 || npx -y neural-trader --version >/dev/null 2>&1 || true"
+   })
+   → { sessionId, agentId, environmentId }
+   ```
+   For a **sweep**: create the environment once, run all configs in **one** `managed_agent_prompt` (one container), not N sessions.
+
+3. **Pre-flight cheap.** Before a 1000-path / multi-year run, do a tiny smoke first (1 MC path, ~3 months) — catches a bad strategy name / symbol in seconds:
+   ```
+   managed_agent_prompt({ sessionId, message: "Run `npx neural-trader --backtest --strategy <name> --symbol <TICKER> --period <last 3 months> --mc-paths 1`. Just confirm it ran and report the Sharpe. Then stop.", maxWaitMs: 60000 })
+   ```
+   If that fails, fix the args before the real run (and `managed_agent_terminate`).
+
+4. **Run the real job:**
+   ```
+   managed_agent_prompt({
+     sessionId,
+     message: "Run `npx neural-trader --backtest --strategy <name> --symbol <TICKER> --period <range> --walk-forward --mc-paths <N>` (for training: `npx neural-trader --train --model <lstm|transformer|nbeats> --symbol <TICKER> --period <range>`; for a sweep: loop the configs and run each). Report: total return, annualized return, Sharpe, Sortino, max drawdown, win rate, profit factor, # trades, 95% CVaR. Write the equity curve to /tmp/equity.csv and the trade log to /tmp/trades.csv. Then stop.",
+     maxWaitMs: <generous — minutes>
+   })
+   → { finished, status, stopReason, assistantText (the metrics), toolUses }
+   ```
+   If `finished:false`, follow up with `managed_agent_events({ sessionId })` until idle.
+
+5. **Pull artifacts (if needed):** `managed_agent_prompt({ sessionId, message: "cat /tmp/equity.csv" })` or `managed_agent_events` and read the tool_result.
+
+6. **Ingest locally:**
+   - `memory_store({ key: "backtest-<strategy>-<ts>", value: <metrics+params JSON>, namespace: "trading-backtests" })`
+   - If Sharpe > 1.5: `agentdb_pattern-store({ pattern: "profitable-<strategy-type>", data: "<params + results>" })`
+   - Record the run's container time + token cost to the `cost-tracking` namespace (per ADR-117 — cloud sessions bill until terminated).
+
+7. **Terminate immediately** — results in hand:
+   ```
+   managed_agent_terminate({ sessionId, environmentId })   → { sessionDeleted: true, environmentDeleted: true }
+   ```
+   Never leave an idle billing container. (`ruflo doctor` / GC catches orphans — #1931.)
+
+## Cost rules (don't skip)
+
+- Install once (`initScript`), reuse the environment, batch sweeps into one prompt, pre-flight cheap, terminate eagerly, use Haiku/Sonnet for the agent loop, estimate before kicking off. (ADR-117 §"Cost optimization".)
+- A cloud backtest that runs for an hour costs an hour of container time + the agent-loop tokens. Be deliberate.
+
+## Quick example
+
+```
+managed_agent_create  { "name":"nt-cloud", "model":"claude-haiku-4-5-20251001", "packages":{"npm":["neural-trader"]}, "initScript":"npm install -g neural-trader >/dev/null 2>&1 || true" }
+  → { sessionId:"sesn_…", environmentId:"env_…" }
+managed_agent_prompt   { "sessionId":"sesn_…", "message":"Run `npx neural-trader --backtest --strategy multi-indicator --symbol SPY --period 2020-2024 --walk-forward --mc-paths 1000`. Report Sharpe/Sortino/max-DD/win-rate/CVaR; write /tmp/equity.csv. Then stop.", "maxWaitMs":600000 }
+  → { finished:true, status:"idle", assistantText:"<metrics>", toolUses:[{bash:"npx neural-trader --backtest …"}] }
+# … memory_store the metrics, agentdb_pattern-store if Sharpe>1.5, record cost …
+managed_agent_terminate { "sessionId":"sesn_…", "environmentId":"env_…" }
+```

--- a/v3/docs/adr/ADR-115-managed-agents-rvagent-backend.md
+++ b/v3/docs/adr/ADR-115-managed-agents-rvagent-backend.md
@@ -152,4 +152,5 @@ Landed as a **separate `managed_agent_*` toolset** (rather than a `runtime:` fla
 - ADR-097 — federation peers (a Managed Agent session ≈ a federated executor)
 - ADR-026 — 3-tier model routing (Managed Agent `model` selection should route through this)
 - ADR-112 — MCP tool discoverability (every new `*_agent_*({runtime:"managed"})` tool description must comply; must state the cost/beta caveats)
+- ADR-117 — first consumer: `ruflo-neural-trader` dispatches heavy backtests / Monte-Carlo / sweeps / model training to the `managed_agent_*` runtime (the `trader-cloud-backtest` skill), with cost-optimization rules
 - #1916 — hive task-execution dispatch (Managed Agents as a third executor option)

--- a/v3/docs/adr/ADR-117-neural-trader-managed-agent-backtests.md
+++ b/v3/docs/adr/ADR-117-neural-trader-managed-agent-backtests.md
@@ -1,0 +1,93 @@
+# ADR-117 — Run neural-trader heavy jobs on the Managed Agent cloud runtime
+
+**Status**: Accepted (2026-05-12)
+**Date**: 2026-05-12
+**Authors**: claude (drafted with rUv)
+**Related**: ADR-115 (Claude Managed Agents as the cloud agent runtime — `managed_agent_*` MCP tools in `ruflo-agent`) · `ruflo-neural-trader` plugin (`neural-trader` npm — Rust/NAPI engine, 112+ MCP tools, 4 agents, 7 skills incl. the new `trader-cloud-backtest`) · ADR-026 (3-tier model routing) · ADR-112 (MCP tool discoverability) · #1931 (ruflo-agent / managed agents tracking) · [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview)
+**Supersedes**: nothing
+
+## Context
+
+`ruflo-neural-trader` wraps the `neural-trader` npm package (Rust/NAPI engine): walk-forward backtests, Monte-Carlo simulation, parameter sweeps, LSTM/Transformer/N-BEATS training, regime detection, risk metrics (VaR/CVaR, Kelly, circuit breakers). The expensive jobs — a multi-year walk-forward with thousands of Monte-Carlo paths, a parameter sweep over a strategy grid, training a Transformer on a long history — are **long-running (minutes to hours), CPU/compute-heavy, and async**. Today they run one of two places:
+
+- **Locally** — ties up the dev box, bounded by local cores, and you can't close the laptop on a 40-minute sweep.
+- **A WASM sandbox (`wasm_agent_*`)** — too constrained: no Rust/NAPI native build, no multi-minute compute, no real filesystem for the data + artifacts.
+
+ADR-115 added a third runtime — **Anthropic Claude Managed Agents** (`managed_agent_*` in the `ruflo-agent` plugin): a cloud container with pre-installed packages (`pip`/`npm`/`apt`/`cargo`/`gem`/`go`), network access, a persistent filesystem, and a managed agent loop. That is *exactly* the shape neural-trader's heavy jobs want. The `managed_agent_*` tools shipped in `3.7.0-alpha.27` and are validated end-to-end — so the building blocks exist; this ADR is about wiring neural-trader to them as a first-class flow (not just "you could call those tools").
+
+## Decision
+
+**Add a "cloud backtest/train" recipe to `ruflo-neural-trader` that dispatches heavy `neural-trader` jobs to a Managed Agent cloud container, via the `managed_agent_*` tools — no new MCP tools, no new dependencies, just orchestration.**
+
+### Surface
+
+- **`plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md`** — the recipe:
+  1. `managed_agent_create({ packages: { npm: ["neural-trader"], apt: ["build-essential"] }, initScript: "npm install -g neural-trader >/dev/null 2>&1 || true; node -e \"require('neural-trader')\" >/dev/null 2>&1", system: "<neural-trader operator prompt>", name: "nt-cloud", networking: "unrestricted" })` → a container with `neural-trader` pre-installed at start (so the agent doesn't reinstall mid-run; `apt: build-essential` only if there's no prebuilt NAPI binary for the container arch — neural-trader ships prebuilds, so usually omit it).
+  2. `managed_agent_prompt({ sessionId, message: "Run `npx neural-trader --backtest --strategy <name> --symbol <TICKER> --period <range> --walk-forward --mc-paths <N>`. Report total/annualized return, Sharpe, Sortino, max-DD, win rate, profit factor, # trades, and 95% CVaR. Write the equity curve to /tmp/equity.csv and the trade log to /tmp/trades.csv. Then stop.", maxWaitMs: <generous> })` → the cloud agent runs it, streams the trace, and returns the metrics in `assistantText` + `toolUses`.
+  3. `managed_agent_events({ sessionId })` if needed for the full transcript / to read `cat /tmp/equity.csv`.
+  4. **Locally**, ingest the result: `memory_store({ key: "backtest-<strategy>-<ts>", value: <metrics+params>, namespace: "trading-backtests" })`; if Sharpe > threshold, `agentdb_pattern-store`; and record the run's container time + tokens to the `cost-tracking` namespace.
+  5. `managed_agent_terminate({ sessionId, environmentId })` — immediately, results in hand. (For a *sweep* across strategies, reuse one environment + one session for the whole sweep — one `managed_agent_prompt` that runs all the configs — rather than N sessions.)
+- **`/trader cloud <backtest|train|sweep> …`** subcommand in `commands/trader.md` — thin entry to the skill.
+- The `trading-strategist` / `backtest-engineer` agents decide **locally** which runtime: a quick sanity check or a single short backtest → run it locally with the existing `trader-backtest` skill; a long walk-forward, a big MC count, a parameter sweep, or model training → dispatch to the cloud recipe. (Same WASM-vs-local-vs-managed decision pattern as `ruflo-agent`.)
+
+### Cost optimization (the "optimize" requirement)
+
+A cloud session bills container time + tokens until terminated, so the recipe is built to minimize both:
+
+1. **Install once, in `initScript`** — `neural-trader` lands at container start, not via an agent tool call mid-run.
+2. **Reuse the environment** — create the environment once; spawn a session per job (or one session per sweep). Don't re-provision per backtest.
+3. **Pre-flight cheap** — before a 1000-path / multi-year run, the recipe first runs a 1-path / 3-month smoke to catch a bad strategy name or symbol — fail in seconds, not after 20 cloud-minutes.
+4. **Batch sweeps** — a parameter grid is *one* `managed_agent_prompt` (one container), not N sessions; the agent loops the configs inside the container.
+5. **Terminate eagerly** — `managed_agent_terminate` the instant the metrics + artifacts are pulled; never leave an idle billing container. A `ruflo doctor` / GC check (per #1931) catches orphans.
+6. **Cheap agent model** — the agent loop is *orchestration* (it shells out to the Rust engine and reports numbers); route it to Haiku/Sonnet (ADR-026), never Opus. The compute is in `neural-trader`, not the LM.
+7. **Estimate before kicking off** — the skill prints an estimated container-minutes × rate + token cost (from the job size) before the `managed_agent_create`, so a long sweep is a deliberate choice.
+
+### Security / data
+
+- If the backtest pulls from a **private market-data feed**, the credentials go in the environment's `environment` (env-var) block — the user provides them; never hardcode (per the project's "don't expose keys" rule). A `restricted` networking policy can pin the container to only the data host.
+- `neural-trader` runs native Rust in the container — that's fine: it's in Anthropic's isolated container, not on the user's machine (strictly better isolation than the local runtime).
+- Requires `ANTHROPIC_API_KEY` + Managed Agents beta access (the `managed_agent_*` prereq). Without it the skill degrades: it tells the user to fall back to the local `trader-backtest` skill.
+
+### Out of scope (future)
+
+- Wiring `ruflo mcp start` as the cloud agent's `mcpServers` so the cloud agent can write to ruflo memory / cost-tracking *directly* — needs a publicly reachable HTTP ruflo MCP server (ADR-115 follow-up). Until then, ruflo-memory ingestion happens *locally* after `managed_agent_events`.
+- The same recipe applies to `ruflo-market-data` (ingest a large feed in the cloud, vectorize OHLCV) — note it, don't build it here.
+
+### Implementation (shipped with this ADR)
+
+- `plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md` — the recipe (provision-once · pre-flight-cheap · run · ingest-locally · terminate-eagerly), `allowed-tools` scoped to `managed_agent_*` + `memory_*` + `agentdb_pattern-store` + `Bash`/`Read` (no wildcard grant).
+- `commands/trader.md` — the `/trader cloud <backtest|train|sweep> …` subcommand entry.
+- `scripts/smoke.sh` — step 2 now asserts the 7th skill (`trader-cloud-backtest`) exists, references `managed_agent_create`, and names the local `trader-backtest` fallback (the contract for "cloud recipe present + degrades").
+- `README.md` — overview + skills table + Architecture-Decisions + Related-Plugins cross-refs to this ADR / ADR-115 / `ruflo-agent`.
+- No new MCP tools, no new dependencies — the `managed_agent_*` tools (ADR-115) shipped in `3.7.0-alpha.27` and the recipe is pure orchestration on top of them.
+
+## Consequences
+
+### Positive
+
+- **The right runtime for the workload.** Long backtests / sweeps / training are exactly what Managed Agents is for; this stops them tying up the dev box or being stuck inside the WASM sandbox.
+- **No new code surface to maintain.** It's a recipe-skill over `managed_agent_*` — no new MCP tools, no new deps, no new runtime. Reuses everything ADR-115 already shipped + validated.
+- **Cost-conscious by construction.** The optimization rules above (install-once, reuse-env, pre-flight, batch sweeps, terminate-eagerly, cheap agent model, pre-estimate) are baked into the recipe, not bolted on.
+- **Prototype→production path.** Iterate a strategy locally with `trader-backtest`; when it's worth a serious 2-year/1000-path validation or a Transformer train, dispatch to the cloud — same plugin, same agents.
+- **Generalizes.** The "heavy-job → managed-agent recipe" pattern transfers to `ruflo-market-data` and any other compute-heavy plugin.
+
+### Negative
+
+- **Real cost.** A long cloud backtest = a long-lived billing container. The optimization rules mitigate it but don't eliminate it; the estimate + the eager-terminate + the GC check are load-bearing.
+- **Beta exposure.** Managed Agents is beta (`managed-agents-2026-04-01`); the recipe inherits that churn.
+- **Two execution paths for backtests** (local `trader-backtest` vs cloud `trader-cloud-backtest`) — the agents must pick correctly; a parity smoke (same tiny backtest on both, diff the metrics shape) keeps them aligned.
+- **Data-feed credentials in the cloud.** If the feed is private, its creds now live in a cloud environment's env block — one more place a secret can leak; the user owns it, and `restricted` networking limits the blast radius.
+
+### Neutral
+
+- Opt-in; users who don't invoke the cloud recipe see no change. The local `trader-backtest` stays the default.
+- "Adopt the cloud runtime for a heavy workload" — not a new pattern, just applying ADR-115 to neural-trader. Same posture as `ruflo-agent` adopting Managed Agents.
+
+## Links
+
+- ADR-115 — Claude Managed Agents as the cloud agent runtime (`managed_agent_*`); ADR-115 §"Implementation" + §"Future: a third runtime (Claude Agent SDK / ADR-116)"
+- `ruflo-neural-trader` — `plugins/ruflo-neural-trader/README.md`; `neural-trader` npm: https://www.npmjs.com/package/neural-trader
+- ADR-026 — 3-tier model routing (route the cloud-agent *loop* to Haiku/Sonnet)
+- ADR-112 — MCP tool discoverability (the new `/trader cloud` skill/command must comply)
+- #1931 — ruflo-agent / managed agents tracking (orphaned-session GC, `ruflo mcp start` HTTP server for the cloud-MCP combo)
+- Claude Managed Agents: https://platform.claude.com/docs/en/managed-agents/overview


### PR DESCRIPTION
## Summary

**ADR-117 (Accepted)** — dispatch heavy `neural-trader` jobs (multi-year walk-forward backtests, big Monte-Carlo, parameter sweeps, LSTM/Transformer/N-BEATS training) to an **Anthropic Managed Agent cloud container** via the `managed_agent_*` tools (ADR-115, shipped in `3.7.0-alpha.27`). No new MCP tools, no new dependencies — pure orchestration on top of what ADR-115 already ships.

- `v3/docs/adr/ADR-117-neural-trader-managed-agent-backtests.md` — the decision + cost-optimization rules + the shipped-implementation manifest.
- `plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md` — the recipe: provision-once → pre-flight-cheap → run → ingest-locally → terminate-eagerly. `allowed-tools` scoped to `managed_agent_*` + `memory_*` + `agentdb_pattern-store` + `Bash`/`Read` (no wildcard grant).
- `plugins/ruflo-neural-trader/commands/trader.md` — `/trader cloud <backtest|train|sweep>` subcommand.
- `plugins/ruflo-neural-trader/scripts/smoke.sh` — step 2 asserts the 7th skill (`trader-cloud-backtest`) exists, references `managed_agent_create`, and names the local `trader-backtest` fallback; step 10 ADR-status check corrected (`Proposed` → `Accepted`, matching the actual contract ADR).
- `plugins/ruflo-neural-trader/README.md` — overview + skills table + Architecture-Decisions + Related-Plugins cross-refs to ADR-117 / ADR-115 / `ruflo-agent`.
- `v3/docs/adr/ADR-115-…` Links — cross-refs ADR-117 as the first consumer of the `managed_agent_*` runtime.

### Cost optimization (the "optimize" requirement)
A cloud session bills container time + tokens until terminated, so the recipe is built to minimize both: install-once in `initScript`, reuse the environment, **pre-flight cheap** (1-path / 3-month smoke before a 1000-path / multi-year run), batch sweeps into one prompt (one container), terminate eagerly + GC orphans (#1931), cheap agent model (Haiku/Sonnet — the compute is the Rust engine, not the LM; ADR-026), estimate before kicking off.

### Security
Private market-data-feed creds go in the environment's env-var block (user-provided, **never hardcoded** — per the project's "don't expose keys" rule); native Rust runs in Anthropic's isolated container (strictly better isolation than the local runtime). Requires `ANTHROPIC_API_KEY` + Managed Agents beta — the skill degrades to the local `trader-backtest` skill without it.

## Test plan

- [x] `bash plugins/ruflo-neural-trader/scripts/smoke.sh` → **11 passed, 0 failed**
- [x] `bash plugins/ruflo-agent/scripts/smoke.sh` → **12 passed, 0 failed**
- [x] `node scripts/audit-cli-mcp-tools.mjs` → 311 registered, 0 dangling (baseline 0)
- [x] `node scripts/audit-tool-descriptions.mjs` → OK, all gates pass
- [x] `node scripts/audit-plugin-packages.mjs` → no install-safety issues
- [x] `node scripts/audit-hook-commands.mjs` → no install-safety violations
- [x] No new MCP tools / no `v3/@claude-flow/cli` code change → cli build + witness manifest unaffected

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)