### PR TITLE
fix(types): resolve all TypeScript lint errors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,11 +77,11 @@ importers:
         specifier: ^0.1.5
         version: 0.1.6
       agentdb:
-        specifier: ^3.0.0-alpha.9
+        specifier: ^3.0.0-alpha.14
         version: 3.0.0-alpha.14(@types/node@20.19.39)(zod@3.25.76)
       agentic-flow:
-        specifier: ^2.0.7
-        version: 2.0.11(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@types/node@20.19.39)
+        specifier: ^2.0.13
+        version: 2.0.13(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@types/node@20.19.39)
 
 packages:
 
@@ -1505,8 +1505,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  agentic-flow@2.0.11:
-    resolution: {integrity: sha512-x5IHADYCTSA+mLXxaNEQOSjaUK8jSTi5Sv7nJeZEk1iaFd9JWGrAGx4P/zDZnaeMZfWmNRE8vlXvuWrILrvyGA==}
+  agentic-flow@2.0.13:
+    resolution: {integrity: sha512-VN3OVYUweVtCE4ARzxwf0Qf22Z3+6dgYWukKvnE5qlBIa5FEPjD5rRN4Fz5mecQ+88+0fnFgJ/00lb6MVhWsNQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -4864,7 +4864,7 @@ snapshots:
       - supports-color
       - zod
 
-  agentic-flow@2.0.11(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@types/node@20.19.39):
+  agentic-flow@2.0.13(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@types/node@20.19.39):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.77(zod@3.25.76)
       '@anthropic-ai/sdk': 0.65.0(zod@3.25.76)
@@ -4875,7 +4875,6 @@ snapshots:
       '@ruvector/ruvllm': 0.2.4
       '@ruvector/tiny-dancer': 0.1.18
       '@supabase/supabase-js': 2.105.3
-      '@xenova/transformers': 2.17.2
       axios: 1.16.0(debug@4.4.3)
       dotenv: 16.6.1
       express: 5.2.1
@@ -4894,6 +4893,7 @@ snapshots:
       '@rollup/rollup-darwin-arm64': 4.60.3
       '@ruvector/attention': 0.1.32
       '@ruvector/sona': 0.1.6
+      '@xenova/transformers': 2.17.2
       agentdb: 3.0.0-alpha.14(@types/node@20.19.39)(zod@3.25.76)
       better-sqlite3: 11.10.0
       onnxruntime-node: 1.25.1

--- a/v3/@claude-flow/cli/src/types/optional-modules.d.ts
+++ b/v3/@claude-flow/cli/src/types/optional-modules.d.ts
@@ -436,3 +436,48 @@ declare module '@claude-flow/mcp' {
   export const startMCPServer: any;
   export class MCPServer { constructor(...args: any[]); }
 }
+
+declare module '@claude-flow/memory' {
+  export class ControllerRegistry {
+    constructor(...args: any[]);
+    [key: string]: any;
+  }
+  export const INIT_LEVELS: any;
+  const mod: any;
+  export default mod;
+  export const smartSearch: any;
+  export const search: any;
+  export const store: any;
+  export const retrieve: any;
+}
+
+declare module '@ruvector/learning-wasm' {
+  export class WasmMicroLoRA {
+    constructor(...args: any[]);
+    apply(input: Float32Array): Float32Array;
+    adapt(...args: any[]): void;
+    adapt_array(...args: any[]): void;
+    stats(): any;
+    reset(): void;
+    [key: string]: any;
+  }
+  export class WasmScopedLoRA {
+    constructor(...args: any[]);
+    apply(input: Float32Array): Float32Array;
+    adapt(...args: any[]): void;
+    set_category_fallback(val: boolean): void;
+    stats(): any;
+    reset(): void;
+    [key: string]: any;
+  }
+  export class WasmTrajectoryBuffer {
+    constructor(...args: any[]);
+    push(...args: any[]): void;
+    sample(...args: any[]): any[];
+    len(): number;
+    clear(): void;
+    [key: string]: any;
+  }
+  export function initSync(opts: { module: BufferSource } | BufferSource): void;
+  export default function init(...args: any[]): Promise<any>;
+}

--- a/v3/@claude-flow/swarm/tsconfig.json
+++ b/v3/@claude-flow/swarm/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Add ambient declarations for `@claude-flow/memory` and `@ruvector/learning-wasm` in `optional-modules.d.ts` so dynamic imports type-check without the packages being installed
- Add `composite`, `declaration`, and `declarationMap` flags to `@claude-flow/swarm` tsconfig so it satisfies the CLI project reference and its dist `.d.ts` files are generated correctly

## Test plan

- [x] Run `npx tsc --noEmit` in `v3/@claude-flow/cli` — should produce zero errors
- [x] Verify `@claude-flow/swarm` builds cleanly with `npx tsc` in its directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)