### PR TITLE
fix(ruflo-graph-intelligence): make plugin.json `repository` field a string

### DIFF
--- a/plugins/ruflo-graph-intelligence/.claude-plugin/plugin.json
+++ b/plugins/ruflo-graph-intelligence/.claude-plugin/plugin.json
@@ -23,9 +23,5 @@
     "adr-123"
   ],
   "categories": ["intelligence", "graph", "memory", "substrate"],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ruvnet/ruflo.git",
-    "directory": "plugins/ruflo-graph-intelligence"
-  }
+  "repository": "https://github.com/ruvnet/ruflo"
 }


### PR DESCRIPTION
## Problem

Installing `ruflo-graph-intelligence` via the Claude Code plugin marketplace fails for every user:

```
Failed to install: Plugin ... has an invalid manifest file at
.claude-plugin/plugin.json.

Validation errors: repository: Invalid input: expected string, received object
```

Claude Code's plugin manifest schema requires the `repository` field to be a **plain string URL**. This plugin's `plugin.json` declares it as an npm `package.json`-style object:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/ruvnet/ruflo.git",
  "directory": "plugins/ruflo-graph-intelligence"
}
```

`ruflo-graph-intelligence` is the **only** plugin of the 33 in the marketplace with this bug — every other plugin either omits `repository` or uses the string form, so this is the lone install failure.

## Fix

Change the `repository` field to the string form expected by the Claude Code plugin spec:

```json
"repository": "https://github.com/ruvnet/ruflo"
```

No other fields changed.

## Verification

With this manifest, `/plugin install ruflo-graph-intelligence@ruflo` succeeds and the plugin loads (verified locally by applying the same one-line patch to the marketplace clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)