### PR TITLE
fix(daemon): make ruflo daemon AI workers work on WSL2 (isAvailable cache + CPU gate + result.success validation)

### DIFF
--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -632,8 +632,12 @@ export class HeadlessWorkerExecutor extends EventEmitter {
    * Check if Claude Code CLI is available
    */
   async isAvailable(): Promise<boolean> {
-    if (this.claudeCodeAvailable !== null) {
-      return this.claudeCodeAvailable;
+    // Only short-circuit on a positive cached result. Caching `false` would lock the
+    // daemon to local-fallback mode for its entire lifetime after a single transient
+    // miss (e.g. WSL2 cold start, AV scanner racing with execSync). Always re-probe
+    // when the previous answer was false or unknown.
+    if (this.claudeCodeAvailable === true) {
+      return true;
     }
 
     try {

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -641,19 +641,21 @@ export class HeadlessWorkerExecutor extends EventEmitter {
     }
 
     try {
+      const timeoutMs = parseInt(process.env.CLAUDE_CODE_AVAILABILITY_TIMEOUT_MS || '30000', 10);
       const output = execSync('claude --version', {
         encoding: 'utf-8',
         stdio: 'pipe',
-        timeout: 5000,
+        timeout: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 30000,
         windowsHide: true, // Prevent phantom console windows on Windows
       });
       this.claudeCodeAvailable = true;
       this.claudeCodeVersion = output.trim();
       this.emit('status', { available: true, version: this.claudeCodeVersion });
       return true;
-    } catch {
+    } catch (error) {
       this.claudeCodeAvailable = false;
-      this.emit('status', { available: false });
+      const reason = error instanceof Error ? error.message : String(error);
+      this.emit('status', { available: false, reason });
       return false;
     }
   }

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -1064,6 +1064,14 @@ export class WorkerDaemon extends EventEmitter {
       try {
         this.log('info', `Running ${workerConfig.type} in headless mode (Claude Code AI)`);
         const result = await this.headlessExecutor.execute(workerConfig.type as HeadlessWorkerType);
+        // HeadlessWorkerExecutor.execute() returns createErrorResult({success:false}) when its
+        // own isAvailable() check fails, instead of throwing. Without this guard, that error
+        // result is persisted as a successful headless run and downstream consumers cannot
+        // tell a real AI run apart from a silent fallback.
+        if (!result || (result as { success?: boolean }).success !== true) {
+          const errMsg = (result as { error?: string } | undefined)?.error;
+          throw new Error(errMsg ? String(errMsg) : 'headless executor returned success=false');
+        }
         // #1793: persist the headless result to the same metrics files the
         // local workers write to. Without this, AI-mode runs produced rich
         // parsedOutput that lived only in `.claude-flow/logs/headless/*` and

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -528,7 +528,21 @@ export class WorkerDaemon extends EventEmitter {
     const freeMem = os.freemem();
     const freePercent = (freeMem / totalMem) * 100;
 
-    if (cpuLoad > this.config.resourceThresholds.maxCpuLoad) {
+    // WSL2 reports inflated load averages (200-400 on 4-CPU systems) because Windows-side
+    // process counting is mapped into /proc/loadavg. Skip the CPU gate when running on WSL2
+    // to avoid permanently deferring every worker; honour the gate on native Linux / macOS.
+    const isWsl2 = (() => {
+      if (process.env.WSL_DISTRO_NAME) return true;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const fs = require('fs');
+        const release = fs.readFileSync('/proc/sys/kernel/osrelease', 'utf-8');
+        return /microsoft/i.test(release);
+      } catch {
+        return false;
+      }
+    })();
+    if (!isWsl2 && cpuLoad > this.config.resourceThresholds.maxCpuLoad) {
       return { allowed: false, reason: `CPU load too high: ${cpuLoad.toFixed(2)}` };
     }
     if (freePercent < this.config.resourceThresholds.minFreeMemoryPercent) {


### PR DESCRIPTION
# Daemon silently degrades to local mode under WSL2 — compounding bugs in `isAvailable()` cache + CPU load gate + missing `result.success` validation

## Environment

- ruflo: `3.7.0-alpha.78`
- `@claude-flow/cli` (nested in ruflo): `3.7.0-alpha.78`
- Claude Code CLI: `2.1.132`
- OS: Windows 11 + WSL2 (Ubuntu)
- Node: bundled with ruflo (Hermes)
- systemd user unit `ruflo-daemon.service`

## Symptom

`ruflo` daemon active, `claude auth status` shows `loggedIn: true`, `claude --print 'OK'` returns `OK` from the daemon's shell environment, yet **all scheduled AI workers (audit / optimize / testgaps / predict / document) fall back to local stubs** and write `mode: "local"` results.

Worker run counts increment in `daemon-state.json` (so the scheduler is healthy) but `.claude-flow/logs/headless/*_result.log` files are not created and `.claude-flow/metrics/*.json` contain the local-stub bodies (`"note": "Install Claude Code CLI for AI-powered ..."`). The daemon log alternates between `Claude Code headless mode available - AI workers enabled` and `Claude Code not found - AI workers will run in local fallback mode` across restarts of the same machine, within minutes of each other, with no underlying environmental change.

## Three compounding root causes

### 1. `HeadlessWorkerExecutor.isAvailable()` caches `false` forever

`v3/@claude-flow/cli/src/services/headless-worker-executor.ts:1034-1052`:

```ts
async isAvailable(): Promise<boolean> {
  if (this.claudeCodeAvailable !== null) {
    return this.claudeCodeAvailable;
  }
  try {
    const output = execSync('claude --version', {
      encoding: 'utf-8',
      stdio: 'pipe',
      timeout: 5000,
      windowsHide: true,
    });
    this.claudeCodeAvailable = true;
    this.claudeCodeVersion = output.trim();
    this.emit('status', { available: true, version: this.claudeCodeVersion });
    return true;
  } catch {
    this.claudeCodeAvailable = false;
    this.emit('status', { available: false });
    return false;
  }
}
```

Problems:

- **Single 5 s timeout** is fragile on WSL2 cold start where `claude --version` itself takes ~80 ms but the daemon process is often spawned during heavy I/O (systemd `Type=forking` + `--foreground --quiet --workspace` re-exec, the surrounding shell pipeline, AV scanners). One transient miss → `claudeCodeAvailable = false` cached for the rest of the daemon lifetime.
- **No retry mechanism.** Even after the user fixes the underlying cause (e.g. runs `claude auth login`), the daemon keeps returning `false` until the process is restarted.
- **`catch {}` swallows the actual error** — no log line, no `error` event payload, no way for the operator to know whether the failure was timeout, ENOENT, exit-code, or auth.

Reproduction:

```bash
# WSL2, after fresh `claude auth login --claudeai`
systemctl --user restart ruflo-daemon.service
# 50 % of the time daemon log shows
#   [INFO] Claude Code headless mode available - AI workers enabled
# the other 50 %
#   [INFO] Claude Code not found - AI workers will run in local fallback mode
# despite `which claude` and `claude --version` both succeeding from the same shell.
```

### 2. WSL2 `/proc/loadavg` permanently fails the daemon CPU gate

`v3/@claude-flow/cli/src/services/worker-daemon.ts:809-811`:

```ts
if (cpuLoad > this.config.resourceThresholds.maxCpuLoad) {
  return { allowed: false, reason: `CPU load too high: ${cpuLoad.toFixed(2)}` };
}
```

The smart default is `Math.max(cpuCount * 0.8, 2.0)` (i.e. `3.2` on a 4-CPU box). On WSL2 the kernel reports load averages of `200–400` due to Windows-side process counting being mapped into the Linux `/proc/loadavg`:

```
$ cat /proc/loadavg
326.19 328.39 327.87 1/1162 49986
$ nproc
4
```

Result: every scheduled worker logs `Worker X deferred: CPU load too high: 326.XX` and the daemon is effectively idle while reporting "AI workers enabled".

The `--max-cpu-load` CLI flag is not forwarded by the ruflo wrapper to the nested `@claude-flow/cli daemon start --foreground --quiet --workspace ...` invocation, and `ruflo config set` writes to `<workspace>/claude-flow.config.json` while `readDaemonConfigFromFile` reads `<workspace>/.claude-flow/config.json` (different path). Both routes are dead from the user side, leaving source-patching as the only escape hatch.

### 3. `runWorkerLogic` doesn't validate `result.success` from the headless executor

`v3/@claude-flow/cli/src/services/worker-daemon.ts:867` (method) and lines 872-887 (try block):

```ts
private async runWorkerLogic(workerConfig: WorkerConfig): Promise<unknown> {
  if (isHeadlessWorker(workerConfig.type) && this.headlessAvailable && this.headlessExecutor) {
    try {
      this.log('info', `Running ${workerConfig.type} in headless mode (Claude Code AI)`);
      const result = await this.headlessExecutor.execute(workerConfig.type as HeadlessWorkerType);
      this.persistHeadlessResult(workerConfig.type as HeadlessWorkerType, result);
      return { mode: 'headless', ...result };
    } catch (error) {
      this.log('warn', `Headless execution failed for ${workerConfig.type}, falling back to local mode`);
      // Fall through to local execution
    }
  }
  // ... local switch
}
```

`HeadlessWorkerExecutor.execute()` returns `createErrorResult(...)` (`success: false`) when `isAvailable()` is false, instead of throwing. The daemon's `try/catch` never fires the warn log; the result is persisted with `mode: "headless"` despite `success: false` and the executor's note explaining the local fallback. Downstream consumers (`memory stats`, dashboards) cannot distinguish a real AI run from a stub.

Suggested fix: after `await execute(...)`, check `result.success === true` and treat falsy success as the same failure as a thrown exception (warn log + fall through to local switch).

## Proposed fixes (in order of impact)

1. **Add a "retry on false" policy to `isAvailable()`**: stop caching `false`; only cache `true`. Or expose `forceRefresh: boolean` and call it on every scheduled worker fire.
2. **Log the actual error** from the `catch` block so operators can distinguish `timeout` / `ENOENT` / `exit-code != 0`.
3. **Increase the default timeout to 30 s** for WSL2-class slow cold starts, or expose `CLAUDE_CODE_AVAILABILITY_TIMEOUT_MS` env var.
4. **WSL2-aware default for `maxCpuLoad`**: detect `process.env.WSL_DISTRO_NAME` / `/proc/sys/kernel/osrelease` containing `microsoft` and either disable the gate or use a far higher floor (200+).
5. **Honour `--max-cpu-load` end-to-end** through the ruflo wrapper, or document `.claude-flow/config.json` as the supported config path (consistent with `readDaemonConfigFromFile`) and have `ruflo config set` write to the same file.
6. **Treat `result.success === false` from headless executor as a fall-through trigger** in `runWorkerLogic`, with a warn log identical to the throw path.

## Workaround (current production patch)

Four source-level patches applied locally to restore AI workers on WSL2:

```bash
F1=/path/to/@claude-flow/cli/dist/src/services/worker-daemon.js
F2=/path/to/@claude-flow/cli/dist/src/services/headless-worker-executor.js

# (1) bypass CPU gate
sed -i 's|if (cpuLoad > this.config.resourceThresholds.maxCpuLoad)|if (false /* WSL2 load avg unreliable */)|' "$F1"

# (2) force-enable headless flag at init
sed -i 's|this.headlessAvailable = await this.headlessExecutor.isAvailable();|this.headlessAvailable = true;|' "$F1"

# (3) only cache `true` results; allow retry on false
sed -i 's|if (this.claudeCodeAvailable !== null)|if (this.claudeCodeAvailable === true)|' "$F2"

# (4) bypass inner isAvailable in execute()
sed -i 's|const available = await this.isAvailable();|const available = true;|' "$F2"

systemctl --user restart ruflo-daemon.service
```

After these patches, daemon log shows the headless code path firing and a real worker run looks like:

```
[INFO] Starting worker: predict (1/2 concurrent)
[INFO] Running predict in headless mode (Claude Code AI)
[INFO] Worker predict completed in 16154ms
```

Result file in `.claude-flow/logs/headless/predict_<id>_result.log`:

```json
{ "success": true, "model": "haiku", "durationMs": 16153, "sandboxMode": "strict",
  "parsedOutput": { "filesToPreload": [...], "confidence": 0.85, ... } }
```

`metrics/predictions.json` then contains real AI output rather than the local stub.

## Why this matters

Without these fixes, ruflo daemon on WSL2 advertises itself as healthy (`systemctl is-active`, `daemon-state.json` runs incrementing, `Claude Code headless mode available - AI workers enabled` in logs), but the entire AI-worker layer is silently a no-op. Users see "Install Claude Code CLI for AI-powered ..." in metrics and assume their setup is broken — when in fact CLI + auth are perfectly fine, and the daemon's own logic is rejecting them.

Happy to PR any of the proposed fixes if useful.
