### PR TITLE
fix(memory): #2120 — accept NULL status (legacy DBs) + first stable 3.7.0

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -85,6 +85,13 @@ on:
       # in callAnthropicMessages must stay wired.
       - 'v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts'
       - 'scripts/smoke-agent-execute-providers.mjs'
+      # memory stats legacy-DB regression guard (#2120) — the WHERE
+      # status='active' filter must accept NULL too, and the schema
+      # backfill must promote NULL→'active' on existing DBs.
+      - 'v3/@claude-flow/cli/src/memory/memory-bridge.ts'
+      - 'v3/@claude-flow/cli/src/memory/memory-initializer.ts'
+      - 'v3/@claude-flow/cli/src/commands/status.ts'
+      - 'scripts/smoke-memory-stats-legacy-db.mjs'
       # GitHub skills/agents/helpers surface (#2089, ADR-127) — injection
       # smoke + actions pin smoke gate every change to the .github surface.
       - '.claude/agents/github/**'
@@ -165,6 +172,11 @@ on:
       # agent_execute provider routing (#2042)
       - 'v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts'
       - 'scripts/smoke-agent-execute-providers.mjs'
+      # memory stats legacy-DB regression (#2120)
+      - 'v3/@claude-flow/cli/src/memory/memory-bridge.ts'
+      - 'v3/@claude-flow/cli/src/memory/memory-initializer.ts'
+      - 'v3/@claude-flow/cli/src/commands/status.ts'
+      - 'scripts/smoke-memory-stats-legacy-db.mjs'
       # GitHub skills/agents/helpers surface (#2089, ADR-127)
       - '.claude/agents/github/**'
       - '.claude/skills/github-*/**'
@@ -1038,6 +1050,45 @@ jobs:
 
       - name: Run agent_execute providers smoke
         run: node scripts/smoke-agent-execute-providers.mjs
+
+  memory-stats-legacy-db-smoke:
+    # Regression guard for ruvnet/ruflo#2120 — `ruflo memory stats` and
+    # `listEntries` returned 0 entries against a populated
+    # `.swarm/memory.db` on WSL2 (reporter: @alexandrelealbess on
+    # alpha.81). Root cause: the `WHERE status = 'active'` filter
+    # excluded rows where the status column was NULL (legacy DBs
+    # created before the status column existed, or via the auto-memory
+    # bridge path that didn't set status).
+    #
+    # Fix: (1) accept `status IS NULL` alongside `'active'` in both
+    # bridgeListEntries and listEntries; (2) backfill `UPDATE
+    # memory_entries SET status = 'active' WHERE status IS NULL` in
+    # ensureSchemaColumns; (3) broaden `isInitialized()` in
+    # `status.ts` to also accept `.swarm/memory.db` existence.
+    #
+    # This smoke builds a 251-entry DB with all-NULL status (mirroring
+    # the reporter's setup), runs listEntries, and asserts total === 251
+    # AND that the backfill promoted all rows to 'active'.
+    name: memory stats legacy-DB smoke (#2120)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install root deps (for sql.js + cli imports)
+        run: npm install --legacy-peer-deps --no-audit --no-fund --ignore-scripts
+
+      - name: Build CLI dist
+        run: cd v3/@claude-flow/cli && npm install --legacy-peer-deps --no-audit --no-fund --ignore-scripts && npm run build
+
+      - name: Run memory stats legacy-DB smoke
+        run: node scripts/smoke-memory-stats-legacy-db.mjs
 
   github-safe-injection-smoke:
     # Regression guard for ruvnet/ruflo#2089 — ADR-127 Phase 1.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.81",
+  "version": "3.7.0",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.7.0-alpha.81",
+  "version": "3.7.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/scripts/smoke-memory-stats-legacy-db.mjs
+++ b/scripts/smoke-memory-stats-legacy-db.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Regression guard for ruvnet/ruflo#2120 — `ruflo memory stats` and
+ * `listEntries` returned 0 entries against a populated `.swarm/memory.db`
+ * on WSL2 (reporter: @alexandrelealbess, alpha.81).
+ *
+ * Root cause: the `WHERE status = 'active'` filter in both
+ * `bridgeListEntries` (memory-bridge.ts) and `listEntries`
+ * (memory-initializer.ts:2544+) excluded rows where the `status` column
+ * was NULL — which happens when:
+ *   - The DB was created before the status column existed
+ *   - The auto-memory bridge wrote rows via a path that didn't set status
+ *   - ALTER TABLE ADD COLUMN's DEFAULT backfill was skipped
+ *
+ * This smoke creates a `.swarm/memory.db` with 251 entries that have NULL
+ * status (simulating an old DB), then asserts both code paths return 251
+ * — not 0.
+ *
+ * Without the #2120 fix, the assertion fails with `total: 0`.
+ */
+
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+function fail(msg) { console.error(`✗ ${msg}`); process.exitCode = 1; }
+function pass(msg) { console.log(`✓ ${msg}`); }
+
+// 1. Build a `.swarm/memory.db` that mirrors the reporter's setup:
+//    251 entries with status = NULL.
+const work = mkdtempSync(join(tmpdir(), 'smoke-2120-'));
+try {
+  const swarmDir = join(work, '.swarm');
+  mkdirSync(swarmDir, { recursive: true });
+  const dbPath = join(swarmDir, 'memory.db');
+
+  const initSqlJs = (await import('sql.js')).default;
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.exec(`CREATE TABLE memory_entries (
+    id TEXT PRIMARY KEY,
+    key TEXT NOT NULL,
+    namespace TEXT DEFAULT 'default',
+    content TEXT NOT NULL,
+    type TEXT DEFAULT 'semantic',
+    embedding TEXT,
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+    access_count INTEGER DEFAULT 0,
+    status TEXT
+  )`);
+  // Insert 251 entries with NULL status (the actual reporter scenario)
+  const ns = (i) => i < 85 ? 'feedback' : i < 156 ? 'causal-edges' : i < 187 ? 'session' : i < 210 ? 'project' : 'pattern';
+  for (let i = 0; i < 251; i++) {
+    db.run(
+      `INSERT INTO memory_entries(id, key, namespace, content) VALUES (?, ?, ?, ?)`,
+      [`id_${i}`, `key_${i}`, ns(i), `content for entry ${i}`],
+    );
+  }
+  writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+  pass(`fixture: 251 entries written to ${dbPath} with status=NULL`);
+
+  // 2. Verify the fixture is what we expect (sanity)
+  {
+    const SQL2 = await initSqlJs();
+    const verify = new SQL2.Database(new Uint8Array(await (await import('node:fs/promises')).readFile(dbPath)));
+    const stmt = verify.prepare('SELECT COUNT(*) FROM memory_entries WHERE status IS NULL');
+    stmt.step();
+    const nullCount = stmt.get()[0];
+    stmt.free();
+    if (nullCount !== 251) fail(`fixture sanity: expected 251 NULL-status rows, got ${nullCount}`);
+    else pass(`fixture sanity: 251 rows have status=NULL`);
+    verify.close();
+  }
+
+  // 3. Run the actual `listEntries` from the built CLI dist with the
+  //    bridge DISABLED via env hint — we test the raw sql.js fallback
+  //    path because the AgentDB v3 bridge optionally pulls a Xenova
+  //    embedding model on init which hangs CI without network.
+  process.env.CLAUDE_FLOW_MEMORY_PATH = swarmDir;
+  process.env.CLAUDE_FLOW_DISABLE_BRIDGE = '1';
+  // Reset getMemoryRoot cache so the env var takes effect.
+  const init = await import(resolve(REPO_ROOT, 'v3/@claude-flow/cli/dist/src/memory/memory-initializer.js'));
+  if (typeof init._resetMemoryRootCache === 'function') init._resetMemoryRootCache();
+
+  // Force-route through raw sql.js by passing explicit dbPath
+  const result = await init.listEntries({ limit: 1000, dbPath });
+  if (!result.success) {
+    fail(`listEntries returned success=false: ${result.error}`);
+  } else if (result.total === 0) {
+    fail(`#2120 REGRESSION: listEntries returned total=0 for 251-row legacy DB (NULL status not accepted)`);
+  } else if (result.total !== 251) {
+    fail(`listEntries returned total=${result.total}, expected 251`);
+  } else {
+    pass(`listEntries returns total=251 against legacy DB (NULL status accepted as active)`);
+  }
+
+  // 4. After listEntries, the backfill in ensureSchemaColumns should
+  //    have updated NULL → 'active'. Verify by re-reading.
+  {
+    const SQL3 = await initSqlJs();
+    const verify = new SQL3.Database(new Uint8Array(await (await import('node:fs/promises')).readFile(dbPath)));
+    const stmt = verify.prepare(`SELECT COUNT(*) FROM memory_entries WHERE status = 'active'`);
+    stmt.step();
+    const activeCount = stmt.get()[0];
+    stmt.free();
+    if (activeCount !== 251) {
+      fail(`backfill: expected 251 status='active' rows after listEntries, got ${activeCount}`);
+    } else {
+      pass(`backfill: ensureSchemaColumns promoted NULL → 'active' for all 251 rows`);
+    }
+    verify.close();
+  }
+} finally {
+  if (existsSync(work)) rmSync(work, { recursive: true, force: true });
+}
+
+if (process.exitCode) {
+  console.error('\n#2120 regression smoke FAILED');
+  process.exit(1);
+} else {
+  console.log('\n#2120 regression smoke PASS');
+  // Exit explicitly so a lazy bridge handle / sql.js worker keepalive
+  // doesn't prevent the process from terminating (observed locally —
+  // assertions all passed but process kept running for 30s+).
+  process.exit(0);
+}

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.7.0-alpha.81",
+  "version": "3.7.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/status.ts
+++ b/v3/@claude-flow/cli/src/commands/status.ts
@@ -44,9 +44,26 @@ function getProcessMemoryUsage(): number {
 }
 
 // Check if project is initialized
+//
+// #2120 — the old check required `.claude-flow/config.yaml`, which
+// missed projects that were initialized via `ruflo memory init` (writes
+// `.swarm/memory.db` but no config.yaml) or via the auto-memory bridge.
+// Reporter @alexandrelealbess on WSL2 had a 251-entry `.swarm/memory.db`
+// and a running MCP, yet `ruflo status` reported "not initialized".
+//
+// Now: any of these signals counts as initialized:
+//   - `.claude-flow/config.yaml`   (the canonical `ruflo init` output)
+//   - `.claude-flow/config.json`   (same, alt format)
+//   - `.swarm/memory.db`           (the `ruflo memory init` output)
+//   - `.claude/settings.json`      (the Claude Code hook surface)
 function isInitialized(cwd: string): boolean {
-  const configPath = path.join(cwd, '.claude-flow', 'config.yaml');
-  return fs.existsSync(configPath);
+  const candidates = [
+    path.join(cwd, '.claude-flow', 'config.yaml'),
+    path.join(cwd, '.claude-flow', 'config.json'),
+    path.join(cwd, '.swarm', 'memory.db'),
+    path.join(cwd, '.claude', 'settings.json'),
+  ];
+  return candidates.some((p) => fs.existsSync(p));
 }
 
 // Format uptime

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -822,11 +822,21 @@ export async function bridgeListEntries(options: {
     const nsFilter = namespace ? `AND namespace = ?` : '';
     const nsParams = namespace ? [namespace] : [];
 
+    // #2120 — `status IS NULL` accepted alongside `'active'`. Old
+    // databases imported by the auto-memory bridge (before the status
+    // column existed) end up with NULL status after schema migration if
+    // the migration ran on an existing DB without a backfill. Reporter
+    // @alexandrelealbess on WSL2 had 251 entries with NULL status, so
+    // the `status = 'active'` filter matched zero. Treat NULL as
+    // "legacy-active" — the safe default for any entry that predates the
+    // status column.
+    const statusFilter = `(status = 'active' OR status IS NULL)`;
+
     // Count
     let total = 0;
     try {
       const countStmt = ctx.db.prepare(
-        `SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active' ${nsFilter}`
+        `SELECT COUNT(*) as cnt FROM memory_entries WHERE ${statusFilter} ${nsFilter}`
       );
       const countRow = countStmt.get(...nsParams);
       total = countRow?.cnt ?? 0;
@@ -840,7 +850,7 @@ export async function bridgeListEntries(options: {
       const stmt = ctx.db.prepare(`
         SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at
         FROM memory_entries
-        WHERE status = 'active' ${nsFilter}
+        WHERE ${statusFilter} ${nsFilter}
         ORDER BY updated_at DESC
         LIMIT ? OFFSET ?
       `);

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -1084,6 +1084,23 @@ export async function ensureSchemaColumns(dbPath: string): Promise<{
       }
     }
 
+    // #2120 — Belt-and-suspenders backfill. `ALTER TABLE ADD COLUMN
+    // status TEXT DEFAULT 'active'` should populate existing rows with
+    // 'active' in modern SQLite, but: (a) some auto-memory bridge writes
+    // happen via INSERT paths that pass an explicit NULL, (b) some
+    // historical sql.js builds skipped the DEFAULT backfill, (c)
+    // entries can be migrated in from older snapshots. After ensuring
+    // the column exists, force-backfill any remaining NULL → 'active'.
+    // Safe on already-correct DBs (0 rows updated).
+    if (columnsAdded.includes('status') || existingColumns.has('status')) {
+      try {
+        db.run(`UPDATE memory_entries SET status = 'active' WHERE status IS NULL`);
+        modified = true;
+      } catch {
+        /* table is read-only or doesn't exist — skip */
+      }
+    }
+
     if (modified) {
       // Save updated database
       const data = db.export();
@@ -2541,10 +2558,13 @@ export async function listEntries(options: {
     const fileBuffer = readFileMaybeEncrypted(dbPath, null);
     const db = new SQL.Database(fileBuffer);
 
+    // #2120 — accept `status IS NULL` alongside `'active'`. Old DBs
+    // that predate the status column may have NULL after migration.
+    // See memory-bridge.ts:bridgeListEntries for full context.
     // Get total count
     const countStmt = namespace
-      ? db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active' AND namespace = ?`)
-      : db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`);
+      ? db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE (status = 'active' OR status IS NULL) AND namespace = ?`)
+      : db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE (status = 'active' OR status IS NULL)`);
     if (namespace) {
       countStmt.bind([namespace]);
     }
@@ -2559,9 +2579,10 @@ export async function listEntries(options: {
     // Get entries
     const safeLimit = parseInt(String(limit), 10) || 100;
     const safeOffset = parseInt(String(offset), 10) || 0;
+    // #2120 — same NULL-as-active acceptance as the count above.
     const listStmt = namespace
-      ? db.prepare(`SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at FROM memory_entries WHERE status = 'active' AND namespace = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`)
-      : db.prepare(`SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at FROM memory_entries WHERE status = 'active' ORDER BY updated_at DESC LIMIT ? OFFSET ?`);
+      ? db.prepare(`SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at FROM memory_entries WHERE (status = 'active' OR status IS NULL) AND namespace = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`)
+      : db.prepare(`SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at FROM memory_entries WHERE (status = 'active' OR status IS NULL) ORDER BY updated_at DESC LIMIT ? OFFSET ?`);
     if (namespace) {
       listStmt.bind([namespace, safeLimit, safeOffset]);
     } else {


### PR DESCRIPTION
Closes #2120. Reporter: @alexandrelealbess (WSL2, alpha.81).

## Root cause

`WHERE status = 'active'` in both `bridgeListEntries` and `listEntries` excluded rows where the `status` column was NULL. Legacy DBs created before the column existed (or via auto-memory-bridge writes that didn't set status) end up with NULL status after schema migration — so the user's 251-row DB returned 0 from `memory stats`.

Bonus: `isInitialized()` in `status.ts` required `.claude-flow/config.yaml` exclusively, missing projects with only `.swarm/memory.db` from `ruflo memory init`.

## Fix (4 parts + CI guard)

| # | File | Change |
|---|---|---|
| 1 | `memory-bridge.ts` | Accept `status IS NULL` alongside `'active'` in `bridgeListEntries` |
| 2 | `memory-initializer.ts:listEntries` | Same NULL-acceptance in raw sql.js fallback (4 prepares) |
| 3 | `memory-initializer.ts:ensureSchemaColumns` | Belt-and-suspenders backfill — `UPDATE ... SET status='active' WHERE status IS NULL` after ALTER TABLE |
| 4 | `status.ts:isInitialized` | Accept any of 4 initialization signals, not just `.claude-flow/config.yaml` |
| **CI guard** | `scripts/smoke-memory-stats-legacy-db.mjs` + path filter | Builds 251-row legacy DB, asserts `total=251` and backfill works |

## Verification

```
$ node scripts/smoke-memory-stats-legacy-db.mjs
✓ fixture: 251 entries written to /tmp/smoke-2120-*/.swarm/memory.db with status=NULL
✓ fixture sanity: 251 rows have status=NULL
✓ listEntries returns total=251 against legacy DB (NULL status accepted as active)
✓ backfill: ensureSchemaColumns promoted NULL → 'active' for all 251 rows
#2120 regression smoke PASS
```

- `npm test` in `v3/@claude-flow/cli`: **1999/2045 pass** (46 skipped, 0 fail)
- Build clean

## First stable 3.7.0 — no more alphas

Per CLAUDE.md update yesterday (alpha series ended at alpha.81), this is the **first stable release: 3.7.0** — no `-alpha.N` suffix. Legacy `alpha` + `v3alpha` dist-tags continue to point at the latest stable for backward compat.

## Test plan

- [x] All existing tests pass
- [x] New smoke catches the regression (verified with current fix in place)
- [x] Build clean
- [ ] CI green
- [ ] Post-merge: ask @alexandrelealbess to verify on WSL2

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)