### PR TITLE
fix(ruflo-core): suppress non-hookSpecificOutput stdout in ruflo-hook.sh

### DIFF
--- a/plugins/ruflo-core/scripts/ruflo-hook.sh
+++ b/plugins/ruflo-core/scripts/ruflo-hook.sh
@@ -20,7 +20,19 @@
 # Swallow all diagnostics — nothing this script prints should reach Claude Code.
 exec 2>/dev/null
 
-run() { "$@" || true; }
+# run <cmd> [args…]
+# Executes the command with stdin passed through. Only forwards stdout to
+# Claude Code if it contains a valid hookSpecificOutput JSON object.
+# Plain text (help messages, warnings, unimplemented-subcommand output) is
+# suppressed so third-party PreToolUse hooks in the same chain are not
+# disrupted by noise that Claude Code may interpret as hook protocol output.
+run() {
+  local out
+  out=$("$@") || true
+  if [ -n "$out" ] && printf '%s' "$out" | jq -e '.hookSpecificOutput' >/dev/null 2>&1; then
+    printf '%s\n' "$out"
+  fi
+}
 
 if command -v ruflo >/dev/null 2>&1; then
   run ruflo hooks "$@"


### PR DESCRIPTION
## Problem

When a hook subcommand is not yet implemented in the ruflo CLI (e.g. `modify-bash`), the `ruflo-hook.sh` shim falls through to:

```
npx --prefer-offline ruflo@alpha hooks modify-bash
```

This prints the full CLI help text to **stdout** and exits 0. Claude Code receives this text as hook protocol output on every Bash tool call.

**Consequence**: any other `PreToolUse` hook in the same chain is broken. The help-text noise shadows valid `hookSpecificOutput` JSON from co-installed hooks, so their command rewrites are silently discarded. Reported via the `ruflo-rtk` integration (#1900, #1915) where RTK stopped rewriting commands after upgrading to ruflo-core 0.2.2 (alpha 38).

## Root cause

```bash
# before
run() { "$@" || true; }   # stdout passes through unconditionally
```

When `"$@"` outputs help text, it goes straight to Claude Code.

## Fix

```bash
# after
run() {
  local out
  out=$("$@") || true
  # Only forward output that contains a valid hookSpecificOutput JSON object.
  if [ -n "$out" ] && printf '%s' "$out" | jq -e '.hookSpecificOutput' >/dev/null 2>&1; then
    printf '%s\n' "$out"
  fi
}
```

Capture stdout and only forward it when it is valid hook protocol JSON. Plain text (help, warnings, unimplemented subcommand output) is suppressed.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Unimplemented subcommand (`modify-bash`) | Outputs full help text | Suppressed — no stdout |
| Future valid implementation outputting `hookSpecificOutput` | Passes through | Passes through ✓ |
| Existing no-output hooks (`post-command`, `session-end`) | No stdout | No stdout ✓ |
| Co-installed third-party hook (e.g. ruflo-rtk) | Broken by noise | Works correctly ✓ |

## Test

```bash
echo '{"tool_input":{"command":"git status"}}' | \
  bash plugins/ruflo-core/scripts/ruflo-hook.sh modify-bash
# Before: prints "Self-Learning Hooks System\n..."
# After:  prints nothing (exit 0)
```

Fixes the regression introduced in ruflo-core 0.2.2 for users with any co-installed `PreToolUse/Bash` hook.

Related: #1900, #1915, #2017