### PR TITLE
fix(memory-import): resolve Win32 cwd to Claude Code's slug (#1939)

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -135,6 +135,16 @@ function resolveProjectMemoryDir(claudeProjectsDir: string, projectPathOverride?
 
     // Candidate 4: spaces replaced with dashes (Claude Code's space rule)
     candidates.add(source.replace(/\//g, '-').replace(/ /g, '-'));
+
+    // Candidate 5 (#1939): native Win32 path on a Win32 Claude Code install.
+    // `C:\Users\tobia\OneDrive\Desktop\Claude Stuff` →
+    // `C--Users-tobia-OneDrive-Desktop-Claude-Stuff`. Claude Code's on-disk
+    // slug replaces drive-colon AND backslashes AND whitespace with `-`.
+    // The earlier candidates only handled forward slashes, so a Win32+Win32
+    // setup never matched.
+    if (/^[A-Za-z]:[\\/]/.test(source)) {
+      candidates.add(source.replace(/[:\\/]/g, '-').replace(/\s+/g, '-'));
+    }
   }
 
   for (const projectHash of candidates) {


### PR DESCRIPTION
## Summary

\`memory_import_claude({ allProjects: false })\` couldn't find the current project's memory directory on a pure Win32+Win32 install — slug candidates in \`resolveProjectMemoryDir()\` only replaced forward slashes, never the drive-colon / backslash / whitespace a Win32 cwd contains.

- cwd: \`C:\\Users\\tobia\\OneDrive\\Desktop\\Claude Stuff\`
- Claude Code's on-disk slug: \`C--Users-tobia-OneDrive-Desktop-Claude-Stuff\`
- Before: no candidate matched, importer reported \`imported: 0\`.

## Fix

Added a Win32 candidate gated on \`/^[A-Za-z]:[\\\\/]/\` that does the full normalization (\`:\` / \`\\\` / \`/\` / whitespace → \`-\`). The other four candidates (legacy POSIX, WSL \`/mnt/<drive>/\`, leading-dash strip, space rule) are unchanged.

Verified: for the reporter's cwd, the candidate set now contains \`C--Users-tobia-OneDrive-Desktop-Claude-Stuff\` exactly.

## Resolves

- #1939 — Win32 current-project import misses current Claude slug

## Test plan

- [x] \`pnpm run build\` on @claude-flow/cli → clean tsc
- [x] Unit check: \`resolveProjectMemoryDir\`-equivalent emits the expected Win32 slug
- [ ] CI: existing audits + Build V3 across ubuntu/macOS/windows

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)