### PR TITLE
fix(memory): bridge + doctor honor CLAUDE_FLOW_MEMORY_PATH / config (#1945, #1946)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -153,13 +153,27 @@ async function checkDaemonStatus(): Promise<HealthCheck> {
 
 // Check memory database
 async function checkMemoryDatabase(): Promise<HealthCheck> {
-  const dbPaths = [
-    '.claude-flow/memory.db',
+  // Authoritative path comes from `getMemoryRoot()` (honors
+  // `CLAUDE_FLOW_MEMORY_PATH`, claude-flow.config.json's `memory.persistPath`,
+  // then defaults to `.swarm/`). #1946: the previous hard-coded list missed
+  // `data/memory/memory.db` (a common config) and ignored the env var
+  // entirely, so doctor reported "Not initialized" on perfectly-init'd DBs.
+  // Try the configured path first, then fall back to the historic candidates.
+  const candidates: string[] = [];
+  try {
+    const { getMemoryRoot } = await import('../memory/memory-initializer.js');
+    candidates.push(join(getMemoryRoot(), 'memory.db'));
+  } catch {
+    /* memory-initializer not available — fall through to legacy candidates */
+  }
+  candidates.push(
     '.swarm/memory.db',
-    'data/memory.db'
-  ];
+    '.claude-flow/memory.db',
+    'data/memory/memory.db', // matches `CLAUDE_FLOW_MEMORY_PATH=data/memory`
+    'data/memory.db',
+  );
 
-  for (const dbPath of dbPaths) {
+  for (const dbPath of candidates) {
     if (existsSync(dbPath)) {
       try {
         const stats = statSync(dbPath);

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -19,6 +19,7 @@
 
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { createRequire } from 'node:module';
 
 // ===== Lazy singleton =====
 
@@ -28,18 +29,40 @@ let bridgeAvailable: boolean | null = null;
 
 /**
  * Resolve database path with path traversal protection.
- * Only allows paths within or below the project's .swarm directory,
+ * Only allows paths within or below the project's working directory,
  * or the special ':memory:' path.
+ *
+ * #1945: the previous hard-coded `<cwd>/.swarm/memory.db` default ignored
+ * `CLAUDE_FLOW_MEMORY_PATH` / `claude-flow.config.json#memory.persistPath`
+ * — so users with non-default memory paths had `memory init` write to e.g.
+ * `data/memory/memory.db` while `bridgeStoreEntry()` wrote to
+ * `.swarm/memory.db`. CLI store reported success against the wrong file and
+ * a fresh process reading the configured path saw nothing.
+ *
+ * Use `getMemoryRoot()` (from memory-initializer) so the bridge and the
+ * initializer agree on the same file. Imported via require() to avoid a
+ * circular ESM dep between memory-initializer.ts and memory-bridge.ts.
  */
 function getDbPath(customPath?: string): string {
-  const swarmDir = path.resolve(process.cwd(), '.swarm');
-  if (!customPath) return path.join(swarmDir, 'memory.db');
+  let defaultDir = path.resolve(process.cwd(), '.swarm');
+  try {
+    // `getMemoryRoot()` honors $CLAUDE_FLOW_MEMORY_PATH, then the
+    // claude-flow.config.json `memory.persistPath`, then defaults to `.swarm`.
+    const cjsRequire = createRequire(import.meta.url);
+    const mod = cjsRequire('./memory-initializer.js') as { getMemoryRoot?: () => string };
+    if (typeof mod.getMemoryRoot === 'function') {
+      defaultDir = mod.getMemoryRoot();
+    }
+  } catch {
+    /* memory-initializer not resolvable in this build — keep `.swarm/` default */
+  }
+  if (!customPath) return path.join(defaultDir, 'memory.db');
   if (customPath === ':memory:') return ':memory:';
   const resolved = path.resolve(customPath);
-  // Ensure the path doesn't escape the working directory
+  // Ensure the path doesn't escape the working directory.
   const cwd = process.cwd();
   if (!resolved.startsWith(cwd)) {
-    return path.join(swarmDir, 'memory.db'); // fallback to safe default
+    return path.join(defaultDir, 'memory.db'); // fallback to safe default
   }
   return resolved;
 }


### PR DESCRIPTION
## Summary

Two CLI memory bugs caused by hard-coded `.swarm/memory.db` paths that ignored the configured memory location.

### #1945 — CLI \`memory store\` doesn't persist (the user-visible "store reports success but next process can't find it" bug)

`memory-bridge.ts::getDbPath()` always defaulted to `<cwd>/.swarm/memory.db` regardless of \`CLAUDE_FLOW_MEMORY_PATH\` or \`claude-flow.config.json#memory.persistPath\`. So a user with a non-default memory layout (e.g. \`data/memory/memory.db\`) had \`memory init\` write the schema to the configured file, while \`bridgeStoreEntry()\` silently wrote INSERTs to \`.swarm/memory.db\` — a different file, sometimes a different directory. CLI \`memory store\` reported success against the wrong DB, and a fresh process reading the configured path saw zero rows.

**Fix:** route \`getDbPath()\` through \`getMemoryRoot()\` (from memory-initializer), the same function \`memory init\` already uses. The two now agree on the same file. \`:memory:\` and explicit \`customPath\` still work unchanged; path-traversal protection unchanged. Imported via \`createRequire\` so the cross-module dep doesn't create an ESM cycle.

### #1946 — \`ruflo doctor\` reports DB "Not initialized" on a perfectly-init'd DB

\`doctor.ts::checkMemoryDatabase()\` only checked the legacy candidates \`.claude-flow/memory.db\` / \`.swarm/memory.db\` / \`data/memory.db\` and ignored \`CLAUDE_FLOW_MEMORY_PATH\` / config entirely. The reporter's DB at \`data/memory/memory.db\` (with the \`memory/\` subdir, off by one) made doctor lie about a perfectly-functional install.

**Fix:** check \`getMemoryRoot() + '/memory.db'\` first (the authoritative path the rest of the CLI uses); fall back to the legacy candidates for non-standard layouts; add \`data/memory/memory.db\` to the fallback list.

## Resolves

- #1945 — CLI memory store doesn't persist (same-process bridge writes a different file than the configured one)
- #1946 — doctor reports DB "Not initialized" when it exists

## Test plan

- [x] \`pnpm run build\` (\`@claude-flow/cli\`) → clean tsc
- [ ] CI: existing audits + Build V3 across ubuntu/macOS/windows
- [ ] Manual repro on fresh install with \`CLAUDE_FLOW_MEMORY_PATH=data/memory ruflo init\` + \`memory store\` + new-process \`memory list\` (post-merge)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)