### PR TITLE
fix(cost-tracker/compact): resolve from anywhere + free HEALTH_PORT (#1930)

### DIFF
--- a/plugins/ruflo-cost-tracker/scripts/compact.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/compact.mjs
@@ -1,24 +1,65 @@
 #!/usr/bin/env node
 // cost-compact — wraps getTokenOptimizer().getCompactContext() so the
 // cost-compact-context skill can invoke a single command instead of an
-// inlined Node one-liner. A proper MCP tool wrapping getTokenOptimizer is
-// still deferred (would require modifying @claude-flow/cli source); this
-// is the plugin-local equivalent.
+// inlined Node one-liner.
 //
-// Resolution: must run from a directory where `@claude-flow/integration`
-// resolves (typically anywhere under `v3/`). The script resolves from
-// process.cwd() rather than from its own location so the user's `cd v3`
-// works without npm-installing the bridge into the plugin tree.
+// Resolution strategy (#1930): pnpm-workspace marketplace installs don't
+// hoist `@claude-flow/integration` into `v3/node_modules/`, so resolving
+// from cwd alone breaks. Try, in order:
+//   1. createRequire(cwd)           — works for npm-style hoisted installs
+//   2. createRequire(script-dir)    — works when run from inside the plugin
+//   3. absolute path from this file — works on the marketplace layout
+//      (script lives at <ruflo>/plugins/ruflo-cost-tracker/scripts/, the
+//       integration package at <ruflo>/v3/@claude-flow/integration/)
+//
+// Also: agentic-flow's index.js binds `process.env.HEALTH_PORT || 8080`
+// unconditionally on import. On any host with something already on 8080
+// (k8s NodePort, forwarded dev server) the import EADDRINUSEs. Set
+// HEALTH_PORT to 0 by default so the OS picks a free port — users can
+// still override with an explicit value.
 //
 // Usage:
 //   node scripts/compact.mjs "<query>"
 //
 // Optional env:
 //   COMPACT_QUIET=1   emit JSON only (no markdown banner)
+//   HEALTH_PORT=<n>   override agentic-flow's health-server port (default 0)
 
 import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
-import { join } from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { join, resolve, dirname, isAbsolute } from 'node:path';
+import { existsSync } from 'node:fs';
+
+// #1930 step 4: pick a free port unless caller pinned one. Set BEFORE the
+// dynamic import below — agentic-flow reads HEALTH_PORT at module-load time.
+if (!process.env.HEALTH_PORT) process.env.HEALTH_PORT = '0';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function tryResolveFrom(anchorPath) {
+  try {
+    const req = createRequire(anchorPath);
+    return req.resolve('@claude-flow/integration/token-optimizer');
+  } catch {
+    return null;
+  }
+}
+
+function tryAbsolutePath() {
+  // Walk up from this script looking for `v3/@claude-flow/integration/dist/token-optimizer.js`.
+  // Handles the marketplace layout (script at plugins/ruflo-cost-tracker/scripts/) and the
+  // dev-repo layout. Caps depth at 6 to avoid runaway traversal.
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const candidate = join(dir, 'v3', '@claude-flow', 'integration', 'dist', 'token-optimizer.js');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
 
 async function main() {
   const query = process.argv[2] || '';
@@ -27,22 +68,54 @@ async function main() {
     process.exit(2);
   }
 
+  // Resolution chain — cwd → script dir → absolute fallback (#1930 step 5)
+  const candidates = [
+    tryResolveFrom(join(process.cwd(), 'package.json')),
+    tryResolveFrom(join(__dirname, 'package.json')),
+    tryAbsolutePath(),
+  ].filter(Boolean);
+
   let mod;
-  try {
-    const requireFromCwd = createRequire(join(process.cwd(), 'package.json'));
-    const resolved = requireFromCwd.resolve('@claude-flow/integration/token-optimizer');
-    mod = await import(pathToFileURL(resolved).href);
-  } catch (err) {
+  let lastErr = null;
+  for (const resolved of candidates) {
+    try {
+      // Skip dangling resolutions that point at a non-existent file (a
+      // common pnpm-workspace symptom when dist/ wasn't built — see
+      // #1930 step 1).
+      const abs = isAbsolute(resolved) ? resolved : resolve(resolved);
+      if (!existsSync(abs)) {
+        lastErr = new Error(`token-optimizer.js missing at ${abs} — run \`cd v3/@claude-flow/integration && pnpm run build\` (#1930 step 1)`);
+        continue;
+      }
+      mod = await import(pathToFileURL(abs).href);
+      break;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  if (!mod) {
+    const reason = lastErr
+      ? String(lastErr.message || lastErr).slice(0, 300)
+      : 'Cannot find module @claude-flow/integration/token-optimizer';
     const out = {
       bridgeUnavailable: true,
-      reason: String(err.message || err).slice(0, 300),
+      reason,
       memoriesRetrieved: 0,
       tokensSaved: 0,
       agenticFlowAvailable: false,
+      hint: 'Tried cwd, script dir, and absolute path from this script — see #1930 for full troubleshooting.',
     };
     if (process.env.COMPACT_QUIET === '1') return console.log(JSON.stringify(out));
-    console.log(`# cost-compact-context\n\nbridge unavailable: ${out.reason}`);
-    console.log('Run from a directory where `@claude-flow/integration` resolves, e.g. `cd v3 && ...`.');
+    console.log(`# cost-compact-context\n\nbridge unavailable: ${reason}`);
+    console.log('');
+    console.log('Tried:');
+    console.log('  - resolve from cwd');
+    console.log('  - resolve from script dir');
+    console.log('  - absolute path walk from this script (looking for v3/@claude-flow/integration/dist/token-optimizer.js)');
+    console.log('');
+    console.log('If `@claude-flow/integration` is installed but `dist/` is missing, run:');
+    console.log('  cd v3/@claude-flow/integration && pnpm run build');
     return;
   }
 


### PR DESCRIPTION
## Summary

\`plugins/ruflo-cost-tracker/scripts/compact.mjs\` was failing on the marketplace install layout with two distinct bugs:

1. **Resolution** — script only worked when the caller ran from a cwd where \`@claude-flow/integration\` resolved. On a pnpm-workspace marketplace install (the shipped layout: \`~/.claude/plugins/marketplaces/ruflo/v3/\`) that means \`cwd=v3/@claude-flow/integration/\` specifically — pnpm doesn't hoist into \`v3/node_modules/\`. The skill's documented \`cd v3 && node ...\` path failed with \`Cannot find module @claude-flow/integration/token-optimizer\`.
2. **Port** — the script imported agentic-flow indirectly. agentic-flow binds \`process.env.HEALTH_PORT || 8080\` at module-load time and EADDRINUSE'd on any host with something else already on 8080 (k8s NodePort, forwarded dev server, …).

## Fix

**Resolution chain** — try in order:
- \`createRequire(cwd)\` — npm-style hoisted installs
- \`createRequire(script-dir)\` — run from inside the plugin
- absolute path walk from \`import.meta.url\` (up to 6 parents) looking for \`v3/@claude-flow/integration/dist/token-optimizer.js\` — marketplace layout, cwd-independent

**HEALTH_PORT** — set to \`0\` by default before the dynamic import runs (OS picks a free port). Users can still override with an explicit value.

**dist/-missing** — when the resolver finds a path that doesn't exist on disk (the \"\`dist/\` not built\" case from the issue's step 1), surface a clear error pointing at the build command (\`cd v3/@claude-flow/integration && pnpm run build\`) instead of the generic MODULE_NOT_FOUND.

## Out of scope (per the issue)

| # | Step | Why |
|---|---|---|
| 2 | \`agentic-flow\` not in workspace deps | Install-environment issue; \`@claude-flow/integration\` lists it as a peer so consumers opt in. The graceful-fallback path already reports \`agenticFlowAvailable: false\`. |
| 3 | \`sharp\` prebuild missing on linux-x64 | Native binding, upstream sharp/agentic-flow concern. |
| 1 | \`@claude-flow/integration/dist/\` missing | Packaging fix — marketplace bundle should include built dist. Tracked separately. |

## Resolves

- #1930 (script-level — the deeper packaging fix is a separate concern)

## Test plan

- [x] Manual: \`node plugins/ruflo-cost-tracker/scripts/compact.mjs \"test\"\` works from repo root (cwd resolves to v3 via createRequire)
- [x] Manual: same script works from \`cd /tmp && node /path/to/compact.mjs \"test\"\` (absolute-path fallback)
- [x] Manual: HEALTH_PORT collision repro (\`HEALTH_PORT=8080\` already bound) no longer EADDRINUSEs
- [ ] CI: existing audits

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)