### PR TITLE
fix(security): patch CVEs, shell injection, SSRF in ruflo

### DIFF
--- a/.claude/helpers/github-safe.js
+++ b/.claude/helpers/github-safe.js
@@ -19,7 +19,7 @@
  *   ./github-safe.js pr create --title "Title" --body "Complex body"
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -111,10 +111,12 @@ if ((command === 'issue' || command === 'pr') &&
         process.exit(0);
       }
 
-      const ghCommand = `gh ${command} ${subcommand} ${newArgs.join(' ')}`;
-      console.log(`Executing: ${ghCommand}`);
+      const ghArgv = [command, subcommand, ...newArgs];
+      console.log(`Executing: gh ${ghArgv.join(' ')}`);
 
-      execSync(ghCommand, {
+      // Use execFileSync to avoid shell interpolation — args are passed as an
+      // array so shell metacharacters in tmpFile path cannot be exploited.
+      execFileSync('gh', ghArgv, {
         stdio: 'inherit',
         timeout: 30000,
       });
@@ -127,13 +129,13 @@ if ((command === 'issue' || command === 'pr') &&
       try { unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
     }
   } else {
-    // No body content — execute normally (no injection risk).
+    // No body content — execute normally (no injection risk for args).
     if (process.env.GITHUB_SAFE_DRY_RUN === '1') {
       console.log(`[DRY-RUN] gh ${args.join(' ')}`);
       process.exit(0);
     }
     try {
-      execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+      execFileSync('gh', args, { stdio: 'inherit' });
     } catch (error) {
       console.error('[ERROR]', error.message);
       process.exit(1);
@@ -146,7 +148,7 @@ if ((command === 'issue' || command === 'pr') &&
     process.exit(0);
   }
   try {
-    execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+    execFileSync('gh', args, { stdio: 'inherit' });
   } catch (error) {
     console.error('[ERROR]', error.message);
     process.exit(1);

--- a/plugins/ruflo-core/scripts/witness/perf.mjs
+++ b/plugins/ruflo-core/scripts/witness/perf.mjs
@@ -32,7 +32,7 @@
 import { writeFileSync, appendFileSync, readFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { osDir } from './lib.mjs';
 
@@ -50,14 +50,15 @@ const ASJSON = !!args.json;
 const COMPARE_BASELINE = !!args.baseline;
 const ENABLED = (args.capabilities ?? 'install_pack,install_no_optional,memory_load,memory_round_trip,witness_verify').split(',').map(s => s.trim()).filter(Boolean);
 
-const gitCommit = execSync('git rev-parse HEAD', { cwd: REPO_ROOT }).toString().trim();
+const gitCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT }).toString().trim();
 const issuedAt = new Date().toISOString();
 const os = osDir();
 
 // ─── benchmark runners ─────────────────────────────────────────
 const runners = {
   install_pack: () => bench(() => {
-    execSync('pnpm pack --pack-destination ' + tmpdir(), {
+    // execFileSync with array args prevents shell injection (CWE-78).
+    execFileSync('pnpm', ['pack', '--pack-destination', tmpdir()], {
       cwd: join(REPO_ROOT, 'v3/@claude-flow/memory'),
       stdio: 'pipe',
     });
@@ -65,15 +66,16 @@ const runners = {
 
   install_no_optional: () => {
     const dir = mkdtempSync(join(tmpdir(), 'perf-install-'));
-    const tarball = execSync('pnpm pack --pack-destination ' + dir, {
+    const tarball = execFileSync('pnpm', ['pack', '--pack-destination', dir], {
       cwd: join(REPO_ROOT, 'v3/@claude-flow/memory'),
       stdio: 'pipe',
     }).toString().trim().split('\n').filter(l => l.endsWith('.tgz')).pop();
     if (!tarball) throw new Error('pnpm pack produced no tarball');
-    execSync('npm init -y >/dev/null', { cwd: dir, stdio: 'pipe', shell: true });
-    execSync('npm pkg set type=module', { cwd: dir, stdio: 'pipe' });
+    execFileSync('npm', ['init', '-y'], { cwd: dir, stdio: 'pipe' });
+    execFileSync('npm', ['pkg', 'set', 'type=module'], { cwd: dir, stdio: 'pipe' });
     const ms = bench(() => {
-      execSync(`npm install "${tarball}" --omit=optional --no-audit --no-fund`, { cwd: dir, stdio: 'pipe' });
+      // Pass tarball path as a discrete argument — no shell quoting needed.
+      execFileSync('npm', ['install', tarball, '--omit=optional', '--no-audit', '--no-fund'], { cwd: dir, stdio: 'pipe' });
     });
     rmSync(dir, { recursive: true, force: true });
     return ms;
@@ -113,7 +115,8 @@ const runners = {
     const manifest = join(REPO_ROOT, 'verification', os, 'manifest.md.json');
     if (!existsSync(manifest)) return null;
     return bench(() => {
-      execSync(`node ${join(__dirname, 'verify.mjs')} --manifest ${manifest} --json`, {
+      // Use execFileSync so paths with spaces or special chars are safe (CWE-78).
+      execFileSync(process.execPath, [join(__dirname, 'verify.mjs'), '--manifest', manifest, '--json'], {
         cwd: REPO_ROOT, stdio: 'pipe',
       });
     });

--- a/ruflo/src/mcp-bridge/index.js
+++ b/ruflo/src/mcp-bridge/index.js
@@ -640,10 +640,34 @@ Requires: OPENAI_API_KEY environment variable (already set for OpenAI models).
 }
 
 // =============================================================================
+// SSRF GUARD — Reject requests to private/loopback ranges (CWE-918)
+// =============================================================================
+
+const PRIVATE_IP_RE = /^(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|::1|fc|fd)/i;
+
+function assertSafeUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`SSRF guard: invalid URL — ${rawUrl}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`SSRF guard: only HTTPS URLs are permitted, got ${parsed.protocol}`);
+  }
+  const host = parsed.hostname;
+  if (PRIVATE_IP_RE.test(host) || host === "localhost" || host.endsWith(".local")) {
+    throw new Error(`SSRF guard: private/loopback host rejected — ${host}`);
+  }
+}
+
+// =============================================================================
 // HELPER — Call a backend Cloud Function / API
 // =============================================================================
 
 async function callCloudFunction(url, payload, timeoutMs = 25000) {
+  // Validate the URL before making any network request.
+  assertSafeUrl(url);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/ruflo/src/ruvocal/mcp-bridge/index.js
+++ b/ruflo/src/ruvocal/mcp-bridge/index.js
@@ -729,10 +729,34 @@ async function geminiGroundedSearch(query, mode = "search") {
 }
 
 // =============================================================================
+// SSRF GUARD — Reject requests to private/loopback ranges (CWE-918)
+// =============================================================================
+
+const PRIVATE_IP_RE = /^(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.|127\.|0\.|::1|fc|fd)/i;
+
+function assertSafeUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`SSRF guard: invalid URL — ${rawUrl}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`SSRF guard: only HTTPS URLs are permitted, got ${parsed.protocol}`);
+  }
+  const host = parsed.hostname;
+  if (PRIVATE_IP_RE.test(host) || host === "localhost" || host.endsWith(".local")) {
+    throw new Error(`SSRF guard: private/loopback host rejected — ${host}`);
+  }
+}
+
+// =============================================================================
 // HELPER — Call a backend Cloud Function / API
 // =============================================================================
 
 async function callCloudFunction(url, payload, timeoutMs = 25000) {
+  // Validate the URL before making any network request.
+  assertSafeUrl(url);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/scripts/audit-supply-chain.mjs
+++ b/scripts/audit-supply-chain.mjs
@@ -125,7 +125,7 @@ function runCveAudit(packageDir, accepted) {
 
   let audit;
   try {
-    const out = execSync('npm audit --json --audit-level=high', {
+    const out = execFileSync('npm', ['audit', '--json', '--audit-level=high'], {
       cwd: join(REPO_ROOT, packageDir),
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 60_000,

--- a/scripts/audit-supply-chain.mjs
+++ b/scripts/audit-supply-chain.mjs
@@ -32,7 +32,7 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -298,7 +298,9 @@ function runPublisherTrustAudit(allowlist) {
   const critical = allowlist.publisherTrust?.criticalUpstreamPackages ?? [];
   for (const name of critical) {
     try {
-      const out = execSync(`npm view "${name}" maintainers --json`, {
+      // Use execFileSync + array args to prevent shell injection through
+      // package names sourced from the allowlist JSON (CWE-78 mitigation).
+      const out = execFileSync('npm', ['view', name, 'maintainers', '--json'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: 10_000,
       });

--- a/scripts/track-clones.mjs
+++ b/scripts/track-clones.mjs
@@ -26,7 +26,7 @@
  * written so the raw chronology is human-readable in PR reviews.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve as path_resolve, dirname as path_dirname } from 'node:path';
@@ -62,7 +62,9 @@ const NPM_PKGS_HEADLINE = [
 
 function fetchClones(repo) {
   try {
-    const out = execSync(`gh api repos/${repo}/traffic/clones`, {
+    // Use execFileSync with array args — repo name is program-controlled but
+    // array form prevents accidental shell metacharacter expansion (CWE-78).
+    const out = execFileSync('gh', ['api', `repos/${repo}/traffic/clones`], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });

--- a/v3/@claude-flow/browser/tests/e2e/browser-e2e.test.ts
+++ b/v3/@claude-flow/browser/tests/e2e/browser-e2e.test.ts
@@ -6,17 +6,23 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const TEST_URL = process.env.TEST_URL || 'http://localhost:3000';
 const SESSION = 'e2e-test';
 
 /**
- * Execute agent-browser command
+ * Execute agent-browser command.
+ *
+ * The `command` argument is split on whitespace into discrete tokens so that
+ * execFileSync can receive an argv array.  This prevents shell injection when
+ * test fixtures contain special characters (CWE-78).
  */
 function browser(command: string): string {
   try {
-    const result = execSync(`agent-browser --session ${SESSION} --json ${command}`, {
+    // Split command into tokens and pass as array — no shell expansion.
+    const argv = ['--session', SESSION, '--json', ...command.trim().split(/\s+/)];
+    const result = execFileSync('agent-browser', argv, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/v3/@claude-flow/cli/.claude/helpers/github-safe.js
+++ b/v3/@claude-flow/cli/.claude/helpers/github-safe.js
@@ -19,7 +19,7 @@
  *   ./github-safe.js pr create --title "Title" --body "Complex body"
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -111,10 +111,12 @@ if ((command === 'issue' || command === 'pr') &&
         process.exit(0);
       }
 
-      const ghCommand = `gh ${command} ${subcommand} ${newArgs.join(' ')}`;
-      console.log(`Executing: ${ghCommand}`);
+      const ghArgv = [command, subcommand, ...newArgs];
+      console.log(`Executing: gh ${ghArgv.join(' ')}`);
 
-      execSync(ghCommand, {
+      // Use execFileSync to avoid shell interpolation — args are passed as an
+      // array so shell metacharacters in tmpFile path cannot be exploited.
+      execFileSync('gh', ghArgv, {
         stdio: 'inherit',
         timeout: 30000,
       });
@@ -127,13 +129,13 @@ if ((command === 'issue' || command === 'pr') &&
       try { unlinkSync(tmpFile); } catch (_) { /* ignore cleanup errors */ }
     }
   } else {
-    // No body content — execute normally (no injection risk).
+    // No body content — execute normally (no injection risk for args).
     if (process.env.GITHUB_SAFE_DRY_RUN === '1') {
       console.log(`[DRY-RUN] gh ${args.join(' ')}`);
       process.exit(0);
     }
     try {
-      execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+      execFileSync('gh', args, { stdio: 'inherit' });
     } catch (error) {
       console.error('[ERROR]', error.message);
       process.exit(1);
@@ -146,7 +148,7 @@ if ((command === 'issue' || command === 'pr') &&
     process.exit(0);
   }
   try {
-    execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+    execFileSync('gh', args, { stdio: 'inherit' });
   } catch (error) {
     console.error('[ERROR]', error.message);
     process.exit(1);

--- a/v3/@claude-flow/mcp/.claude/helpers/github-safe.js
+++ b/v3/@claude-flow/mcp/.claude/helpers/github-safe.js
@@ -9,7 +9,7 @@
  *   ./github-safe.js pr create --title "Title" --body "Complex body"
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -76,13 +76,13 @@ if ((command === 'issue' || command === 'pr') &&
         newArgs[bodyIndex + 1] = tmpFile;
       }
       
-      // Execute safely
-      const ghCommand = `gh ${command} ${subcommand} ${newArgs.join(' ')}`;
-      console.log(`Executing: ${ghCommand}`);
-      
-      const result = execSync(ghCommand, { 
+      // Execute safely — use execFileSync so shell cannot interpret args.
+      const ghArgv = [command, subcommand, ...newArgs];
+      console.log(`Executing: gh ${ghArgv.join(' ')}`);
+
+      execFileSync('gh', ghArgv, {
         stdio: 'inherit',
-        timeout: 30000 // 30 second timeout
+        timeout: 30000,
       });
       
     } catch (error) {
@@ -97,10 +97,10 @@ if ((command === 'issue' || command === 'pr') &&
       }
     }
   } else {
-    // No body content, execute normally
-    execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+    // No body content — pass args array directly to avoid shell splitting.
+    execFileSync('gh', args, { stdio: 'inherit' });
   }
 } else {
-  // Other commands, execute normally
-  execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+  // Other commands — pass args array directly to avoid shell splitting.
+  execFileSync('gh', args, { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Summary

Comprehensive security audit of the ruflo codebase (2026-05-23). `npm audit` returned 0 vulnerabilities (existing `overrides` in `package.json` already cover all known CVEs). Static analysis found two classes of real vulnerabilities patched in this PR:

**CWE-78 — Shell Injection (9 sites)**

Every call to `execSync(templateLiteral)` that assembled a shell command string was replaced with `execFileSync(cmd, argArray)`. Passing an array bypasses the OS shell entirely so shell metacharacters (backticks, `$(...)`, semicolons, whitespace) in any argument cannot be interpreted as commands.

Sites fixed:
- `.claude/helpers/github-safe.js` — `execSync(\`gh ${args.join(' ')}\`)` in no-body and non-body paths (the body path already used `--body-file` but still joined args into a shell string for the final `gh` call)
- `v3/@claude-flow/cli/.claude/helpers/github-safe.js` — identical copy, same fix
- `v3/@claude-flow/mcp/.claude/helpers/github-safe.js` — older variant without body-cap
- `scripts/audit-supply-chain.mjs` — `execSync(\`npm view "${name}" maintainers --json\`)` where `name` comes from a JSON config file
- `scripts/track-clones.mjs` — `execSync(\`gh api repos/${repo}/traffic/clones\`)`
- `plugins/ruflo-core/scripts/witness/perf.mjs` — six `execSync` calls in benchmark runners (`git rev-parse`, `pnpm pack` ×2, `npm init`, `npm pkg set`, `npm install <tarball>`, `node verify.mjs`)
- `v3/@claude-flow/browser/tests/e2e/browser-e2e.test.ts` — `execSync(\`agent-browser ... ${command}\`)`

**CWE-918 — SSRF (2 sites)**

`callCloudFunction(url, ...)` in both `ruflo/src/mcp-bridge/index.js` and `ruflo/src/ruvocal/mcp-bridge/index.js` accepted an arbitrary URL without validation. Added `assertSafeUrl()` called before every `fetch()` that:
1. Parses the URL with `new URL()` and rejects malformed strings
2. Requires `https:` scheme — rejects `http:`, `file:`, `ftp:`, etc.
3. Rejects private/loopback ranges: `10.x`, `172.16-31.x`, `192.168.x`, `127.x`, `::1`, `fc`/`fd` ULA, `localhost`, `*.local`

## Test plan

- [x] `node scripts/smoke-github-safe-injection.mjs` — all 10 github-safe injection cases pass (both helper copies)
- [x] `npx vitest run` — no new test file failures vs pre-patch baseline (variance is pre-existing flakiness in `router-bandit.test.ts` Thompson sampling test)
- [x] `npm audit` — 0 vulnerabilities confirmed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)