### PR TITLE
fix(neural-trader): mitigate upstream fork-bomb on install + CI guard (#1974)

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -553,6 +553,10 @@ jobs:
         shell: bash
         run: node scripts/audit-fix-invariants.mjs
 
+      - name: Run neural-trader install-safety audit (#1974)
+        shell: bash
+        run: node scripts/audit-neural-trader-safety.mjs
+
       - name: Lint the ruflo-hook shims
         shell: bash
         run: |

--- a/plugins/ruflo-neural-trader/README.md
+++ b/plugins/ruflo-neural-trader/README.md
@@ -10,9 +10,34 @@ Heavy jobs — multi-year walk-forward backtests, large Monte-Carlo runs, parame
 
 ## Prerequisites
 
+> ⚠️ **Critical install advisory — #1974**
+>
+> `neural-trader@2.7.1` (and every earlier published version we audited) has a
+> dangerous `install` lifecycle script that **recursively invokes `npm install`
+> from inside the install hook**. On any non-`linux-x64` host (macOS Apple
+> Silicon, Windows, linux-arm64) the recursion is unbounded — one report saw
+> 3,049 stuck processes consuming ~120 GB of RAM in ~80 minutes before manual
+> intervention. The platform-binary subpackages it advertises in
+> `optionalDependencies` (`neural-trader-darwin-arm64`, etc.) are **not
+> published to npm**, which is what triggers the fallback path.
+>
+> Until upstream ships a fix, always install neural-trader with
+> `--ignore-scripts` to skip the malicious install hook. The `linux-x64`
+> binary is hardcoded inline in the tarball, so on `linux-x64` the package
+> still works after `--ignore-scripts`. On other platforms `--ignore-scripts`
+> at least won't fork-bomb your machine; whether the runtime works depends on
+> upstream publishing the platform binary.
+
 ```bash
-npm install neural-trader
+# SAFE — skips the upstream install script that fork-bombs on non-linux-x64
+npm install --ignore-scripts neural-trader
+
+# DO NOT run `npm install neural-trader` (no flags) on macOS / Windows /
+# linux-arm64 until #1974 is resolved upstream.
 ```
+
+Set the env var `npm_config_ignore_scripts=1` in your shell rc to make this
+the default for all subsequent `npx neural-trader` calls.
 
 ## Installation
 

--- a/plugins/ruflo-neural-trader/agents/trading-strategist.md
+++ b/plugins/ruflo-neural-trader/agents/trading-strategist.md
@@ -10,8 +10,9 @@ You are a trading strategist agent that orchestrates the `neural-trader` npm pac
 All trading operations go through the `neural-trader` CLI. Install once, then invoke via npx:
 
 ```bash
-# Ensure installed
-npm ls neural-trader 2>/dev/null || npm install neural-trader
+# Ensure installed. --ignore-scripts skips the upstream `install` hook that
+# fork-bombs on non-linux-x64 hosts — see #1974 + the README's prereq.
+npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader
 
 # Core commands
 npx neural-trader --strategy <type> --symbol <TICKER> [options]

--- a/plugins/ruflo-neural-trader/skills/trader-backtest/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-backtest/SKILL.md
@@ -8,7 +8,7 @@ Run a historical backtest using the `neural-trader` Rust/NAPI engine.
 
 Steps:
 1. Ensure neural-trader is available:
-   `npm ls neural-trader 2>/dev/null || npm install neural-trader`
+   `npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader`
 2. Check for saved strategy config:
    `mcp__claude-flow__memory_retrieve({ key: "strategy-STRATEGY_NAME", namespace: "trading-strategies" })`
    If not found, list available: `mcp__claude-flow__memory_search({ query: "strategy", namespace: "trading-strategies", limit: 10 })`

--- a/plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-cloud-backtest/SKILL.md
@@ -30,7 +30,7 @@ Prereq: `ANTHROPIC_API_KEY` (or `CLAUDE_API_KEY`) + Managed Agents beta access. 
      system: "You operate the `neural-trader` CLI in this container. Run exactly the commands asked, report the metrics, write requested artifacts, then stop.",
      networking: "unrestricted",                     // or "restricted" pinned to your data host
      packages: { npm: ["neural-trader"] },           // add apt:["build-essential"] ONLY if there's no prebuilt NAPI binary for the arch (neural-trader ships prebuilds → usually omit)
-     initScript: "npm install -g neural-trader >/dev/null 2>&1 || npx -y neural-trader --version >/dev/null 2>&1 || true"
+     initScript: "npm install -g --ignore-scripts neural-trader >/dev/null 2>&1 || npx -y neural-trader --version >/dev/null 2>&1 || true"
    })
    → { sessionId, agentId, environmentId }
    ```
@@ -74,7 +74,7 @@ Prereq: `ANTHROPIC_API_KEY` (or `CLAUDE_API_KEY`) + Managed Agents beta access. 
 ## Quick example
 
 ```
-managed_agent_create  { "name":"nt-cloud", "model":"claude-haiku-4-5-20251001", "packages":{"npm":["neural-trader"]}, "initScript":"npm install -g neural-trader >/dev/null 2>&1 || true" }
+managed_agent_create  { "name":"nt-cloud", "model":"claude-haiku-4-5-20251001", "packages":{"npm":["neural-trader"]}, "initScript":"npm install -g --ignore-scripts neural-trader >/dev/null 2>&1 || true" }
   → { sessionId:"sesn_…", environmentId:"env_…" }
 managed_agent_prompt   { "sessionId":"sesn_…", "message":"Run `npx neural-trader --backtest --strategy multi-indicator --symbol SPY --period 2020-2024 --walk-forward --mc-paths 1000`. Report Sharpe/Sortino/max-DD/win-rate/CVaR; write /tmp/equity.csv. Then stop.", "maxWaitMs":600000 }
   → { finished:true, status:"idle", assistantText:"<metrics>", toolUses:[{bash:"npx neural-trader --backtest …"}] }

--- a/plugins/ruflo-neural-trader/skills/trader-portfolio/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-portfolio/SKILL.md
@@ -8,7 +8,7 @@ Optimize portfolio allocation using neural-trader's portfolio engine.
 
 Steps:
 1. Ensure neural-trader is available:
-   `npm ls neural-trader 2>/dev/null || npm install neural-trader`
+   `npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader`
 2. Load current portfolio:
    `mcp__claude-flow__memory_search({ query: "current portfolio holdings", namespace: "trading-portfolio" })`
 3. Run portfolio optimization:

--- a/plugins/ruflo-neural-trader/skills/trader-regime/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-regime/SKILL.md
@@ -8,7 +8,7 @@ Detect the current market regime using neural-trader's regime detection engine.
 
 Steps:
 1. Ensure neural-trader is available:
-   `npm ls neural-trader 2>/dev/null || npm install neural-trader`
+   `npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader`
 2. Run regime detection:
    ```bash
    npx neural-trader --regime-detect --symbol TICKER

--- a/plugins/ruflo-neural-trader/skills/trader-risk/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-risk/SKILL.md
@@ -8,7 +8,7 @@ Assess portfolio and position risk using neural-trader's risk engine.
 
 Steps:
 1. Ensure neural-trader is available:
-   `npm ls neural-trader 2>/dev/null || npm install neural-trader`
+   `npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader`
 2. Run risk assessment:
    ```bash
    # Single position

--- a/plugins/ruflo-neural-trader/skills/trader-signal/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-signal/SKILL.md
@@ -8,7 +8,7 @@ Generate trading signals using neural-trader's anomaly detection engine.
 
 Steps:
 1. Ensure neural-trader is available:
-   `npm ls neural-trader 2>/dev/null || npm install neural-trader`
+   `npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader`
 2. Scan for signals:
    ```bash
    npx neural-trader --signal scan --symbols <TICKERS>

--- a/plugins/ruflo-neural-trader/skills/trader-train/SKILL.md
+++ b/plugins/ruflo-neural-trader/skills/trader-train/SKILL.md
@@ -8,7 +8,7 @@ Train neural prediction models using neural-trader's ML engine.
 
 Steps:
 1. Ensure neural-trader is available:
-   `npm ls neural-trader 2>/dev/null || npm install neural-trader`
+   `npm ls neural-trader 2>/dev/null || npm install --ignore-scripts neural-trader`
 2. Train the specified model:
    ```bash
    npx neural-trader --model lstm --symbol TICKER --confidence 0.95

--- a/scripts/audit-neural-trader-safety.mjs
+++ b/scripts/audit-neural-trader-safety.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Neural-trader install-safety audit (regression guard for #1974).
+ *
+ * The upstream `neural-trader` npm package (verified across versions
+ * 2.6.3, 2.7.0, 2.7.1) ships a malicious-by-accident `install` lifecycle
+ * script that recursively invokes `npm install` from inside the install
+ * hook. On any non-`linux-x64` host the recursion is unbounded — one
+ * report saw 3,049 stuck processes consuming ~120 GB of RAM in ~80
+ * minutes before manual intervention.
+ *
+ * Until the upstream package is patched, every recommended invocation of
+ * `npm install neural-trader` in THIS repo must pass `--ignore-scripts`
+ * (or use the env equivalent `npm_config_ignore_scripts=1`) to skip the
+ * fork-bombing install hook. This audit fails CI if a raw `npm install
+ * neural-trader` slips back in.
+ *
+ * Scope: scans tracked markdown / shell / json files in
+ *   - plugins/ruflo-neural-trader/
+ *   - any agent / skill that mentions neural-trader
+ * Exclusions: this script itself (the pattern is the literal we're
+ * guarding against) plus the README's "DO NOT" example block.
+ *
+ * Usage:
+ *   node scripts/audit-neural-trader-safety.mjs           # exit 1 on hit
+ *   node scripts/audit-neural-trader-safety.mjs --json    # machine-readable
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+const JSON_OUT = process.argv.includes('--json');
+
+// Catches `npm install neural-trader` / `npm i neural-trader` (with or
+// without preceding `||`/`&&`/whitespace). Lines that include
+// `--ignore-scripts` anywhere on the same line are checked separately
+// below (regex-only lookahead doesn't catch `--ignore-scripts` placed
+// BEFORE the package name, which is the common form).
+const BAD = /(^|[\s|&;])npm\s+(?:install|i)\s+(?:[^|&\n]*\s)?neural-trader\b/;
+
+const ROOTS = [
+  'plugins/ruflo-neural-trader',
+  // future: add other plugins / docs if they ever recommend neural-trader
+];
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', 'target']);
+const EXT_OK = new Set(['.md', '.mdx', '.sh', '.bash', '.zsh', '.json']);
+
+// Lines that are deliberately bad (e.g. the README's "DO NOT" example).
+// Match by exact substring on the line so the marker is auditable.
+const ALLOWLIST_MARKERS = [
+  'DO NOT run',
+  'do not run',
+];
+
+function walk(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    if (e.name.startsWith('.') && e.name !== '.claude-plugin') continue;
+    const p = join(dir, e.name);
+    let s;
+    try { s = statSync(p); } catch { continue; }
+    if (s.isDirectory()) walk(p, out);
+    else if (s.isFile()) {
+      const dot = e.name.lastIndexOf('.');
+      const ext = dot >= 0 ? e.name.slice(dot) : '';
+      if (EXT_OK.has(ext)) out.push(p);
+    }
+  }
+  return out;
+}
+
+const offenders = [];
+for (const root of ROOTS) {
+  for (const file of walk(join(REPO_ROOT, root))) {
+    let src;
+    try { src = readFileSync(file, 'utf8'); } catch { continue; }
+    const lines = src.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!BAD.test(line)) continue;
+      // Safe: line opts out of the install script via --ignore-scripts
+      // (placement before OR after the package name is fine).
+      if (line.includes('--ignore-scripts')) continue;
+      // Skip lines marked as deliberately-bad examples.
+      const context = lines.slice(Math.max(0, i - 2), i + 1).join('\n');
+      if (ALLOWLIST_MARKERS.some((m) => context.includes(m))) continue;
+      offenders.push({
+        file: relative(REPO_ROOT, file),
+        line: i + 1,
+        text: line.trim(),
+      });
+    }
+  }
+}
+
+if (JSON_OUT) {
+  process.stdout.write(JSON.stringify({ offenders }, null, 2) + '\n');
+  process.exit(offenders.length === 0 ? 0 : 1);
+}
+
+console.log('neural-trader install-safety audit — guard for #1974');
+console.log(`  scanned ${ROOTS.join(', ')}`);
+if (offenders.length === 0) {
+  console.log('  ✓ no raw `npm install neural-trader` (all use --ignore-scripts or are in allowlisted DO-NOT examples)');
+  process.exit(0);
+}
+console.error(`\n  ✗ ${offenders.length} unsafe invocation(s) — #1974 regression:`);
+for (const o of offenders) {
+  console.error(`    ${o.file}:${o.line}`);
+  console.error(`      ${o.text}`);
+}
+console.error('\n  Fix: add `--ignore-scripts` to the `npm install`, OR add a "DO NOT" marker on the line above if the example is deliberately showing the unsafe form.');
+process.exit(1);


### PR DESCRIPTION
## Summary

The upstream \`neural-trader@2.7.1\` (and every earlier published version we audited) ships a malicious-by-accident \`install\` lifecycle script that recursively invokes \`npm install\` from inside the install hook. On non-\`linux-x64\` hosts the recursion is unbounded — the reporter saw **3,049 stuck processes consuming ~120 GB of RAM in ~80 minutes** on macOS Apple Silicon.

The \`plugins/ruflo-neural-trader/README.md\` Prerequisites section said plainly \`npm install neural-trader\`. We can't patch upstream from here, but we CAN stop telling users to run the dangerous command.

## Mitigations in this repo

| File | Change |
|---|---|
| \`README.md\` Prerequisites | Prominent warning advisory + switch recommended install to \`npm install --ignore-scripts neural-trader\` |
| \`agents/trading-strategist.md\` | Same \`--ignore-scripts\` fix on the "Ensure installed" line |
| 6 skill files (\`trader-backtest/portfolio/regime/risk/signal/train\`) | Same one-liner fix |
| \`trader-cloud-backtest/SKILL.md\` | Patch \`npm install -g neural-trader\` in the Managed-Agent \`initScript\` too (cloud containers ARE isolated, but in-container fork-bomb amplification still bites) |

The upstream linux-x64 binary is hardcoded inline in the tarball, so the package still works on linux-x64 after \`--ignore-scripts\`. On macOS / Windows / linux-arm64 the runtime won't work until upstream publishes the platform-binary subpackages it advertises in \`optionalDependencies\` — but at least \`--ignore-scripts\` doesn't fork-bomb the host.

## CI guard

\`scripts/audit-neural-trader-safety.mjs\` (new) scans \`plugins/ruflo-neural-trader/\` for any \`npm install neural-trader\` / \`npm i neural-trader\` invocation that doesn't also carry \`--ignore-scripts\`. Allowlist: lines preceded by a "DO NOT run" marker (the README's anti-example block). Wired into the existing \`hook-command-audit\` job (which is in \`witness-verify.needs\`, so any regression-by-removal blocks the release pipeline).

## Resolves

- #1974 (in this repo). Upstream fix still required for the underlying bug.

## Test plan

- [x] \`node scripts/audit-neural-trader-safety.mjs\` → clean (exit 0)
- [x] Inject regression (drop \`--ignore-scripts\` from one invocation) → exit 1 with per-file diagnostic
- [x] All other audits (\`vector-dim\`, \`hook-handler-prompt\`, \`fix-invariants\`, \`hook-commands\`) still green
- [x] \`bash plugins/ruflo-neural-trader/scripts/smoke.sh\` → 11 passed, 0 failed
- [ ] CI: existing audits + new \`Run neural-trader install-safety audit (#1974)\` step

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)