### PR TITLE
chore(cli): #2141 — remove unused default exports + audit guard

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -1830,6 +1830,27 @@ jobs:
         shell: bash
         run: node scripts/audit-vector-dim.mjs
 
+  no-default-export-audit:
+    # #2141 — guard against re-introducing `export default` in the CLI's
+    # commands/, mcp-tools/, production/, ruvector/ directories.
+    # Callers always use named imports; a default export here is dead code.
+    # Exception: commands/update.ts has an active caller in commands-deep.test.ts.
+    name: No-default-export leak guard (#2141)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Audit for unexpected export default (#2141)
+        shell: bash
+        run: node scripts/audit-no-default-export-leak.mjs
+
   witness-verify:
     # Cryptographic regression guard: runs `ruflo verify --manifest` against
     # the local build to confirm every documented fix in verification.md.json
@@ -1972,7 +1993,7 @@ jobs:
   publish:
     name: Publish to npm (alpha)
     runs-on: ubuntu-latest
-    needs: [build, smoke-install-no-bsqlite, plugin-hooks-smoke, witness-verify]
+    needs: [build, smoke-install-no-bsqlite, plugin-hooks-smoke, witness-verify, no-default-export-audit]
     if: github.ref == 'refs/heads/v3' && github.event_name == 'push'
 
     steps:

--- a/scripts/audit-no-default-export-leak.mjs
+++ b/scripts/audit-no-default-export-leak.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * audit-no-default-export-leak.mjs
+ *
+ * Scans v3/@claude-flow/cli/src/{commands,mcp-tools,production,ruvector}
+ * for any `export default` statement and exits 1 if found.
+ *
+ * Exception: commands/update.ts is allowed because it has an active
+ * default import in __tests__/commands-deep.test.ts.
+ *
+ * Wire into CI via:
+ *   node scripts/audit-no-default-export-leak.mjs
+ *
+ * Issue: #2141
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = join(__dirname, '..');
+
+const SCAN_DIRS = [
+  'v3/@claude-flow/cli/src/commands',
+  'v3/@claude-flow/cli/src/mcp-tools',
+  'v3/@claude-flow/cli/src/production',
+  'v3/@claude-flow/cli/src/ruvector',
+];
+
+/** Files with active default imports that are exempt from this rule. */
+const EXEMPT = new Set([
+  'v3/@claude-flow/cli/src/commands/update.ts',
+]);
+
+function walkDir(dir) {
+  const entries = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      entries.push(...walkDir(full));
+    } else if (name.endsWith('.ts') && !name.endsWith('.d.ts')) {
+      entries.push(full);
+    }
+  }
+  return entries;
+}
+
+let violations = 0;
+
+for (const dir of SCAN_DIRS) {
+  const absDir = join(ROOT, dir);
+  let files;
+  try {
+    files = walkDir(absDir);
+  } catch {
+    continue;
+  }
+
+  for (const file of files) {
+    const rel = relative(ROOT, file);
+    if (EXEMPT.has(rel)) continue;
+
+    const src = readFileSync(file, 'utf8');
+    const lines = src.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (/^export default\b/.test(lines[i])) {
+        console.error(`FAIL  ${rel}:${i + 1}  unexpected \`export default\``);
+        violations++;
+      }
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(
+    `\n${violations} violation(s) found in commands/, mcp-tools/, production/, ruvector/.` +
+    '\nRemove the `export default` lines — callers use named imports only.' +
+    '\nSee issue #2141 for context.'
+  );
+  process.exit(1);
+} else {
+  console.log('OK  no unexpected `export default` in commands/, mcp-tools/, production/, ruvector/');
+  process.exit(0);
+}

--- a/v3/@claude-flow/cli/src/commands/agent.ts
+++ b/v3/@claude-flow/cli/src/commands/agent.ts
@@ -1064,5 +1064,3 @@ function formatStatus(status: unknown): string {
       return statusStr;
   }
 }
-
-export default agentCommand;

--- a/v3/@claude-flow/cli/src/commands/analyze.ts
+++ b/v3/@claude-flow/cli/src/commands/analyze.ts
@@ -2338,5 +2338,3 @@ export const analyzeCommand: Command = {
     return { success: true };
   },
 };
-
-export default analyzeCommand;

--- a/v3/@claude-flow/cli/src/commands/appliance.ts
+++ b/v3/@claude-flow/cli/src/commands/appliance.ts
@@ -439,5 +439,3 @@ export const applianceCommand: Command = {
     return { success: true };
   },
 };
-
-export default applianceCommand;

--- a/v3/@claude-flow/cli/src/commands/autopilot.ts
+++ b/v3/@claude-flow/cli/src/commands/autopilot.ts
@@ -400,5 +400,3 @@ export const autopilotCommand: Command = {
     return { success: true };
   },
 };
-
-export default autopilotCommand;

--- a/v3/@claude-flow/cli/src/commands/benchmark.ts
+++ b/v3/@claude-flow/cli/src/commands/benchmark.ts
@@ -509,5 +509,3 @@ export const benchmarkCommand: Command = {
     return { success: true, message: 'Use a subcommand to run benchmarks' };
   },
 };
-
-export default benchmarkCommand;

--- a/v3/@claude-flow/cli/src/commands/claims.ts
+++ b/v3/@claude-flow/cli/src/commands/claims.ts
@@ -673,5 +673,3 @@ export const claimsCommand: Command = {
     return { success: true };
   },
 };
-
-export default claimsCommand;

--- a/v3/@claude-flow/cli/src/commands/cleanup.ts
+++ b/v3/@claude-flow/cli/src/commands/cleanup.ts
@@ -265,5 +265,3 @@ export const cleanupCommand: Command = {
     };
   },
 };
-
-export default cleanupCommand;

--- a/v3/@claude-flow/cli/src/commands/completions.ts
+++ b/v3/@claude-flow/cli/src/commands/completions.ts
@@ -554,5 +554,3 @@ export const completionsCommand: Command = {
     return { success: true };
   }
 };
-
-export default completionsCommand;

--- a/v3/@claude-flow/cli/src/commands/config.ts
+++ b/v3/@claude-flow/cli/src/commands/config.ts
@@ -437,5 +437,3 @@ export const configCommand: Command = {
     return { success: true };
   }
 };
-
-export default configCommand;

--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -1167,5 +1167,3 @@ export const daemonCommand: Command = {
     return { success: true };
   },
 };
-
-export default daemonCommand;

--- a/v3/@claude-flow/cli/src/commands/deployment.ts
+++ b/v3/@claude-flow/cli/src/commands/deployment.ts
@@ -766,5 +766,3 @@ export const deploymentCommand: Command = {
     return { success: true };
   },
 };
-
-export default deploymentCommand;

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -922,5 +922,3 @@ export const doctorCommand: Command = {
     }
   }
 };
-
-export default doctorCommand;

--- a/v3/@claude-flow/cli/src/commands/embeddings.ts
+++ b/v3/@claude-flow/cli/src/commands/embeddings.ts
@@ -1792,5 +1792,3 @@ export const embeddingsCommand: Command = {
     return { success: true };
   },
 };
-
-export default embeddingsCommand;

--- a/v3/@claude-flow/cli/src/commands/guidance.ts
+++ b/v3/@claude-flow/cli/src/commands/guidance.ts
@@ -622,5 +622,3 @@ export const guidanceCommand: Command = {
     return { success: true };
   },
 };
-
-export default guidanceCommand;

--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -1451,5 +1451,3 @@ function formatPriority(priority: string): string {
       return priority;
   }
 }
-
-export default hiveMindCommand;

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -5325,5 +5325,3 @@ export const hooksCommand: Command = {
     return { success: true };
   }
 };
-
-export default hooksCommand;

--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -1159,5 +1159,3 @@ export const initCommand: Command = {
   ],
   action: initAction,
 };
-
-export default initCommand;

--- a/v3/@claude-flow/cli/src/commands/issues.ts
+++ b/v3/@claude-flow/cli/src/commands/issues.ts
@@ -638,5 +638,3 @@ function formatDuration(ms: number): string {
   if (hours < 24) return `${hours}h`;
   return `${Math.floor(hours / 24)}d`;
 }
-
-export default issuesCommand;

--- a/v3/@claude-flow/cli/src/commands/mcp.ts
+++ b/v3/@claude-flow/cli/src/commands/mcp.ts
@@ -808,5 +808,3 @@ export const mcpCommand: Command = {
     return { success: true };
   }
 };
-
-export default mcpCommand;

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -1688,5 +1688,3 @@ export const memoryCommand: Command = {
     return { success: true };
   }
 };
-
-export default memoryCommand;

--- a/v3/@claude-flow/cli/src/commands/migrate.ts
+++ b/v3/@claude-flow/cli/src/commands/migrate.ts
@@ -779,5 +779,3 @@ function getMigrationSteps(target: string): Array<{ name: string; description: s
 
   return allSteps.filter(s => s.name.toLowerCase().includes(target.toLowerCase()));
 }
-
-export default migrateCommand;

--- a/v3/@claude-flow/cli/src/commands/neural.ts
+++ b/v3/@claude-flow/cli/src/commands/neural.ts
@@ -1788,5 +1788,3 @@ export const neuralCommand: Command = {
     return { success: true };
   },
 };
-
-export default neuralCommand;

--- a/v3/@claude-flow/cli/src/commands/performance.ts
+++ b/v3/@claude-flow/cli/src/commands/performance.ts
@@ -651,5 +651,3 @@ export const performanceCommand: Command = {
     return { success: true };
   },
 };
-
-export default performanceCommand;

--- a/v3/@claude-flow/cli/src/commands/plugins.ts
+++ b/v3/@claude-flow/cli/src/commands/plugins.ts
@@ -938,5 +938,3 @@ export const pluginsCommand: Command = {
     return { success: true };
   },
 };
-
-export default pluginsCommand;

--- a/v3/@claude-flow/cli/src/commands/progress.ts
+++ b/v3/@claude-flow/cli/src/commands/progress.ts
@@ -294,5 +294,3 @@ export const progressCommand: Command = {
     return (await checkCommand.action!(ctx)) as CommandResult;
   },
 };
-
-export default progressCommand;

--- a/v3/@claude-flow/cli/src/commands/providers.ts
+++ b/v3/@claude-flow/cli/src/commands/providers.ts
@@ -567,5 +567,3 @@ export const providersCommand: Command = {
     return { success: true };
   },
 };
-
-export default providersCommand;

--- a/v3/@claude-flow/cli/src/commands/route.ts
+++ b/v3/@claude-flow/cli/src/commands/route.ts
@@ -901,5 +901,3 @@ export const routeCommand: Command = {
     return { success: true };
   },
 };
-
-export default routeCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/backup.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/backup.ts
@@ -802,5 +802,3 @@ export const backupCommand: Command = {
     return { success: true };
   },
 };
-
-export default backupCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/benchmark.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/benchmark.ts
@@ -527,5 +527,3 @@ export const benchmarkCommand: Command = {
     }
   },
 };
-
-export default benchmarkCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/import.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/import.ts
@@ -424,5 +424,3 @@ export const importCommand: Command = {
     return { success: true };
   },
 };
-
-export default importCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/index.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/index.ts
@@ -124,7 +124,6 @@ export const ruvectorCommand: Command = {
   },
 };
 
-export default ruvectorCommand;
 
 // Re-export subcommands for direct access
 export { initCommand } from './init.js';

--- a/v3/@claude-flow/cli/src/commands/ruvector/init.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/init.ts
@@ -511,5 +511,3 @@ export const initCommand: Command = {
     }
   },
 };
-
-export default initCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/migrate.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/migrate.ts
@@ -537,5 +537,3 @@ export const migrateCommand: Command = {
     }
   },
 };
-
-export default migrateCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/optimize.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/optimize.ts
@@ -572,5 +572,3 @@ export const optimizeCommand: Command = {
     }
   },
 };
-
-export default optimizeCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/setup.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/setup.ts
@@ -779,5 +779,3 @@ export const setupCommand: Command = {
     }
   },
 };
-
-export default setupCommand;

--- a/v3/@claude-flow/cli/src/commands/ruvector/status.ts
+++ b/v3/@claude-flow/cli/src/commands/ruvector/status.ts
@@ -496,5 +496,3 @@ export const statusCommand: Command = {
     }
   },
 };
-
-export default statusCommand;

--- a/v3/@claude-flow/cli/src/commands/security.ts
+++ b/v3/@claude-flow/cli/src/commands/security.ts
@@ -959,5 +959,3 @@ export const securityCommand: Command = {
     return { success: true };
   },
 };
-
-export default securityCommand;

--- a/v3/@claude-flow/cli/src/commands/session.ts
+++ b/v3/@claude-flow/cli/src/commands/session.ts
@@ -901,5 +901,3 @@ export const sessionCommand: Command = {
     return { success: true };
   }
 };
-
-export default sessionCommand;

--- a/v3/@claude-flow/cli/src/commands/start.ts
+++ b/v3/@claude-flow/cli/src/commands/start.ts
@@ -474,5 +474,3 @@ export const startCommand: Command = {
   ],
   action: startAction
 };
-
-export default startCommand;

--- a/v3/@claude-flow/cli/src/commands/status.ts
+++ b/v3/@claude-flow/cli/src/commands/status.ts
@@ -755,5 +755,3 @@ export const statusCommand: Command = {
   ],
   action: statusAction
 };
-
-export default statusCommand;

--- a/v3/@claude-flow/cli/src/commands/swarm.ts
+++ b/v3/@claude-flow/cli/src/commands/swarm.ts
@@ -939,5 +939,3 @@ function getAgentPlan(strategy: string): Array<{ role: string; type: string; cou
 
   return plans[strategy] || plans.development;
 }
-
-export default swarmCommand;

--- a/v3/@claude-flow/cli/src/commands/task.ts
+++ b/v3/@claude-flow/cli/src/commands/task.ts
@@ -792,5 +792,3 @@ export const taskCommand: Command = {
     return { success: true };
   }
 };
-
-export default taskCommand;

--- a/v3/@claude-flow/cli/src/commands/transfer-store.ts
+++ b/v3/@claude-flow/cli/src/commands/transfer-store.ts
@@ -489,5 +489,3 @@ export const storeCommand: Command = {
     return { success: true };
   },
 };
-
-export default storeCommand;

--- a/v3/@claude-flow/cli/src/commands/verify.ts
+++ b/v3/@claude-flow/cli/src/commands/verify.ts
@@ -309,5 +309,3 @@ export const verifyCommand: Command = {
     return { success: false, exitCode: 1 };
   },
 };
-
-export default verifyCommand;

--- a/v3/@claude-flow/cli/src/commands/workflow.ts
+++ b/v3/@claude-flow/cli/src/commands/workflow.ts
@@ -738,5 +738,3 @@ function getTemplateDuration(template: string): string {
   };
   return durations[template] || '10-20 min';
 }
-
-export default workflowCommand;

--- a/v3/@claude-flow/cli/src/mcp-tools/analyze-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/analyze-tools.ts
@@ -350,5 +350,3 @@ export const analyzeTools: MCPTool[] = [
   fileRiskTool,
   diffStatsTool,
 ];
-
-export default analyzeTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/auto-install.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/auto-install.ts
@@ -153,11 +153,3 @@ export const OPTIONAL_PACKAGES = {
     tools: ['neural_*'],
   },
 } as const;
-
-export default {
-  autoInstallPackage,
-  tryImportOrInstall,
-  isPackageAvailable,
-  resetInstallAttempts,
-  OPTIONAL_PACKAGES,
-};

--- a/v3/@claude-flow/cli/src/mcp-tools/browser-session-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/browser-session-tools.ts
@@ -341,5 +341,3 @@ export const browserSessionTools: MCPTool[] = [
     },
   },
 ];
-
-export default browserSessionTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/browser-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/browser-tools.ts
@@ -700,5 +700,3 @@ export const browserTools: MCPTool[] = [
     },
   },
 ];
-
-export default browserTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/claims-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/claims-tools.ts
@@ -918,5 +918,3 @@ export const claimsTools: MCPTool[] = [
     },
   },
 ];
-
-export default claimsTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/guidance-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/guidance-tools.ts
@@ -678,5 +678,3 @@ export const guidanceTools: MCPTool[] = [
   guidanceWorkflow,
   guidanceQuickRef,
 ];
-
-export default guidanceTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -4184,5 +4184,3 @@ export const hooksTools: MCPTool[] = [
   hooksModelOutcome,
   hooksModelStats,
 ];
-
-export default hooksTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/progress-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/progress-tools.ts
@@ -383,5 +383,3 @@ export const progressTools: MCPTool[] = [
   progressSummary,
   progressWatch,
 ];
-
-export default progressTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/security-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/security-tools.ts
@@ -554,5 +554,3 @@ export const securityTools: MCPTool[] = [
   aidefenceIsSafeTool,
   aidefenceHasPIITool,
 ];
-
-export default securityTools;

--- a/v3/@claude-flow/cli/src/mcp-tools/transfer-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/transfer-tools.ts
@@ -415,5 +415,3 @@ export const transferTools: MCPTool[] = [
     },
   },
 ];
-
-export default transferTools;

--- a/v3/@claude-flow/cli/src/production/circuit-breaker.ts
+++ b/v3/@claude-flow/cli/src/production/circuit-breaker.ts
@@ -318,5 +318,3 @@ export function resetAllCircuits(): void {
     breaker.reset();
   }
 }
-
-export default CircuitBreaker;

--- a/v3/@claude-flow/cli/src/production/error-handler.ts
+++ b/v3/@claude-flow/cli/src/production/error-handler.ts
@@ -394,5 +394,3 @@ export function withErrorHandling<T extends (...args: unknown[]) => Promise<unkn
 ): T {
   return defaultHandler.wrap(handler, context);
 }
-
-export default ErrorHandler;

--- a/v3/@claude-flow/cli/src/production/monitoring.ts
+++ b/v3/@claude-flow/cli/src/production/monitoring.ts
@@ -484,5 +484,3 @@ export function createMonitor(config?: Partial<MonitorConfig>): MonitoringHooks 
 export function getMonitor(): MonitoringHooks {
   return createMonitor();
 }
-
-export default MonitoringHooks;

--- a/v3/@claude-flow/cli/src/production/rate-limiter.ts
+++ b/v3/@claude-flow/cli/src/production/rate-limiter.ts
@@ -278,5 +278,3 @@ export class RateLimiter {
 export function createRateLimiter(config?: Partial<RateLimiterConfig>): RateLimiter {
   return new RateLimiter(config);
 }
-
-export default RateLimiter;

--- a/v3/@claude-flow/cli/src/production/retry.ts
+++ b/v3/@claude-flow/cli/src/production/retry.ts
@@ -266,5 +266,3 @@ export function Retryable(
     return descriptor;
   };
 }
-
-export default withRetry;

--- a/v3/@claude-flow/cli/src/ruvector/coverage-tools.ts
+++ b/v3/@claude-flow/cli/src/ruvector/coverage-tools.ts
@@ -169,5 +169,3 @@ export const coverageRouterTools: MCPTool[] = [
   hooksCoverageSuggest,
   hooksCoverageGaps,
 ];
-
-export default coverageRouterTools;

--- a/v3/@claude-flow/cli/src/ruvector/lora-adapter.ts
+++ b/v3/@claude-flow/cli/src/ruvector/lora-adapter.ts
@@ -680,17 +680,3 @@ export async function getLoRAStats(): Promise<LoRAStats> {
   const adapter = await getLoRAAdapter();
   return adapter.getStats();
 }
-
-export default {
-  LoRAAdapter,
-  getLoRAAdapter,
-  resetLoRAAdapter,
-  createLoRAAdapter,
-  adaptEmbedding,
-  trainLoRA,
-  getLoRAStats,
-  DEFAULT_RANK,
-  DEFAULT_ALPHA,
-  INPUT_DIM,
-  OUTPUT_DIM,
-};

--- a/v3/@claude-flow/cli/src/ruvector/semantic-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/semantic-router.ts
@@ -224,5 +224,3 @@ export class SemanticRouter {
 export function createSemanticRouter(config: RouterConfig): SemanticRouter {
   return new SemanticRouter(config);
 }
-
-export default SemanticRouter;


### PR DESCRIPTION
## Summary

- Remove 63 unused `export default` statements from `@claude-flow/cli/src/` scoped dirs
- Add `scripts/audit-no-default-export-leak.mjs` — exits 1 on any new violation
- Wire audit as `no-default-export-audit` job in `v3-ci.yml` (strict, no continue-on-error, gated by `publish`)

## Per-directory removals

| Directory | Files |
|-----------|-------|
| `src/commands/` (incl. `ruvector/` sub) | 45 |
| `src/mcp-tools/` | 10 |
| `src/production/` | 5 |
| `src/ruvector/` | 3 |
| **Total** | **63** |

`commands/update.ts` is intentionally excluded — `__tests__/commands-deep.test.ts` line 93 uses a default import of that file.

## Test plan

- [x] `npm test` in `v3/@claude-flow/cli` → 1999 passing | 46 skipped (baseline unchanged)
- [x] `node scripts/audit-no-default-export-leak.mjs` → OK
- [x] CI `no-default-export-audit` job added (strict, no continue-on-error)

Closes #2141

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)