### PR TITLE
Register ruflo-graph-intelligence in marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,6 +127,11 @@
       "description": "Cross-installation agent federation with zero-trust security, PII-gated data flow, and compliance-grade audit trails"
     },
     {
+      "name": "ruflo-graph-intelligence",
+      "source": "./plugins/ruflo-graph-intelligence",
+      "description": "Real-time graph intelligence — personalized PageRank, streaming delta updates, witness-signed reasoning, and federation-distributable vectors"
+    },
+    {
       "name": "ruflo-iot-cognitum",
       "source": "./plugins/ruflo-iot-cognitum",
       "description": "IoT device lifecycle, telemetry anomaly detection, fleet management, and witness chain verification for Cognitum Seed hardware"


### PR DESCRIPTION
## Summary

The `plugins/ruflo-graph-intelligence/` directory exists in the repo with a valid `.claude-plugin/plugin.json`, but it is not listed in `.claude-plugin/marketplace.json`. Because the Claude Code marketplace resolver only knows about plugins explicitly registered in the manifest's `plugins[]` array, the install command fails:

```
$ /plugin install ruflo-graph-intelligence@ruflo
Plugin "ruflo-graph-intelligence" not found in marketplace "ruflo"
```

This one-line addition registers the plugin, alphabetically placed between `ruflo-federation` and `ruflo-iot-cognitum` to match the ordering convention of the recent additions block.

The description follows the terse `— feature list` style used by sibling entries (`ruflo-ruvector`, `ruflo-knowledge-graph`, etc.) rather than the longer first-person tagline from the plugin's own `plugin.json`.

## Workaround for users hitting this before merge

Until this is released, the plugin can still be installed by cloning the repo and pointing `/plugin install` at the directory directly:

```
git clone https://github.com/ruvnet/ruflo /tmp/ruflo
/plugin install /tmp/ruflo/plugins/ruflo-graph-intelligence
```

That path bypasses the marketplace resolver and reads the plugin's own `plugin.json` manifest.

## Test plan

- [ ] `python3 -m json.tool .claude-plugin/marketplace.json` confirms the manifest is still valid JSON
- [ ] `/plugin install ruflo-graph-intelligence@ruflo` succeeds after merge