### PR TITLE
docs(plugins): aidefence 2.3.0 surface in 3 plugin READMEs (per ADR-118)

### DIFF
--- a/plugins/ruflo-aidefence/README.md
+++ b/plugins/ruflo-aidefence/README.md
@@ -51,6 +51,18 @@ Every consumer plugin handling untrusted content should apply these three gates 
 
 This is the pattern `ruflo-browser` ADR-0001 §4 codified and `ruflo-aidefence` ADR-0001 canonicalizes. Reference these gates by name in any new plugin that handles user-supplied content.
 
+### What the gates catch (after [ADR-118](../../v3/docs/adr/ADR-118-aidefence-2.3.0-upgrade.md))
+
+The upstream `aidefence@2.3.0` / `aimds-*@0.1.1` release (shipped 2026-05-14) widens the detection net without changing the MCP-tool surface. Gate 3 (`aidefence_is_safe`) now flags:
+
+| Category | Sample input |
+|----------|--------------|
+| **Prompt injection** (0..4 modifier-word window) | `ignore all previous instructions`, `forget every rule above`, `disregard the system prompt` |
+| **Role hijack** | `you are now …`, `act as …`, `pretend to be …` |
+| **Jailbreak markers** | `DAN mode`, `developer mode`, `god mode`, `root mode` |
+
+`aidefence_stats` now also reports accurate `total_mitigations` and `successful_mitigations` (previously hardcoded `0` — an unclosed TODO that's now backed by `AtomicU64` counters).
+
 ## Namespace coordination
 
 This plugin owns the `security-patterns` AgentDB namespace (kebab-case, follows the convention from [ruflo-agentdb ADR-0001 §"Namespace convention"](../ruflo-agentdb/docs/adrs/0001-agentdb-optimization.md)). Reserved namespaces (`pattern`, `claude-memories`, `default`) MUST NOT be shadowed.

--- a/plugins/ruflo-browser/README.md
+++ b/plugins/ruflo-browser/README.md
@@ -72,7 +72,7 @@ Raw cookies and tokens never enter AgentDB unwrapped — see ADR §3.
 
 1. **Pre-storage scan** — every scraped string passes `aidefence_has_pii` before AgentDB store.
 2. **Cookie sanitization** — `aidefence_scan` flags high-entropy strings; vault them in `browser-cookies`.
-3. **Prompt-injection check** — extracted text returning to an LLM passes `aidefence_is_safe`. Hits get quarantined to `findings.md`.
+3. **Prompt-injection check** — extracted text returning to an LLM passes `aidefence_is_safe`. Hits get quarantined to `findings.md`. With [`aidefence@2.3.0` (ADR-118)](../../v3/docs/adr/ADR-118-aidefence-2.3.0-upgrade.md) the check now catches role-hijack (`you are now …` / `act as …` / `pretend to be …`) and jailbreak markers (`DAN mode` / `developer mode` / `god mode` / `root mode`) in addition to the canonical `ignore all previous instructions` family — high-leverage upgrade for browser-scraped pages.
 
 ## MCP surface
 

--- a/plugins/ruflo-federation/README.md
+++ b/plugins/ruflo-federation/README.md
@@ -79,6 +79,8 @@ Federation's "PII Pipeline" feature is a richer specialization of the canonical 
 
 Federation extends the canonical gates with adaptive confidence calibration and trust-level-aware policies, but the gate ordering and intent are identical. New federated content paths should reference the canonical 3-gate pattern by name.
 
+With the [`aidefence@2.3.0` upgrade (ADR-118)](../../v3/docs/adr/ADR-118-aidefence-2.3.0-upgrade.md), the inbound `aidefence_is_safe` gate (Gate 3) now catches a wider injection surface — `ignore all previous instructions` family (0..4 modifier-word window), role-hijack (`you are now …` / `act as …` / `pretend to be …`), and jailbreak markers (`DAN mode` / `developer mode` / `god mode` / `root mode`). Federation's adaptive confidence calibration runs over the broader detection set automatically; no plugin code change required.
+
 ## Namespace coordination
 
 This plugin owns the `federation` AgentDB namespace. This is the documented exception to the kebab-case `<plugin-stem>-<intent>` rule: when a plugin's name *is* the intent, the namespace can match the plugin stem. See [ruflo-agentdb ADR-0001 §"Namespace convention"](../ruflo-agentdb/docs/adrs/0001-agentdb-optimization.md). Reserved namespaces (`pattern`, `claude-memories`, `default`) MUST NOT be shadowed.


### PR DESCRIPTION
Documents the wider injection-detection surface (canonical injection + role-hijack + jailbreak) and accurate audit counters in ruflo-aidefence, ruflo-browser, ruflo-federation READMEs.