### PR TITLE
fix(init): #2078 — CLAUDE.md rule overrides Claude Code's default Co-Authored-By trailer

### DIFF
--- a/v3/@claude-flow/cli/src/init/claudemd-generator.ts
+++ b/v3/@claude-flow/cli/src/init/claudemd-generator.ts
@@ -19,6 +19,7 @@ function behavioralRules(): string {
 - NEVER save working files or tests to root — use \`/src\`, \`/tests\`, \`/docs\`, \`/config\`, \`/scripts\`
 - ALWAYS read a file before editing it
 - NEVER commit secrets, credentials, or .env files
+- NEVER add a \`Co-Authored-By\` trailer to user commits unless this project's \`.claude/settings.json\` has \`attribution.commit\` set (#2078). The Claude Code Bash tool may suggest one in its default commit-message template — ignore it. \`Co-Authored-By\` is semantic authorship attribution under git/GitHub convention; the tool is the facilitator, not a co-author.
 - Keep files under 500 lines
 - Validate input at system boundaries`;
 }


### PR DESCRIPTION
Closes #2078.

Final piece of the #2078 fix that ruvnet acknowledged but hadn't shipped: a project-level rule in the generated CLAUDE.md that tells the agent to ignore Claude Code's built-in Bash-tool commit-template suggestion.

## Why this matters

ruvnet's earlier reply on #2078 acknowledged @shaal's five points, then noted that #2079 only fixed half the surface (the settings-generator opt-in defaulting to `false`). The other half — the Claude Code Bash tool's default commit-message instructions — still suggests `Co-Authored-By: RuFlo <ruv@ruv.net>` regardless of project settings. Users were left having to discover the override themselves.

## What this patch does

Adds one rule to the generated `CLAUDE.md`'s Behavioral Rules section:

```
- NEVER add a `Co-Authored-By` trailer to user commits unless this project's
  `.claude/settings.json` has `attribution.commit` set (#2078). The Claude Code
  Bash tool may suggest one in its default commit-message template — ignore it.
  `Co-Authored-By` is semantic authorship attribution under git/GitHub convention;
  the tool is the facilitator, not a co-author.
```

Agents read CLAUDE.md on every session start, so the override is automatic for every project that runs `ruflo init` going forward. Users who DO want the trailer still get it via the `settings.attribution.commit` opt-in that #2079 added.

## Test plan

- [x] Build clean
- [x] `ruflo init --preset default` in fresh tmpdir → rule present in CLAUDE.md
- [ ] CI green on this branch

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)