### PR TITLE
fix(memory): provision vector_indexes per namespace + truthful bridge_status (#1941, #1940)

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -911,14 +911,32 @@ export const memoryTools: MCPTool[] = [
       }
 
       // AgentDB status
+      // #1940: previously used `allEntries.entries.length` for the totals,
+      // but `listEntries({})` returns the first 20 entries with a separate
+      // `total` field for the full row count. So `memory_bridge_status`
+      // reported `totalEntries: 0`...20 even when the DB had hundreds of
+      // rows. Use `.total` for the count, and surface the namespaces with
+      // entries so the report matches what's actually in the store.
       let agentdbEntries = 0;
       let claudeMemoryEntries = 0;
+      const namespaceCounts: Record<string, number> = {};
       try {
         const { listEntries } = await getMemoryFunctions();
         const allEntries = await listEntries({});
-        agentdbEntries = allEntries?.entries?.length ?? 0;
+        agentdbEntries = (allEntries as { total?: number })?.total
+          ?? allEntries?.entries?.length ?? 0;
         const claudeEntries = await listEntries({ namespace: 'claude-memories' });
-        claudeMemoryEntries = claudeEntries?.entries?.length ?? 0;
+        claudeMemoryEntries = (claudeEntries as { total?: number })?.total
+          ?? claudeEntries?.entries?.length ?? 0;
+        // Per-namespace counts for the namespaces the reporter referenced
+        // (#1940). Best-effort — a namespace with 0 entries is omitted.
+        for (const ns of ['default', 'patterns', 'claude-memories', 'auto-memory', 'tasks', 'feedback', 'pretrain']) {
+          try {
+            const r = await listEntries({ namespace: ns });
+            const t = (r as { total?: number })?.total ?? r?.entries?.length ?? 0;
+            if (t > 0) namespaceCounts[ns] = t;
+          } catch { /* skip per-namespace failure */ }
+        }
       } catch { /* ignore */ }
 
       // Intelligence status
@@ -931,9 +949,12 @@ export const memoryTools: MCPTool[] = [
 
       return {
         claudeCode: { memoryFiles: claudeFiles, projects: claudeProjects },
-        agentdb: { totalEntries: agentdbEntries, claudeMemoryEntries, backend: 'sql.js + ONNX' },
+        agentdb: { totalEntries: agentdbEntries, claudeMemoryEntries, namespaces: namespaceCounts, backend: 'sql.js + ONNX' },
         intelligence,
-        bridge: { status: claudeMemoryEntries > 0 ? 'connected' : 'not-synced', embedding: 'all-MiniLM-L6-v2 (384-dim)' },
+        // #1940: report 'connected' whenever ANY namespace has imported
+        // content, not just `claude-memories` — the bridge can be in active
+        // use from other import paths (e.g. plugin namespaces, task memory).
+        bridge: { status: agentdbEntries > 0 ? 'connected' : 'not-synced', embedding: 'all-MiniLM-L6-v2 (384-dim)' },
       };
     },
   },

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -608,6 +608,17 @@ export async function bridgeStoreEntry(options: {
           tags, metadata, created_at, updated_at, expires_at, status
         ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`;
 
+    // #1941: provision a `vector_indexes` row for this namespace before the
+    // entry insert. AgentDB's HNSW/router keys lookups by namespace via this
+    // table — if it has no row for e.g. `claude-memories`, `memory_search`
+    // returns 0 results even when memory_entries holds hundreds of rows for
+    // that namespace. INSERT OR IGNORE so existing index rows are preserved.
+    try {
+      ctx.db
+        .prepare(`INSERT OR IGNORE INTO vector_indexes (id, name, dimensions) VALUES (?, ?, ?)`)
+        .run(namespace, namespace, dimensions || 384);
+    } catch { /* vector_indexes may not exist on legacy DBs — fall through */ }
+
     const stmt = ctx.db.prepare(insertSql);
     stmt.run(
       id, key, namespace, value,

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -2194,6 +2194,18 @@ export async function storeEntry(options: {
       embeddingModel = embResult.model;
     }
 
+    // #1941: provision a `vector_indexes` row for this namespace before the
+    // entry insert. The HNSW lookup uses this table to find which namespaces
+    // are indexed — without a row, `memory_search({namespace:"X"})` returns
+    // 0 even when memory_entries holds matching rows. INSERT OR IGNORE
+    // preserves the existing `default` / `patterns` rows.
+    try {
+      db.run(
+        `INSERT OR IGNORE INTO vector_indexes (id, name, dimensions) VALUES (?, ?, ?)`,
+        [namespace, namespace, embeddingDimensions ?? 384]
+      );
+    } catch { /* vector_indexes may not exist on legacy DBs — fall through */ }
+
     // Insert or update entry (upsert mode uses REPLACE)
     const insertSql = upsert
       ? `INSERT OR REPLACE INTO memory_entries (


### PR DESCRIPTION
## Summary

Two related memory-bridge bugs both surfaced by the same reporter on Win32 alpha.21:

### #1941 — \`memory_search({namespace:\"claude-memories\"})\` always returned 0

\`memory_import_claude\` inserts hundreds of rows under \`claude-memories\`, but the schema's \`vector_indexes\` table only held \`default\` and \`patterns\` rows. AgentDB's HNSW/router keys namespace lookups by this table — without a row, the namespace was effectively unindexed for search.

**Fix:** every store path (both \`bridgeStoreEntry\` and the raw-sql.js fallback \`storeEntry\`) now does \`INSERT OR IGNORE INTO vector_indexes (id, name, dimensions) VALUES (?, ?, ?)\` for the entry's namespace before the row insert. Idempotent; legacy DBs without the table fall through cleanly. Dimensions defaults to the embedding's actual dim (384 for the default MiniLM-L6 model), preserving #1947's contract.

### #1940 — \`memory_bridge_status\` reported \`totalEntries: 0\` on a DB with 237 rows

Root cause was a page-size bug: it used \`listEntries({}).entries.length\`, but \`listEntries\` returns at most 20 entries with the full count in a separate \`.total\` field. So the reporter capped at 20 (or 0 if the first page was empty), regardless of the actual row count.

**Fix:** use \`listEntries({}).total\` for the count. Plus surface a per-namespace breakdown (\`agentdb.namespaces\`) for the common namespaces (\`default\`, \`patterns\`, \`claude-memories\`, \`auto-memory\`, \`tasks\`, \`feedback\`, \`pretrain\`) so callers can see where the rows actually live. \`bridge.status\` now flips to \`connected\` on ANY persisted row, not only \`claude-memories\`.

## Resolves
- #1941
- #1940

## Test plan
- [x] \`pnpm run build\` on @claude-flow/cli → clean tsc
- [ ] CI: existing audits + Build V3 across ubuntu/macOS/windows

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)