### PR TITLE
docs: update hooks reference from wildcard patterns to explicit event names.

### DIFF
--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -1794,7 +1794,7 @@ Full MCP server with tools for coordination, monitoring, memory, and GitHub inte
 | **Memory & Neural** | `memory_usage`, `neural_status`, `neural_train`, `neural_patterns` | Memory operations and learning |
 | **GitHub** | `github_swarm`, `repo_analyze`, `pr_enhance`, `issue_triage`, `code_review` | Repository integration |
 | **Workers** | `worker/run`, `worker/status`, `worker/alerts`, `worker/history` | Background task management |
-| **Hooks** | `hooks/pre-*`, `hooks/post-*`, `hooks/route`, `hooks/session-*`, `hooks/teammate-*`, `hooks/task-*` | 33 lifecycle hooks |
+| **Hooks** | `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `PreCompact`, `SubagentStop` | 33 lifecycle hooks |
 | **Progress** | `progress/check`, `progress/sync`, `progress/summary`, `progress/watch` | V3 implementation tracking |
 
 </details>


### PR DESCRIPTION
## Summary
- Updated stale wildcard hook references in USERGUIDE.md to reflect current Claude Code hook event names

## Issue / motivation
Closes #743

## Approach
The USERGUIDE.md referenced old-style wildcard hook patterns (`hooks/pre-*`, `hooks/post-*`, etc.) that no longer match how hooks are configured. The actual settings.json uses explicit Claude Code lifecycle events (`PreToolUse`, `PostToolUse`, `SessionStart`, etc.). Updated line 1797 to reflect the current hook event names.

## Test plan
- [x] Verified against `.claude/settings.json` which uses the explicit event names
- [x] No functional code changes — documentation only

## Risks / open questions
None — documentation-only change.