### PR TITLE
fix(swarm): scaleAgents target-not-delta + executeTask error wrap (#1872 2/5)

### DIFF
--- a/v3/__tests__/integration/swarm-integration.test.ts
+++ b/v3/__tests__/integration/swarm-integration.test.ts
@@ -122,10 +122,10 @@ describe('Swarm Integration Tests', () => {
     expect(stateAfter.topology).toBe('hierarchical');
   });
 
-  // SKIP #1872 — real bug: SwarmCoordinator doesn't catch errors from
-  // agent.executeTask; mocked rejection propagates instead of returning
-  // {status:'failed', error:...} as the test (and contract) expects.
-  it.skip('should handle agent failures gracefully', async () => {
+  // ruflo#1872 — fixed: SwarmCoordinator.executeTask now wraps the
+  // agent call in try/catch so a thrown error becomes a structured
+  // {status:'failed', error} result.
+  it('should handle agent failures gracefully', async () => {
     const agent = await coordinator.spawnAgent({
       id: 'fragile-agent',
       type: 'coder',
@@ -194,10 +194,10 @@ describe('Swarm Integration Tests', () => {
     expect(connections.every(c => c.type === 'peer')).toBe(true);
   });
 
-  // SKIP #1872 — real bug: scaleAgents({count: N}) accumulates rather
-  // than targets N total. Scale-down path also broken (1 → 4 → 6 instead
-  // of 1 → 4 → 2).
-  it.skip('should handle dynamic agent scaling', async () => {
+  // ruflo#1872 — fixed: scaleAgents({count:N}) now interprets count as
+  // the TARGET TOTAL of that agent type (spawning or terminating to
+  // reach it) rather than as a delta.
+  it('should handle dynamic agent scaling', async () => {
     await coordinator.spawnAgent({ id: 'base-agent', type: 'coder', capabilities: ['code'] });
 
     const initialCount = (await coordinator.listAgents()).length;

--- a/v3/src/coordination/application/SwarmCoordinator.ts
+++ b/v3/src/coordination/application/SwarmCoordinator.ts
@@ -202,7 +202,24 @@ export class SwarmCoordinator {
     }
 
     const startTime = Date.now();
-    const result = await agent.executeTask(task);
+    // ruflo#1872 — `agent.executeTask` can throw (mock rejection in
+    // tests, real broker/network errors in production). Previously the
+    // throw propagated up to the caller, defeating the
+    // "TaskResult{status:'failed', error}" contract callers rely on
+    // for graceful degradation. Wrap in try/catch so a crashed agent
+    // produces a structured failure result instead of an unhandled
+    // promise rejection.
+    let result: TaskResult;
+    try {
+      result = await agent.executeTask(task);
+    } catch (err) {
+      result = {
+        taskId: task.id,
+        status: 'failed',
+        error: err instanceof Error ? err.message : String(err),
+        agentId,
+      };
+    }
     const duration = Date.now() - startTime;
 
     // Update metrics
@@ -317,25 +334,28 @@ export class SwarmCoordinator {
    * Scale agents
    */
   async scaleAgents(config: { type: string; count: number }): Promise<void> {
+    // ruflo#1872 — `count` is the TARGET TOTAL of this agent type, not
+    // a delta. Previously `count` was added to the existing count, so
+    // calling `scaleAgents({count:3})` then `scaleAgents({count:2})`
+    // ended up at 1+3+2=6 instead of the intuitive 2.
     const existingOfType = Array.from(this.agents.values()).filter(
       a => a.type === config.type
     );
-
     const currentCount = existingOfType.length;
-    const targetCount = currentCount + config.count;
+    const targetCount = Math.max(0, Math.floor(config.count));
 
-    if (config.count > 0) {
+    if (targetCount > currentCount) {
       // Scale up
       for (let i = currentCount; i < targetCount; i++) {
         await this.spawnAgent({
           id: `${config.type}-${Date.now()}-${i}`,
           type: config.type,
-          capabilities: this.getDefaultCapabilities(config.type)
+          capabilities: this.getDefaultCapabilities(config.type),
         });
       }
-    } else if (config.count < 0) {
-      // Scale down
-      const toRemove = existingOfType.slice(0, Math.abs(config.count));
+    } else if (targetCount < currentCount) {
+      // Scale down — terminate the oldest first so deterministic.
+      const toRemove = existingOfType.slice(0, currentCount - targetCount);
       for (const agent of toRemove) {
         await this.terminateAgent(agent.id);
       }


### PR DESCRIPTION
Fixes 2 of the 5 integration bugs catalogued in #1872. scaleAgents now interprets count as the target total; executeTask wraps agent.executeTask so throws become {status:'failed',error}. Both tests un-skipped.