### PR TITLE
fix(mcp): exit cleanly on SIGTERM/SIGINT in auto-detected MCP mode

### DIFF
--- a/v3/@claude-flow/cli/__tests__/sigterm-cleanup.test.ts
+++ b/v3/@claude-flow/cli/__tests__/sigterm-cleanup.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test: bin/cli.js auto-detected MCP mode must exit on SIGTERM/SIGINT.
+ *
+ * Catches the case where a long-running stdio MCP server kept alive by stdin
+ * does not respond to termination signals and survives parent death as an
+ * orphaned process (PPID=1).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const CLI = resolve(__dirname, '..', 'bin', 'cli.js');
+const DIST = resolve(__dirname, '..', 'dist', 'src', 'mcp-client.js');
+
+describe('bin/cli.js — signal handling in MCP mode', () => {
+  it.runIf(existsSync(DIST))('exits cleanly when SIGTERM is sent', async () => {
+    const child = spawn(process.execPath, [CLI], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+
+    // Wait for the server to print its initialization line on stderr.
+    await new Promise<void>((resolve) => {
+      const onData = (buf: Buffer) => {
+        if (buf.toString().includes('Starting in stdio mode')) {
+          child.stderr?.off('data', onData);
+          resolve();
+        }
+      };
+      child.stderr?.on('data', onData);
+      setTimeout(() => resolve(), 2000);
+    });
+
+    const exitCode = await new Promise<number>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve(-1);
+      }, 5000);
+      child.once('exit', (code) => {
+        clearTimeout(timer);
+        resolve(code ?? 0);
+      });
+      child.kill('SIGTERM');
+    });
+
+    expect(exitCode).toBe(0);
+  }, 10_000);
+
+  it.runIf(existsSync(DIST))('exits cleanly when SIGINT is sent', async () => {
+    const child = spawn(process.execPath, [CLI], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+
+    await new Promise<void>((resolve) => {
+      const onData = (buf: Buffer) => {
+        if (buf.toString().includes('Starting in stdio mode')) {
+          child.stderr?.off('data', onData);
+          resolve();
+        }
+      };
+      child.stderr?.on('data', onData);
+      setTimeout(() => resolve(), 2000);
+    });
+
+    const exitCode = await new Promise<number>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve(-1);
+      }, 5000);
+      child.once('exit', (code) => {
+        clearTimeout(timer);
+        resolve(code ?? 0);
+      });
+      child.kill('SIGINT');
+    });
+
+    expect(exitCode).toBe(0);
+  }, 10_000);
+});

--- a/v3/@claude-flow/cli/bin/cli.js
+++ b/v3/@claude-flow/cli/bin/cli.js
@@ -129,6 +129,15 @@ if (isMCPMode) {
     process.exit(0);
   });
 
+  // Exit cleanly when the parent process sends a termination signal.
+  // Without these handlers, the auto-detected MCP server can survive the
+  // parent's death (e.g. when the client is killed with SIGKILL and the
+  // stdin pipe is not closed gracefully) and accumulate as an orphaned
+  // process under PPID=1. The explicit `mcp-server.js` entrypoint already
+  // registers these handlers — this brings the auto-detect path to parity.
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+
   async function handleMessage(message) {
     if (!message.method) {
       return {


### PR DESCRIPTION
The auto-detected MCP server in bin/cli.js (triggered when stdin is piped and no CLI args are provided) already exits on stdin 'end' but had no SIGTERM/SIGINT handlers. When the parent process is killed with SIGKILL or the connection drops without closing stdin gracefully, the server continues running and is reparented to init (PPID=1), where it accumulates indefinitely.

Add SIGINT and SIGTERM handlers that call process.exit(0), matching the explicit bin/mcp-server.js entrypoint which already registers both.

Adds a regression test that spawns the CLI in auto-detect MCP mode, sends each signal, and asserts a clean exit within 5 seconds.