### PR TITLE
feat(test): multi-repo test runner + statusline version/test-count fixes

### DIFF
--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# dev-install.sh — Build and link the local Ruflo dev build globally.
+#
+# After running this, `ruflo` on the terminal points to the source in THIS repo,
+# picking up every change after a rebuild (npm run build in v3/@claude-flow/cli).
+#
+# Usage:
+#   bash scripts/dev-install.sh          # build + link
+#   bash scripts/dev-install.sh --build  # same (explicit)
+#   bash scripts/dev-install.sh --link   # skip build, re-link only
+#   bash scripts/dev-install.sh --unlink # remove both global links
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI_DIR="$REPO_ROOT/v3/@claude-flow/cli"
+RUFLO_DIR="$REPO_ROOT/ruflo"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+info() { echo -e "  ${YELLOW}▸${NC} $*"; }
+err()  { echo -e "${RED}✗${NC} $*" >&2; }
+
+MODE="build"
+if [[ "${1:-}" == "--link" ]];   then MODE="link"; fi
+if [[ "${1:-}" == "--unlink" ]]; then MODE="unlink"; fi
+
+# ── Unlink ────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "unlink" ]]; then
+  echo -e "${BOLD}Removing local dev links...${NC}"
+  cd "$RUFLO_DIR" && npm unlink --no-save 2>/dev/null && ok "ruflo global link removed" || info "ruflo was not linked"
+  cd "$CLI_DIR"   && npm unlink          2>/dev/null && ok "@claude-flow/cli global link removed" || info "@claude-flow/cli was not linked"
+  echo ""
+  echo -e "Reverted. Install from npm with: ${BOLD}npm install -g ruflo@latest${NC}"
+  exit 0
+fi
+
+echo ""
+echo -e "${BOLD}Ruflo — local dev install${NC}"
+echo -e "Repo:  $REPO_ROOT"
+echo ""
+
+# ── 1. Install CLI dependencies ───────────────────────────────────────────────
+info "Installing @claude-flow/cli dependencies..."
+cd "$CLI_DIR"
+# Use --no-workspaces to avoid workspace:* resolution issues (project uses pnpm)
+npm install --no-workspaces --legacy-peer-deps --prefer-offline 2>&1 \
+  | grep -E "added|updated|removed|warn" | head -5 || true
+ok "@claude-flow/cli deps ready"
+
+# Ensure devDependencies (typescript, vitest) are installed
+if [[ ! -f "node_modules/.bin/tsc" ]]; then
+  info "Installing devDependencies (TypeScript compiler)..."
+  npm install typescript@^5.3.0 vitest@^4.0.16 --save-dev --no-workspaces --legacy-peer-deps 2>&1 \
+    | tail -2 || true
+fi
+
+# ── 2. Build TypeScript ───────────────────────────────────────────────────────
+if [[ "$MODE" == "build" ]]; then
+  info "Compiling TypeScript..."
+  # --noEmitOnError false: pre-existing @claude-flow/swarm reference errors are
+  # harmless (the swarm package isn't built locally); we still emit valid JS.
+  node_modules/.bin/tsc --noEmitOnError false 2>&1 | grep "error TS" \
+    | grep -v "swarm\|in-memory-repositories" || true
+  ok "Build complete  →  dist/"
+fi
+
+# ── 3. Global-link @claude-flow/cli ──────────────────────────────────────────
+info "Linking @claude-flow/cli globally..."
+npm link
+ok "@claude-flow/cli linked"
+
+# ── 4. Install ruflo umbrella deps + link CLI into it ─────────────────────────
+info "Linking @claude-flow/cli into ruflo umbrella..."
+cd "$RUFLO_DIR"
+npm install --prefer-offline 2>&1 | grep -E "added|updated|removed|warn" | head -5 || true
+npm link @claude-flow/cli
+ok "ruflo/node_modules/@claude-flow/cli → local build"
+
+# ── 5. Global-link ruflo binary ───────────────────────────────────────────────
+info "Linking ruflo globally..."
+npm link
+ok "ruflo binary linked globally"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}Done!${NC} The global \`ruflo\` command now runs your local build."
+echo ""
+echo -e "  ${BOLD}ruflo --version${NC}            # verify"
+echo -e "  ${BOLD}ruflo test --dry-run${NC}       # test the new test command"
+echo ""
+echo -e "After editing source files, rebuild with:"
+echo -e "  ${BOLD}cd v3/@claude-flow/cli && npm run build${NC}"
+echo -e "  (no re-link needed — the symlink already points here)"
+echo ""

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -38,11 +38,19 @@ let RUFLO_VERSION = '3.6';
 try {
   const home = os.homedir();
   const cwd = process.cwd();
+  const npmGlobalWin = path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'npm', 'node_modules');
   const pkgPaths = [
     path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
     path.join(cwd, 'node_modules', '@claude-flow', 'cli', 'package.json'),
     path.join(cwd, 'node_modules', 'ruflo', 'package.json'),
     path.join(cwd, 'v3', '@claude-flow', 'cli', 'package.json'),
+    // Global npm installs (including npm link) — Windows and Unix
+    path.join(npmGlobalWin, '@claude-flow', 'cli', 'package.json'),
+    path.join(npmGlobalWin, 'ruflo', 'package.json'),
+    '/usr/local/lib/node_modules/@claude-flow/cli/package.json',
+    '/usr/local/lib/node_modules/ruflo/package.json',
+    path.join(home, '.npm-global', 'lib', 'node_modules', '@claude-flow', 'cli', 'package.json'),
+    path.join(home, '.npm-global', 'lib', 'node_modules', 'ruflo', 'package.json'),
   ];
   for (const p of pkgPaths) {
     if (!fs.existsSync(p)) continue;

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -4294,8 +4294,34 @@ const statuslineCommand: Command = {
       return '[' + '●'.repeat(filled) + '○'.repeat(empty) + ']';
     };
 
+    // Read installed version (same probe order as statusline.cjs helpers)
+    let rufloVersion = '3';
+    try {
+      const home = process.env.HOME || process.env.USERPROFILE || '';
+      const appdata = process.env.APPDATA || join(home, 'AppData', 'Roaming');
+      const cwd = process.cwd();
+      const versionPaths = [
+        join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
+        join(cwd, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+        join(cwd, 'node_modules', 'ruflo', 'package.json'),
+        join(cwd, 'v3', '@claude-flow', 'cli', 'package.json'),
+        join(appdata, 'npm', 'node_modules', '@claude-flow', 'cli', 'package.json'),
+        join(appdata, 'npm', 'node_modules', 'ruflo', 'package.json'),
+        '/usr/local/lib/node_modules/@claude-flow/cli/package.json',
+        '/usr/local/lib/node_modules/ruflo/package.json',
+        join(home, '.npm-global', 'lib', 'node_modules', '@claude-flow', 'cli', 'package.json'),
+      ];
+      for (const p of versionPaths) {
+        if (!existsSync(p)) continue;
+        try {
+          const pkg = JSON.parse(readFileSync(p, 'utf-8'));
+          if (pkg?.version) { rufloVersion = pkg.version; break; }
+        } catch { /* try next */ }
+      }
+    } catch { /* fall through */ }
+
     // Generate lines
-    let header = `${c.bold}${c.brightPurple}▊ RuFlo V3 ${c.reset}`;
+    let header = `${c.bold}${c.brightPurple}▊ RuFlo V${rufloVersion} ${c.reset}`;
     header += `${swarm.coordinationActive ? c.brightCyan : c.dim}● ${c.brightCyan}${user.name}${c.reset}`;
     if (user.gitBranch) {
       header += `  ${c.dim}│${c.reset}  ${c.brightBlue}⎇ ${user.gitBranch}${c.reset}`;
@@ -4403,19 +4429,54 @@ const statuslineCommand: Command = {
       } catch { /* ignore */ }
     }
 
-    // Get test stats
+    // Get test stats — supports single-repo and multi-repo (workspace.yaml)
     const testStats = { testFiles: 0, testCases: 0 };
-    const testPaths = ['tests', '__tests__', 'test', 'spec'];
-    for (const testPath of testPaths) {
-      const fullPath = path.join(process.cwd(), testPath);
-      if (fs.existsSync(fullPath)) {
+    const TEST_FILE_RE = /\.(test|spec)\.(ts|js|tsx|jsx)$/;
+    const EXCLUDE_RE = /node_modules|dist|build|coverage|\.next/;
+
+    function countTestsInDir(baseDir: string): number {
+      let count = 0;
+      const scanDirs = ['src', 'tests', '__tests__', 'test', 'spec', '.'];
+      const visited = new Set<string>();
+      for (const sub of scanDirs) {
+        const fullPath = sub === '.' ? baseDir : path.join(baseDir, sub);
+        if (!fs.existsSync(fullPath) || visited.has(fullPath)) continue;
+        visited.add(fullPath);
         try {
           const files = fs.readdirSync(fullPath, { recursive: true }) as string[];
-          testStats.testFiles = files.filter((f: string) => /\.(test|spec)\.(ts|js|tsx|jsx)$/.test(f)).length;
-          testStats.testCases = testStats.testFiles * 28; // Estimate
+          count += files.filter((f: string) => TEST_FILE_RE.test(f) && !EXCLUDE_RE.test(f)).length;
         } catch { /* ignore */ }
       }
+      return count;
     }
+
+    // Check for multi-repo workspace.yaml
+    const wsYamlPath = ['workspace.yaml', 'workspace.yml']
+      .map(n => path.join(process.cwd(), n))
+      .find(p => fs.existsSync(p));
+
+    if (wsYamlPath) {
+      try {
+        // Dynamically import yaml (available as dep) to parse workspace
+        const { parse: parseYaml } = await import('yaml');
+        const ws = parseYaml(fs.readFileSync(wsYamlPath, 'utf-8')) as Record<string, unknown>;
+        const repos = (ws?.ruflo as Record<string, unknown>)?.tests as { repos?: Array<{ path: string }> } | undefined;
+        const repoList = repos?.repos ?? (ws?.repos as Array<{ path: string }> | undefined) ?? [];
+        for (const repo of repoList) {
+          const repoPath = path.resolve(process.cwd(), repo.path);
+          if (fs.existsSync(repoPath)) {
+            testStats.testFiles += countTestsInDir(repoPath);
+          }
+        }
+      } catch { /* fall through to single-repo scan */ }
+    }
+
+    // Single-repo fallback (or supplement if workspace scan found nothing)
+    if (testStats.testFiles === 0) {
+      testStats.testFiles = countTestsInDir(process.cwd());
+    }
+
+    testStats.testCases = testStats.testFiles * 4; // conservative estimate per file
 
     // Get MCP stats
     const mcpStats = { enabled: 0, total: 0 };

--- a/v3/@claude-flow/cli/src/commands/index.ts
+++ b/v3/@claude-flow/cli/src/commands/index.ts
@@ -54,6 +54,8 @@ const commandLoaders: Record<string, CommandLoader> = {
   doctor: () => import('./doctor.js'),
   // Verification (ADR-095, signed witness manifest)
   verify: () => import('./verify.js'),
+  // Multi-repo test runner
+  test: () => import('./test.js'),
   // Analysis Commands
   analyze: () => import('./analyze.js'),
   // Q-Learning Routing Commands
@@ -176,6 +178,7 @@ export async function getClaimsCommand() { return loadCommand('claims'); }
 export async function getEmbeddingsCommand() { return loadCommand('embeddings'); }
 export async function getCompletionsCommand() { return loadCommand('completions'); }
 export async function getAnalyzeCommand() { return loadCommand('analyze'); }
+export async function getTestCommand() { return loadCommand('test'); }
 export async function getRouteCommand() { return loadCommand('route'); }
 export async function getProgressCommand() { return loadCommand('progress'); }
 export async function getIssuesCommand() { return loadCommand('issues'); }
@@ -238,7 +241,7 @@ export async function getCommandsByCategory(): Promise<Record<string, Command[]>
     analyzeCmd, routeCmd, progressCmd, providersCmd,
     pluginsCmd, deploymentCmd, claimsCmd, issuesCmd,
     updateCmd, processCmd, guidanceCmd, applianceCmd,
-    cleanupCmd, autopilotCmd,
+    cleanupCmd, autopilotCmd, testCmd,
   ] = await Promise.all([
     loadCommand('daemon'), loadCommand('doctor'), loadCommand('embeddings'), loadCommand('neural'),
     loadCommand('performance'), loadCommand('security'), loadCommand('ruvector'), loadCommand('hive-mind'),
@@ -246,7 +249,7 @@ export async function getCommandsByCategory(): Promise<Record<string, Command[]>
     loadCommand('analyze'), loadCommand('route'), loadCommand('progress'), loadCommand('providers'),
     loadCommand('plugins'), loadCommand('deployment'), loadCommand('claims'), loadCommand('issues'),
     loadCommand('update'), loadCommand('process'), loadCommand('guidance'), loadCommand('appliance'),
-    loadCommand('cleanup'), loadCommand('autopilot'),
+    loadCommand('cleanup'), loadCommand('autopilot'), loadCommand('test'),
   ]);
 
   return {
@@ -261,7 +264,7 @@ export async function getCommandsByCategory(): Promise<Record<string, Command[]>
     ].filter(Boolean) as Command[],
     utility: [
       configCmd, doctorCmd, daemonCmd, completionsCmd,
-      migrateCmd, workflowCmd,
+      migrateCmd, workflowCmd, testCmd,
     ].filter(Boolean) as Command[],
     analysis: [
       analyzeCmd, routeCmd, progressCmd,

--- a/v3/@claude-flow/cli/src/commands/test.ts
+++ b/v3/@claude-flow/cli/src/commands/test.ts
@@ -1,0 +1,394 @@
+/**
+ * V3 CLI Test Command
+ * Multi-repo test discovery and execution via workspace.yaml
+ */
+
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { output } from '../output.js';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { spawn } from 'child_process';
+import { parse as parseYaml } from 'yaml';
+
+interface WorkspaceTestRepo {
+  name: string;
+  path: string;
+  command?: string;
+  framework?: string;
+}
+
+interface WorkspaceTestConfig {
+  discover?: boolean;
+  scanSubRepos?: boolean;
+  pattern?: string[];
+  exclude?: string[];
+  repos?: WorkspaceTestRepo[];
+}
+
+interface WorkspaceConfig {
+  name?: string;
+  ruflo?: {
+    tests?: WorkspaceTestConfig;
+  };
+}
+
+interface TestResult {
+  name: string;
+  path: string;
+  command: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  duration: number;
+  passed: boolean;
+}
+
+async function loadWorkspace(workspacePath: string): Promise<WorkspaceConfig | null> {
+  try {
+    const content = await fs.readFile(workspacePath, 'utf-8');
+    return parseYaml(content) as WorkspaceConfig;
+  } catch {
+    return null;
+  }
+}
+
+async function findWorkspaceFile(startDir: string): Promise<string | null> {
+  for (const name of ['workspace.yaml', 'workspace.yml']) {
+    const candidate = path.join(startDir, name);
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // not found
+    }
+  }
+  return null;
+}
+
+async function repoHasPackageJson(repoPath: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(repoPath, 'package.json'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runCommand(
+  cmd: string,
+  cwd: string,
+  onLine: (line: string, isErr: boolean) => void
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const [prog, ...args] = cmd.split(' ');
+    const child = spawn(prog, args, {
+      cwd,
+      shell: true,
+      env: { ...process.env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      for (const line of text.split('\n').filter(Boolean)) onLine(line, false);
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      for (const line of text.split('\n').filter(Boolean)) onLine(line, true);
+    });
+
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+
+    child.on('error', (err) => {
+      resolve({ exitCode: 1, stdout, stderr: err.message });
+    });
+  });
+}
+
+async function runRepoTests(
+  repo: WorkspaceTestRepo,
+  baseDir: string,
+  verbose: boolean
+): Promise<TestResult> {
+  const repoPath = path.resolve(baseDir, repo.path);
+  const cmd = repo.command ?? 'npm test';
+  const start = Date.now();
+
+  if (verbose) {
+    output.printInfo(`  Running: ${output.highlight(cmd)} in ${output.dim(repoPath)}`);
+  }
+
+  const { exitCode, stdout, stderr } = await runCommand(
+    cmd,
+    repoPath,
+    (line, isErr) => {
+      if (verbose) {
+        if (isErr) output.writeln(output.dim(`    [stderr] ${line}`));
+        else output.writeln(output.dim(`    ${line}`));
+      }
+    }
+  );
+
+  return {
+    name: repo.name,
+    path: repoPath,
+    command: cmd,
+    exitCode,
+    stdout,
+    stderr,
+    duration: Date.now() - start,
+    passed: exitCode === 0,
+  };
+}
+
+async function runSequential(
+  repos: WorkspaceTestRepo[],
+  baseDir: string,
+  verbose: boolean
+): Promise<TestResult[]> {
+  const results: TestResult[] = [];
+  for (const repo of repos) {
+    output.printInfo(`Running tests: ${output.highlight(repo.name)}`);
+    const result = await runRepoTests(repo, baseDir, verbose);
+    printRepoResult(result);
+    results.push(result);
+  }
+  return results;
+}
+
+async function runParallel(
+  repos: WorkspaceTestRepo[],
+  baseDir: string,
+  verbose: boolean
+): Promise<TestResult[]> {
+  output.printInfo(`Running ${repos.length} repos in parallel...`);
+  const results = await Promise.all(
+    repos.map((repo) => runRepoTests(repo, baseDir, verbose))
+  );
+  for (const r of results) printRepoResult(r);
+  return results;
+}
+
+function printRepoResult(result: TestResult): void {
+  const icon = result.passed ? output.success('✔') : output.error('✖');
+  const duration = `(${(result.duration / 1000).toFixed(1)}s)`;
+  output.writeln(`  ${icon} ${result.name} ${output.dim(duration)}`);
+  if (!result.passed && result.stderr) {
+    const lines = result.stderr.split('\n').filter(Boolean).slice(0, 5);
+    for (const line of lines) output.writeln(output.dim(`     ${line}`));
+  }
+}
+
+function printSummary(results: TestResult[], totalMs: number): void {
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+
+  output.writeln('');
+  output.printBox(
+    [
+      `Repos tested: ${results.length}`,
+      `Passed:       ${passed}`,
+      `Failed:       ${failed}`,
+      `Total time:   ${(totalMs / 1000).toFixed(1)}s`,
+    ].join('\n'),
+    'Test Summary'
+  );
+
+  if (failed > 0) {
+    output.writeln('');
+    output.writeln(output.bold('Failed repos:'));
+    for (const r of results.filter((r) => !r.passed)) {
+      output.writeln(`  ${output.error('✖')} ${r.name}  (exit ${r.exitCode})`);
+    }
+  }
+}
+
+export const testCommand: Command = {
+  name: 'test',
+  description: 'Discover and run tests across multi-repo workspace',
+  aliases: ['t'],
+  options: [
+    {
+      name: 'workspace',
+      short: 'w',
+      description: 'Path to workspace.yaml (default: auto-detect in cwd)',
+      type: 'string',
+    },
+    {
+      name: 'repo',
+      short: 'r',
+      description: 'Run only specific repo(s) — comma-separated names',
+      type: 'string',
+    },
+    {
+      name: 'parallel',
+      short: 'p',
+      description: 'Run repos in parallel (default: true)',
+      type: 'boolean',
+      default: true,
+    },
+    {
+      name: 'sequential',
+      short: 's',
+      description: 'Run repos one at a time',
+      type: 'boolean',
+      default: false,
+    },
+    {
+      name: 'framework',
+      short: 'f',
+      description: 'Filter repos by test framework (e.g. jest, karma)',
+      type: 'string',
+    },
+    {
+      name: 'dry-run',
+      short: 'd',
+      description: 'Print what would run without executing',
+      type: 'boolean',
+      default: false,
+    },
+    {
+      name: 'verbose',
+      short: 'v',
+      description: 'Stream test output as it runs',
+      type: 'boolean',
+      default: false,
+    },
+  ],
+  examples: [
+    { command: 'ruflo test', description: 'Run all tests defined in workspace.yaml' },
+    { command: 'ruflo test --repo bidchex-backend', description: 'Run tests for a single repo' },
+    { command: 'ruflo test --framework jest', description: 'Run only jest repos' },
+    { command: 'ruflo test --sequential --verbose', description: 'Run sequentially with live output' },
+    { command: 'ruflo test --dry-run', description: 'Preview what commands would run' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const workspaceOpt = ctx.flags.workspace as string | undefined;
+    const repoFilter = ctx.flags.repo as string | undefined;
+    const parallelFlag = ctx.flags.parallel as boolean;
+    const sequentialFlag = ctx.flags.sequential as boolean;
+    const frameworkFilter = ctx.flags.framework as string | undefined;
+    const dryRun = (ctx.flags['dryRun'] ?? ctx.flags['dry-run']) as boolean;
+    const verbose = ctx.flags.verbose as boolean;
+
+    const useParallel = !sequentialFlag && parallelFlag;
+
+    // Locate workspace.yaml
+    const cwd = process.cwd();
+    const workspaceFile = workspaceOpt
+      ? path.resolve(workspaceOpt)
+      : await findWorkspaceFile(cwd);
+
+    if (!workspaceFile) {
+      output.printError(
+        'No workspace.yaml found. Run from a multi-repo root or pass --workspace <path>.'
+      );
+      return { success: false, message: 'workspace.yaml not found' };
+    }
+
+    const workspace = await loadWorkspace(workspaceFile);
+    if (!workspace) {
+      output.printError(`Failed to parse ${workspaceFile}`);
+      return { success: false, message: 'parse error' };
+    }
+
+    const testConfig = workspace.ruflo?.tests;
+    if (!testConfig?.repos?.length) {
+      output.printError(
+        'No test repos configured. Add a ruflo.tests.repos section to workspace.yaml.'
+      );
+      return { success: false, message: 'no test repos configured' };
+    }
+
+    const baseDir = path.dirname(workspaceFile);
+
+    // Filter repos
+    let repos = testConfig.repos;
+
+    if (repoFilter) {
+      const names = repoFilter.split(',').map((n) => n.trim());
+      repos = repos.filter((r) => names.includes(r.name));
+      if (!repos.length) {
+        output.printError(`No repos matched filter: ${repoFilter}`);
+        return { success: false, message: 'no matching repos' };
+      }
+    }
+
+    if (frameworkFilter) {
+      repos = repos.filter((r) => r.framework === frameworkFilter);
+      if (!repos.length) {
+        output.printError(`No repos with framework: ${frameworkFilter}`);
+        return { success: false, message: 'no matching repos' };
+      }
+    }
+
+    // Verify repo paths exist
+    const verified: WorkspaceTestRepo[] = [];
+    for (const repo of repos) {
+      const repoPath = path.resolve(baseDir, repo.path);
+      try {
+        await fs.access(repoPath);
+        verified.push(repo);
+      } catch {
+        output.printWarning(`Skipping ${repo.name} — path not found: ${repoPath}`);
+      }
+    }
+
+    if (!verified.length) {
+      output.printError('No valid repo paths found.');
+      return { success: false, message: 'no valid repos' };
+    }
+
+    const wsName = workspace.name ?? 'workspace';
+    output.printBox(
+      [
+        `Workspace: ${wsName}`,
+        `Config:    ${workspaceFile}`,
+        `Repos:     ${verified.length}`,
+        `Mode:      ${useParallel ? 'parallel' : 'sequential'}`,
+      ].join('\n'),
+      'Ruflo Test Runner'
+    );
+    output.writeln('');
+
+    // Dry run
+    if (dryRun) {
+      output.writeln(output.bold('Would run:'));
+      for (const repo of verified) {
+        const cmd = repo.command ?? 'npm test';
+        const repoPath = path.resolve(baseDir, repo.path);
+        output.writeln(`  ${output.highlight(repo.name)}`);
+        output.writeln(`    cd ${repoPath}`);
+        output.writeln(`    ${cmd}`);
+      }
+      return { success: true };
+    }
+
+    const start = Date.now();
+    const results = useParallel
+      ? await runParallel(verified, baseDir, verbose)
+      : await runSequential(verified, baseDir, verbose);
+
+    printSummary(results, Date.now() - start);
+
+    const allPassed = results.every((r) => r.passed);
+    return {
+      success: allPassed,
+      data: {
+        total: results.length,
+        passed: results.filter((r) => r.passed).length,
+        failed: results.filter((r) => !r.passed).length,
+        results,
+      },
+    };
+  },
+};
+
+export default testCommand;

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -346,7 +346,7 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
   if (existingStatusLine) {
     merged.statusLine = {
       type: 'command',
-      command: existingStatusLine.command || `node -e "var c=require('child_process'),p=require('path'),r;try{r=c.execSync('git rev-parse --show-toplevel',{encoding:'utf8'}).trim()}catch(e){r=process.cwd()}var s=p.join(r,'.claude/helpers/statusline.cjs');process.argv.splice(1,0,s);require(s)"`,
+      command: existingStatusLine.command || 'ruflo hooks statusline --full 2>/dev/null',
       // Remove invalid fields: refreshMs, enabled (not supported by Claude Code)
     };
   }

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -223,14 +223,9 @@ function generateStatusLineConfig(_options: InitOptions): object {
   // Same project-local / $HOME fallback as `hookCmd()` (see #1943): the
   // earlier `${CLAUDE_PROJECT_DIR:-.}` form broke statusline for any
   // global-install user. Probe project-local first, fall back to $HOME.
-  const script = '.claude/helpers/statusline.cjs';
-  // eslint-disable-next-line no-template-curly-in-string
-  const projVar = '${CLAUDE_PROJECT_DIR:-.}';
-  // eslint-disable-next-line no-template-curly-in-string
-  const homeVar = '${HOME}';
   return {
     type: 'command',
-    command: `sh -c 'D="${projVar}"; [ -f "$D/${script}" ] || D="${homeVar}"; exec node "$D/${script}"'`,
+    command: 'ruflo hooks statusline --full 2>/dev/null',
   };
 }
 


### PR DESCRIPTION
## Summary

- **New \`ruflo test\` command** — discovers and runs tests across all repos in \`workspace.yaml\`, with parallel execution, \`--repo\`/\`--framework\` filters, \`--dry-run\`, and \`--verbose\`
- **Fix statusline version** — statusline and \`ruflo hooks statusline\` now probe global npm paths (Windows \`%APPDATA%\npm\node_modules\`, Unix \`/usr/local/lib/node_modules\`, \`~/.npm-global\`) so the correct version always shows instead of the \`3.6\` fallback
- **Fix \`Tests ●0\` in multi-repo projects** — test counter reads \`workspace.yaml\` \`ruflo.tests.repos\` and counts across all child repos; falls back to recursive scan for single-repo
- **Fix \`ruflo init\` generates stale helpers** — \`settings-generator.ts\` and \`executor.ts\` now emit \`ruflo hooks statusline --full 2>/dev/null\` instead of a copied static \`.cjs\` file — projects never get stale statusline helpers again
- **Add \`scripts/dev-install.sh\`** — build + \`npm link\` workflow for local ruflo development

## Test plan

- [ ] \`ruflo test --dry-run\` from a multi-repo root with \`workspace.yaml\` lists all repos
- [ ] \`ruflo test --repo <name>\` runs a single repo
- [ ] \`ruflo test --framework jest\` filters by framework
- [ ] \`ruflo hooks statusline --full\` shows correct version from any directory, including projects without local \`node_modules/ruflo\`
- [ ] \`Tests ●N\` in statusline reflects real test file count across child repos
- [ ] \`ruflo init\` in a new directory generates \`settings.json\` with \`ruflo hooks statusline --full\` (no \`.cjs\` copy)
- [ ] \`bash scripts/dev-install.sh\` builds and links local dev version globally

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)