### PR TITLE
fix(init): #2078 — use no-reply bot email for opt-in Co-Authored-By

### DIFF
--- a/v3/@claude-flow/cli/.claude/settings.json
+++ b/v3/@claude-flow/cli/.claude/settings.json
@@ -115,7 +115,7 @@
     ]
   },
   "attribution": {
-    "commit": "Co-Authored-By: claude-flow <ruv@ruv.net>",
+    "commit": "Co-Authored-By: ruflo-bot <ruflo-bot@users.noreply.github.com>",
     "pr": "Generated with [claude-flow](https://github.com/ruvnet/claude-flow)"
   },
   "claudeFlow": {

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -46,9 +46,15 @@ export function generateSettings(options: InitOptions): object {
   // line into the user's commits — that pattern silently inflated GitHub
   // contributor graphs and was hard to undo without rewriting history. Pass
   // `--attribution` (or `attribution: true` in InitOptions) to enable.
+  //
+  // #2078 — when the user DOES opt in, write a no-reply bot email so GitHub
+  // treats this as a tool, not a personal contribution. Personal emails get
+  // added to user repos' contributor graphs even when the trailer is opt-in.
+  // `ruflo-bot@users.noreply.github.com` is GitHub's no-reply convention and
+  // is excluded from contributor graphs / mapped to a tool identity.
   if (options.attribution === true) {
     settings.attribution = {
-      commit: 'Co-Authored-By: RuFlo <ruv@ruv.net>',
+      commit: 'Co-Authored-By: ruflo-bot <ruflo-bot@users.noreply.github.com>',
       pr: '🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)',
     };
   }

--- a/v3/@claude-flow/codex/AGENTS.md
+++ b/v3/@claude-flow/codex/AGENTS.md
@@ -103,7 +103,7 @@ Use `$skill-name` syntax to invoke:
 
 [optional body]
 
-Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: ruflo-bot <ruflo-bot@users.noreply.github.com>
 ```
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`

--- a/v3/@claude-flow/codex/src/generators/agents-md.ts
+++ b/v3/@claude-flow/codex/src/generators/agents-md.ts
@@ -232,7 +232,7 @@ Use MCP tools for coordination, then keep coding:
 
 [optional body]
 
-Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: ruflo-bot <ruflo-bot@users.noreply.github.com>
 \`\`\`
 
 Types: \`feat\`, \`fix\`, \`docs\`, \`style\`, \`refactor\`, \`perf\`, \`test\`, \`chore\`


### PR DESCRIPTION
## Summary

- Switch the opt-in attribution trailer from `ruv@ruv.net` (personal email) to `ruflo-bot@users.noreply.github.com` (GitHub no-reply convention). This excludes the trailer from user repos' contributor graphs and maps it to a tool identity instead of a person.
- Update the three sibling locations that hardcoded the personal email — codex AGENTS.md template generator + its generated output + this repo's own `.claude/settings.json` (eating our own dog food).
- Default behavior (no `--attribution` flag) is unchanged: no trailer is written at all, per #1670.

## Background

The opt-in attribution feature shipped in #1670 stopped injecting the trailer by default, but the format itself still used a personal email. Any user who opts in (or who carried a legacy `.claude/settings.json` from before #1670 landed) silently adds the maintainer to their repo's contributor graph — which is hard to undo without rewriting history. The fix is a one-line format change.

## Files changed

| File | Why |
|------|-----|
| `v3/@claude-flow/cli/src/init/settings-generator.ts` | Primary fix — the init template that ships to users |
| `v3/@claude-flow/cli/.claude/settings.json` | This repo's local Claude Code settings — dog-fooding the new format |
| `v3/@claude-flow/codex/src/generators/agents-md.ts` | Codex AGENTS.md template generator — same trailer was hardcoded |
| `v3/@claude-flow/codex/AGENTS.md` | Generated artifact from the above, regenerated to match |

## Out of scope

The harness portion referenced in #2078 (the Claude Code runtime trailer) is a separate concern handled by Claude Code itself, not by ruflo. This PR only addresses the ruflo-side templates.

## Test plan

- [x] `npm run build` in `v3/@claude-flow/cli` passes with no TS errors
- [x] `grep -rn 'ruv@ruv.net' v3/@claude-flow/cli/src/ ruflo/` returns no results
- [x] Commit message of this PR uses the new trailer format (eats own dog food)
- [ ] After merge: next `ruflo init --attribution` should write `ruflo-bot <ruflo-bot@users.noreply.github.com>` into the generated `.claude/settings.json`

Refs #2078

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)