### PR TITLE
chore(deps): initialize npm lockfile on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.25",
+  "version": "3.7.0-alpha.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.7.0-alpha.25",
+      "version": "3.7.0-alpha.30",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "^3.7.0-alpha.5",


### PR DESCRIPTION
## Summary

- Ran `npm install --ignore-scripts` on Windows to initialize `node_modules` (851 packages)
- Used `npm` over `pnpm` — the project's `overrides` field in `package.json` is npm-native syntax and internal scripts call `npm run` directly
- Skipped native compilation of `better-sqlite3` via `--ignore-scripts` due to missing Python/C++ build toolchain at time of install

## What changed

- `package-lock.json` — minor update (2 lines) reflecting the local install

## Reviewer notes

- No source code was modified
- `better-sqlite3` can be rebuilt with `npm rebuild better-sqlite3` once Python 3.11+ and Visual Studio Build Tools with C++ workload are confirmed working