### PR TITLE
fix(memory) : include value in listEntries so memory_export actually exports content

### DIFF
--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -797,6 +797,7 @@ export async function bridgeListEntries(options: {
     id: string;
     key: string;
     namespace: string;
+    value: string;
     size: number;
     accessCount: number;
     createdAt: string;
@@ -846,6 +847,7 @@ export async function bridgeListEntries(options: {
           id: String(row.id).substring(0, 20),
           key: row.key || String(row.id).substring(0, 15),
           namespace: row.namespace || 'default',
+          value: row.content ?? '',
           size: (row.content || '').length,
           accessCount: row.access_count ?? 0,
           createdAt: row.created_at || new Date().toISOString(),

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -2496,6 +2496,7 @@ export async function listEntries(options: {
     id: string;
     key: string;
     namespace: string;
+    value: string;
     size: number;
     accessCount: number;
     createdAt: string;
@@ -2573,6 +2574,7 @@ export async function listEntries(options: {
       id: string;
       key: string;
       namespace: string;
+      value: string;
       size: number;
       accessCount: number;
       createdAt: string;
@@ -2589,6 +2591,7 @@ export async function listEntries(options: {
           id: String(id).substring(0, 20),
           key: key || String(id).substring(0, 15),
           namespace: ns || 'default',
+          value: content ?? '',
           size: (content || '').length,
           accessCount: accessCount || 0,
           createdAt: createdAt || new Date().toISOString(),


### PR DESCRIPTION
## Summary

`memory_export` writes JSON with `"value": null` for every entry — content is dropped on export. Round-tripping through `memory_import` then clobbers the original content with the literal string `"null"`, since the import handler does `JSON.stringify(e.value ?? null)`. A single export+import cycle today is a silent data-loss event.

## Root cause

`listEntries()` in `memory-initializer.ts` (and its AgentDB v3 bridge counterpart `bridgeListEntries` in `memory-bridge.ts`) destructure `content` from the SQL row, use it to compute `size`, and then omit it from the returned entry object. The `memory_export` MCP handler maps `value: e.value ?? null`, which always evaluates to `null` because `e.value` doesn't exist on the entry.

## Repro (before this fix)

npx -y ruflo@latest memory store -n shared -k k -v "real content"
npx -y ruflo@latest memory export -o /tmp/x.json -n shared --format json
grep '"value":' /tmp/x.json

→ "value": null,


## Fix

Thread the existing `content` value through `listEntries` and `bridgeListEntries` so it lands on the entry object. The SQL queries already SELECT `content`; the destructure already binds it locally — this is purely a dropped-field bug. Same fix in both the bridge path (tried first per ADR-053) and the sql.js fallback so behavior is consistent regardless of backend. Side benefit: `memory list --format json` now returns full rows instead of metadata only.

## Validation

End-to-end against published `@claude-flow/cli@3.7.0-alpha.38`: applied this patch's runtime equivalent to the compiled `dist/` output, then ran a store → export → delete → import → retrieve round-trip. The 68-char test value survives byte-identically:

expected:  "Round-trip-with-import validation — must survive export AND import."
retrieved: "Round-trip-with-import validation — must survive export AND import."
[PASS]



## Note on related import-side hardening

With this export-side patch in place, the unsafe `JSON.stringify(e.value ?? null)` branch in the import handler never fires during normal use (real string values come through). Hardening that branch is a worthwhile follow-up but kept out of this PR to keep the diff scoped to 6 lines.

## Build note

Couldn't run a clean `tsc` locally — main has ~600 pre-existing errors in `v3/mcp/`, `v3/plugins/`, `v3/src/` (missing peer deps, WebAssembly types, isolatedModules re-exports), and `better-sqlite3` requires MSVC Build Tools on Windows. The two changed files are isolated to `v3/@claude-flow/cli/src/memory/`. Diff is 6 lines, type-safe by inspection (`content` is destructured as `string` per the explicit tuple type at memory-initializer.ts:2585).
'@ | Out-File -Encoding utf8 $env:TEMP\pr-body.md