### PR TITLE
fix(deps): pin @opentelemetry/core to 1.25.1 (closes #1921)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,10 @@
     "make-fetch-happen": ">=15.0.0",
     "express-rate-limit": ">=8.4.1",
     "protobufjs": ">=7.5.5",
-    "uuid": ">=14.0.0"
+    "uuid": ">=14.0.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "devDependencies": {
     "@openai/codex": "^0.98.0",


### PR DESCRIPTION
Adds overrides for @opentelemetry/{core,resources,sdk-trace-base}@1.25.1 to eliminate the arborist empty-version placeholder bug that fails every npx claude-flow@alpha install on npm 10.8.x.