### PR TITLE
feat(federation-peer): wire real midstreamer-quic@0.3.0 + aimds-core@0.2.0 (ADR-120 Step 3)

### DIFF
--- a/scripts/audit-fix-invariants.mjs
+++ b/scripts/audit-fix-invariants.mjs
@@ -249,8 +249,26 @@ const INVARIANTS = [
   {
     issue: 'ADR-120',
     file: 'v3/crates/ruflo-federation-peer/Cargo.toml',
-    substring: 'midstreamer-quic = { version = "0.2.1"',
-    why: 'Step 3 crate pins midstreamer-quic@0.2.1 (the published upstream version with the strictly-better security posture — OS trust store via rustls-platform-verifier).',
+    substring: 'midstreamer-quic = { version = "0.3.0"',
+    why: 'Step 3 crate pins midstreamer-quic@0.3.0 (ruvnet/midstream PR #82 added the QuicTransport embedding trait this crate needs for its TransportProvider blanket impl).',
+  },
+  {
+    issue: 'ADR-120',
+    file: 'v3/crates/ruflo-federation-peer/Cargo.toml',
+    substring: 'aimds-core = { version = "0.2.0"',
+    why: 'Step 3 crate pins aimds-core@0.2.0 (ruvnet/midstream PR #82 added the SafetyGate composing trait this crate adapts in native_gate).',
+  },
+  {
+    issue: 'ADR-120',
+    file: 'v3/crates/ruflo-federation-peer/src/lib.rs',
+    substring: 'midstreamer_quic::{QuicConnection, QuicTransport}',
+    why: 'Step 3 native_transport must import the upstream QuicTransport trait (not just QuicConnection) so MidstreamerTransport is generic over any embedder-supplied transport.',
+  },
+  {
+    issue: 'ADR-120',
+    file: 'v3/crates/ruflo-federation-peer/src/lib.rs',
+    substring: 'aimds_core::{PromptInput, SafetyGate as AimdsSafetyGate, SafetyVerdict as AimdsVerdict}',
+    why: 'Step 3 native_gate must adapt aimds_core::SafetyGate to the peer-local SafetyGate trait — without this import the adapter degrades to a typed placeholder.',
   },
   {
     issue: 'ADR-120',

--- a/v3/crates/ruflo-federation-peer/Cargo.lock
+++ b/v3/crates/ruflo-federation-peer/Cargo.lock
@@ -12,36 +12,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "aimds-analysis"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f1b5a52ba651e21809c432789c33acd0cd51cf35b3b2aaf3a3f90929c505f7"
-dependencies = [
- "aimds-core",
- "anyhow",
- "chrono",
- "dashmap 5.5.3",
- "midstreamer-attractor",
- "midstreamer-neural-solver",
- "midstreamer-strange-loop",
- "ndarray 0.15.6",
- "petgraph",
- "serde",
- "serde_json",
- "statrs",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "aimds-core"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4da9ee7c71c9dd59d85b2dff58df8347bcd8dffa807abc275e4311a166b3276"
+checksum = "3c8c9252e38bc01a3c099b830e86b7da2c16a9b066bebbe04302d944ef1c2efb"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "derive_more",
  "serde",
@@ -52,66 +29,6 @@ dependencies = [
  "uuid",
  "validator",
 ]
-
-[[package]]
-name = "aimds-detection"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c19d590a998b3ea4e21f5e4709ef44ed7068345d398401685aa6e5be9d6609"
-dependencies = [
- "aho-corasick",
- "aimds-core",
- "anyhow",
- "blake3",
- "chrono",
- "dashmap 5.5.3",
- "fancy-regex",
- "lru",
- "midstreamer-scheduler",
- "midstreamer-temporal-compare",
- "parking_lot",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aimds-response"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98bdb5ef98f7adea336b4998fc51a06e31e79dea33fc68d096857256e04d5288"
-dependencies = [
- "aimds-analysis",
- "aimds-core",
- "aimds-detection",
- "anyhow",
- "async-trait",
- "chrono",
- "dashmap 5.5.3",
- "futures",
- "metrics",
- "midstreamer-strange-loop",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -127,27 +44,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
@@ -173,60 +69,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -287,12 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,90 +159,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "darling"
@@ -434,33 +196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,16 +215,6 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -520,17 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fancy-regex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,7 +252,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.4",
+ "rand",
  "siphasher",
 ]
 
@@ -547,12 +261,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -664,16 +372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,18 +413,10 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -862,6 +552,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -956,12 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,38 +695,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
 
 [[package]]
 name = "memchr"
@@ -1041,46 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "metrics"
-version = "0.24.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
-dependencies = [
- "portable-atomic",
- "rapidhash",
-]
-
-[[package]]
-name = "midstreamer-attractor"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebe548a4e74b80ecb8dd058e352a91fed9e5685c49c5d3fa5062520c660c6c9"
-dependencies = [
- "midstreamer-temporal-compare",
- "nalgebra 0.33.3",
- "ndarray 0.16.1",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "midstreamer-neural-solver"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dde200f86405da65caf2f6ae4013f29090bb162ea0959dc08f5ce17d9023a9a"
-dependencies = [
- "midstreamer-scheduler",
- "ndarray 0.16.1",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "midstreamer-quic"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7174c6f9448f2ec89811c7c04930ed036565eba32b146246f6c3644a51c43b53"
+checksum = "9d4dcf971dfa9eb5087e9c79e078f88c1508110bf010b8bb2d29b0b7229fd229"
 dependencies = [
+ "async-trait",
  "futures",
  "js-sys",
  "quinn",
@@ -1096,46 +728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "midstreamer-scheduler"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8085dbcfb13808d075c0b31681022b41acc1c8021313d45fa7461e97d7767ff"
-dependencies = [
- "crossbeam",
- "parking_lot",
- "serde",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "midstreamer-strange-loop"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511947933055e04a8bc5e711f9e2bd00dff6bdf8bc9d0fb3972b5211bfbbda4f"
-dependencies = [
- "dashmap 6.1.0",
- "midstreamer-attractor",
- "midstreamer-neural-solver",
- "midstreamer-scheduler",
- "midstreamer-temporal-compare",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "midstreamer-temporal-compare"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87063b1eb79672a76f88377799152d8e149328e9a19455345851a264bdced20"
-dependencies = [
- "dashmap 6.1.0",
- "lru",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,142 +739,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros 0.1.0",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.8.6",
- "rand_distr",
- "simba 0.6.0",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros 0.2.2",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba 0.9.1",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1291,7 +751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1330,12 +789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,35 +805,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1417,25 +845,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+ "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error-attr"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "version_check",
 ]
 
 [[package]]
@@ -1477,7 +907,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1527,33 +957,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1563,16 +972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1583,31 +983,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "rapidhash"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rcgen"
@@ -1677,17 +1052,16 @@ dependencies = [
 name = "ruflo-federation-peer"
 version = "0.1.0"
 dependencies = [
- "aimds-analysis",
  "aimds-core",
- "aimds-detection",
- "aimds-response",
  "async-trait",
+ "chrono",
  "midstreamer-quic",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1786,15 +1160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,26 +1256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,32 +1269,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "simba"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
-name = "simba"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
 ]
 
 [[package]]
@@ -1987,19 +1306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "statrs"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
-dependencies = [
- "approx",
- "lazy_static",
- "nalgebra 0.29.0",
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,7 +1324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -2082,15 +1387,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2166,23 +1462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
- "hashbrown 0.15.5",
- "pin-project-lite",
- "slab",
- "tokio",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,62 +1491,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
+name = "unicode-bidi"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -2288,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -2313,11 +1558,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
 dependencies = [
- "idna",
+ "idna 0.5.0",
  "once_cell",
  "regex",
  "serde",
@@ -2329,23 +1574,17 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "df0bcf92720c40105ac4b2dda2a4ea3aa717d4d6a862cc217da653a4bd5c6b10"
 dependencies = [
  "darling",
  "once_cell",
- "proc-macro-error2",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2503,16 +1742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/v3/crates/ruflo-federation-peer/Cargo.toml
+++ b/v3/crates/ruflo-federation-peer/Cargo.toml
@@ -19,10 +19,17 @@ path = "src/bin.rs"
 [features]
 default = []
 # When `native` is enabled the binary actually wires midstreamer-quic
-# + aimds-* into the runtime. Off by default so `cargo check` works
-# in CI environments that haven't materialized the upstream Rust
-# dependency tree yet — the trait surface compiles either way.
-native = ["dep:midstreamer-quic", "dep:aimds-core", "dep:aimds-detection", "dep:aimds-analysis", "dep:aimds-response"]
+# + aimds-core into the runtime via the embedding traits exposed in
+# ruvnet/midstream PR #82 (midstreamer-quic@0.3.0, aimds-core@0.2.0).
+# Off by default so `cargo check` works in CI environments that
+# haven't materialized the upstream Rust dependency tree yet — the
+# trait surface compiles either way.
+native = [
+    "dep:midstreamer-quic",
+    "dep:aimds-core",
+    "dep:uuid",
+    "dep:chrono",
+]
 
 [dependencies]
 # Core async runtime (always required for the trait surface).
@@ -34,15 +41,15 @@ serde_json = "1.0"
 tracing = "0.1"
 
 # Optional — only pulled in when `--features native` is on. These are
-# the upstream crates this peer is designed to compose:
-#   - midstreamer-quic@0.2.1 — quinn-backed transport (ruvnet/midstream)
-#   - aimds-{core,detection,analysis,response}@0.1.1 — the
-#     3-gate safety pipeline (ADR-118)
-midstreamer-quic = { version = "0.2.1", optional = true }
-aimds-core = { version = "0.1.1", optional = true }
-aimds-detection = { version = "0.1.1", optional = true }
-aimds-analysis = { version = "0.1.1", optional = true }
-aimds-response = { version = "0.1.1", optional = true }
+# the upstream crates this peer composes:
+#   - midstreamer-quic@0.3.0 — quinn-backed transport with the new
+#     `QuicTransport` embedding trait (ruvnet/midstream PR #82)
+#   - aimds-core@0.2.0 — `SafetyGate` composing trait + verdict enum
+#     (`Pass` / `Block` / `Redact`) for the 3-gate pipeline (ADR-118)
+midstreamer-quic = { version = "0.3.0", optional = true }
+aimds-core = { version = "0.2.0", optional = true }
+uuid = { version = "1", optional = true, features = ["v4"] }
+chrono = { version = "0.4", optional = true, features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.42", features = ["full"] }

--- a/v3/crates/ruflo-federation-peer/src/bin.rs
+++ b/v3/crates/ruflo-federation-peer/src/bin.rs
@@ -4,34 +4,116 @@
 //! TypeScript federation plugin already understands) and runs the
 //! peer until the transport closes.
 //!
-//! Without `--features native` the binary's runtime backend isn't
-//! wired (it would dispatch through the trait surface to an
-//! in-process noop). This is intentional: the binary builds and
-//! tests in CI without the upstream Rust crate tree, and the
-//! `native` feature is flipped on once the Cargo workspace is
-//! locked against the published `midstreamer-quic` + `aimds-*`
-//! versions per ADR-120 Step 1.
+//! Under `--features native` the binary boots a tokio runtime that
+//! drives [`Peer::run`] against a real `MidstreamerTransport`
+//! (midstreamer-quic@0.3.0) and a real `AimdsGate` adapter
+//! (aimds-core@0.2.0). Without that feature it's a smoke binary
+//! useful only for probing `--version`.
 
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    eprintln!(
-        "ruflo-federation-peer {} — ADR-120 Step 3.\n\
-         Native QUIC + AIMDS backend is gated behind `--features native`.\n\
-         Without it, the binary's trait surface is exported as a library only;\n\
-         binary boots as a no-op so callers can probe `--version`/`--help` without\n\
-         pulling in the optional upstream Rust deps.",
-        env!("CARGO_PKG_VERSION"),
-    );
-
-    // Print the version + exit so the binary is useful for smoke
-    // verification today. Once `--features native` is wired into the
-    // ruflo CI workflow, this gets replaced by a real
-    // `tokio::runtime::Runtime` driving `Peer::run`.
     if std::env::args().any(|a| a == "--version" || a == "-V") {
         println!("ruflo-federation-peer {}", env!("CARGO_PKG_VERSION"));
         return ExitCode::SUCCESS;
     }
 
-    ExitCode::SUCCESS
+    #[cfg(feature = "native")]
+    {
+        return native_main();
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        eprintln!(
+            "ruflo-federation-peer {} — built without `--features native`.\n\
+             The binary's trait surface is exported as a library only;\n\
+             rebuild with `--features native` to drive the real QUIC + AIMDS backend.",
+            env!("CARGO_PKG_VERSION"),
+        );
+        ExitCode::SUCCESS
+    }
+}
+
+#[cfg(feature = "native")]
+fn native_main() -> ExitCode {
+    use aimds_core::{AimdsError, PromptInput, SafetyGate, SafetyVerdict};
+    use async_trait::async_trait;
+    use ruflo_federation_peer::{
+        native_gate::AimdsGate,
+        native_transport::MidstreamerTransport,
+        Dispatcher, FederationMessage, Peer, PeerError,
+    };
+
+    let remote = match std::env::var("RUFLO_FEDERATION_REMOTE_ADDR") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!(
+                "RUFLO_FEDERATION_REMOTE_ADDR is required (e.g. hub.local:4433).",
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    // Default gate: pass-through. Operators wanting the real 3-gate
+    // pipeline construct `AimdsGate::new(ComposedGate::default())`
+    // from their own bin shim; this default keeps the smoke boot
+    // path useful when AIMDS detection rules aren't yet configured.
+    struct PassGate;
+    #[async_trait]
+    impl SafetyGate for PassGate {
+        async fn inspect(
+            &self,
+            _input: &PromptInput,
+        ) -> Result<SafetyVerdict, AimdsError> {
+            Ok(SafetyVerdict::Pass)
+        }
+    }
+
+    // Default dispatcher: emit NDJSON to stdout so the parent
+    // process (the ruflo MCP server) can ingest verdicts.
+    struct StdoutDispatcher;
+    #[async_trait]
+    impl Dispatcher for StdoutDispatcher {
+        async fn dispatch(
+            &self,
+            sender: &str,
+            msg: FederationMessage,
+        ) -> Result<(), PeerError> {
+            let line = serde_json::to_string(&serde_json::json!({
+                "sender": sender,
+                "message": msg,
+            }))?;
+            println!("{line}");
+            Ok(())
+        }
+    }
+
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ruflo-federation-peer: failed to build runtime: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    rt.block_on(async move {
+        let transport = match MidstreamerTransport::connect(&remote).await {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("ruflo-federation-peer: connect failed: {e}");
+                return ExitCode::from(1);
+            }
+        };
+        let gate = AimdsGate::new(PassGate);
+        let peer = Peer::new(transport, gate, StdoutDispatcher);
+        if let Err(e) = peer.run().await {
+            eprintln!("ruflo-federation-peer: run failed: {e}");
+            return ExitCode::from(1);
+        }
+        ExitCode::SUCCESS
+    })
 }

--- a/v3/crates/ruflo-federation-peer/src/lib.rs
+++ b/v3/crates/ruflo-federation-peer/src/lib.rs
@@ -216,55 +216,240 @@ where
     }
 }
 
-/// Production transport wrapping `midstreamer-quic`. Only available
-/// under `--features native` because the upstream crate is otherwise
-/// optional.
+/// Production transport wrapping `midstreamer-quic@0.3.0`'s
+/// `QuicTransport` trait. Only available under `--features native`
+/// because the upstream crate is otherwise optional.
 #[cfg(feature = "native")]
 pub mod native_transport {
-    //! Real-QUIC wrapper. Implementation lands once the upstream
-    //! `midstreamer-quic` API stabilizes its `QuicTransport` trait.
-    //! Today this is a typed placeholder so `cargo check
-    //! --features native` succeeds.
+    //! Real-QUIC wrapper over the `midstreamer-quic@0.3.0`
+    //! `QuicTransport` trait surface (ruvnet/midstream PR #82).
+    //!
+    //! `MidstreamerTransport` owns a single established
+    //! [`midstreamer_quic::QuicConnection`] (typically a
+    //! ruflo↔hub-peer link). Outbound `send` opens a fresh
+    //! bidirectional stream and writes one NDJSON line per
+    //! [`FederationMessage`]; `recv` accepts an incoming
+    //! bidirectional stream and reads one NDJSON line. This matches
+    //! the framing used by the TS-side `midstream-aware-loader`.
+    //!
+    //! Full mesh (accept-from-many-peers) waits for an upstream
+    //! `Endpoint::accept_connection` API; today the peer establishes
+    //! exactly one connection at startup.
     use super::*;
+    use midstreamer_quic::{QuicConnection, QuicTransport};
 
-    /// Concrete [`TransportProvider`] backed by `midstreamer-quic`.
-    pub struct MidstreamerTransport;
+    /// Concrete [`TransportProvider`] backed by `midstreamer-quic`'s
+    /// `QuicTransport` trait. Generic over any embedder-supplied
+    /// transport so tests can substitute a fake.
+    pub struct MidstreamerTransport<T: QuicTransport = QuicConnection> {
+        connection: T,
+        remote_addr: String,
+    }
+
+    impl MidstreamerTransport<QuicConnection> {
+        /// Open a client connection to `addr` and wrap it. The
+        /// returned transport is ready to `send` / `recv`.
+        ///
+        /// `addr` must be a `host:port` string parseable by
+        /// `midstreamer-quic`'s connect path; the same string is
+        /// later echoed back from `recv` as the sender.
+        pub async fn connect(addr: &str) -> Result<Self, PeerError> {
+            let connection = QuicConnection::connect(addr)
+                .await
+                .map_err(|e| PeerError::Transport(format!("connect {addr}: {e}")))?;
+            Ok(Self {
+                connection,
+                remote_addr: addr.to_string(),
+            })
+        }
+    }
+
+    impl<T: QuicTransport> MidstreamerTransport<T> {
+        /// Wrap an already-established transport. Used when the peer
+        /// is the server side of a connection (accepted) or in tests.
+        pub fn from_connection(connection: T, remote_addr: String) -> Self {
+            Self {
+                connection,
+                remote_addr,
+            }
+        }
+    }
 
     #[async_trait]
-    impl TransportProvider for MidstreamerTransport {
-        async fn send(&self, _addr: &str, _msg: FederationMessage) -> Result<(), PeerError> {
-            Err(PeerError::Transport("not implemented — see ADR-120".into()))
+    impl<T: QuicTransport + 'static> TransportProvider for MidstreamerTransport<T> {
+        async fn send(&self, addr: &str, msg: FederationMessage) -> Result<(), PeerError> {
+            // Today the transport is single-connection; only sends
+            // to the established remote are valid. The TS-side
+            // loader holds the routing table, so an addr mismatch
+            // here is a programmer error rather than a runtime one.
+            if addr != self.remote_addr {
+                return Err(PeerError::Transport(format!(
+                    "addr {addr} does not match established remote {}",
+                    self.remote_addr
+                )));
+            }
+            let mut stream = self
+                .connection
+                .open_bi_stream()
+                .await
+                .map_err(|e| PeerError::Transport(format!("open_bi_stream: {e}")))?;
+            let mut line = serde_json::to_vec(&msg)?;
+            line.push(b'\n');
+            stream
+                .send(&line)
+                .await
+                .map_err(|e| PeerError::Transport(format!("write: {e}")))?;
+            stream
+                .finish()
+                .await
+                .map_err(|e| PeerError::Transport(format!("finish: {e}")))?;
+            Ok(())
         }
+
         async fn recv(&self) -> Result<(String, FederationMessage), PeerError> {
-            Err(PeerError::Transport("not implemented — see ADR-120".into()))
+            let mut stream = self
+                .connection
+                .accept_bi_stream()
+                .await
+                .map_err(|e| PeerError::Transport(format!("accept_bi_stream: {e}")))?;
+            // QUIC streams are reliable + framed-by-finish; read in
+            // chunks until the peer finishes the stream. Cap total
+            // at 16 MiB to bound memory; federation messages are
+            // small.
+            const MAX: usize = 16 * 1024 * 1024;
+            const CHUNK: usize = 8 * 1024;
+            let mut buf: Vec<u8> = Vec::with_capacity(4096);
+            let mut chunk = [0u8; CHUNK];
+            loop {
+                let n = stream
+                    .recv(&mut chunk)
+                    .await
+                    .map_err(|e| PeerError::Transport(format!("read: {e}")))?;
+                if n == 0 {
+                    break;
+                }
+                if buf.len() + n > MAX {
+                    return Err(PeerError::Transport(format!(
+                        "inbound message exceeded {MAX} bytes",
+                    )));
+                }
+                buf.extend_from_slice(&chunk[..n]);
+            }
+            // Strip trailing newline framing if present.
+            let trimmed: &[u8] = match buf.last() {
+                Some(&b'\n') => &buf[..buf.len() - 1],
+                _ => &buf,
+            };
+            let msg: FederationMessage = serde_json::from_slice(trimmed)?;
+            Ok((self.remote_addr.clone(), msg))
         }
+
         async fn close(&self) -> Result<(), PeerError> {
+            self.connection.close(0, b"peer shutdown");
             Ok(())
         }
     }
 }
 
-/// Production safety gate wrapping AIMDS detection + analysis +
-/// response layers. Only available under `--features native`.
+/// Production safety gate adapting any `aimds_core::SafetyGate`
+/// (e.g. AIMDS's `ComposedGate` running detection + analysis +
+/// response) to the peer's `FederationMessage` shape. Only
+/// available under `--features native`.
 #[cfg(feature = "native")]
 pub mod native_gate {
-    //! AIMDS 3-gate wrapper. Composes the four `aimds-*` crates.
-    //! Today this is a typed placeholder; the real implementation
-    //! lands in a follow-up once the upstream crates expose the
-    //! handle the ruflo MCP tools already use.
+    //! Adapter that lets the peer compose any `aimds_core::SafetyGate`
+    //! implementation. Converts `FederationMessage` → `PromptInput`
+    //! by serializing the payload to a string + carrying the
+    //! metadata as context; converts the verdict back into the
+    //! peer-local enum.
+    //!
+    //! Embedders construct one of these with their preferred gate
+    //! pipeline. AIMDS's canonical `ComposedGate` (detection +
+    //! analysis + response, short-circuit on Block) is the expected
+    //! default, but any `aimds_core::SafetyGate` works.
     use super::*;
+    use aimds_core::{PromptInput, SafetyGate as AimdsSafetyGate, SafetyVerdict as AimdsVerdict};
+    use std::sync::Arc;
 
-    /// Concrete [`SafetyGate`] backed by the AIMDS pipeline.
-    pub struct AimdsGate;
+    /// Concrete [`SafetyGate`] that delegates to a user-provided
+    /// `aimds_core::SafetyGate`. Cheap to clone (Arc-wrapped).
+    pub struct AimdsGate {
+        inner: Arc<dyn AimdsSafetyGate>,
+    }
+
+    impl AimdsGate {
+        /// Construct from any `aimds_core::SafetyGate` implementor.
+        /// Pass `AIMDS`'s canonical `ComposedGate` here, or a custom
+        /// 3-gate composition.
+        pub fn new<G: AimdsSafetyGate + 'static>(gate: G) -> Self {
+            Self {
+                inner: Arc::new(gate),
+            }
+        }
+    }
+
+    impl Clone for AimdsGate {
+        fn clone(&self) -> Self {
+            Self {
+                inner: Arc::clone(&self.inner),
+            }
+        }
+    }
+
+    /// Adapt a `FederationMessage` to `aimds-core`'s `PromptInput`.
+    /// The gate inspects message content as a stringified JSON
+    /// payload; metadata + stream-id ride along in `context` so the
+    /// gate can correlate per-session.
+    fn to_prompt_input(msg: &FederationMessage) -> PromptInput {
+        let content = serde_json::to_string(&msg.payload)
+            .unwrap_or_else(|_| msg.payload.to_string());
+        let context = serde_json::json!({
+            "federation_id": msg.id,
+            "kind": msg.kind,
+            "metadata": msg.metadata,
+            "streamId": msg.stream_id,
+        });
+        PromptInput {
+            id: uuid::Uuid::new_v4(),
+            timestamp: chrono::Utc::now(),
+            content,
+            context,
+            session_id: msg.stream_id.clone(),
+            user_id: None,
+        }
+    }
 
     #[async_trait]
     impl SafetyGate for AimdsGate {
-        async fn inspect(&self, _msg: &FederationMessage) -> Result<SafetyVerdict, PeerError> {
-            // The wired implementation walks `aimds-detection` →
-            // `aimds-analysis` → `aimds-response`. Until the upstream
-            // crates publish their public-API trait for embedding,
-            // this default safely passes everything through.
-            Ok(SafetyVerdict::Pass)
+        async fn inspect(&self, msg: &FederationMessage) -> Result<SafetyVerdict, PeerError> {
+            let input = to_prompt_input(msg);
+            let verdict = self
+                .inner
+                .inspect(&input)
+                .await
+                .map_err(|e| PeerError::Gate(format!("aimds: {e}")))?;
+            Ok(match verdict {
+                AimdsVerdict::Pass => SafetyVerdict::Pass,
+                AimdsVerdict::Block(reason) => SafetyVerdict::Block(reason),
+                AimdsVerdict::Redact(sanitized) => {
+                    // The peer's verdict carries a full
+                    // `FederationMessage`; rewrap the sanitized
+                    // content as the message payload + preserve the
+                    // routing metadata.
+                    let redacted = FederationMessage {
+                        id: msg.id.clone(),
+                        kind: msg.kind.clone(),
+                        payload: serde_json::json!({
+                            "sanitized": sanitized.sanitized_content,
+                            "modifications": sanitized.modifications,
+                            "is_safe": sanitized.is_safe,
+                        }),
+                        metadata: msg.metadata.clone(),
+                        stream_id: msg.stream_id.clone(),
+                    };
+                    SafetyVerdict::Redact(redacted)
+                }
+            })
         }
     }
 }
@@ -377,6 +562,62 @@ mod tests {
         match err {
             PeerError::Gate(reason) => assert_eq!(reason, "test rule"),
             other => panic!("expected Gate error, got {other:?}"),
+        }
+    }
+
+    /// Round-trips a `FederationMessage` through the real
+    /// `AimdsGate` adapter wired to an in-test `aimds_core::SafetyGate`
+    /// implementor. Exercises the actual upstream trait surface
+    /// (`midstreamer-quic@0.3.0` and `aimds-core@0.2.0`).
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn aimds_gate_adapter_forwards_pass_and_block_verdicts() {
+        use crate::native_gate::AimdsGate;
+        use aimds_core::{
+            AimdsError, PromptInput, SafetyGate as AimdsSafetyGate,
+            SafetyVerdict as AimdsVerdict,
+        };
+
+        // Test gate: block messages whose payload contains "secret".
+        struct PatternGate;
+        #[async_trait]
+        impl AimdsSafetyGate for PatternGate {
+            async fn inspect(
+                &self,
+                input: &PromptInput,
+            ) -> Result<AimdsVerdict, AimdsError> {
+                if input.content.contains("secret") {
+                    Ok(AimdsVerdict::Block("pattern: 'secret'".into()))
+                } else {
+                    Ok(AimdsVerdict::Pass)
+                }
+            }
+        }
+
+        let adapter = AimdsGate::new(PatternGate);
+
+        let safe = FederationMessage {
+            id: "1".into(),
+            kind: "task".into(),
+            payload: serde_json::json!({"text": "hello world"}),
+            metadata: Default::default(),
+            stream_id: None,
+        };
+        match adapter.inspect(&safe).await.unwrap() {
+            SafetyVerdict::Pass => {}
+            other => panic!("expected Pass, got {other:?}"),
+        }
+
+        let unsafe_msg = FederationMessage {
+            id: "2".into(),
+            kind: "task".into(),
+            payload: serde_json::json!({"text": "the secret is out"}),
+            metadata: Default::default(),
+            stream_id: None,
+        };
+        match adapter.inspect(&unsafe_msg).await.unwrap() {
+            SafetyVerdict::Block(reason) => assert!(reason.contains("secret")),
+            other => panic!("expected Block, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes ADR-120 Step 3. Replaces the typed `not implemented` placeholders in `native_transport` and `native_gate` with real implementations that delegate to the embedding traits published in [ruvnet/midstream PR #82](https://github.com/ruvnet/midstream/pull/82) (now on crates.io as `midstreamer-quic@0.3.0` and `aimds-core@0.2.0`).

Both upstream crates are now real published versions; this PR wires them in.

## Changes

### Cargo.toml

| Dep | Old | New |
|-----|-----|-----|
| `midstreamer-quic` | 0.2.1 | **0.3.0** (now exposes `QuicTransport` trait) |
| `aimds-core` | 0.1.1 | **0.2.0** (now exposes `SafetyGate` + `SafetyVerdict`) |
| `aimds-detection` / `-analysis` / `-response` | optional 0.1.1 | _dropped_ |
| `uuid` (v4) | — | **added (optional, native)** |
| `chrono` | — | **added (optional, native)** |

Dropping the three concrete `aimds-*` impl crates keeps the peer minimal: it composes **any** `aimds_core::SafetyGate`, so the concrete 3-gate pipeline is supplied by the caller (e.g. AIMDS's `ComposedGate` or a custom composition).

### `native_transport::MidstreamerTransport<T: QuicTransport>`

Real, no stubs:
- Generic over any embedder-supplied transport (defaults to `QuicConnection`)
- `connect(addr)`: opens a client connection via `QuicConnection::connect`
- `send(addr, msg)`: opens a bidirectional stream, writes one NDJSON line per `FederationMessage`, finishes the stream
- `recv()`: accepts an inbound bidirectional stream, reads to EOF (16 MiB cap), parses one JSON value
- `close()`: closes the connection with reason `peer shutdown`

### `native_gate::AimdsGate`

Real adapter, no stubs:
- Holds `Arc<dyn aimds_core::SafetyGate>` — composes any 3-gate pipeline (AIMDS's canonical `ComposedGate`, custom composition, or test stub)
- Converts `FederationMessage` ↔ `PromptInput` (payload-as-string + metadata-as-context)
- Converts `aimds_core::SafetyVerdict` ↔ peer-local `SafetyVerdict`, preserving routing metadata on `Redact`

### `bin.rs`

Under `--features native`, boots a real tokio runtime:
- `MidstreamerTransport::connect()` against `RUFLO_FEDERATION_REMOTE_ADDR`
- `AimdsGate::new(PassGate)` (pass-through default so the smoke path works without AIMDS rules configured)
- NDJSON-stdout dispatcher — parent process (ruflo MCP server) ingests verdicts

Without `--features native`, prints a help message and exits.

## Tests

- **3/3** tests pass (default features)
- **4/4** tests pass (`--features native`) — includes new `aimds_gate_adapter_forwards_pass_and_block_verdicts` that exercises the real `aimds_core::SafetyGate` trait against an in-test pattern gate

## CI guard

`scripts/audit-fix-invariants.mjs`:
- Bumped Cargo.toml pin invariants to 0.3.0 / 0.2.0
- Added two new invariants checking the lib.rs imports actually reference upstream `QuicTransport` and `aimds_core::SafetyGate` — guards against silent reversion to a typed placeholder
- **34/34** invariants pass

## Why now

The two upstream PRs ([midstream#82](https://github.com/ruvnet/midstream/pull/82) for `QuicTransport` + `SafetyGate` traits) just merged + published to crates.io. This is the unblocking change for the typed-placeholder backends in `ruflo-federation-peer` that have been waiting on those embedding-trait surfaces.

## Test plan

- [x] `cargo test --lib` — 3/3 green
- [x] `cargo test --lib --features native` — 4/4 green
- [x] `cargo build --bins` — both feature flavors compile
- [x] `node scripts/audit-fix-invariants.mjs` — 34/34 invariants pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [RuFlo](https://github.com/ruvnet/ruflo)