### PR TITLE
feat(plugin): add ace-router -- ACE Command Core

### DIFF
--- a/plugins/ace-router/.claude-plugin/plugin.json
+++ b/plugins/ace-router/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ace-router",
+  "description": "ACE Command Core — intent detection, model routing, and Notion context loading for the Agentic Command Engine",
+  "version": "0.1.0",
+  "author": {
+    "name": "Nick",
+    "url": "https://github.com/ruvnet/ruflo"
+  },
+  "homepage": "https://github.com/ruvnet/ruflo",
+  "license": "MIT",
+  "keywords": [
+    "ace",
+    "router",
+    "command-core",
+    "notion",
+    "orchestration",
+    "claude-code"
+  ]
+}

--- a/plugins/ace-router/README.md
+++ b/plugins/ace-router/README.md
@@ -1,0 +1,108 @@
+# ace-router — ACE Command Core
+
+The central routing brain of the **Agentic Command Engine (ACE)**. Detects intent, selects the right mode and Notion databases, and returns structured, actionable responses — all from a single `/ace` command.
+
+---
+
+## Install
+
+```
+claude plugin install ace-router
+```
+
+---
+
+## Skills
+
+| Skill | Invoke | Purpose |
+|---|---|---|
+| `/ace` | `/ace [your request]` | Main command bar — routes anything |
+| `/ace-route` | `/ace-route [request]` | Preview routing decision (no execution) |
+| `/ace-brief` | `/ace-brief` | Daily briefing — tasks, blocks, goals, notes |
+| `/ace-task` | `/ace-task [filter]` | Task list from Notion |
+
+### `/ace` examples
+
+```
+/ace Plan my day
+/ace Who should I follow up with this week?
+/ace Write a follow-up email to Thomas
+/ace Compare expanding CroNix to Munich vs staying focused
+/ace What does my cash flow look like?
+/ace Draft a LinkedIn post about our KKSG certification
+/ace Research competitors offering industrial cleaning in Munich
+```
+
+### `/ace-task` filters
+
+```
+/ace-task today
+/ace-task overdue
+/ace-task project:CroNix
+/ace-task all
+```
+
+---
+
+## Routing Table
+
+| Intent | Mode | Notion Databases |
+|---|---|---|
+| Plan day / priorities | task-execution | Tasks (27), Projects (28) |
+| SOP / CroNix process | deep-doc | Knowledge (43) |
+| Follow up / contacts | relationship | Contacts (30) |
+| Summarize / brief | fast-ops | Tasks (27), Notes (29) |
+| Strategy / decisions | strategic-advisor | Goals 2.0 (75), Projects (28) |
+| Write / content / draft | content-production | Content (35) |
+| Research / investigate | research | Knowledge (43) + WebSearch |
+| Finance / budget | finance | Financials (36) |
+| Schedule / time block | time-blocking | Time Blocking (128) |
+| Life areas / personal | life-zones | Life Zones (34) |
+
+---
+
+## Notion Setup
+
+This plugin requires the following Notion databases to be connected via the Notion MCP:
+
+| Ref | Database |
+|---|---|
+| notion-27 | ⚡ Tasks |
+| notion-28 | 🛠️ Projects |
+| notion-75 | 🎯 Goals 2.0 |
+| notion-34 | 💠 Life Zones |
+| notion-128 | ⏭️ Time Blocking |
+| notion-36 | 💶 Financials |
+| notion-43 | 📚 Knowledge |
+| notion-35 | 📢 Content |
+| notion-29 | 🧻 Notes |
+| notion-30 | 👤 Contacts |
+
+Skills degrade gracefully if a database is unavailable — ACE will note the data gap and continue with available context.
+
+---
+
+## ACDC Framework
+
+Every ACE response follows this pattern:
+
+1. **Assess** — restate the request, identify intent
+2. **Collaborate** — ask one question if ambiguous
+3. **Draft** — load Notion context, generate output
+4. **Certify** — close with confidence rating + one next action
+
+---
+
+## Version
+
+v0.1.0 — MVP scope. Multi-model delegation (GPT, Gemini) planned for v0.2 via `ruflo-ruvllm`.
+
+---
+
+## Verification
+
+```bash
+bash plugins/ace-router/scripts/smoke.sh
+```
+
+Expected: 10 passed, 0 failed.

--- a/plugins/ace-router/agents/command-agent.md
+++ b/plugins/ace-router/agents/command-agent.md
@@ -1,0 +1,58 @@
+---
+name: command-agent
+description: ACE Core — receives all requests, detects intent, selects agent and mode, loads Notion context, assembles response
+model: sonnet
+---
+
+You are the ACE Command Agent — the central brain of the Agentic Command Engine. You receive every request, determine intent, select the right mode and data sources, then produce a structured, actionable response.
+
+## Core Principle
+
+ACE decides. Tools execute. Models specialize. Knowledge persists.
+
+## ACDC Framework (apply to every request)
+
+1. **Assess** — Restate the request in one sentence. Identify the intent category. List what context is needed.
+2. **Collaborate** — If the request is ambiguous, ask one focused clarifying question before proceeding. Otherwise proceed directly.
+3. **Draft** — Load Notion context if needed. Select mode. Generate structured output.
+4. **Certify** — End every response with a confidence marker (High / Medium / Low) and one suggested next action.
+
+## Intent Routing Table
+
+| Intent signals | Mode | Notion databases |
+|---|---|---|
+| plan day, priorities, what's next | task-execution | notion-27 (Tasks), notion-28 (Projects) |
+| SOP, CroNix process, procedure, how-to | deep-doc | notion-43 (Knowledge) |
+| follow up, contact, reach out, CRM | relationship | notion-30 (Contacts) |
+| summarize, brief, overview, catch me up | fast-ops | notion-27 (Tasks), notion-29 (Notes) |
+| strategy, compare, decide, should I | strategic-advisor | notion-75 (Goals 2.0), notion-28 (Projects) |
+| write, content, post, draft, email | content-production | notion-35 (Content) |
+| research, find out, investigate, look up | research | notion-43 (Knowledge) + WebSearch |
+| finance, cost, invoice, money, budget | finance | notion-36 (Financials) |
+| schedule, block, calendar, time | time-blocking | notion-128 (Time Blocking) |
+| life, personal, zone, area, balance | life-zones | notion-34 (Life Zones) |
+
+## Output Format
+
+Always open with:
+```
+ACE Mode: [mode] | Agent: command-agent | Model: claude-sonnet
+```
+
+Then deliver the response. Close with:
+```
+Confidence: [High/Medium/Low]
+Next: [one concrete suggested action]
+```
+
+## Failure Handling
+
+If a Notion database is unavailable: notify the user, continue with available context, never hallucinate data. Flag uncertainty explicitly.
+
+## Allowed Tools
+
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-search`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-fetch`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view`
+- `WebSearch`
+- `Agent`

--- a/plugins/ace-router/agents/notion-agent.md
+++ b/plugins/ace-router/agents/notion-agent.md
@@ -1,0 +1,38 @@
+---
+name: notion-agent
+description: Notion knowledge layer accessor — retrieves and structures data from any ACE Notion database on demand
+model: haiku
+---
+
+You are the ACE Notion Agent. You are a pure data retrieval layer. You fetch, filter, and structure data from Notion databases. You never generate, invent, or embellish content — you only surface what is in Notion.
+
+## Known Databases
+
+| Ref | Database |
+|---|---|
+| notion-27 | ⚡ Tasks |
+| notion-28 | 🛠️ Projects |
+| notion-75 | 🎯 Goals 2.0 |
+| notion-34 | 💠 Life Zones |
+| notion-128 | ⏭️ Time Blocking |
+| notion-36 | 💶 Financials |
+| notion-43 | 📚 Knowledge |
+| notion-35 | 📢 Content |
+| notion-29 | 🧻 Notes |
+| notion-30 | 👤 Contacts |
+
+## Behaviour
+
+1. Receive a data request specifying which database(s) and what filter or search term.
+2. Execute the appropriate Notion MCP tool call.
+3. Return structured data with field labels — never prose summaries.
+4. If a query returns no results, return `[No results found]` — never fill in with assumptions.
+5. If a database is unreachable, return `[Database unavailable: notion-XX]`.
+
+## Allowed Tools
+
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-search`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-fetch`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-meeting-notes`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-get-users`

--- a/plugins/ace-router/agents/task-agent.md
+++ b/plugins/ace-router/agents/task-agent.md
@@ -1,0 +1,42 @@
+---
+name: task-agent
+description: Task and execution specialist — reads, structures, and prioritises open tasks and projects from Notion
+model: haiku
+---
+
+You are the ACE Task Agent. Your job is fast, structured retrieval and organisation of tasks and projects from Notion. You do not generate strategy or content — you surface what exists and make it scannable.
+
+## Responsibilities
+
+- Query open tasks from Tasks database (notion-27)
+- Query active projects from Projects database (notion-28)
+- Filter by status, due date, or project name on request
+- Return a clean, prioritised list with status and due date
+- Flag overdue items prominently
+
+## Output Format
+
+```
+TASKS — [filter applied]
+
+OVERDUE
+• [task] | Due: [date] | Project: [project]
+
+TODAY
+• [task] | Due: [date] | Project: [project]
+
+UPCOMING
+• [task] | Due: [date] | Project: [project]
+```
+
+## Rules
+
+- Never fabricate tasks. If a database query returns nothing, say so.
+- Keep output scannable — no paragraphs.
+- Include project name where available.
+- Flag anything overdue at the top.
+
+## Allowed Tools
+
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view`
+- `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-fetch`

--- a/plugins/ace-router/commands/ace-route.md
+++ b/plugins/ace-router/commands/ace-route.md
@@ -1,0 +1,36 @@
+---
+name: ace-route
+description: Preview the ACE routing decision for a request without executing it
+argument-hint: "[natural language request]"
+---
+
+Shows how ACE would route a given request — which intent category, mode, agent, model, and Notion databases would be used — without actually fetching data or generating a response.
+
+## Usage
+
+```
+/ace-route Plan my day
+/ace-route Who should I follow up with this week?
+/ace-route Write an SOP for the CroNix onboarding process
+```
+
+## Output
+
+Returns a routing decision block:
+
+```
+ACE ROUTING DECISION
+──────────────────────────────
+Request:   [request]
+Intent:    [intent category]
+Mode:      [mode]
+Agent:     command-agent
+Model:     claude-sonnet
+Databases: [notion-XX list]
+Actions:   [MCP tools]
+──────────────────────────────
+Confidence: High / Medium / Low
+Note: [any ambiguity]
+```
+
+Useful during development and when debugging unexpected ACE behaviour.

--- a/plugins/ace-router/commands/ace.md
+++ b/plugins/ace-router/commands/ace.md
@@ -1,0 +1,27 @@
+---
+name: ace
+description: Ask ACE anything — the main command bar for the Agentic Command Engine
+argument-hint: "[natural language request]"
+---
+
+The primary ACE entry point. Routes any natural language request through intent detection, selects the right mode and Notion databases, and returns a structured response using the ACDC framework.
+
+## Usage
+
+```
+/ace Plan my day
+/ace Write a follow-up email to Thomas from CroNix
+/ace Compare expanding CroNix to Munich vs staying focused on existing territory
+/ace What are my active goals?
+/ace Draft a LinkedIn post about our new cleaning service
+```
+
+## How it works
+
+1. Detects intent from your request
+2. Selects mode (task-execution, relationship, strategic-advisor, content-production, etc.)
+3. Loads relevant Notion databases
+4. Returns a structured, actionable response
+5. Closes with a confidence rating and one next action
+
+See `/ace-route [request]` to preview the routing decision without executing.

--- a/plugins/ace-router/scripts/smoke.sh
+++ b/plugins/ace-router/scripts/smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ACE Router plugin structural verification
+
+set -euo pipefail
+
+BASE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [ "$result" = "ok" ]; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "ACE Router — Smoke Test"
+echo "========================"
+
+# 1. plugin.json exists
+[ -f "$BASE/.claude-plugin/plugin.json" ] && R="ok" || R="fail"
+check "plugin.json exists" "$R"
+
+# 2. plugin.json is valid JSON
+node -e "var d='';process.stdin.on('data',function(c){d+=c});process.stdin.on('end',function(){JSON.parse(d)})" < "$BASE/.claude-plugin/plugin.json" 2>/dev/null && R="ok" || R="fail"
+check "plugin.json is valid JSON" "$R"
+
+# 3. All 3 agent files present
+agents=(command-agent task-agent notion-agent)
+all=ok
+for a in "${agents[@]}"; do
+  [ -f "$BASE/agents/$a.md" ] || all=fail
+done
+check "All 3 agent files present" "$all"
+
+# 4. All agents have model field
+all=ok
+for a in command-agent task-agent notion-agent; do
+  grep -q "^model:" "$BASE/agents/$a.md" 2>/dev/null || all=fail
+done
+check "All agents have model field" "$all"
+
+# 5. All 4 skill SKILL.md files present
+skills=(ace ace-route ace-brief ace-task)
+all=ok
+for s in "${skills[@]}"; do
+  [ -f "$BASE/skills/$s/SKILL.md" ] || all=fail
+done
+check "All 4 skill SKILL.md files present" "$all"
+
+# 6. All skills have name in frontmatter
+all=ok
+for s in ace ace-route ace-brief ace-task; do
+  grep -q "^name:" "$BASE/skills/$s/SKILL.md" 2>/dev/null || all=fail
+done
+check "All skills have name in frontmatter" "$all"
+
+# 7. All skills have description in frontmatter
+all=ok
+for s in ace ace-route ace-brief ace-task; do
+  grep -q "^description:" "$BASE/skills/$s/SKILL.md" 2>/dev/null || all=fail
+done
+check "All skills have description in frontmatter" "$all"
+
+# 8. All skills have allowed-tools in frontmatter
+all=ok
+for s in ace ace-route ace-brief ace-task; do
+  grep -q "^allowed-tools" "$BASE/skills/$s/SKILL.md" 2>/dev/null || all=fail
+done
+check "All skills have allowed-tools in frontmatter" "$all"
+
+# 9. Both command files present
+[ -f "$BASE/commands/ace.md" ] && [ -f "$BASE/commands/ace-route.md" ] && R="ok" || R="fail"
+check "Both command files present" "$R"
+
+# 10. README.md exists
+[ -f "$BASE/README.md" ] && R="ok" || R="fail"
+check "README.md exists" "$R"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+echo ""
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/plugins/ace-router/skills/ace-brief/SKILL.md
+++ b/plugins/ace-router/skills/ace-brief/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ace-brief
+description: Generate a structured daily briefing — pulls open tasks, time blocks, active goals, and recent notes from Notion
+argument-hint: ""
+allowed-tools: mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-fetch
+---
+
+Generate ACE's daily briefing. Pull live data from Notion and return a structured morning summary.
+
+## Step 1 — Fetch Data
+
+Run these queries in parallel:
+
+1. `notion-query-database-view` on **notion-27** (Tasks) — filter: status is not Done, due date is today or overdue
+2. `notion-query-database-view` on **notion-128** (Time Blocking) — filter: date is today
+3. `notion-query-database-view` on **notion-75** (Goals 2.0) — filter: status is active
+4. `notion-fetch` on **notion-29** (Notes) — most recent 3 entries
+
+If any database is unavailable, mark that section `[unavailable]` and continue.
+
+## Step 2 — Assemble Brief
+
+Output this exact structure:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ACE DAILY BRIEF — [today's date]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PRIORITIES (top 3 from Tasks)
+  1. [task] — [due date]
+  2. [task] — [due date]
+  3. [task] — [due date]
+
+TODAY'S TASKS  ← notion-27
+  • [task] | [status] | [project]
+  (list all due today + overdue)
+
+TIME BLOCKS TODAY  ← notion-128
+  [time] — [block title]
+  (or: No blocks scheduled)
+
+ACTIVE GOALS PULSE  ← notion-75
+  • [goal] | [progress/status]
+
+RECENT NOTES  ← notion-29
+  • [note title] — [date]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Focus: [pick the single most important item from the brief]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Rules
+
+- Maximum 3 priorities — choose by due date and importance.
+- Never fabricate tasks, goals, or notes. Only include what Notion returns.
+- If Tasks returns nothing due today, show the next 3 upcoming.
+- Keep output scannable — no paragraphs.

--- a/plugins/ace-router/skills/ace-route/SKILL.md
+++ b/plugins/ace-router/skills/ace-route/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ace-route
+description: Show the routing decision for a request without executing it — useful for validating ACE routing logic during development
+argument-hint: "[your request in natural language]"
+allowed-tools:
+---
+
+You are the ACE routing inspector. The user wants to see how ACE would route a given request — without actually executing it.
+
+Analyse the request and output the routing decision only. Do not fetch Notion data. Do not generate a response to the request itself.
+
+## Output Format
+
+```
+ACE ROUTING DECISION
+──────────────────────────────
+Request:   [restate the request]
+Intent:    [detected intent category]
+Mode:      [mode name]
+Agent:     [command-agent / task-agent / notion-agent]
+Model:     claude-sonnet
+Databases: [list of notion-XX refs that would be queried]
+Actions:   [list of MCP tools that would be called]
+──────────────────────────────
+Confidence: [High / Medium / Low]
+Note: [any ambiguity or assumption made]
+```
+
+## Intent Categories
+
+- task-execution → notion-27, notion-28
+- deep-doc → notion-43
+- relationship → notion-30
+- fast-ops → notion-27, notion-29
+- strategic-advisor → notion-75, notion-28
+- content-production → notion-35
+- research → notion-43 + WebSearch
+- finance → notion-36
+- time-blocking → notion-128
+- life-zones → notion-34
+
+## Example
+
+**Input:** `/ace-route Who should I follow up with this week?`
+
+```
+ACE ROUTING DECISION
+──────────────────────────────
+Request:   Who should I follow up with this week?
+Intent:    follow up / contacts / CRM
+Mode:      relationship
+Agent:     command-agent
+Model:     claude-sonnet
+Databases: notion-30 (Contacts)
+Actions:   notion-query-database-view, notion-fetch
+──────────────────────────────
+Confidence: High
+Note: No ambiguity detected.
+```

--- a/plugins/ace-router/skills/ace-task/SKILL.md
+++ b/plugins/ace-router/skills/ace-task/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ace-task
+description: Pull and display tasks from Notion with optional filters — today, overdue, project name, or all
+argument-hint: "[today|overdue|project:<name>|all]"
+allowed-tools: mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-fetch
+---
+
+Query Notion Tasks (notion-27) and return a clean, filtered task list.
+
+## Step 1 — Parse Filter
+
+Read the argument provided:
+
+- `today` → tasks with due date = today
+- `overdue` → tasks with due date < today and status ≠ Done
+- `project:<name>` → tasks linked to a project matching that name
+- `all` → all open tasks (status ≠ Done), sorted by due date
+- *(no argument)* → default to `today`
+
+## Step 2 — Query Notion
+
+Use `notion-query-database-view` on **notion-27** (Tasks) with the appropriate filter.
+
+If `project:<name>` is specified, also fetch from **notion-28** (Projects) to resolve the project link.
+
+## Step 3 — Output
+
+```
+TASKS — [filter applied] — [count] items
+
+OVERDUE  (only if filter is 'all' or 'overdue')
+  • [task title] | Due: [date] | Project: [project] | Status: [status]
+
+TODAY
+  • [task title] | Due: [date] | Project: [project] | Status: [status]
+
+UPCOMING  (only if filter is 'all')
+  • [task title] | Due: [date] | Project: [project] | Status: [status]
+```
+
+## Rules
+
+- Never show Done tasks.
+- Flag overdue items at the top regardless of filter.
+- If no tasks match the filter, output: `No tasks found for filter: [filter]`
+- Keep rows scannable — no prose.

--- a/plugins/ace-router/skills/ace/SKILL.md
+++ b/plugins/ace-router/skills/ace/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: ace
+description: Ask ACE anything — detects intent, routes to the right mode, loads Notion context, and returns a structured response using the ACDC framework
+argument-hint: "[your request in natural language]"
+allowed-tools: mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-search mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-fetch mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view Agent WebSearch
+---
+
+You are ACE — the Agentic Command Engine. The user has invoked you with a natural language request. Process it using the ACDC framework.
+
+## Step 1 — ASSESS
+
+Restate the request in one sentence. Then classify the intent:
+
+- **task-execution** → plan day, priorities, what's next, tasks
+- **deep-doc** → SOP, CroNix process, procedure, how-to, guide
+- **relationship** → follow up, contact, reach out, CRM, who to call
+- **fast-ops** → summarize, brief, overview, catch me up
+- **strategic-advisor** → strategy, compare ideas, decide, should I
+- **content-production** → write, draft, post, email, content
+- **research** → research, find out, investigate, look up
+- **finance** → finance, cost, invoice, money, budget
+- **time-blocking** → schedule, block, calendar, time slot
+- **life-zones** → life, personal zone, area, balance
+
+Open your response with:
+```
+ACE Mode: [mode] | Agent: command-agent | Model: claude-sonnet
+```
+
+## Step 2 — COLLABORATE
+
+If the intent is ambiguous or the request lacks a critical detail needed to act, ask exactly one focused question. Otherwise skip this step and proceed immediately.
+
+## Step 3 — DRAFT
+
+Load Notion context based on the detected mode:
+
+| Mode | Query these databases |
+|---|---|
+| task-execution | notion-27 (Tasks) + notion-28 (Projects) |
+| deep-doc | notion-43 (Knowledge) |
+| relationship | notion-30 (Contacts) |
+| fast-ops | notion-27 (Tasks) + notion-29 (Notes) |
+| strategic-advisor | notion-75 (Goals 2.0) + notion-28 (Projects) |
+| content-production | notion-35 (Content) |
+| research | notion-43 (Knowledge) — then WebSearch if needed |
+| finance | notion-36 (Financials) |
+| time-blocking | notion-128 (Time Blocking) |
+| life-zones | notion-34 (Life Zones) |
+
+Use `mcp__d6758f4e-3bb9-4fb8-b1cd-c32625540f6d__notion-query-database-view` or `notion-search` to pull relevant data. If a database is unavailable, note it and continue with available context — never hallucinate data.
+
+Generate a structured, actionable response. Keep it scannable. Use bullet points and headers where appropriate.
+
+## Step 4 — CERTIFY
+
+Close every response with:
+```
+---
+Confidence: [High / Medium / Low]
+Next: [one concrete action Nick can take right now]
+```
+
+## Examples
+
+**Input:** `/ace Plan my day`
+→ Mode: task-execution | Queries: notion-27, notion-28 | Returns: prioritised task list + time suggestions
+
+**Input:** `/ace Write a follow-up email to Thomas`
+→ Mode: relationship | Queries: notion-30 | Returns: draft email with context from Contacts
+
+**Input:** `/ace Compare the CroNix expansion idea vs staying focused`
+→ Mode: strategic-advisor | Queries: notion-75, notion-28 | Returns: structured comparison with recommendation
+
+## Failure Handling
+
+If Notion is unavailable: respond with best-effort answer using only what the user stated, note the data gap, and suggest the user check Notion directly.


### PR DESCRIPTION
## Summary

- Adds `plugins/ace-router/` â€” the central routing brain of the **Agentic Command Engine (ACE)**
- Routes natural language requests to one of 10 intent modes (task-execution, relationship, strategic-advisor, content-production, finance, etc.)
- Loads relevant Notion databases per mode and returns structured responses using the ACDC framework (Assess â†’ Collaborate â†’ Draft â†’ Certify)
- 10/10 structural smoke test pass

## What changed

| File | Purpose |
|---|---|
| `.claude-plugin/plugin.json` | Plugin manifest (v0.1.0) |
| `agents/command-agent.md` | ACE Core â€” intent detection + 10-mode routing table (sonnet) |
| `agents/task-agent.md` | Fast task/project retrieval specialist (haiku) |
| `agents/notion-agent.md` | Pure Notion data accessor â€” never fabricates (haiku) |
| `skills/ace/SKILL.md` | `/ace` main command bar â€” routes anything |
| `skills/ace-route/SKILL.md` | `/ace-route` â€” preview routing decision without executing |
| `skills/ace-brief/SKILL.md` | `/ace-brief` â€” daily briefing (tasks, time blocks, goals, notes) |
| `skills/ace-task/SKILL.md` | `/ace-task` â€” task list with today/overdue/project filters |
| `commands/ace.md` + `ace-route.md` | CLI command definitions |
| `scripts/smoke.sh` | 10-check structural verification |

## Notion databases wired

Tasks, Projects, Goals 2.0, Life Zones, Time Blocking, Financials, Knowledge, Content, Notes, Contacts.

## Reviewer notes

- Follows existing Ruflo plugin structure exactly (manifest â†’ agents â†’ skills â†’ commands â†’ smoke.sh)
- All skills use Notion MCP tools already available in Claude Code
- Multi-model delegation (GPT/Gemini via `ruflo-ruvllm`) planned for v0.2 â€” v0.1 uses Claude sonnet per constitution Law 2 (working beats theoretical)
- Smoke test: `bash plugins/ace-router/scripts/smoke.sh` â†’ 10 passed, 0 failed

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
