### PR TITLE
fix(statusline): read installed version from plugin package.json (#1951)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -26,18 +26,29 @@ const CONFIG = {
 
 const CWD = process.cwd();
 
-// Read package version once at startup
+// Read package version once at startup. Probe the plugin's own install
+// location first — `~/.claude/plugins/marketplaces/ruflo/package.json` — so
+// users who installed via `/plugin install ruflo@ruflo` see the real version,
+// not the hardcoded fallback (#1951).
 let pkgVersion = '3.5';
 try {
+  const os = require('os');
+  const home = os.homedir();
   const pkgPaths = [
+    path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
     path.join(CWD, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+    path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
     path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
   ];
   for (const p of pkgPaths) {
-    if (fs.existsSync(p)) {
+    if (!fs.existsSync(p)) continue;
+    try {
       const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
-      if (pkg.version) { pkgVersion = pkg.version; break; }
-    }
+      if (pkg && typeof pkg.version === 'string' && pkg.version.length > 0) {
+        pkgVersion = pkg.version;
+        break;
+      }
+    } catch { /* malformed package.json — try next */ }
   }
 } catch { /* use default */ }
 

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -25,7 +25,36 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { execSync, execFileSync } = require('child_process');
+
+// Read the installed plugin version once at startup. Probe the plugin's own
+// install location first (`~/.claude/plugins/marketplaces/ruflo/package.json`),
+// then npm-style installs, then the source-checkout location. The previous
+// code hardcoded `RuFlo V3.5` in the header — so users on alpha.27+ still
+// saw V3.5 in the statusline even though `ruflo doctor` reported the real
+// version (#1951).
+let RUFLO_VERSION = '3.6';
+try {
+  const home = os.homedir();
+  const cwd = process.cwd();
+  const pkgPaths = [
+    path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
+    path.join(cwd, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+    path.join(cwd, 'node_modules', 'ruflo', 'package.json'),
+    path.join(cwd, 'v3', '@claude-flow', 'cli', 'package.json'),
+  ];
+  for (const p of pkgPaths) {
+    if (!fs.existsSync(p)) continue;
+    try {
+      const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      if (pkg && typeof pkg.version === 'string' && pkg.version.length > 0) {
+        RUFLO_VERSION = pkg.version;
+        break;
+      }
+    } catch { /* malformed package.json — try next */ }
+  }
+} catch { /* fall through to the hardcoded default */ }
 
 // Configuration
 const CONFIG = {
@@ -402,7 +431,7 @@ function generateStatusline() {
   const lines = [];
 
   // Header Line
-  let header = `${c.bold}${c.brightPurple}▊ RuFlo V3.5 ${c.reset}`;
+  let header = `${c.bold}${c.brightPurple}▊ RuFlo V${RUFLO_VERSION} ${c.reset}`;
   header += `${swarm.coordinationActive ? c.brightCyan : c.dim}● ${c.brightCyan}${user.name}${c.reset}`;
   if (user.gitBranch) {
     header += `  ${c.dim}│${c.reset}  ${c.brightBlue}⎇ ${user.gitBranch}${c.reset}`;
@@ -508,7 +537,7 @@ function generateSafeStatusline() {
   const lines = [];
 
   // Header Line
-  let header = `${c.bold}${c.brightPurple}▊ RuFlo V3.5 ${c.reset}`;
+  let header = `${c.bold}${c.brightPurple}▊ RuFlo V${RUFLO_VERSION} ${c.reset}`;
   header += `${swarm.coordinationActive ? c.brightCyan : c.dim}● ${c.brightCyan}${user.name}${c.reset}`;
   if (user.gitBranch) {
     header += `  ${c.dim}│${c.reset}  ${c.brightBlue}⎇ ${user.gitBranch}${c.reset}`;

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -641,23 +641,34 @@ function generateStatusline() {
   const integration = getIntegrationStatus();
   const lines = [];
 
-  // Header
-  // Read version from package.json
+  // Header — read version from the FIRST package.json we find, preferring
+  // the plugin install at ~/.claude/plugins/marketplaces/ruflo/package.json.
+  // The previous list only checked project-local node_modules, so plugin
+  // users saw the hard-coded fallback (V3.5) even on newer alphas (#1951).
   let pkgVersion = '3.6';
   try {
-    const pkgPath = path.join(CWD, 'node_modules', '@claude-flow', 'cli', 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-      if (pkg.version) pkgVersion = pkg.version;
-    } else {
-      // Try npx-installed location
-      const npxPkg = path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json');
-      if (fs.existsSync(npxPkg)) {
-        const pkg = JSON.parse(fs.readFileSync(npxPkg, 'utf-8'));
-        if (pkg.version) pkgVersion = pkg.version;
-      }
+    const home = require('os').homedir();
+    const pkgPaths = [
+      // 1. The plugin's own root (installed via /plugin install).
+      path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
+      // 2. Project-local @claude-flow/cli — npm-style install.
+      path.join(CWD, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+      // 3. Project-local ruflo umbrella.
+      path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
+      // 4. Source-checkout location (when developing in this repo).
+      path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
+    ];
+    for (const p of pkgPaths) {
+      if (!fs.existsSync(p)) continue;
+      try {
+        const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
+        if (pkg && typeof pkg.version === 'string' && pkg.version.length > 0) {
+          pkgVersion = pkg.version;
+          break;
+        }
+      } catch { /* malformed package.json — try next */ }
     }
-  } catch { /* use default */ }
+  } catch { /* fall through to the hardcoded default */ }
   let header = c.bold + c.brightPurple + '\\u258A RuFlo V' + pkgVersion + ' ' + c.reset;
   header += (swarm.coordinationActive ? c.brightCyan : c.dim) + '\\u25CF ' + c.brightCyan + git.name + c.reset;
   if (git.gitBranch) {


### PR DESCRIPTION
## Summary

The statusline showed a hard-coded \"RuFlo V3.5\" regardless of the installed version, even on alpha.27 where \`ruflo doctor\` correctly reported the real version.

Three files needed the fix — the two tracked \`statusline.cjs\` deployed copies, and the TypeScript template that generates the project-local statusline at \`ruflo init\` time. All three now probe a fuller candidate list, preferring the plugin install location (which the previous code never checked).

## Probe order (all three files)

1. \`~/.claude/plugins/marketplaces/ruflo/package.json\` — the plugin install, where most users actually run from
2. \`<cwd>/node_modules/@claude-flow/cli/package.json\` — npm-style install
3. \`<cwd>/node_modules/ruflo/package.json\` — umbrella install
4. \`<cwd>/v3/@claude-flow/cli/package.json\` — source checkout

Falls through to the hard-coded default if all four are missing/malformed.

## Resolves

- #1951

## Test plan

- [x] \`pnpm run build\` on @claude-flow/cli → clean tsc
- [ ] CI: existing audits + Build V3 across ubuntu/macOS/windows

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)