### PR TITLE
fix(statusline): resolve version from global npm install (nvm/system)

### DIFF
--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -681,6 +681,10 @@ function generateStatusline() {
   let pkgVersion = '3.6';
   try {
     const home = require('os').homedir();
+    // Resolve global npm prefix so we also cover nvm-style and system-wide
+    // installs (`npm i -g ruflo`). Without this, users on nvm fell through
+    // to the hardcoded fallback even though `ruflo --version` reported correctly.
+    const npmGlobalRoot = safeExec('npm root -g', 1500);
     const pkgPaths = [
       // 1. The plugin's own root (installed via /plugin install).
       path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
@@ -690,6 +694,11 @@ function generateStatusline() {
       path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
       // 4. Source-checkout location (when developing in this repo).
       path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
+      // 5. Global npm install (nvm / system) — resolved at runtime.
+      ...(npmGlobalRoot ? [
+        path.join(npmGlobalRoot, 'ruflo', 'package.json'),
+        path.join(npmGlobalRoot, '@claude-flow', 'cli', 'package.json'),
+      ] : []),
     ];
     for (const p of pkgPaths) {
       if (!fs.existsSync(p)) continue;


### PR DESCRIPTION
## Summary
- Statusline previously fell through to the hardcoded fallback (`v3.6`) for users who installed via `npm i -g ruflo` — particularly on nvm — even though `ruflo --version` reported the correct alpha.
- Follow-up to #1951, which only covered the plugin-install case. Project-local `node_modules` and source-checkout paths are also already covered; the global npm install path was the remaining gap.
- This patch resolves `npm root -g` at runtime and appends `<global>/ruflo/package.json` + `<global>/@claude-flow/cli/package.json` to the lookup list. Falls back gracefully if `npm` is unavailable (the existing `safeExec` 1.5s timeout returns `''`, and the spread becomes a no-op).

## Repro
```bash
nvm use <any node>
npm i -g ruflo@latest
ruflo --version          # → 3.7.0-alpha.81 ✅
# Open a Claude Code session — statusline header shows "RuFlo V3.6" ❌
```

After this patch the statusline header reads the same version `ruflo --version` reports.

## Why a 5th path instead of just bumping the fallback
Bumping the hardcoded `'3.6'` masks the bug for one alpha and recurs at every release. Reading from the actually-installed package.json — wherever it lives — is version-agnostic.

## Test plan
- [x] Manually verified statusline output before/after on a machine where ruflo is only installed via `npm i -g` on nvm
- [x] Verified npm unavailable case: `safeExec('npm root -g')` returns `''`, spread becomes empty, lookup behaves identically to before
- [ ] CI tests for `statusline-generator.ts` (please run the existing suite — I didn't see a dedicated test file for this module)