### PR TITLE
fix(cost-tracker): spawnSync npx ENOENT on Windows

### DIFF
--- a/plugins/ruflo-cost-tracker/scripts/budget.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/budget.mjs
@@ -36,7 +36,7 @@ function memoryStore(key, value) {
     const r = spawnSync('npx', [
       CLI_PKG, 'memory', 'store',
       '--namespace', NS, '--key', stamped, '--value', JSON.stringify(value),
-    ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+    ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
     if (r.status !== 0) throw new Error(`memory store failed: ${r.stderr?.slice(0, 200) || r.status}`);
     // The "current pointer" is found at retrieval time by listing all
     // budget-config-* keys and picking the lexicographically-largest
@@ -46,7 +46,7 @@ function memoryStore(key, value) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'store',
     '--namespace', NS, '--key', key, '--value', JSON.stringify(value),
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) throw new Error(`memory store failed: ${r.stderr?.slice(0, 200) || r.status}`);
 }
 
@@ -54,7 +54,7 @@ function memoryRetrieveOne(key) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'retrieve',
     '--namespace', NS, '--key', key,
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return null;
   const m = /\{[\s\S]*\}/.exec(r.stdout || '');
   if (!m) return null;
@@ -67,7 +67,7 @@ function memoryRetrieve(key) {
     const list = spawnSync('npx', [
       CLI_PKG, 'memory', 'list',
       '--namespace', NS, '--format', 'json',
-    ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+    ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
     if (list.status !== 0) return null;
     const m = /\[[\s\S]*\]/.exec(list.stdout || '');
     if (!m) return null;
@@ -92,7 +92,7 @@ function memoryListSessionRecords() {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'list',
     '--namespace', NS, '--format', 'json',
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return [];
   // CLI may emit a small banner before the JSON array; extract the first '['..']' block.
   const m = /\[[\s\S]*\]/.exec(r.stdout || '');

--- a/plugins/ruflo-cost-tracker/scripts/conversation.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/conversation.mjs
@@ -23,7 +23,7 @@ function memoryListSessionKeys() {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'list',
     '--namespace', NS, '--format', 'json',
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return [];
   const m = /\[[\s\S]*\]/.exec(r.stdout || '');
   if (!m) return [];
@@ -38,7 +38,7 @@ function memoryRetrieve(key) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'retrieve',
     '--namespace', NS, '--key', key,
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return null;
   const m = /\{[\s\S]*\}/.exec(r.stdout || '');
   if (!m) return null;

--- a/plugins/ruflo-cost-tracker/scripts/export.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/export.mjs
@@ -28,7 +28,7 @@ function memoryListKeys() {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'list',
     '--namespace', NS, '--format', 'json',
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return [];
   const m = /\[[\s\S]*\]/.exec(r.stdout || '');
   if (!m) return [];
@@ -38,7 +38,7 @@ function memoryRetrieve(key) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'retrieve',
     '--namespace', NS, '--key', key,
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return null;
   const m = /\{[\s\S]*\}/.exec(r.stdout || '');
   if (!m) return null;

--- a/plugins/ruflo-cost-tracker/scripts/federation.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/federation.mjs
@@ -31,7 +31,7 @@ function memoryList() {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'list',
     '--namespace', NS, '--format', 'json',
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return [];
   const m = /\[[\s\S]*\]/.exec(r.stdout || '');
   if (!m) return [];
@@ -41,7 +41,7 @@ function memoryRetrieve(key) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'retrieve',
     '--namespace', NS, '--key', key,
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return null;
   const m = /\{[\s\S]*\}/.exec(r.stdout || '');
   if (!m) return null;

--- a/plugins/ruflo-cost-tracker/scripts/outcome.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/outcome.mjs
@@ -33,7 +33,7 @@ function main() {
   const r = spawnSync('npx', [
     '@claude-flow/cli@latest', 'hooks', 'model-outcome',
     '-t', task, '-m', model, '-o', outcome,
-  ], { stdio: 'inherit' });
+  ], { stdio: 'inherit', shell: process.platform === 'win32' });
   if (r.status !== 0) {
     console.error(`emit failed (exit ${r.status})`);
     process.exit(r.status || 1);

--- a/plugins/ruflo-cost-tracker/scripts/summary.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/summary.mjs
@@ -36,7 +36,7 @@ function memoryListKeys(ns) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'list',
     '--namespace', ns, '--format', 'json',
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return [];
   const m = /\[[\s\S]*\]/.exec(r.stdout || '');
   if (!m) return [];
@@ -46,7 +46,7 @@ function memoryRetrieve(ns, key) {
   const r = spawnSync('npx', [
     CLI_PKG, 'memory', 'retrieve',
     '--namespace', ns, '--key', key,
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) return null;
   const m = /\{[\s\S]*\}/.exec(r.stdout || '');
   if (!m) return null;

--- a/plugins/ruflo-cost-tracker/scripts/track.mjs
+++ b/plugins/ruflo-cost-tracker/scripts/track.mjs
@@ -132,7 +132,7 @@ function persistToMemory(summary) {
     '--namespace', ns,
     '--key', key,
     '--value', JSON.stringify(summary),
-  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' });
+  ], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', shell: process.platform === 'win32' });
   if (r.status !== 0) {
     return { ok: false, reason: r.stderr?.slice(0, 300) || `exit ${r.status}` };
   }


### PR DESCRIPTION
## Problem

`ruflo-cost-tracker` scripts call `spawnSync('npx', [...], opts)` without the `shell` option. On Windows + Node ≥ 21, this fails with `ENOENT` because Node cannot resolve the `npx.cmd` shim. The failure is silent:

- `cost track` reports `Persisted: FAILED (exit null)` — the session cost summary is computed but never written to the `cost-tracking` namespace.
- All read-side scripts (`summary`, `report`, `conversation`, `budget check`, `export`, `federation`, `optimize`) `spawnSync` `memory list` / `memory retrieve` the same way; both return empty arrays, so reports show `$0.0000`.

### Reproduce

```js
require('child_process').spawnSync('npx', ['--version']);
// { status: null, error: ENOENT, stdout: undefined }
```

This is a known Windows quirk: Node 21+ enforces stricter validation after the `batBadButLong` mitigation (CVE-2024-27980) and refuses to spawn `.cmd` / `.bat` files without `shell: true`.

## Fix

Add `shell: process.platform === 'win32'` to every `spawnSync` options object across the 7 affected scripts. POSIX behavior is unchanged (`shell: false` everywhere else).

## Files changed

| File | spawnSync calls patched |
|---|---:|
| `scripts/track.mjs` | 1 |
| `scripts/budget.mjs` | 5 |
| `scripts/summary.mjs` | 2 |
| `scripts/conversation.mjs` | 2 |
| `scripts/export.mjs` | 2 |
| `scripts/federation.mjs` | 2 |
| `scripts/outcome.mjs` | 1 |

Total: **15 lines changed across 7 files** (15+ / 15-).

## Verification

Before patch:
```
$ node plugins/ruflo-cost-tracker/scripts/track.mjs
| Persisted | **FAILED** (exit null) |
```

After patch:
```
$ node plugins/ruflo-cost-tracker/scripts/track.mjs
| Persisted | `cost-tracking:session-7c5bd4e6-a5c2-40da-90ba-386cd3cc865b` |
```

Confirmed via:
```bash
npx @claude-flow/cli@latest memory list --namespace cost-tracking --format json
# returns the new session record
```

## Note on shell-escape security

`spawnSync` with `shell: true` does not escape argv (Node emits DEP0190). All arguments in this codebase are internal data: package names, namespace strings, keys derived from `summary.sessionId` (UUIDs), and `JSON.stringify(summary)` output. None are user-controlled in a way that could inject shell metacharacters. The risk is bounded.

If preferred, a follow-up could use `process.execPath` + the resolved `npx-cli.js` path to avoid `shell: true` entirely, but that adds platform-specific resolution logic. The 1-line conditional is a pragmatic fix.

## Related

A separate, more impactful CLI bug was discovered while debugging this: `@claude-flow/cli` `memory retrieve` strips quotes from nested JSON values, and `memory export -f json` returns `null` for every `entries[].value`. Filed as #2073. Even with this PR merged, the read pipeline (`cost summary`, `cost report`, etc.) will remain broken until #2073 is fixed upstream.

## Environment

- OS: Windows 10 Pro 19045
- Node: v24.15.0
- Plugin: `ruflo-cost-tracker` 0.16.1
