### PR TITLE
fix(deps): #2112 — opentelemetry pins on published ruflo wrapper (alpha.80)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.79",
+  "version": "3.7.0-alpha.80",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.7.0-alpha.79",
+  "version": "3.7.0-alpha.80",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -56,7 +56,19 @@
     "make-fetch-happen": ">=15.0.0",
     "express-rate-limit": ">=8.4.1",
     "protobufjs": ">=7.5.5",
-    "uuid": ">=14.0.0"
+    "uuid": ">=14.0.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-node": ">=0.218.0",
+    "@opentelemetry/auto-instrumentations-node": ">=0.75.0",
+    "@opentelemetry/exporter-prometheus": ">=0.217.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.7.0-alpha.79",
+  "version": "3.7.0-alpha.80",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Closes #2112.

## Root cause

@crayes reported `npx ruflo@3.7.0-alpha.79 mcp start` crashes with `npm error Invalid Version:` on npm 11.x. Stack trace named `@opentelemetry/exporter-trace-otlp-grpc@0.52.1` — same pattern as #2018, #1921, #1688, #1595, #1147 (optionalDeps ↔ peerDeps overlap with empty-version string crashes arborist's `canDedupe`).

## What was missing

The opentelemetry pins lived in **root** `package.json` since the original fix, but the **published `ruflo` wrapper** — which is what `npm install ruflo@latest` actually consumes — has its own `overrides` block and was missing them. So:

```bash
# At repo root (where overrides exist) — install succeeds
npm install --legacy-peer-deps          # ok

# Via published wrapper (where overrides did NOT exist) — crash on npm 11
npx ruflo@3.7.0-alpha.79 mcp start      # Invalid Version: — issue #2112
```

## Fix

Copies 12 opentelemetry entries from root `package.json` overrides into `ruflo/package.json` overrides:
- 3 core/resource/sdk-trace-base pins
- 3 sdk-node/auto-instrumentations/exporter-prometheus floors
- 6 exporter-base / otlp-transformer transitives the reporter's stack named

Bumps all 3 packages to **3.7.0-alpha.80**.

## Reproduction status

Could not reproduce on local **npm 10.9.4** or **npm 11.15.0** — both succeed with `npx -y ruflo@3.7.0-alpha.79 --version`. The bug is sensitive to the exact (npm patch, cache state, transitive resolution order) triple. Pre-emptive ship under the "fewer-knobs-for-arborist" policy that worked for the prior 5 recurrences of this pattern.

## Test plan

- [x] `npm install --legacy-peer-deps` at repo root: works
- [x] Local install via published tarball after publish: smoke
- [ ] CI green
- [ ] Post-publish: ask @crayes to verify on their npm 11 install

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)