### PR TITLE
fix(release): #2151 — three-way version lockstep + CI guard

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -1593,6 +1593,15 @@ jobs:
         shell: bash
         run: node scripts/audit-wrapper-dep-ranges.mjs
 
+      - name: Run umbrella version-lockstep audit (#2151)
+        # Asserts @claude-flow/cli, claude-flow, and ruflo all share the
+        # same version. #2151 reported ruflo@3.10.2 + cli@3.10.1 drift —
+        # `npx ruflo --version` printed the bundled CLI's 3.10.1, not the
+        # wrapper's 3.10.2. CLAUDE.md publish rules already require lockstep;
+        # this audit enforces it so drift can't reach a release.
+        shell: bash
+        run: node scripts/audit-umbrella-version-lockstep.mjs
+
       - name: Run plugin-hooks cross-platform audit (#2132)
         # Catches /bin/bash literals, POSIX-only pipelines (jq, xargs, tr),
         # and .sh script invocations in plugin hooks.json files — patterns

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.10.1",
+  "version": "3.10.3",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.10.0"
+    "@claude-flow/cli": "^3.10.3"
   },
   "overrides": {
     "@ruvector/rvf-wasm": "0.1.5",

--- a/scripts/audit-umbrella-version-lockstep.mjs
+++ b/scripts/audit-umbrella-version-lockstep.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Static guard for ruvnet/ruflo#2151 — enforce three-way version lockstep
+ * across the umbrella packages that ship together:
+ *
+ *   - @claude-flow/cli  (v3/@claude-flow/cli/package.json)
+ *   - claude-flow       (root package.json — umbrella)
+ *   - ruflo             (ruflo/package.json — thin user-facing wrapper)
+ *
+ * Why: when these drift (e.g. ruflo@3.10.2 but cli@3.10.1, observed in
+ * #2151), `npx ruflo --version` prints the bundled CLI's version (3.10.1),
+ * not the wrapper's package.json version (3.10.2). Users see the "wrong"
+ * version and reasonably assume the install is broken.
+ *
+ * The Publishing Rules in CLAUDE.md require all three to ship at the same
+ * version. This audit enforces that locally so a drift can't reach a
+ * release. Wired into v3-ci.yml as `umbrella-version-lockstep-audit`.
+ *
+ * Also asserts ruflo's @claude-flow/cli dep range INCLUDES the cli's
+ * actual version (overlap with audit-wrapper-dep-ranges.mjs is intentional;
+ * this audit is about identity, that one is about inclusion).
+ *
+ * Exit codes:
+ *   0 — versions identical and dep range covers cli
+ *   1 — drift detected; remediation hints printed
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import semver from 'semver';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const TARGETS = [
+  { label: '@claude-flow/cli', path: 'v3/@claude-flow/cli/package.json' },
+  { label: 'claude-flow',       path: 'package.json' },
+  { label: 'ruflo',             path: 'ruflo/package.json' },
+];
+
+function readPkg(rel) {
+  const p = join(REPO_ROOT, rel);
+  if (!existsSync(p)) return null;
+  try { return JSON.parse(readFileSync(p, 'utf8')); }
+  catch { return null; }
+}
+
+const versions = {};
+const violations = [];
+
+for (const { label, path } of TARGETS) {
+  const pkg = readPkg(path);
+  if (!pkg) {
+    violations.push(`${label} (${path}) not found`);
+    continue;
+  }
+  versions[label] = pkg.version;
+}
+
+console.log('umbrella-version-lockstep audit — three-package identity check');
+for (const { label } of TARGETS) {
+  console.log(`  ${label.padEnd(20)} ${versions[label] ?? '(missing)'}`);
+}
+
+const unique = new Set(Object.values(versions));
+if (unique.size > 1) {
+  violations.push(
+    `version drift across umbrella packages: ${[...unique].join(' / ')}.\n` +
+    `    Bump all three to the same version per CLAUDE.md "Publishing Rules" before shipping:\n` +
+    `      v3/@claude-flow/cli/package.json   ← ${versions['@claude-flow/cli'] ?? '?'}\n` +
+    `      package.json (claude-flow)         ← ${versions['claude-flow'] ?? '?'}\n` +
+    `      ruflo/package.json                 ← ${versions['ruflo'] ?? '?'}`
+  );
+}
+
+// Cross-check: ruflo's dep range must include cli's actual version.
+const rufloPkg = readPkg('ruflo/package.json');
+const cliVersion = versions['@claude-flow/cli'];
+if (rufloPkg && cliVersion) {
+  const range = rufloPkg.dependencies?.['@claude-flow/cli'];
+  if (range) {
+    if (!semver.satisfies(cliVersion, range, { includePrerelease: true })) {
+      violations.push(
+        `ruflo "@claude-flow/cli": "${range}" does NOT include cli's actual version ${cliVersion}.\n` +
+        `    Update ruflo/package.json dependencies to "^${cliVersion}".`
+      );
+    } else {
+      console.log(`  ruflo dep "@claude-flow/cli": "${range}" covers ${cliVersion} ✓`);
+    }
+  }
+}
+
+if (violations.length === 0) {
+  console.log('\n  ok: all three umbrella packages at identical version, ruflo dep covers cli');
+  process.exit(0);
+}
+
+console.error('\nviolations:');
+for (const v of violations) console.error(`  ✗ ${v}`);
+console.error(`\n${violations.length} violation(s).`);
+console.error('Reference: ruvnet/ruflo#2151 (version mismatch — ruflo@3.10.2 + cli@3.10.1).');
+process.exit(1);

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.10.1",
+  "version": "3.10.3",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

- Bump @claude-flow/cli, claude-flow umbrella, ruflo to 3.10.3 (lockstep)
- Pin ruflo's @claude-flow/cli dep to ^3.10.3
- New `scripts/audit-umbrella-version-lockstep.mjs` enforces three-way identity in CI

## Root cause (#2151 mismatch observation)

When v3.10.2 shipped, `ruflo/package.json` bumped to 3.10.2 but `v3/@claude-flow/cli/package.json` and the root `claude-flow` umbrella stayed at 3.10.1. The ruflo wrapper just shells out to `@claude-flow/cli` for `--version`, which printed its own (older) `3.10.1` — so `npx ruflo@latest --version` reported `ruflo v3.10.1` while the wrapper package.json said `3.10.2`.

CLAUDE.md "Publishing Rules" already require all three to ship at the same version; the new audit makes that mechanically enforceable.

## What the cold-cache timeout (>60s) part of #2151 needs

Tracked separately under #1760 / ADR-100 (cli-core split). Large refactor — out of scope for this PR.

## Test plan

- [x] `node scripts/audit-umbrella-version-lockstep.mjs` passes locally
- [x] `node scripts/audit-wrapper-dep-ranges.mjs` still passes (overlap is intentional — different invariant)
- [x] `cd v3/@claude-flow/cli && npm run build && node bin/cli.js --version` prints `ruflo v3.10.3`
- [ ] CI green
- [ ] After merge: publish CLI → claude-flow → ruflo at 3.10.3 with all three dist-tags (latest/alpha/v3alpha)
- [ ] Verify `npx ruflo@latest --version` prints `ruflo v3.10.3`

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)