### PR TITLE
fix(daemon): #2110 — WSL2 silent-degrade triple fix + alpha.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.80",
+  "version": "3.7.0-alpha.81",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.7.0-alpha.80",
+  "version": "3.7.0-alpha.81",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.7.0-alpha.80",
+  "version": "3.7.0-alpha.81",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
+++ b/v3/@claude-flow/cli/src/services/headless-worker-executor.ts
@@ -629,27 +629,49 @@ export class HeadlessWorkerExecutor extends EventEmitter {
   // ============================================
 
   /**
-   * Check if Claude Code CLI is available
+   * Check if Claude Code CLI is available.
+   *
+   * #2110 fix — three issues addressed:
+   *   1. Cache only `true`, never `false`. A transient failure (WSL2 cold
+   *      start, AV scanner, slow shell init) used to set
+   *      `claudeCodeAvailable = false` for the rest of the daemon
+   *      lifetime, so the daemon kept running local stubs even after the
+   *      user fixed `claude auth login`. Now: false results re-probe on
+   *      the next call.
+   *   2. Log the actual error from the catch block instead of silently
+   *      swallowing it. Operators couldn't distinguish timeout / ENOENT /
+   *      auth-failure / exit-code without this.
+   *   3. Honour `CLAUDE_CODE_AVAILABILITY_TIMEOUT_MS` for WSL2 / slow
+   *      systems where `claude --version` can take >5s on first invoke.
    */
   async isAvailable(): Promise<boolean> {
-    if (this.claudeCodeAvailable !== null) {
-      return this.claudeCodeAvailable;
+    // Only the `true` result is cached — `false` is re-probed every call
+    // so a transient failure doesn't poison the rest of the daemon's life.
+    if (this.claudeCodeAvailable === true) {
+      return true;
     }
 
+    const timeoutMs = Number.parseInt(process.env.CLAUDE_CODE_AVAILABILITY_TIMEOUT_MS || '', 10) || 5000;
     try {
       const output = execSync('claude --version', {
         encoding: 'utf-8',
         stdio: 'pipe',
-        timeout: 5000,
+        timeout: timeoutMs,
         windowsHide: true, // Prevent phantom console windows on Windows
       });
       this.claudeCodeAvailable = true;
       this.claudeCodeVersion = output.trim();
       this.emit('status', { available: true, version: this.claudeCodeVersion });
       return true;
-    } catch {
-      this.claudeCodeAvailable = false;
-      this.emit('status', { available: false });
+    } catch (err) {
+      // Don't cache false — let the next call retry. Surface the actual
+      // error via emit so operators can diagnose timeout / ENOENT / auth.
+      this.claudeCodeAvailable = null;
+      const reason =
+        err instanceof Error
+          ? `${err.name}: ${err.message}`.slice(0, 200)
+          : String(err).slice(0, 200);
+      this.emit('status', { available: false, reason });
       return false;
     }
   }

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -149,7 +149,19 @@ export class WorkerDaemon extends EventEmitter {
 
     // CPU-proportional smart default instead of hardcoded 2.0
     const cpuCount = WorkerDaemon.getEffectiveCpuCount();
-    const smartMaxCpuLoad = Math.max(cpuCount * 0.8, 2.0); // Floor of 2.0 for single-CPU machines
+    let smartMaxCpuLoad = Math.max(cpuCount * 0.8, 2.0); // Floor of 2.0 for single-CPU machines
+
+    // #2110 — WSL2 reports `/proc/loadavg` values that include Windows-side
+    // process counts mapped into the Linux kernel. Real load on a 4-CPU
+    // WSL2 host can be 200-400 even when the Linux side is idle. The
+    // default gate of `cpuCount * 0.8` always trips, deferring every
+    // worker as "CPU load too high" while the daemon reports healthy.
+    // Bump the floor to 1000 when WSL is detected so the gate is
+    // effectively disabled (real load on Linux side rarely exceeds 100
+    // even under heavy contention).
+    if (WorkerDaemon.isWslEnvironment()) {
+      smartMaxCpuLoad = Math.max(smartMaxCpuLoad, 1000);
+    }
 
     // Platform-aware default: macOS os.freemem() excludes reclaimable file cache,
     // so reported "free" is much lower than actually available memory.
@@ -262,6 +274,26 @@ export class WorkerDaemon extends EventEmitter {
    * cgroup v2 / v1 quota files first so the maxCpuLoad threshold stays
    * meaningful under resource-limited containers.
    */
+  /**
+   * #2110 — detect WSL2 / WSL1 so the CPU-load gate can use a sane
+   * default. `/proc/loadavg` on WSL maps in Windows-side process counts
+   * and routinely reports values 100-1000x larger than real Linux load.
+   *
+   * Detection order:
+   *   1. `WSL_DISTRO_NAME` env var (set by Microsoft's WSL launcher)
+   *   2. `WSL_INTEROP` env var (set by recent WSL2)
+   *   3. `/proc/sys/kernel/osrelease` contains "microsoft" or "WSL"
+   *      (kernel build marker; survives env stripping)
+   */
+  static isWslEnvironment(): boolean {
+    if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) return true;
+    try {
+      const osrelease = readFileSync('/proc/sys/kernel/osrelease', 'utf8').toLowerCase();
+      if (osrelease.includes('microsoft') || osrelease.includes('wsl')) return true;
+    } catch { /* not on Linux or /proc inaccessible */ }
+    return false;
+  }
+
   static getEffectiveCpuCount(): number {
     // 1. Try cgroup v2: /sys/fs/cgroup/cpu.max
     try {
@@ -1050,20 +1082,42 @@ export class WorkerDaemon extends EventEmitter {
       try {
         this.log('info', `Running ${workerConfig.type} in headless mode (Claude Code AI)`);
         const result = await this.headlessExecutor.execute(workerConfig.type as HeadlessWorkerType);
-        // #1793: persist the headless result to the same metrics files the
-        // local workers write to. Without this, AI-mode runs produced rich
-        // parsedOutput that lived only in `.claude-flow/logs/headless/*` and
-        // never reached `.claude-flow/metrics/<name>.json` — `memory stats`
-        // and downstream consumers saw nothing despite successful runs.
-        try {
-          this.persistHeadlessResult(workerConfig.type as HeadlessWorkerType, result);
-        } catch (persistError) {
-          this.log('warn', `Failed to persist headless result for ${workerConfig.type}: ${(persistError as Error).message}`);
+
+        // #2110 — `HeadlessWorkerExecutor.execute()` returns
+        // `createErrorResult(...)` with `success: false` when
+        // `isAvailable()` is false, instead of throwing. The previous
+        // try/catch never fired in that path, and the result was
+        // persisted as mode:"headless" despite being a stub. Downstream
+        // dashboards / `memory stats` couldn't distinguish a real AI
+        // run from a fallback. Treat falsy success the same as throw.
+        const ok = (result as { success?: unknown })?.success === true;
+        if (!ok) {
+          const reason =
+            (result as { error?: unknown })?.error ||
+            (result as { note?: unknown })?.note ||
+            'headless executor reported success=false';
+          this.log('warn', `Headless ${workerConfig.type} returned success=false (${String(reason).slice(0, 200)}); falling back to local mode`);
+          this.emit('headless:fallback', {
+            type: workerConfig.type,
+            error: String(reason).slice(0, 500),
+          });
+          // Fall through to local switch.
+        } else {
+          // #1793: persist the headless result to the same metrics files the
+          // local workers write to. Without this, AI-mode runs produced rich
+          // parsedOutput that lived only in `.claude-flow/logs/headless/*` and
+          // never reached `.claude-flow/metrics/<name>.json` — `memory stats`
+          // and downstream consumers saw nothing despite successful runs.
+          try {
+            this.persistHeadlessResult(workerConfig.type as HeadlessWorkerType, result);
+          } catch (persistError) {
+            this.log('warn', `Failed to persist headless result for ${workerConfig.type}: ${(persistError as Error).message}`);
+          }
+          return {
+            mode: 'headless',
+            ...result,
+          };
         }
-        return {
-          mode: 'headless',
-          ...result,
-        };
       } catch (error) {
         this.log('warn', `Headless execution failed for ${workerConfig.type}, falling back to local mode`);
         this.emit('headless:fallback', {


### PR DESCRIPTION
Closes #2110. Reporter: @tatyinandy-commits.

## Three compounding bugs, file:line-anchored

Reporter gave a precise breakdown — verified all three:

### 1. `isAvailable()` caches `false` forever (`headless-worker-executor.ts:634`)
A transient `claude --version` failure cached `false` for the daemon's lifetime. Now: cache only `true`, surface the actual error via emit, support `CLAUDE_CODE_AVAILABILITY_TIMEOUT_MS` env var for WSL2-class slow systems.

### 2. WSL2 `/proc/loadavg` permanently fails CPU gate (`worker-daemon.ts:152`)
WSL maps Windows-side process counts into `/proc/loadavg`, reporting 100-1000x real values. New `WorkerDaemon.isWslEnvironment()` static (checks `WSL_DISTRO_NAME`, `WSL_INTEROP`, `/proc/sys/kernel/osrelease`); on WSL the gate floors at 1000 so it's effectively disabled.

### 3. `runWorkerLogic` doesn't check `result.success` (`worker-daemon.ts:1047`)
`HeadlessWorkerExecutor.execute()` returns `success:false` on failure instead of throwing. Catch never fired; stubs got persisted as `mode:"headless"`. Now explicit `success === true` check, falsy falls through to local with a warn log.

## Test plan

- [x] Build clean
- [x] `WorkerDaemon.isWslEnvironment()` returns `false` on macOS (correct)
- [ ] CI green
- [ ] Post-merge: ask @tatyinandy-commits to verify on WSL2

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)