### PR TITLE
fix(memory): verify durable store after bridge writes

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-ruvector-deep.test.ts
@@ -16,6 +16,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // =============================================================================
 // Memory Initializer
@@ -68,6 +71,60 @@ describe('Memory Initializer', () => {
     it('should set WAL journal mode pragma', async () => {
       const { MEMORY_SCHEMA_V3 } = await import('../src/memory/memory-initializer.js');
       expect(MEMORY_SCHEMA_V3).toContain('PRAGMA journal_mode = WAL');
+    });
+  });
+
+  describe('storeEntry durability', () => {
+    it('falls through to a durable SQLite write when the AgentDB bridge reports a cache-only success', async () => {
+      vi.resetModules();
+      vi.doMock('../src/memory/memory-bridge.js', () => ({
+        bridgeStoreEntry: vi.fn(async () => ({
+          success: true,
+          id: 'bridge-cache-only',
+        })),
+        bridgeGenerateEmbedding: vi.fn(async () => null),
+        bridgeGetEntry: vi.fn(async () => null),
+        bridgeSearchEntries: vi.fn(async () => null),
+        bridgeListEntries: vi.fn(async () => null),
+      }));
+
+      const workdir = mkdtempSync(join(tmpdir(), 'memory-durable-'));
+      const dbPath = join(workdir, 'memory.db');
+      try {
+        const memory = await import('../src/memory/memory-initializer.js');
+        const init = await memory.initializeMemoryDatabase({
+          dbPath,
+          force: true,
+          verbose: false,
+        });
+        expect(init.success).toBe(true);
+
+        const stored = await memory.storeEntry({
+          key: 'durable-key',
+          value: 'durable value',
+          namespace: 'durability-test',
+          dbPath,
+          generateEmbeddingFlag: false,
+          upsert: true,
+        });
+
+        expect(stored.success).toBe(true);
+        expect(stored.id).not.toBe('bridge-cache-only');
+
+        const retrieved = await memory.getEntry({
+          key: 'durable-key',
+          namespace: 'durability-test',
+          dbPath,
+        });
+
+        expect(retrieved.success).toBe(true);
+        expect(retrieved.found).toBe(true);
+        expect(retrieved.entry?.content).toBe('durable value');
+      } finally {
+        rmSync(workdir, { recursive: true, force: true });
+        vi.doUnmock('../src/memory/memory-bridge.js');
+        vi.resetModules();
+      }
     });
   });
 

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -11,6 +11,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { createRequire } from 'node:module';
 import { readFileMaybeEncrypted, writeFileRestricted } from '../fs-secure.js';
 
 /**
@@ -81,6 +82,161 @@ async function getBridge(): Promise<typeof import('./memory-bridge.js') | null> 
   } catch {
     _bridge = null;
     return null;
+  }
+}
+
+async function rawMemoryEntryExists(options: {
+  key: string;
+  namespace?: string;
+  dbPath?: string;
+}): Promise<boolean> {
+  const { key, namespace = 'default', dbPath: customPath } = options;
+  const swarmDir = getMemoryRoot();
+  const dbPath = customPath ? path.resolve(customPath) : path.join(swarmDir, 'memory.db');
+
+  try {
+    if (!fs.existsSync(dbPath)) return false;
+
+    const initSqlJs = (await import('sql.js')).default;
+    const SQL = await initSqlJs();
+    const fileBuffer = readFileMaybeEncrypted(dbPath, null);
+    const db = new SQL.Database(fileBuffer);
+    const stmt = db.prepare(`
+      SELECT 1
+      FROM memory_entries
+      WHERE status = 'active'
+        AND key = ?
+        AND namespace = ?
+      LIMIT 1
+    `);
+    stmt.bind([key, namespace]);
+    const found = stmt.step();
+    stmt.free();
+    db.close();
+    return found;
+  } catch {
+    return false;
+  }
+}
+
+async function storeEntryWithBetterSqlite(options: {
+  key: string;
+  value: string;
+  namespace?: string;
+  generateEmbeddingFlag?: boolean;
+  tags?: string[];
+  ttl?: number;
+  dbPath?: string;
+  upsert?: boolean;
+}): Promise<{
+  success: boolean;
+  id: string;
+  embedding?: { dimensions: number; model: string };
+  error?: string;
+}> {
+  const {
+    key,
+    value,
+    namespace = 'default',
+    generateEmbeddingFlag = true,
+    tags = [],
+    ttl,
+    dbPath: customPath,
+    upsert = false
+  } = options;
+  const swarmDir = getMemoryRoot();
+  const dbPath = customPath ? path.resolve(customPath) : path.join(swarmDir, 'memory.db');
+
+  try {
+    if (!fs.existsSync(dbPath)) {
+      return { success: false, id: '', error: 'Database not initialized. Run: claude-flow memory init' };
+    }
+
+    await ensureSchemaColumns(dbPath);
+
+    const require = createRequire(import.meta.url);
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath);
+    const id = `entry_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+    const now = Date.now();
+
+    let embeddingJson: string | null = null;
+    let embeddingDimensions: number | null = null;
+    let embeddingModel: string | null = null;
+
+    if (generateEmbeddingFlag && value.length > 0) {
+      const embResult = await generateEmbedding(value);
+      embeddingJson = JSON.stringify(embResult.embedding);
+      embeddingDimensions = embResult.dimensions;
+      embeddingModel = embResult.model;
+    }
+
+    const insertSql = upsert
+      ? `INSERT OR REPLACE INTO memory_entries (
+          id, key, namespace, content, type,
+          embedding, embedding_dimensions, embedding_model,
+          tags, metadata, created_at, updated_at, expires_at, status
+        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`
+      : `INSERT INTO memory_entries (
+          id, key, namespace, content, type,
+          embedding, embedding_dimensions, embedding_model,
+          tags, metadata, created_at, updated_at, expires_at, status
+        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`;
+
+    const write = db.transaction(() => {
+      try {
+        db.prepare(
+          `INSERT OR IGNORE INTO vector_indexes (id, name, dimensions) VALUES (?, ?, ?)`
+        ).run(namespace, namespace, embeddingDimensions ?? 384);
+      } catch {
+        /* vector_indexes may not exist on legacy DBs — fall through */
+      }
+
+      db.prepare(insertSql).run(
+        id,
+        key,
+        namespace,
+        value,
+        embeddingJson,
+        embeddingDimensions,
+        embeddingModel,
+        tags.length > 0 ? JSON.stringify(tags) : null,
+        '{}',
+        now,
+        now,
+        ttl ? now + (ttl * 1000) : null
+      );
+    });
+
+    write();
+    try {
+      db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch {
+      /* checkpoint is best-effort */
+    }
+    db.close();
+
+    if (embeddingJson) {
+      const embResult = JSON.parse(embeddingJson) as number[];
+      await addToHNSWIndex(id, embResult, {
+        id,
+        key,
+        namespace,
+        content: value
+      });
+    }
+
+    return {
+      success: true,
+      id,
+      embedding: embeddingJson ? { dimensions: embeddingDimensions!, model: embeddingModel! } : undefined
+    };
+  } catch (error) {
+    return {
+      success: false,
+      id: '',
+      error: error instanceof Error ? error.message : String(error)
+    };
   }
 }
 
@@ -2146,8 +2302,31 @@ export async function storeEntry(options: {
           content: options.value,
         }).catch(() => {});
       }
-      return bridgeResult;
+      if (!bridgeResult.success) {
+        return bridgeResult;
+      }
+      if (await rawMemoryEntryExists(options)) {
+        return bridgeResult;
+      }
+
+      // The AgentDB bridge can report success after writing only to an
+      // in-process/cache-backed controller. Verify the configured SQLite store
+      // before accepting success; otherwise write through to the durable DB.
+      const durableResult = await storeEntryWithBetterSqlite(options);
+      if (durableResult.success) {
+        return durableResult;
+      }
+      return {
+        success: false,
+        id: bridgeResult.id || '',
+        error: `Bridge reported success but durable SQLite verification failed: ${durableResult.error || 'unknown error'}`
+      };
     }
+  }
+
+  const betterSqliteResult = await storeEntryWithBetterSqlite(options);
+  if (betterSqliteResult.success) {
+    return betterSqliteResult;
   }
 
   // Fallback: raw sql.js


### PR DESCRIPTION
## Summary
Fixes a memory persistence failure where the AgentDB bridge can report `success=true` for `memory store` without the entry being present in the configured `.swarm/memory.db` in a later CLI process.

## What changed
- Verifies that a successful bridge store is actually present in the durable SQLite store before returning success.
- Falls through to a transactional `better-sqlite3` write when the bridge only produced a cache/process-local success.
- Keeps the existing raw `sql.js` fallback as the last fallback.
- Adds a regression test that mocks a cache-only bridge success and proves `storeEntry()` writes a retrievable SQLite row.

## Validation
- `pnpm install --frozen-lockfile` from `v3`: passed; native modules compiled for Node 25/ARM64.
- `pnpm vitest run __tests__/memory-ruvector-deep.test.ts -t 'storeEntry durability'`: 1 passed.
- `pnpm vitest run __tests__/memory-ruvector-deep.test.ts`: 146 passed.
- `git diff --check`: passed.
- anti-secret grep on diff: passed.

## Known unrelated validation issue
- `pnpm run build` in `v3/@claude-flow/cli` fails on existing workspace/type export issues unrelated to this patch, including missing exports such as `Command`, `CommandContext`, `output`, and unresolved workspace packages such as `@claude-flow/cli-core` / `@claude-flow/memory`.