### PR TITLE
docs: trim badges + add ruflo-graph-intelligence + reshuffle featured plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ There are **two different install paths** with very different surface areas. Pic
 # Install core + any plugins you need
 /plugin install ruflo-core@ruflo
 /plugin install ruflo-swarm@ruflo
-/plugin install ruflo-autopilot@ruflo
-/plugin install ruflo-federation@ruflo
+/plugin install ruflo-rag-memory@ruflo
+/plugin install ruflo-neural-trader@ruflo
 ```
 
 This adds slash commands and agent definitions only. The Ruflo MCP server is NOT registered, so `memory_store`, `swarm_init`, `agent_spawn`, etc. won't be callable from Claude. For the full loop, use Path B below.
 
 <details>
-<summary><strong>🔌 All 32 plugins</strong></summary>
+<summary><strong>🔌 All 33 plugins</strong></summary>
 
 #### Core & Orchestration
 
@@ -105,6 +105,7 @@ This adds slash commands and agent definitions only. The Ruflo MCP server is NOT
 | Plugin | What it does |
 |--------|-------------|
 | [**ruflo-intelligence**](plugins/ruflo-intelligence/README.md) | Agents learn from past successes and get smarter |
+| [**ruflo-graph-intelligence**](plugins/ruflo-graph-intelligence/) | Sublinear graph reasoning — PageRank, delta updates, complexity-aware execution (ADR-123) |
 | [**ruflo-daa**](plugins/ruflo-daa/README.md) | Dynamic agent behavior and cognitive patterns |
 | [**ruflo-ruvllm**](plugins/ruflo-ruvllm/README.md) | Run local LLMs (Ollama, etc.) with smart routing |
 | [**ruflo-goals**](plugins/ruflo-goals/README.md) | Break big goals into plans and track progress |

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 [![Live Agents — goal.ruv.io/agents](https://img.shields.io/badge/_Live_Agents-goal.ruv.io%2Fagents-10b981?style=for-the-badge&logoColor=white&logo=react)](https://goal.ruv.io/agents)
 
 [![npm version (ruflo)](https://img.shields.io/npm/v/ruflo?label=ruflo&style=for-the-badge&logo=npm&color=cb3837)](https://www.npmjs.com/package/ruflo)
-[![npm downloads (ruflo)](https://img.shields.io/npm/dm/ruflo?label=ruflo%20downloads&style=for-the-badge&logo=npm&color=cb3837)](https://www.npmjs.com/package/ruflo)
-[![npm version (claude-flow)](https://img.shields.io/npm/v/claude-flow?label=claude-flow&style=for-the-badge&logo=npm&color=blue)](https://www.npmjs.com/package/claude-flow)
-[![npm downloads (claude-flow)](https://img.shields.io/npm/dm/claude-flow?label=claude-flow%20downloads&style=for-the-badge&logo=npm&color=blue)](https://www.npmjs.com/package/claude-flow)
 [![Ecosystem downloads](https://img.shields.io/badge/ecosystem%20downloads-22.2M%2B-blue?style=for-the-badge&logo=npm)](https://github.com/ruvnet/ruflo/blob/main/data/clone-data.proof.json)
 [![Git clones (14d)](https://img.shields.io/badge/git%20clones%2014d-115k-blueviolet?style=for-the-badge&logo=github)](https://github.com/ruvnet/ruflo/blob/main/data/clone-data.ledger.json)
 

--- a/ruflo/README.md
+++ b/ruflo/README.md
@@ -70,14 +70,14 @@ There are **two different install paths** with very different surface areas. Pic
 # Install core + any plugins you need
 /plugin install ruflo-core@ruflo
 /plugin install ruflo-swarm@ruflo
-/plugin install ruflo-autopilot@ruflo
-/plugin install ruflo-federation@ruflo
+/plugin install ruflo-rag-memory@ruflo
+/plugin install ruflo-neural-trader@ruflo
 ```
 
 This adds slash commands and agent definitions only. The Ruflo MCP server is NOT registered, so `memory_store`, `swarm_init`, `agent_spawn`, etc. won't be callable from Claude. For the full loop, use Path B below.
 
 <details>
-<summary><strong>🔌 All 32 plugins</strong></summary>
+<summary><strong>🔌 All 33 plugins</strong></summary>
 
 #### Core & Orchestration
 
@@ -105,6 +105,7 @@ This adds slash commands and agent definitions only. The Ruflo MCP server is NOT
 | Plugin | What it does |
 |--------|-------------|
 | [**ruflo-intelligence**](plugins/ruflo-intelligence/README.md) | Agents learn from past successes and get smarter |
+| [**ruflo-graph-intelligence**](plugins/ruflo-graph-intelligence/) | Sublinear graph reasoning — PageRank, delta updates, complexity-aware execution (ADR-123) |
 | [**ruflo-daa**](plugins/ruflo-daa/README.md) | Dynamic agent behavior and cognitive patterns |
 | [**ruflo-ruvllm**](plugins/ruflo-ruvllm/README.md) | Run local LLMs (Ollama, etc.) with smart routing |
 | [**ruflo-goals**](plugins/ruflo-goals/README.md) | Break big goals into plans and track progress |

--- a/ruflo/README.md
+++ b/ruflo/README.md
@@ -7,9 +7,6 @@
 [![Live Agents — goal.ruv.io/agents](https://img.shields.io/badge/_Live_Agents-goal.ruv.io%2Fagents-10b981?style=for-the-badge&logoColor=white&logo=react)](https://goal.ruv.io/agents)
 
 [![npm version (ruflo)](https://img.shields.io/npm/v/ruflo?label=ruflo&style=for-the-badge&logo=npm&color=cb3837)](https://www.npmjs.com/package/ruflo)
-[![npm downloads (ruflo)](https://img.shields.io/npm/dm/ruflo?label=ruflo%20downloads&style=for-the-badge&logo=npm&color=cb3837)](https://www.npmjs.com/package/ruflo)
-[![npm version (claude-flow)](https://img.shields.io/npm/v/claude-flow?label=claude-flow&style=for-the-badge&logo=npm&color=blue)](https://www.npmjs.com/package/claude-flow)
-[![npm downloads (claude-flow)](https://img.shields.io/npm/dm/claude-flow?label=claude-flow%20downloads&style=for-the-badge&logo=npm&color=blue)](https://www.npmjs.com/package/claude-flow)
 [![Ecosystem downloads](https://img.shields.io/badge/ecosystem%20downloads-22.2M%2B-blue?style=for-the-badge&logo=npm)](https://github.com/ruvnet/ruflo/blob/main/data/clone-data.proof.json)
 [![Git clones (14d)](https://img.shields.io/badge/git%20clones%2014d-115k-blueviolet?style=for-the-badge&logo=github)](https://github.com/ruvnet/ruflo/blob/main/data/clone-data.ledger.json)
 


### PR DESCRIPTION
Two doc-only changes to root `README.md` and `ruflo/README.md`:

## 1. Trim redundant per-package npm badges

Removes three badges made redundant by the ecosystem-downloads + git-clones badges from PR #2065:

- `npm downloads (ruflo)` (subsumed by the 22.2M+ ecosystem total)
- `npm version (claude-flow)` (legacy umbrella; not the recommended install target)
- `npm downloads (claude-flow)` (subsumed by the 22.2M+ ecosystem total)

Keeps:
- `npm version (ruflo)` — the install target
- `ecosystem downloads 22.2M+` — the cross-package signal
- `git clones 14d 115k` — the GitHub-traffic signal

## 2. Plugin list updates

- **Add `ruflo-graph-intelligence`** to the Intelligence & Learning category (ADR-123 — sublinear graph reasoning, PageRank, delta updates, complexity-aware execution). Plugin count: **32 → 33**.
- **Reshuffle the Path A featured install snippet** to highlight what users actually ask about today:
  - Kept: `ruflo-core`, `ruflo-swarm`
  - Added: `ruflo-rag-memory` (the user-facing wrapper over the ADR-125 memory consolidation we just shipped in #2062 + #2063) and `ruflo-neural-trader` (the headline domain-specific plugin per ADR-117)
  - Removed: `ruflo-autopilot` and `ruflo-federation` (still in the full 33-list — just less of a first-touch story than memory + neural-trader for the typical drop-in user)

Doc-only change. No code touched.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)