### PR TITLE
feat(ruflo-loop-workers): custom-worker manifest schema + register skill (v0.3.0)

### DIFF
--- a/plugins/ruflo-loop-workers/.claude-plugin/plugin.json
+++ b/plugins/ruflo-loop-workers/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruflo-loop-workers",
-  "description": "Cache-aware /loop workers and CronCreate background automation — wraps 5 hooks_worker-* MCP tools (list/dispatch/status/detect/cancel) and exposes 12 background worker triggers (ultralearn, optimize, consolidate, predict, audit, map, preload, deepdive, document, refactor, benchmark, testgaps)",
-  "version": "0.2.0",
+  "description": "Cache-aware /loop workers and CronCreate background automation — wraps 5 hooks_worker-* MCP tools (list/dispatch/status/detect/cancel), exposes 12 background worker triggers (ultralearn, optimize, consolidate, predict, audit, map, preload, deepdive, document, refactor, benchmark, testgaps), and registers consumer-defined custom workers from a YAML manifest",
+  "version": "0.3.0",
   "author": {
     "name": "ruvnet",
     "url": "https://github.com/ruvnet"
@@ -17,6 +17,7 @@
     "mcp",
     "background-workers",
     "cache-aware",
-    "schedule-wakeup"
+    "schedule-wakeup",
+    "custom-workers"
   ]
 }

--- a/plugins/ruflo-loop-workers/README.md
+++ b/plugins/ruflo-loop-workers/README.md
@@ -14,6 +14,7 @@ Cache-aware /loop workers and CronCreate background automation. Substrate plugin
 - **Loop Workers**: Recurring tasks via `/loop` with ScheduleWakeup (delay <270s for prompt cache hits)
 - **CronCreate**: Background cron jobs for audit, optimization, and monitoring
 - **12 Background Workers**: ultralearn, optimize, consolidate, predict, audit, map, preload, deepdive, document, refactor, benchmark, testgaps
+- **Custom workers (v0.3.0)**: register consumer-defined recurring tasks from a YAML manifest. See [Custom workers](#custom-workers) below
 - **Daemon Management**: Start, stop, status, trigger, and enable workers
 - **ADR-091 Integration**: Native Claude Code capabilities preferred over daemon polling
 
@@ -65,6 +66,34 @@ npx @claude-flow/cli@latest hooks worker dispatch --trigger document --scope api
 mcp tool call hooks_worker-dispatch --json -- '{"trigger": "document", "scope": "api"}'
 ```
 
+## Custom workers
+
+The 12 built-in triggers above are dispatched via `mcp__claude-flow__hooks_worker-dispatch` and serve cross-plugin cases. A consumer plugin or downstream project sometimes needs to schedule its own recurring task that doesn't fit those triggers — for example, AgentVille's L4 deterministic anomaly tick.
+
+For those cases, v0.3.0 introduces a **custom-worker manifest** (YAML) plus the `register-custom-workers` skill that reads the manifest and registers each worker via `CronCreate`. The 12 built-ins are unchanged; custom workers run alongside them in a separate registration path.
+
+Minimal manifest:
+
+```yaml
+version: 1
+workers:
+  - name: agentville-l4
+    schedule: '*/15 * * * *'
+    command: ['pnpm', 'auto-ops:l4-tick', '--', '--project-root', '.']
+    cwd: '/var/lib/agentville'
+    env:
+      AGENTVILLE_GLAB_REPO: 'org/repo'
+    timeout_seconds: 60
+```
+
+Register from a Claude Code session:
+
+```text
+Skill: ruflo-loop-workers:register-custom-workers .ruflo/custom-workers.yaml
+```
+
+Schema reference: [`docs/custom-worker-manifest.md`](./docs/custom-worker-manifest.md). Design rationale: [`ADR-0002`](./docs/adrs/0002-custom-worker-manifest.md).
+
 ## Cache-aware /loop integration
 
 This plugin pairs with [ruflo-autopilot ADR-0001](../ruflo-autopilot/docs/adrs/0001-autopilot-contract.md) which **owns the 270s cache-aware ScheduleWakeup heartbeat contract**. Recommended fallback heartbeat is **270 seconds** — under the 5-minute prompt-cache TTL so the next wake-up reads conversation context cached. Going past 300s pays a cache-miss; rounding to 5 minutes is the worst-of-both case.
@@ -87,6 +116,7 @@ bash plugins/ruflo-loop-workers/scripts/smoke.sh
 ## Architecture Decisions
 
 - [`ADR-0001` — ruflo-loop-workers plugin contract (12-worker trigger map, autopilot 270s cross-reference, smoke as contract)](./docs/adrs/0001-loop-workers-contract.md)
+- [`ADR-0002` — custom-worker manifest schema and registration skill (v0.3.0)](./docs/adrs/0002-custom-worker-manifest.md)
 
 ## Related Plugins
 

--- a/plugins/ruflo-loop-workers/docs/adrs/0002-custom-worker-manifest.md
+++ b/plugins/ruflo-loop-workers/docs/adrs/0002-custom-worker-manifest.md
@@ -1,0 +1,69 @@
+---
+id: ADR-0002
+title: ruflo-loop-workers custom-worker manifest schema and registration skill
+status: Proposed
+date: 2026-05-16
+authors:
+  - contributor (AgentVille / Sebastiaan)
+tags: [plugin, loop-workers, cron, custom-workers, manifest, schema]
+---
+
+## Context
+
+ADR-0001 anchors `ruflo-loop-workers` around 12 built-in triggers (`audit`, `optimize`, ..., `testgaps`) dispatched through `mcp__claude-flow__hooks_worker-dispatch`. The trigger list is closed — each new trigger requires a consumer-plugin commit naming the trigger and a documentation update here.
+
+Downstream projects with their own deterministic recurring work (e.g. AgentVille's L4 anomaly-detection tick: `docs/superpowers/specs/2026-05-16-auto-ops-l4-loop-worker-design.md` §7.5) hit two friction points:
+
+1. The 12-trigger contract has no slot for project-specific workers, so the natural path is to bypass the plugin entirely and call `CronCreate` directly from the consumer's operator runbook. Every consumer reinvents the same wrapper-script + cron-prompt boilerplate.
+2. The plugin's value-add for those bypass cases is purely social (discovery, audit trail). Without a contract surface for custom workers, that value isn't expressed in code.
+
+## Decision
+
+Add a thin, additive surface for custom workers. The plugin stays markdown-only; the schema lives in `docs/custom-worker-manifest.md`; a new skill `register-custom-workers` reads a manifest path and registers each worker via `CronCreate`.
+
+Concrete additions in v0.3.0:
+
+1. `skills/register-custom-workers/SKILL.md` — skill definition with `allowed-tools: Read CronCreate CronList CronDelete`. Tells the model to read the manifest, validate, build a `Bash:` invocation per worker, call `CronCreate`, and report back. All-or-nothing validation.
+2. `docs/custom-worker-manifest.md` — canonical schema. Required: `name`, `schedule`, `command`. Optional: `cwd`, `env`, `timeout_seconds`, `token_budget`, `description`. Version pinned at `1`.
+3. README "Custom workers" section linking to the schema and skill, explicitly noting the contract is complementary to (not a replacement for) the 12 built-in triggers.
+4. `plugin.json` keywords gain `custom-workers`; version bumps `0.2.0 → 0.3.0`.
+5. `scripts/smoke.sh` adds structural checks (custom-worker skill exists with valid frontmatter, schema doc exists with required-field section, ADR-0002 status `Proposed`, plugin.json version bumped, `custom-workers` keyword present). Drive-by fix: check 11 accepts `Proposed|Accepted` (ADR-0001 drifted to `Accepted` upstream without a smoke update).
+
+## What this is not
+
+- Not a generic job runner. `CronCreate` is the executor; the skill is a registration helper.
+- Not secret management. Manifests must not carry plaintext secrets; they reference wrapper scripts that read from disk.
+- Not lifecycle. No update / delete from the skill itself — that's `CronList` + `CronDelete` on the operator side.
+- Not a competitor to the 12 built-in triggers. Custom workers run alongside, in a separate namespace, with separate observability.
+
+## Consequences
+
+**Positive:**
+
+- Consumer plugins (AgentVille L4 first, others later) have a canonical place to declare their cron workers instead of duplicating wrapper-script + `CronCreate` boilerplate.
+- The skill makes operator workflow auditable: every custom worker registered through this surface goes through one validation path and one `CronList` discovery.
+- Additive change. Existing 12-trigger workflow is untouched.
+
+**Negative:**
+
+- Two parallel surfaces (12 fixed triggers + custom manifest). README needs to clarify which to use when, otherwise newcomers will pick wrong.
+- Manifest validation lives in the skill (model-interpreted), not in a runnable validator. A future hardening could add a JSON Schema + validator script; deferred per minimal-surface principle.
+
+## Verification
+
+```bash
+bash plugins/ruflo-loop-workers/scripts/smoke.sh
+# Expected after this PR: "16 passed, 0 failed"
+```
+
+End-to-end smoke that exercises the skill against a fixture manifest is out of scope for this contract PR; the schema doc + skill prompt are the verification artifacts.
+
+## Related
+
+- ADR-0001 — 12-trigger contract (this ADR is additive; the trigger map is unchanged)
+- AgentVille L4 design spec §7.5 — the motivating consumer (out-of-repo)
+- AgentVille L4 deployment runbook — the bridge before this manifest schema existed; documents three concrete `CronCreate` / cron / systemd recipes that the manifest schema now generalises
+
+## Implementation status
+
+Proposed in PR #(TBD) to `ruvnet/ruflo`. Plugin version bumps `0.2.0 → 0.3.0` in the same PR.

--- a/plugins/ruflo-loop-workers/docs/custom-worker-manifest.md
+++ b/plugins/ruflo-loop-workers/docs/custom-worker-manifest.md
@@ -1,0 +1,79 @@
+# Custom worker manifest
+
+Schema and conventions for the optional custom-worker manifest consumed by the [`register-custom-workers`](../skills/register-custom-workers/SKILL.md) skill. Introduced in v0.3.0 ([ADR-0002](./adrs/0002-custom-worker-manifest.md)).
+
+## Purpose
+
+The 12 built-in triggers (`audit`, `optimize`, etc.) dispatch through `mcp__claude-flow__hooks_worker-dispatch` and cover the common cross-plugin cases. A consumer plugin or downstream project sometimes needs to schedule its own recurring task that doesn't fit those triggers — e.g. AgentVille's L4 deterministic anomaly tick. The custom-worker manifest is the contract surface for that case: declare the worker once in YAML, register all entries through `CronCreate` via the skill.
+
+## Schema
+
+```yaml
+version: 1
+workers:
+  - name: <kebab-case identifier, required>
+    schedule: '<5-field cron expression, required>'
+    command: [<arg0>, <arg1>, ...]   # non-empty list of strings, required
+    cwd: '<absolute path>'           # optional
+    env:                             # optional
+      KEY: VALUE
+    timeout_seconds: <positive int>  # optional, advisory
+    token_budget: <non-negative int> # optional, advisory (0 = deterministic)
+    description: '<one line>'        # optional
+```
+
+### Required fields
+
+| Field      | Type   | Constraints                                                                                                      |
+| ---------- | ------ | ---------------------------------------------------------------------------------------------------------------- |
+| `name`     | string | Kebab-case identifier (`^[a-z][a-z0-9-]*$`). Must be unique within the manifest. Used in operator-facing reports |
+| `schedule` | string | 5-field POSIX cron expression (`m h dom mon dow`). `CronCreate` is the executor; it accepts the standard syntax  |
+| `command`  | list   | Non-empty list of strings. Joined by single spaces when the skill builds the `Bash:` invocation                  |
+
+### Optional fields
+
+| Field             | Type         | Default                | Notes                                                                                                                       |
+| ----------------- | ------------ | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `cwd`             | string       | (operator's PWD)       | Absolute path. The skill prepends `cd <cwd> && ` to the command when set                                                    |
+| `env`             | object       | (none)                 | Key→string map. The skill emits `KEY=VALUE` pairs before the command. Quote values that contain spaces                      |
+| `timeout_seconds` | int          | (none)                 | Advisory. `CronCreate` does not enforce it. Surfaced in operator reports for the audit trail                                |
+| `token_budget`    | int          | (none)                 | Advisory. `0` signals a deterministic worker (no LLM). Surfaced in operator reports                                         |
+| `description`     | string       | (none)                 | One-line summary shown alongside the registered cron ID                                                                     |
+
+## Example: AgentVille L4 deterministic anomaly tick
+
+```yaml
+# .ruflo/custom-workers.yaml in the AgentVille project root
+version: 1
+workers:
+  - name: agentville-l4
+    schedule: '*/15 * * * *'
+    command: ['pnpm', 'auto-ops:l4-tick', '--', '--project-root', '.']
+    cwd: '/var/lib/agentville'
+    env:
+      AGENTVILLE_AUTOOPS_ENABLED: 'true'
+      AGENTVILLE_GRAFANA_URL: 'https://grafana.example.com'
+      AGENTVILLE_GLAB_REPO: 'altitudes-cloud/ai/agentville'
+    timeout_seconds: 60
+    token_budget: 0
+    description: 'AgentVille L4 anomaly detection (Grafana + GitLab + adapter log)'
+```
+
+Registering it:
+
+```text
+Skill: ruflo-loop-workers:register-custom-workers .ruflo/custom-workers.yaml
+```
+
+The skill reads the file, validates each entry, and calls `CronCreate({ schedule: '*/15 * * * *', prompt: "Bash: cd /var/lib/agentville && AGENTVILLE_AUTOOPS_ENABLED=true AGENTVILLE_GRAFANA_URL=https://grafana.example.com AGENTVILLE_GLAB_REPO=altitudes-cloud/ai/agentville pnpm auto-ops:l4-tick -- --project-root ." })` for each worker.
+
+## What the skill does not do
+
+- **Secret expansion.** Manifest values are written into the `CronCreate` prompt verbatim. Do not put plaintext secrets in the manifest. Reference a wrapper script that reads secrets from disk (`/etc/<project>/<env>`) and `chmod 0600` the file.
+- **Timeout enforcement.** `CronCreate` runs each invocation as a normal session turn. `timeout_seconds` is informational; the consumer's command should self-terminate.
+- **Update detection.** Re-running the skill on an updated manifest does not replace existing crons; it adds new ones. To update: `CronList` to find the old ID, `CronDelete({ id })`, then re-run the skill.
+- **Cross-project deduplication.** Two manifests with the same worker name in different projects produce two cron entries. Worker names are namespacing-by-convention only.
+
+## Versioning
+
+The schema is `version: 1`. Future versions are additive; field additions land in the same major. A breaking change (field renamed, semantics shifted) bumps the schema major and the plugin's minor, with a migration note in the ADR for that release.

--- a/plugins/ruflo-loop-workers/scripts/smoke.sh
+++ b/plugins/ruflo-loop-workers/scripts/smoke.sh
@@ -7,11 +7,11 @@ step() { printf "→ %s ... " "$1"; }
 ok()   { printf "PASS\n"; PASS=$((PASS+1)); }
 bad()  { printf "FAIL: %s\n" "$1"; FAIL=$((FAIL+1)); }
 
-step "1. plugin.json declares 0.2.0 with new keywords"
+step "1. plugin.json declares 0.3.0 with new keywords"
 v=$(grep -E '"version"' "$ROOT/.claude-plugin/plugin.json" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-if [[ "$v" != "0.2.0" ]]; then bad "expected 0.2.0, got '$v'"; else
+if [[ "$v" != "0.3.0" ]]; then bad "expected 0.3.0, got '$v'"; else
   miss=""
-  for k in mcp background-workers cache-aware schedule-wakeup; do
+  for k in mcp background-workers cache-aware schedule-wakeup custom-workers; do
     grep -q "\"$k\"" "$ROOT/.claude-plugin/plugin.json" || miss="$miss $k"
   done
   [[ -z "$miss" ]] && ok || bad "missing keywords:$miss"
@@ -79,10 +79,10 @@ grep -q "ruflo-docs" "$F" || miss="$miss docs-attribution"
 grep -q "ruflo-testgen" "$F" || miss="$miss testgen-attribution"
 [[ -z "$miss" ]] && ok || bad "$miss"
 
-step "11. ADR-0001 exists with status Proposed"
+step "11. ADR-0001 exists with status Proposed or Accepted"
 ADR="$ROOT/docs/adrs/0001-loop-workers-contract.md"
-[[ -f "$ADR" ]] && grep -qE "^status:[[:space:]]*Proposed" "$ADR" \
-  && ok || bad "ADR missing or status != Proposed"
+[[ -f "$ADR" ]] && grep -qE "^status:[[:space:]]*(Proposed|Accepted)" "$ADR" \
+  && ok || bad "ADR missing or status not in {Proposed,Accepted}"
 
 step "12. no wildcard tool grants in skills"
 bad_skills=""
@@ -90,6 +90,42 @@ for f in "$ROOT"/skills/*/SKILL.md; do
   grep -q '^allowed-tools:[[:space:]]*\*' "$f" && bad_skills="$bad_skills $(basename $(dirname "$f"))"
 done
 [[ -z "$bad_skills" ]] && ok || bad "wildcard:$bad_skills"
+
+step "13. register-custom-workers skill present with valid frontmatter"
+F="$ROOT/skills/register-custom-workers/SKILL.md"
+miss=""
+[[ -f "$F" ]] || miss=" missing-file"
+if [[ -z "$miss" ]]; then
+  for k in 'name:' 'description:' 'allowed-tools:'; do
+    grep -q "^$k" "$F" || miss="$miss no-$k"
+  done
+  grep -q '^allowed-tools:.*CronCreate' "$F" || miss="$miss no-CronCreate"
+fi
+[[ -z "$miss" ]] && ok || bad "$miss"
+
+step "14. custom-worker manifest schema doc present"
+F="$ROOT/docs/custom-worker-manifest.md"
+miss=""
+[[ -f "$F" ]] || miss=" missing-file"
+if [[ -z "$miss" ]]; then
+  for s in 'version' 'name' 'schedule' 'command' 'cwd' 'env' 'timeout_seconds' 'token_budget'; do
+    grep -q "$s" "$F" || miss="$miss no-$s"
+  done
+fi
+[[ -z "$miss" ]] && ok || bad "$miss"
+
+step "15. ADR-0002 exists with status Proposed"
+ADR="$ROOT/docs/adrs/0002-custom-worker-manifest.md"
+[[ -f "$ADR" ]] && grep -qE "^status:[[:space:]]*Proposed" "$ADR" \
+  && ok || bad "ADR-0002 missing or status != Proposed"
+
+step "16. README references the custom-workers schema and skill"
+F="$ROOT/README.md"
+miss=""
+grep -q "custom-worker-manifest" "$F" || miss="$miss no-schema-link"
+grep -q "register-custom-workers" "$F" || miss="$miss no-skill-link"
+grep -q "Custom workers" "$F" || miss="$miss no-section"
+[[ -z "$miss" ]] && ok || bad "$miss"
 
 printf "\n%s passed, %s failed\n" "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/ruflo-loop-workers/skills/register-custom-workers/SKILL.md
+++ b/plugins/ruflo-loop-workers/skills/register-custom-workers/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: register-custom-workers
+description: Register consumer-defined background workers from a YAML manifest as CronCreate schedules
+argument-hint: "<manifest-path>"
+allowed-tools: Read CronCreate CronList CronDelete
+---
+
+Use this skill when a consumer plugin (or downstream project) ships its own recurring worker that doesn't map to one of the 12 built-in triggers (`audit`, `optimize`, ..., `testgaps`). The built-ins dispatch through `mcp__claude-flow__hooks_worker-dispatch`; custom workers run arbitrary `Bash` commands on a cron schedule via `CronCreate`.
+
+## Manifest schema
+
+Canonical schema at `docs/custom-worker-manifest.md` in this plugin. Minimal example:
+
+```yaml
+version: 1
+workers:
+  - name: agentville-l4
+    schedule: '*/15 * * * *'
+    command: ['pnpm', 'auto-ops:l4-tick', '--', '--project-root', '.']
+    cwd: '/var/lib/agentville'
+    env:
+      AGENTVILLE_GLAB_REPO: 'org/repo'
+    timeout_seconds: 60
+```
+
+## Workflow
+
+1. Read the manifest file at the path supplied by the operator.
+2. Validate top-to-bottom. Stop before any `CronCreate` if validation fails — registration is all-or-nothing:
+   - `version` must be the integer `1`.
+   - `workers` must be a non-empty list.
+   - Each worker requires `name` (kebab-case identifier), `schedule` (5-field cron expression), and `command` (non-empty list of strings).
+   - `cwd`, `env`, `timeout_seconds`, `token_budget`, `description` are optional.
+   - Worker `name`s must be unique within the manifest.
+3. For each worker, build a single-line shell command:
+   - `cd <cwd> && <KEY=VAL ...> <command joined by spaces>`
+   - Omit the `cd` clause when `cwd` is absent.
+   - Omit the env prefix when `env` is empty.
+4. Call `CronCreate({ schedule: <worker.schedule>, prompt: "Bash: " + <built command> })` for each worker, in manifest order.
+5. After all registrations succeed, call `CronList` and report each registered cron ID alongside its worker name to the operator.
+
+## Updating or removing a worker
+
+`CronCreate` does not deduplicate. To update a worker:
+
+1. `CronList` to find the existing cron ID by matching the prompt prefix.
+2. `CronDelete({ id })` to drop it.
+3. Re-run this skill against the updated manifest.
+
+## Notes
+
+- `timeout_seconds` and `token_budget` are advisory. `CronCreate` does not enforce them. Surface them in the operator-facing report so the audit trail is complete.
+- The skill does not start, stop, or monitor running workers. For active worker management of the 12 built-in triggers, use `mcp__claude-flow__hooks_worker-status` and `mcp__claude-flow__hooks_worker-cancel` via the `loop-worker-coordinator` agent.
+- Custom workers do not contribute to the `worker-history` namespace; that namespace is reserved for the 12 built-ins per ADR-0001.


### PR DESCRIPTION
## Summary

Adds a thin, additive surface for consumer plugins (and downstream projects) to declare their own recurring workers in a YAML manifest and register each as a `CronCreate` schedule via a new skill. The 12 built-in triggers continue to dispatch through `mcp__claude-flow__hooks_worker-dispatch` unchanged; custom workers run alongside, in a separate registration path.

**Marked draft so the design can be redirected before merge.** Happy to rework the schema, naming, or scope based on your read.

## Motivating consumer

AgentVille's L4 deterministic anomaly tick. The L4 spec [§7.5](https://gitlab.com/altitudes-cloud/ai/agentville/-/blob/main/docs/superpowers/specs/2026-05-16-auto-ops-l4-loop-worker-design.md) defines a manifest contract; AgentVille's [deployment runbook](https://gitlab.com/altitudes-cloud/ai/agentville/-/blob/main/docs/runbooks/2026-05-16-auto-ops-l4-deployment.md) currently documents three concrete cron recipes (CronCreate, Unix cron, systemd) the operator picks from. Generalising that surface here so consumers declare once in YAML, the skill walks the entries through `CronCreate`.

## What changed

- **`plugin.json`**: bump `0.2.0 → 0.3.0`; add `custom-workers` keyword.
- **`skills/register-custom-workers/SKILL.md`**: new skill. Reads a manifest, validates all-or-nothing, builds the per-worker `Bash:` invocation, calls `CronCreate`, reports cron IDs back to the operator. `allowed-tools: Read CronCreate CronList CronDelete`.
- **`docs/custom-worker-manifest.md`**: canonical schema. Required fields: `name`, `schedule`, `command`. Optional: `cwd`, `env`, `timeout_seconds`, `token_budget`, `description`. Pinned at `version: 1`.
- **`docs/adrs/0002-custom-worker-manifest.md`**: rationale, scope, what-this-is-not (job runner / secret manager / lifecycle).
- **`README.md`**: new "Custom workers" section linking to schema + skill, plus ADR-0002 in Architecture Decisions.
- **`scripts/smoke.sh`**: +4 checks for the new surface, bumps the version check from `0.2.0` to `0.3.0`. Drive-by fix on check 11: accepts `Proposed|Accepted` (ADR-0001 had drifted to `Accepted` upstream without a matching smoke update; check 11 was failing pre-PR).

## Scope discipline

What this PR is **not**:

- Not a generic job runner. `CronCreate` is the executor; the skill is a registration helper.
- Not secret management. Manifests must not carry plaintext secrets; they reference wrapper scripts that read from disk.
- Not lifecycle. No update / delete from the skill itself — that's `CronList` + `CronDelete` on the operator side.
- Not a competitor to the 12 built-in triggers. Custom workers run alongside, in a separate namespace, with separate observability.

## Verification

```bash
bash plugins/ruflo-loop-workers/scripts/smoke.sh
# Expected: 16 passed, 0 failed
```

Before this PR: 11 passed, 1 failed (the pre-existing ADR-0001 status drift).
After this PR: 16 passed, 0 failed (12 originals + 4 new, with check 11 relaxed).

## Open questions for the maintainer

1. **Scope of validation.** The skill instructs the model to validate the manifest. A future hardening could ship a JSON Schema + a runnable validator (Node? Python? Bash + jq + yq?). Worth doing now, or defer until a second consumer lands?
2. **Worker name namespacing.** The schema treats `name` as a free-form kebab-case identifier with uniqueness only within a manifest. Should cross-project name collision be a real concern (e.g. prefix worker names with the plugin/project key)?
3. **Plugin layout.** I added the skill under the existing `ruflo-loop-workers` plugin to keep the surface in one place. Would you prefer a sibling plugin (`ruflo-custom-workers`) to keep the 12-trigger contract pristine?

Happy to iterate. AgentVille L4 will adopt whatever shape this lands in.