### PR TITLE
fix(memory): report durable vector count in `memory stats` (#1987)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-stats-hnsw-count.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-stats-hnsw-count.test.ts
@@ -17,8 +17,6 @@ import {
   _resetMemoryRootCache,
   countVectorEntries,
   getMemoryRoot,
-  initializeMemoryDatabase,
-  storeEntry,
 } from '../src/memory/memory-initializer.js';
 
 const SAVED_ENV: Record<string, string | undefined> = {};
@@ -32,18 +30,42 @@ function restoreEnv() {
   }
 }
 
+// Minimal schema mirror of memory_entries — only the columns
+// countVectorEntries actually queries. Keeps the test independent of
+// future schema evolution while pinning the count contract.
+const MEMORY_ENTRIES_MIN_SCHEMA = `
+  CREATE TABLE memory_entries (
+    id TEXT PRIMARY KEY,
+    key TEXT NOT NULL,
+    namespace TEXT DEFAULT 'default',
+    content TEXT NOT NULL,
+    type TEXT DEFAULT 'semantic',
+    embedding TEXT,
+    embedding_dimensions INTEGER,
+    embedding_model TEXT,
+    created_at INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0
+  );
+`;
+
+async function loadSqlJs() {
+  const { createRequire } = await import('node:module');
+  const req = createRequire(import.meta.url);
+  const initSqlJs = req('sql.js') as typeof import('sql.js').default;
+  return initSqlJs();
+}
+
 describe('#1987 memory stats HNSW count', () => {
   let workdir: string;
   let dbPath: string;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     saveEnv('CLAUDE_FLOW_MEMORY_PATH', 'CLAUDE_FLOW_ENCRYPT_AT_REST');
     delete process.env.CLAUDE_FLOW_ENCRYPT_AT_REST;
     workdir = mkdtempSync(join(tmpdir(), 'mem-stats-hnsw-'));
     process.env.CLAUDE_FLOW_MEMORY_PATH = workdir;
     _resetMemoryRootCache();
     dbPath = join(workdir, 'memory.db');
-    await initializeMemoryDatabase({ dbPath, force: true });
   });
 
   afterEach(() => {
@@ -52,42 +74,83 @@ describe('#1987 memory stats HNSW count', () => {
     restoreEnv();
   });
 
+  async function seedDb(rows: Array<{ id: string; key: string; embedding: string | null }>): Promise<void> {
+    const SQL = await loadSqlJs();
+    const db = new SQL.Database();
+    db.exec(MEMORY_ENTRIES_MIN_SCHEMA);
+    const now = Date.now();
+    for (const r of rows) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, type, embedding, embedding_dimensions, embedding_model, created_at, updated_at)
+         VALUES (?, ?, 'ns', ?, 'semantic', ?, ?, ?, ?, ?)`,
+        [r.id, r.key, `content for ${r.key}`, r.embedding, r.embedding ? 384 : null, r.embedding ? 'test' : null, now, now]
+      );
+    }
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(dbPath, Buffer.from(db.export()));
+    db.close();
+  }
+
   it('resolves to the tmpdir via CLAUDE_FLOW_MEMORY_PATH', () => {
     expect(getMemoryRoot()).toBe(workdir);
   });
 
-  it('returns 0 from an empty DB', async () => {
-    const count = await countVectorEntries(dbPath);
-    expect(count).toBe(0);
-  });
-
   it('returns 0 when the DB file is missing', async () => {
-    const missing = join(workdir, 'does-not-exist.db');
-    const count = await countVectorEntries(missing);
-    expect(count).toBe(0);
+    expect(await countVectorEntries(dbPath)).toBe(0);
   });
 
-  it('counts entries that have an embedding after store', async () => {
-    const result = await storeEntry({
-      key: 'oauth-design',
-      value: 'OAuth2 with PKCE flow for the auth service',
-      namespace: 'test-ns',
-      dbPath,
-    });
-    expect(result.success).toBe(true);
-
-    const count = await countVectorEntries(dbPath);
-    // Pre-fix this assertion failed because `getHNSWStatus().entryCount`
-    // (the value the stats handler used) was always 0 in a fresh process.
-    expect(count).toBeGreaterThanOrEqual(1);
+  it('returns 0 from a DB with no embedded rows', async () => {
+    await seedDb([
+      { id: 'a', key: 'no-vec', embedding: null },
+      { id: 'b', key: 'also-no-vec', embedding: null },
+    ]);
+    expect(await countVectorEntries(dbPath)).toBe(0);
   });
 
-  it('counts multiple entries across namespaces', async () => {
-    await storeEntry({ key: 'a', value: 'first entry with text', namespace: 'ns1', dbPath });
-    await storeEntry({ key: 'b', value: 'second entry with text', namespace: 'ns1', dbPath });
-    await storeEntry({ key: 'c', value: 'third entry with text', namespace: 'ns2', dbPath });
+  it('returns the count of rows with a non-empty embedding', async () => {
+    const fakeEmbedding = JSON.stringify(new Array(384).fill(0).map(() => Math.random()));
+    await seedDb([
+      { id: 'a', key: 'has-vec-1', embedding: fakeEmbedding },
+      { id: 'b', key: 'has-vec-2', embedding: fakeEmbedding },
+      { id: 'c', key: 'has-vec-3', embedding: fakeEmbedding },
+      { id: 'd', key: 'no-vec', embedding: null },
+    ]);
+    // Pre-fix the stats command read this number from an empty in-process
+    // HNSW singleton and reported 0 every time. After the fix, it queries
+    // SQLite and returns the durable count — independent of process state.
+    expect(await countVectorEntries(dbPath)).toBe(3);
+  });
 
-    const count = await countVectorEntries(dbPath);
-    expect(count).toBeGreaterThanOrEqual(3);
+  it('treats empty-string embeddings as missing', async () => {
+    await seedDb([
+      { id: 'a', key: 'empty-str', embedding: '' },
+      { id: 'b', key: 'valid', embedding: JSON.stringify([0.1, 0.2]) },
+    ]);
+    expect(await countVectorEntries(dbPath)).toBe(1);
+  });
+
+  it('honors a custom dbPath argument over CLAUDE_FLOW_MEMORY_PATH', async () => {
+    // No file at the default path — only at a custom one.
+    const customDir = mkdtempSync(join(tmpdir(), 'mem-stats-custom-'));
+    try {
+      const customDb = join(customDir, 'memory.db');
+      const SQL = await loadSqlJs();
+      const db = new SQL.Database();
+      db.exec(MEMORY_ENTRIES_MIN_SCHEMA);
+      db.run(
+        `INSERT INTO memory_entries (id, key, content, embedding, created_at, updated_at)
+         VALUES ('a', 'k', 'c', ?, 0, 0)`,
+        [JSON.stringify([1, 2, 3])]
+      );
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(customDb, Buffer.from(db.export()));
+      db.close();
+
+      expect(await countVectorEntries(customDb)).toBe(1);
+      // Default path is still empty.
+      expect(await countVectorEntries(dbPath)).toBe(0);
+    } finally {
+      rmSync(customDir, { recursive: true, force: true });
+    }
   });
 });

--- a/v3/@claude-flow/cli/__tests__/memory-stats-hnsw-count.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-stats-hnsw-count.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for #1987 — `memory stats` reported HNSW
+ * `active (0 entries)` in a fresh CLI process even when persisted rows had
+ * embeddings, because `getHNSWStatus()` reads an in-process singleton that
+ * is never hydrated on the stats code path.
+ *
+ * Fix exposes `countVectorEntries()` which queries `memory_entries` for
+ * `embedding IS NOT NULL` directly. This test pins the contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  _resetMemoryRootCache,
+  countVectorEntries,
+  getMemoryRoot,
+  initializeMemoryDatabase,
+  storeEntry,
+} from '../src/memory/memory-initializer.js';
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+function saveEnv(...names: string[]) {
+  for (const n of names) SAVED_ENV[n] = process.env[n];
+}
+function restoreEnv() {
+  for (const [n, v] of Object.entries(SAVED_ENV)) {
+    if (v === undefined) delete process.env[n];
+    else process.env[n] = v;
+  }
+}
+
+describe('#1987 memory stats HNSW count', () => {
+  let workdir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    saveEnv('CLAUDE_FLOW_MEMORY_PATH', 'CLAUDE_FLOW_ENCRYPT_AT_REST');
+    delete process.env.CLAUDE_FLOW_ENCRYPT_AT_REST;
+    workdir = mkdtempSync(join(tmpdir(), 'mem-stats-hnsw-'));
+    process.env.CLAUDE_FLOW_MEMORY_PATH = workdir;
+    _resetMemoryRootCache();
+    dbPath = join(workdir, 'memory.db');
+    await initializeMemoryDatabase({ dbPath, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+    _resetMemoryRootCache();
+    restoreEnv();
+  });
+
+  it('resolves to the tmpdir via CLAUDE_FLOW_MEMORY_PATH', () => {
+    expect(getMemoryRoot()).toBe(workdir);
+  });
+
+  it('returns 0 from an empty DB', async () => {
+    const count = await countVectorEntries(dbPath);
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 when the DB file is missing', async () => {
+    const missing = join(workdir, 'does-not-exist.db');
+    const count = await countVectorEntries(missing);
+    expect(count).toBe(0);
+  });
+
+  it('counts entries that have an embedding after store', async () => {
+    const result = await storeEntry({
+      key: 'oauth-design',
+      value: 'OAuth2 with PKCE flow for the auth service',
+      namespace: 'test-ns',
+      dbPath,
+    });
+    expect(result.success).toBe(true);
+
+    const count = await countVectorEntries(dbPath);
+    // Pre-fix this assertion failed because `getHNSWStatus().entryCount`
+    // (the value the stats handler used) was always 0 in a fresh process.
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('counts multiple entries across namespaces', async () => {
+    await storeEntry({ key: 'a', value: 'first entry with text', namespace: 'ns1', dbPath });
+    await storeEntry({ key: 'b', value: 'second entry with text', namespace: 'ns1', dbPath });
+    await storeEntry({ key: 'c', value: 'third entry with text', namespace: 'ns2', dbPath });
+
+    const count = await countVectorEntries(dbPath);
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -729,9 +729,14 @@ const statsCommand: Command = {
       // a fresh call still resolves quickly because we only need the
       // metadata, not a real embedding.
       try {
-        const { loadEmbeddingModel, getHNSWStatus } = await import('../memory/memory-initializer.js');
+        const { loadEmbeddingModel, getHNSWStatus, countVectorEntries } = await import('../memory/memory-initializer.js');
         const embedding = await loadEmbeddingModel({ verbose: false });
         const hnsw = getHNSWStatus();
+        // #1987: getHNSWStatus().entryCount reflects only the in-process
+        // singleton, which is always 0 in a fresh `memory stats` process.
+        // Pull the durable count from the SQLite store so the display matches
+        // what `memory list` and `memory search` actually see.
+        const persistedVectorCount = await countVectorEntries();
         // Map model name → semantic capability so users can spot the
         // hash-fallback case without reading docs.
         const semanticProviders = new Set([
@@ -768,8 +773,12 @@ const statsCommand: Command = {
             },
             {
               metric: 'HNSW Index',
-              value: hnsw.available && hnsw.initialized
-                ? output.success(`active (${hnsw.entryCount.toLocaleString()} entries)`)
+              // #1987: report the persisted vector-entry count (queried from
+              // SQLite each call) rather than the in-process singleton size.
+              // "active" means the store has indexable rows; the in-process
+              // index is built lazily on first search.
+              value: persistedVectorCount > 0
+                ? output.success(`active (${persistedVectorCount.toLocaleString()} entries)`)
                 : hnsw.available
                   ? output.warning('available but not initialized')
                   : output.dim('not active'),

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -664,6 +664,12 @@ export async function searchHNSWIndex(
 
 /**
  * Get HNSW index status
+ *
+ * #1987: `entryCount` here reflects ONLY the in-process `hnswIndex` singleton.
+ * A fresh CLI invocation never hydrates that singleton (it loads lazily on
+ * search), so this count is always 0 for `memory stats`. Callers that want
+ * the durable count of embedded rows should use `countVectorEntries()` and
+ * keep this function for the in-process index status alone.
  */
 export function getHNSWStatus(): {
   available: boolean;
@@ -688,6 +694,36 @@ export function getHNSWStatus(): {
     entryCount: hnswIndex?.entries.size ?? 0,
     dimensions: hnswIndex?.dimensions ?? 384
   };
+}
+
+/**
+ * #1987: Count persisted `memory_entries` rows that have an embedding,
+ * independent of the in-process HNSW singleton. Used by `memory stats` so a
+ * fresh CLI process reports the durable count, not the empty in-process
+ * cache. Returns 0 if the DB does not exist yet or the query fails — same
+ * shape as a never-populated index, which is the correct fallback for stats.
+ */
+export async function countVectorEntries(dbPath?: string): Promise<number> {
+  const path_ = dbPath || path.join(getMemoryRoot(), 'memory.db');
+  if (!fs.existsSync(path_)) return 0;
+
+  try {
+    const initSqlJs = (await import('sql.js')).default;
+    const SQL = await initSqlJs();
+    const fileBuffer = fs.readFileSync(path_);
+    const db = new SQL.Database(fileBuffer);
+    try {
+      const result = db.exec(
+        "SELECT COUNT(*) FROM memory_entries WHERE embedding IS NOT NULL AND embedding != ''"
+      );
+      const count = (result[0]?.values[0]?.[0] as number) ?? 0;
+      return typeof count === 'number' ? count : 0;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return 0;
+  }
 }
 
 /**

--- a/v3/@claude-flow/cli/src/memory/rabitq-index.ts
+++ b/v3/@claude-flow/cli/src/memory/rabitq-index.ts
@@ -92,8 +92,11 @@ export async function buildRabitqIndex(options?: {
     }
 
     const dimensions = options?.dimensions ?? 384;
-    const swarmDir = path.resolve(process.cwd(), '.swarm');
-    const dbPath = options?.dbPath ? path.resolve(options.dbPath) : path.join(swarmDir, 'memory.db');
+    // #1987: route through getMemoryRoot() so CLAUDE_FLOW_MEMORY_PATH and
+    // claude-flow.config.json#memory.persistPath are honored here too. Same
+    // pattern #1945 applied to the bridge.
+    const { getMemoryRoot } = await import('./memory-initializer.js');
+    const dbPath = options?.dbPath ? path.resolve(options.dbPath) : path.join(getMemoryRoot(), 'memory.db');
 
     const entries: RabitqEntry[] = [];
     const vectors: number[] = [];
@@ -175,7 +178,7 @@ export async function buildRabitqIndex(options?: {
 
     // Persist metadata for fast reload hint
     try {
-      const metaPath = path.join(swarmDir, 'rabitq.meta.json');
+      const metaPath = path.join(path.dirname(dbPath), 'rabitq.meta.json');
       fs.writeFileSync(metaPath, JSON.stringify({
         vectorCount: entries.length,
         dimensions,

--- a/v3/@claude-flow/cli/vitest.config.ts
+++ b/v3/@claude-flow/cli/vitest.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
         if (source.startsWith('@huggingface/transformers')) return { id: source, external: true };
         if (source.startsWith('@xenova/transformers')) return { id: source, external: true };
         if (source.startsWith('@noble/ed25519')) return { id: source, external: true };
+        // #1987: sql.js is dynamically imported by memory-initializer; the
+        // CLI package resolves it via the workspace hoist at runtime, but
+        // Vite tries to transform it at test load and fails. Externalize
+        // so Node's resolver handles it like in production. Same for the
+        // node:sqlite builtin used by the #1987 regression test.
+        if (source === 'sql.js') return { id: source, external: true };
+        if (source === 'node:sqlite' || source === 'sqlite') return { id: source, external: true };
         return null;
       },
     },
@@ -30,6 +37,14 @@ export default defineConfig({
     globals: true,
     coverage: {
       enabled: false,
+    },
+    // #1987: sql.js is dynamically imported via `await import('sql.js')` in
+    // memory-initializer; mark it external for the vitest deps optimizer so
+    // Node resolves it from the workspace hoist (same as production).
+    server: {
+      deps: {
+        external: [/sql\.js/],
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes #1987.

`memory stats` was reporting `HNSW Index: active (0 entries)` in every fresh CLI process even when the persisted `memory_entries` table had rows with embeddings. The displayed count was being read from the in-process `hnswIndex` singleton (`getHNSWStatus().entryCount`), which is hydrated lazily on the **search** code path and never on the **stats** path. Each `npx claude-flow memory stats` invocation is a new Node process → singleton empty → display always 0.

## What changed

| File | Change |
|---|---|
| `v3/@claude-flow/cli/src/memory/memory-initializer.ts` | Export new `countVectorEntries(dbPath?)` — runs `SELECT COUNT(*) FROM memory_entries WHERE embedding IS NOT NULL AND embedding != ''` via sql.js. Returns 0 for missing DB or query failure (correct stats fallback, matches the never-populated shape). |
| `v3/@claude-flow/cli/src/commands/memory.ts` | `memory stats` reads from `countVectorEntries()` for the displayed entry count. `getHNSWStatus()` still drives the available/initialized hints — the in-process index status is still useful, just not the durable count. |
| `v3/@claude-flow/cli/src/memory/rabitq-index.ts` | Builder now routes through `getMemoryRoot()` instead of the hard-coded `path.resolve(process.cwd(), '.swarm')`. Same fix #1945 applied to the bridge — `CLAUDE_FLOW_MEMORY_PATH` and `claude-flow.config.json#memory.persistPath` are now honored here too. `rabitq.meta.json` follows the resolved dbPath dir. |
| `v3/@claude-flow/cli/__tests__/memory-stats-hnsw-count.test.ts` | New regression test (6 cases). Pins the count contract end-to-end without needing the ONNX embedder or the full `initializeMemoryDatabase` path — uses sql.js to seed a minimal compatible schema. |
| `v3/@claude-flow/cli/vitest.config.ts` | `server.deps.external` adds `sql.js` so the dynamic `await import('sql.js')` in `memory-initializer` resolves at runtime via Node (same as production) instead of being transformed by Vite. |

## Test plan

- [x] `npx vitest run __tests__/memory-stats-hnsw-count.test.ts` → 6 passing
- [x] `npx vitest run __tests__/memory-db-encryption.test.ts` → 9 passing (unchanged adjacent suite still green)
- [x] Manual repro: `npx claude-flow@v3alpha memory store -n test -k a --value "x"` then `memory stats` previously showed `0 entries`; with the patch shows `1 entries`
- [x] Manual: `CLAUDE_FLOW_MEMORY_PATH=/tmp/x memory stats` now reads from the configured path (was previously stuck on cwd-derived `.swarm/`)

## Out of scope (separate concerns, deferred)

1. The legacy `<cwd>/.claude/memory.db` sync at `commands/memory.ts:1582-1596` — confused diagnostics initially but doesn't affect stats. Worth removing in a follow-up after operator messaging is reviewed.
2. Migration tool for users with rows in `./.claude/memory.db` from older versions — those rows are not read on any hot path; safe to leave until a proper migration command lands.
3. `getHNSWStatus()` itself — kept as-is because it correctly describes the in-process index state, which is still useful for "did search build the index this session?" diagnostics.

## Notes

The initial issue framing in #1987 (two databases — `./.claude/memory.db` vs `./.swarm/memory.db`) turned out to be a red herring. Post-#1945, every memory subcommand resolves through `getMemoryRoot()` and lands on the same `.swarm/memory.db`. The `.claude/memory.db` file is a one-shot legacy copy made at `memory init` time and isn't read by `stats`. The root cause is the in-process singleton vs durable storage mismatch, which this PR addresses.
