### PR TITLE
fix(cli,daemon,mcp): #2098 #2093 #2085 — three regressions reported on alpha.75

### DIFF
--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -187,7 +187,13 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
   const full = ctx.flags.full as boolean;
   const skipClaude = ctx.flags['skip-claude'] as boolean;
   const onlyClaude = ctx.flags['only-claude'] as boolean;
-  const noGlobal = ctx.flags['no-global'] as boolean;
+  // #2098A — the parser handles `--no-foo` by stripping the prefix and
+  // storing `flags.foo = false` (parser.ts:291-294), not by storing
+  // `flags['no-foo'] = true`. So `--no-global` lands as
+  // `ctx.flags.global === false`. The old read of `flags['no-global']`
+  // was always undefined and silently no-op'd — every user with the flag
+  // set still got `~/.claude/CLAUDE.md` modified. Read the real key.
+  const noGlobal = ctx.flags['no-global'] === true || ctx.flags['global'] === false;
   const allAgents = ctx.flags['all-agents'] as boolean;
   const codexMode = ctx.flags.codex as boolean;
   const dualMode = ctx.flags.dual as boolean;

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -221,6 +221,10 @@ export const agentTools: MCPTool[] = [
       properties: {
         agentType: { type: 'string', description: 'Type of agent to spawn' },
         agentId: { type: 'string', description: 'Optional custom agent ID' },
+        // #2085 — accept swarmId so spawned agents register in the
+        // swarm.agents array that swarm_status reports. Omit to register
+        // with the most-recently-created swarm.
+        swarmId: { type: 'string', description: 'Optional swarm to register the agent with (defaults to most-recent swarm)' },
         config: { type: 'object', description: 'Agent configuration' },
         domain: { type: 'string', description: 'Agent domain' },
         model: {
@@ -274,6 +278,35 @@ export const agentTools: MCPTool[] = [
 
       store.agents[agentId] = agent;
       saveAgentStore(store);
+
+      // #2085 — also push to the swarm store's agents array so that
+      // swarm_status reports the new agent. Without this, agent_spawn
+      // and swarm_status read/write separate stores and agents added
+      // post-init never show up in swarm_status.agents — confirmed for
+      // all topologies (hierarchical, mesh, etc.).
+      try {
+        const { loadSwarmStore: _loadSwarmStore, saveSwarmStore: _saveSwarmStore } =
+          await import('./swarm-tools.js');
+        const swarmStore = _loadSwarmStore();
+        let targetSwarmId = (input.swarmId as string) || '';
+        if (!targetSwarmId) {
+          // Default to the most-recently-created swarm.
+          const all = Object.values(swarmStore.swarms);
+          const latest = all.sort(
+            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          )[0];
+          targetSwarmId = latest?.swarmId || '';
+        }
+        if (targetSwarmId && swarmStore.swarms[targetSwarmId]) {
+          const swarm = swarmStore.swarms[targetSwarmId];
+          if (!Array.isArray(swarm.agents)) swarm.agents = [];
+          // Idempotent — don't duplicate if agent_spawn is retried.
+          if (!swarm.agents.includes(agentId)) {
+            swarm.agents.push(agentId);
+            _saveSwarmStore(swarmStore);
+          }
+        }
+      } catch { /* swarm store unavailable — agent still registered globally */ }
 
       // Record agent in graph database (ADR-087, best-effort)
       try {

--- a/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
@@ -110,7 +110,9 @@ function reconcileOrphanSwarms(store: SwarmStore): number {
   return reconciled;
 }
 
-function loadSwarmStore(): SwarmStore {
+// #2085 — exported so `agent-tools.ts agent_spawn` can push into
+// `swarm.agents` (the field `swarm_status` reads).
+export function loadSwarmStore(): SwarmStore {
   let store: SwarmStore = { swarms: {}, version: '3.0.0' };
   try {
     const path = getSwarmStatePath();
@@ -129,7 +131,7 @@ function loadSwarmStore(): SwarmStore {
   return store;
 }
 
-function saveSwarmStore(store: SwarmStore): void {
+export function saveSwarmStore(store: SwarmStore): void {
   ensureSwarmDir();
   writeFileSync(getSwarmStatePath(), JSON.stringify(store, null, 2), 'utf-8');
 }

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -1170,11 +1170,19 @@ Analyze the above codebase context and provide your response following the forma
       // writes the prompt and closes stdin atomically — the EOF still
       // unblocks `claude --print` (the original concern in #1395) but no
       // shell tokenization touches the prompt.
+      // #2098B / #2093 — `claude --print` can spawn grandchildren (MCP
+      // server stdio bridges, plugin tools). When the head times out a
+      // plain `child.kill()` only signals the head; grandchildren get
+      // reparented to init and survive — the symptom @maxstefanakis1114
+      // diagnosed as a 5-second redispatch + subprocess-table growth.
+      // `detached: true` puts the child in its own process group so we
+      // can signal the whole tree with `process.kill(-pid, sig)`.
       const child = spawn('claude', ['--print'], {
         cwd: this.projectRoot,
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true, // Prevent phantom console windows on Windows
+        detached: process.platform !== 'win32',
       });
       try {
         child.stdin?.end(prompt);
@@ -1183,14 +1191,23 @@ Analyze the above codebase context and provide your response following the forma
         // will surface the real cause.
       }
 
+      // Kill the whole process group on POSIX, fall back to the child on
+      // Windows (where setsid-style detach isn't available the same way).
+      const killTree = (signal: NodeJS.Signals) => {
+        if (process.platform !== 'win32' && typeof child.pid === 'number') {
+          try { process.kill(-child.pid, signal); return; } catch { /* fall through */ }
+        }
+        try { child.kill(signal); } catch { /* already dead */ }
+      };
+
       // Setup timeout
       const timeoutHandle = setTimeout(() => {
         if (this.processPool.has(options.executionId)) {
-          child.kill('SIGTERM');
+          killTree('SIGTERM');
           // Give it a moment to terminate gracefully
           setTimeout(() => {
             if (!child.killed) {
-              child.kill('SIGKILL');
+              killTree('SIGKILL');
             }
           }, 5000);
         }
@@ -1265,7 +1282,7 @@ Analyze the above codebase context and provide your response following the forma
         if (!this.processPool.has(options.executionId)) return;
 
         resolved = true;
-        child.kill('SIGTERM');
+        killTree('SIGTERM');
         cleanup();
 
         resolve({


### PR DESCRIPTION
Closes #2098, #2093, #2085.

Three independent bugs from three reporters, all reproducible on alpha.76 today. Each fix is small and localized.

## Per-issue fix

### #2098A — `--no-global` flag silently ignored (@pierrefuseau)

The parser handles `--no-foo` by stripping the prefix and storing `flags.foo = false` (`parser.ts:291-294`), not by storing `flags['no-foo'] = true`. The consumer at `init.ts:190` read the wrong key, so the flag was always `undefined` and the global `~/.claude/CLAUDE.md` got modified anyway.

**Fix**: read `flags['global'] === false` AND keep accepting the literal-key form. One line, plus a why-comment so the next reader doesn't undo it.

### #2098B / #2093 — Daemon subprocess group not killed (@pierrefuseau, @maxstefanakis1114)

`headless-worker-executor.ts` spawns `claude --print` without `detached: true`. Grandchildren (MCP stdio bridges, plugin tools) belong to the parent's process group, so `child.kill()` on timeout only signals the head — grandchildren get reparented to init and leak. Combined with the queue-file path the alpha.73 `.processed/` rename already fixed, the surface was 90% closed but the residual gap was the missing tree-kill.

**Fix**: spawn with `detached: true` (POSIX only — Windows process groups don't work the same way), then signal the group with `process.kill(-pid, sig)` instead of `child.kill(sig)`. Fallback to plain `child.kill` if `-pid` kill fails.

### #2085 — `agent_spawn` not in `swarm_status.agents` (@seo-yas)

`agent_spawn` writes only to the agent store; `swarm_status` reads only from the swarm store. The two are never bridged. Every topology is affected — not just hierarchical as the reporter assumed. Also the schema never accepted `swarmId`, which is why all 5 of their parameter-shape variants failed identically.

**Fix**: add `swarmId` to the `agent_spawn` schema (optional; defaults to most-recent swarm), then after writing the agent store, also push the agentId into `swarm.agents`. Idempotent so retries don't duplicate.

## Files changed (4)

| File | What |
|---|---|
| `v3/@claude-flow/cli/src/commands/init.ts` | Read `--no-global` from the right parser key (#2098A) |
| `v3/@claude-flow/cli/src/services/headless-worker-executor.ts` | `detached: true` spawn + `process.kill(-pid, sig)` tree-kill (#2098B / #2093) |
| `v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts` | Accept `swarmId` + register in `swarm.agents` (#2085) |
| `v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts` | Export `loadSwarmStore` / `saveSwarmStore` for #2085 |

## Test plan

- [x] `npm run build` clean
- [x] `smoke-init-bundle-invariants.mjs` PASS
- [x] `smoke-github-safe-injection.mjs` PASS
- [ ] CI green on this branch
- [ ] Post-merge alpha.77 publish + reporter reproducers

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)