### PR TITLE
fix(ci): graph benchmark process.exit — eliminate 40-min hang

### DIFF
--- a/scripts/benchmark-graph.mjs
+++ b/scripts/benchmark-graph.mjs
@@ -259,3 +259,8 @@ if (jsonMode) {
   checks.forEach(([label, ok]) => console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}`));
   console.log(`\nTargets: ${pass}/${total} met`);
 }
+
+// The sql.js/agentdb bridge keeps a native handle alive after the script
+// finishes its work, which would otherwise stall the Node event loop until
+// the CI 40-min timeout. Hard-exit once results have been emitted.
+process.exit(0);


### PR DESCRIPTION
## Summary

- Graph benchmark (ADR-130 P6) completed measurements in ~87s but sat idle until 40-min CI timeout
- Root cause: sql.js/agentdb bridge keeps a native handle alive; `_resetBridgeDb()` only nulls the JS reference, doesn't close the native db
- Fix: `process.exit(0)` after the report block

## Evidence

Last 10+ runs on `main` for `graph benchmark (ADR-130 P6)`: all CANCELLED.
Sample log from PR #2146's run (job `77801863440`):
- 03:18:40 — benchmark started
- 03:20:07 — printed `Targets: 4/6 met` (87s elapsed, all measurements complete)
- 03:58:53 — CANCELLED at 40-min timeout (38min 46s of idle hang)

Local verification after fix:
```
node scripts/benchmark-graph.mjs  0.61s user 0.08s system 167% cpu 0.416 total
```

Same 4/6 targets met outcome preserved. The 2/6 FAILs (SQLite footprint, k-hop depth=1) are real perf characteristics, reported as `FAIL  …` lines but not surfaced via exit code — matches original behaviour.

## Test plan

- [x] Run `node scripts/benchmark-graph.mjs` locally — completes in <1s ✓
- [x] All 6 targets report ✓
- [ ] CI `graph benchmark (ADR-130 P6)` job completes in under 2 min (was timing out at 40)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)