### PR TITLE
fix(financial-risk): guard monteCarloSimulation against empty input

### DIFF
--- a/v3/plugins/financial-risk/src/bridges/economy-bridge.ts
+++ b/v3/plugins/financial-risk/src/bridges/economy-bridge.ts
@@ -197,6 +197,12 @@ export class PortfolioRiskCalculator {
     horizon: number = 252,
     seed?: number
   ): number[] {
+    // Empty input would make mean = 0/0 = NaN and silently poison every scenario.
+    // Match the sentinel-on-empty pattern used elsewhere in this class.
+    if (portfolioReturns.length === 0) {
+      return [];
+    }
+
     // Simple random number generator with seed
     let rng = seed !== undefined ? this.seededRandom(seed) : Math.random;
 

--- a/v3/plugins/financial-risk/tests/bridges.test.ts
+++ b/v3/plugins/financial-risk/tests/bridges.test.ts
@@ -170,6 +170,21 @@ describe('FinancialEconomyBridge', () => {
       expect(bridge.initialized).toBe(false);
     });
   });
+
+  describe('Edge cases - empty input', () => {
+    beforeEach(async () => {
+      await bridge.initialize();
+    });
+
+    it('simulateMonteCarlo must not silently produce NaN scenarios on empty portfolio', async () => {
+      const result = await bridge.simulateMonteCarlo(new Float32Array([]), 10, 5);
+      // JS fallback: mean = 0/0 = NaN poisons every scenario. Either return an
+      // empty result (signal no data) or finite scenarios, but never NaN -
+      // callers can't tell NaN-poisoning apart from a successful simulation.
+      const containsNaN = Array.from(result).some((v) => Number.isNaN(v));
+      expect(containsNaN).toBe(false);
+    });
+  });
 });
 
 describe('FinancialSparseBridge', () => {


### PR DESCRIPTION
`monteCarloSimulation` divided by `portfolioReturns.length` with no length guard. Empty input gave `mean = 0/0 = NaN`, which then poisoned every scenario via `cumulativeReturn += mean + std * z`. The wrapper `simulateMonteCarlo` returned a `Float32Array` full of NaN with no indication anything was wrong.

Matched the existing sentinel-on-empty pattern from the surrounding helpers (`calculateVolatility`, `calculateSharpe`, etc.) - return an empty array on empty input.

Test results:

```
$ vitest run tests/bridges.test.ts
Test Files  1 passed (1)
     Tests  29 passed (29)
```

Verified the new test actually catches the bug by reverting the guard and re-running:

```
expected true to be false
expect(containsNaN).toBe(false)
```

Closes #2024
