### PR TITLE
docs(hooks): correct skill docs for v3 hooks schema + plural subcommand

### DIFF
--- a/.agents/skills/hooks-automation/SKILL.md
+++ b/.agents/skills/hooks-automation/SKILL.md
@@ -38,7 +38,7 @@ This skill provides a comprehensive hook system that automatically manages devel
 
 ```bash
 # Initialize with default hooks configuration
-npx claude-flow init --hooks
+npx claude-flow@v3alpha init
 ```
 
 This creates:
@@ -50,13 +50,13 @@ This creates:
 
 ```bash
 # Pre-task hook (auto-spawns agents)
-npx claude-flow hook pre-task --description "Implement authentication"
+npx claude-flow@v3alpha hooks pre-task --description "Implement authentication"
 
 # Post-edit hook (auto-formats and stores in memory)
-npx claude-flow hook post-edit --file "src$auth.js" --memory-key "auth$login"
+npx claude-flow@v3alpha hooks post-edit --file "src$auth.js" --memory-key "auth$login"
 
 # Session end hook (saves state and metrics)
-npx claude-flow hook session-end --session-id "dev-session" --export-metrics
+npx claude-flow@v3alpha hooks session-end --session-id "dev-session" --export-metrics
 ```
 
 ---
@@ -71,7 +71,7 @@ Hooks that execute BEFORE operations to prepare and validate:
 
 **pre-edit** - Validate and assign agents before file modifications
 ```bash
-npx claude-flow hook pre-edit [options]
+npx claude-flow@v3alpha hooks pre-edit [options]
 
 Options:
   --file, -f <path>         File path to be edited
@@ -81,9 +81,9 @@ Options:
   --backup-file             Create backup before editing
 
 Examples:
-  npx claude-flow hook pre-edit --file "src$auth$login.js"
-  npx claude-flow hook pre-edit -f "config$db.js" --validate-syntax
-  npx claude-flow hook pre-edit -f "production.env" --backup-file --check-conflicts
+  npx claude-flow@v3alpha hooks pre-edit --file "src$auth$login.js"
+  npx claude-flow@v3alpha hooks pre-edit -f "config$db.js" --validate-syntax
+  npx claude-flow@v3alpha hooks pre-edit -f "production.env" --backup-file --check-conflicts
 ```
 
 **Features:**
@@ -94,7 +94,7 @@ Examples:
 
 **pre-bash** - Check command safety and resource requirements
 ```bash
-npx claude-flow hook pre-bash --command <cmd>
+npx claude-flow@v3alpha hooks pre-bash --command <cmd>
 
 Options:
   --command, -c <cmd>       Command to validate
@@ -103,8 +103,8 @@ Options:
   --require-confirmation    Request user confirmation for risky commands
 
 Examples:
-  npx claude-flow hook pre-bash -c "rm -rf /tmp/cache"
-  npx claude-flow hook pre-bash --command "docker build ." --estimate-resources
+  npx claude-flow@v3alpha hooks pre-bash -c "rm -rf /tmp/cache"
+  npx claude-flow@v3alpha hooks pre-bash --command "docker build ." --estimate-resources
 ```
 
 **Features:**
@@ -115,7 +115,7 @@ Examples:
 
 **pre-task** - Auto-spawn agents and prepare for complex tasks
 ```bash
-npx claude-flow hook pre-task [options]
+npx claude-flow@v3alpha hooks pre-task [options]
 
 Options:
   --description, -d <text>  Task description for context
@@ -125,9 +125,9 @@ Options:
   --estimate-complexity     Analyze task complexity
 
 Examples:
-  npx claude-flow hook pre-task --description "Implement user authentication"
-  npx claude-flow hook pre-task -d "Continue API dev" --load-memory
-  npx claude-flow hook pre-task -d "Refactor codebase" --optimize-topology
+  npx claude-flow@v3alpha hooks pre-task --description "Implement user authentication"
+  npx claude-flow@v3alpha hooks pre-task -d "Continue API dev" --load-memory
+  npx claude-flow@v3alpha hooks pre-task -d "Refactor codebase" --optimize-topology
 ```
 
 **Features:**
@@ -138,7 +138,7 @@ Examples:
 
 **pre-search** - Prepare and optimize search operations
 ```bash
-npx claude-flow hook pre-search --query <query>
+npx claude-flow@v3alpha hooks pre-search --query <query>
 
 Options:
   --query, -q <text>        Search query
@@ -146,7 +146,7 @@ Options:
   --optimize-query          Optimize search pattern
 
 Examples:
-  npx claude-flow hook pre-search -q "authentication middleware"
+  npx claude-flow@v3alpha hooks pre-search -q "authentication middleware"
 ```
 
 **Features:**
@@ -160,7 +160,7 @@ Hooks that execute AFTER operations to process and learn:
 
 **post-edit** - Auto-format, validate, and update memory
 ```bash
-npx claude-flow hook post-edit [options]
+npx claude-flow@v3alpha hooks post-edit [options]
 
 Options:
   --file, -f <path>         File path that was edited
@@ -170,9 +170,9 @@ Options:
   --validate-output         Validate edited file
 
 Examples:
-  npx claude-flow hook post-edit --file "src$components/Button.jsx"
-  npx claude-flow hook post-edit -f "api$auth.js" --memory-key "auth$login"
-  npx claude-flow hook post-edit -f "utils$helpers.ts" --train-patterns
+  npx claude-flow@v3alpha hooks post-edit --file "src$components/Button.jsx"
+  npx claude-flow@v3alpha hooks post-edit -f "api$auth.js" --memory-key "auth$login"
+  npx claude-flow@v3alpha hooks post-edit -f "utils$helpers.ts" --train-patterns
 ```
 
 **Features:**
@@ -183,7 +183,7 @@ Examples:
 
 **post-bash** - Log execution and update metrics
 ```bash
-npx claude-flow hook post-bash --command <cmd>
+npx claude-flow@v3alpha hooks post-bash --command <cmd>
 
 Options:
   --command, -c <cmd>       Command that was executed
@@ -192,7 +192,7 @@ Options:
   --store-result            Store result in memory
 
 Examples:
-  npx claude-flow hook post-bash -c "npm test" --update-metrics
+  npx claude-flow@v3alpha hooks post-bash -c "npm test" --update-metrics
 ```
 
 **Features:**
@@ -203,7 +203,7 @@ Examples:
 
 **post-task** - Performance analysis and decision storage
 ```bash
-npx claude-flow hook post-task [options]
+npx claude-flow@v3alpha hooks post-task [options]
 
 Options:
   --task-id, -t <id>        Task identifier for tracking
@@ -213,9 +213,9 @@ Options:
   --generate-report         Create task completion report
 
 Examples:
-  npx claude-flow hook post-task --task-id "auth-implementation"
-  npx claude-flow hook post-task -t "api-refactor" --analyze-performance
-  npx claude-flow hook post-task -t "bug-fix-123" --store-decisions
+  npx claude-flow@v3alpha hooks post-task --task-id "auth-implementation"
+  npx claude-flow@v3alpha hooks post-task -t "api-refactor" --analyze-performance
+  npx claude-flow@v3alpha hooks post-task -t "bug-fix-123" --store-decisions
 ```
 
 **Features:**
@@ -226,7 +226,7 @@ Examples:
 
 **post-search** - Cache results and improve patterns
 ```bash
-npx claude-flow hook post-search --query <query> --results <path>
+npx claude-flow@v3alpha hooks post-search --query <query> --results <path>
 
 Options:
   --query, -q <text>        Original search query
@@ -235,7 +235,7 @@ Options:
   --train-patterns          Improve search patterns
 
 Examples:
-  npx claude-flow hook post-search -q "auth" -r "results.json" --train-patterns
+  npx claude-flow@v3alpha hooks post-search -q "auth" -r "results.json" --train-patterns
 ```
 
 **Features:**
@@ -249,7 +249,7 @@ Hooks that coordinate with MCP swarm tools:
 
 **mcp-initialized** - Persist swarm configuration
 ```bash
-npx claude-flow hook mcp-initialized --swarm-id <id>
+npx claude-flow@v3alpha hooks mcp-initialized --swarm-id <id>
 
 Features:
 - Save swarm topology and configuration
@@ -259,7 +259,7 @@ Features:
 
 **agent-spawned** - Update agent roster and memory
 ```bash
-npx claude-flow hook agent-spawned --agent-id <id> --type <type>
+npx claude-flow@v3alpha hooks agent-spawned --agent-id <id> --type <type>
 
 Features:
 - Register agent in coordination memory
@@ -269,7 +269,7 @@ Features:
 
 **task-orchestrated** - Monitor task progress
 ```bash
-npx claude-flow hook task-orchestrated --task-id <id>
+npx claude-flow@v3alpha hooks task-orchestrated --task-id <id>
 
 Features:
 - Track task progress through memory
@@ -279,7 +279,7 @@ Features:
 
 **neural-trained** - Save pattern improvements
 ```bash
-npx claude-flow hook neural-trained --pattern <name>
+npx claude-flow@v3alpha hooks neural-trained --pattern <name>
 
 Features:
 - Export trained neural patterns
@@ -309,7 +309,7 @@ Features:
 
 **memory-sync** - Synchronize memory across swarm agents
 ```bash
-npx claude-flow hook memory-sync --namespace <ns>
+npx claude-flow@v3alpha hooks memory-sync --namespace <ns>
 
 Features:
 - Sync memory state across agents
@@ -322,7 +322,7 @@ Features:
 
 **session-start** - Initialize new session
 ```bash
-npx claude-flow hook session-start --session-id <id>
+npx claude-flow@v3alpha hooks session-start --session-id <id>
 
 Options:
   --session-id, -s <id>     Session identifier
@@ -338,7 +338,7 @@ Features:
 
 **session-restore** - Load previous session state
 ```bash
-npx claude-flow hook session-restore --session-id <id>
+npx claude-flow@v3alpha hooks session-restore --session-id <id>
 
 Options:
   --session-id, -s <id>     Session to restore
@@ -346,8 +346,8 @@ Options:
   --restore-agents          Restore agent configurations
 
 Examples:
-  npx claude-flow hook session-restore --session-id "swarm-20241019"
-  npx claude-flow hook session-restore -s "feature-auth" --restore-memory
+  npx claude-flow@v3alpha hooks session-restore --session-id "swarm-20241019"
+  npx claude-flow@v3alpha hooks session-restore -s "feature-auth" --restore-memory
 ```
 
 **Features:**
@@ -358,7 +358,7 @@ Examples:
 
 **session-end** - Cleanup and persist session state
 ```bash
-npx claude-flow hook session-end [options]
+npx claude-flow@v3alpha hooks session-end [options]
 
 Options:
   --session-id, -s <id>     Session identifier to end
@@ -368,9 +368,9 @@ Options:
   --cleanup-temp            Remove temporary files
 
 Examples:
-  npx claude-flow hook session-end --session-id "dev-session-2024"
-  npx claude-flow hook session-end -s "feature-auth" --export-metrics --generate-summary
-  npx claude-flow hook session-end -s "quick-fix" --cleanup-temp
+  npx claude-flow@v3alpha hooks session-end --session-id "dev-session-2024"
+  npx claude-flow@v3alpha hooks session-end -s "feature-auth" --export-metrics --generate-summary
+  npx claude-flow@v3alpha hooks session-end -s "quick-fix" --cleanup-temp
 ```
 
 **Features:**
@@ -381,7 +381,7 @@ Examples:
 
 **notify** - Custom notifications with swarm status
 ```bash
-npx claude-flow hook notify --message <msg>
+npx claude-flow@v3alpha hooks notify --message <msg>
 
 Options:
   --message, -m <text>      Notification message
@@ -390,8 +390,8 @@ Options:
   --broadcast               Send to all agents
 
 Examples:
-  npx claude-flow hook notify -m "Task completed" --level info
-  npx claude-flow hook notify -m "Critical error" --level error --broadcast
+  npx claude-flow@v3alpha hooks notify -m "Task completed" --level info
+  npx claude-flow@v3alpha hooks notify -m "Critical error" --level error --broadcast
 ```
 
 **Features:**
@@ -400,28 +400,80 @@ Examples:
 - Broadcast to all agents
 - Log important events
 
+### Two-Layer Model
+
+Claude Flow's hook system operates at **two distinct layers**. Understanding the distinction prevents
+misconfiguration.
+
+#### Layer 1 — Claude Code Matcher Hooks (`.claude/settings.json`)
+
+These fire around **Claude Code's own tool calls** (`Write`, `Edit`, `Bash`, `Task`, …). Configured
+under `hooks.PreToolUse` / `hooks.PostToolUse` in `.claude/settings.json`.
+
+**Key characteristic**: Claude Code evaluates these; if the command exits non-zero the tool call is
+blocked. `${tool.params.*}` interpolation is performed by Claude Code's harness, not claude-flow.
+
+#### Layer 2 — claude-flow Internal Hooks (`npx claude-flow@v3alpha hooks <subcommand>`)
+
+These are invoked **by the claude-flow CLI itself** to manage agent coordination, session state,
+learning, and Agent Teams events. They are independent of Claude Code's tool lifecycle and operate
+inside the swarm's orchestration engine.
+
+```bash
+# Agent Teams hooks — fired by the swarm when a teammate finishes or a task completes
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+npx claude-flow@v3alpha hooks task-completed --task-id "my-task" --train-patterns true
+```
+
+---
+
 ### Configuration
 
 #### Basic Configuration
 
-Edit `.claude$settings.json` to configure hooks:
+The full `settings.json` emitted by `npx claude-flow@v3alpha init` activates **both layers** together:
 
 ```json
 {
+  "env": {
+    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "agentTeams": {
+      "hooks": {
+        "teammateIdle": {
+          "autoAssign": true,
+          "notifyLead": true
+        },
+        "taskCompleted": {
+          "trainPatterns": true,
+          "exportLearnings": true
+        }
+      }
+    }
+  },
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --memory-key 'swarm$editor$current'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
         }]
       },
       {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-bash --command '${tool.params.command}'"
+          "command": "npx claude-flow@v3alpha hooks pre-command --command '${tool.params.command}'"
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.prompt}' --load-memory",
+          "async": true
         }]
       }
     ],
@@ -430,20 +482,33 @@ Edit `.claude$settings.json` to configure hooks:
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'swarm$editor$complete' --auto-format --train-patterns"
+          "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns",
+          "async": true
         }]
       },
       {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook post-bash --command '${tool.params.command}' --update-metrics"
+          "command": "npx claude-flow@v3alpha hooks post-command --command '${tool.params.command}' --track-metrics",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --store-decisions",
+          "async": true
         }]
       }
     ]
   }
 }
 ```
+
+**Layer 1 keys** (`hooks.PreToolUse` / `hooks.PostToolUse`) are read by Claude Code.
+**Layer 2 keys** (`env.CLAUDE_FLOW_HOOKS_ENABLED`, `claudeFlow.agentTeams.hooks`) are read by claude-flow.
 
 #### Advanced Configuration
 
@@ -462,7 +527,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
+            "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
             "timeout": 3000,
             "continueOnError": true
           }
@@ -473,7 +538,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
+            "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
             "async": true
           }
         ]
@@ -483,7 +548,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-search --query '${tool.params.pattern}' --check-cache"
+            "command": "npx claude-flow@v3alpha hooks pre-search --query '${tool.params.pattern}' --check-cache"
           }
         ]
       }
@@ -495,7 +560,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
+            "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
             "async": true
           }
         ]
@@ -505,7 +570,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
+            "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
             "async": true
           }
         ]
@@ -515,7 +580,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
+            "command": "npx claude-flow@v3alpha hooks post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
           }
         ]
       }
@@ -526,7 +591,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook session-start --session-id '${session.id}' --load-context"
+            "command": "npx claude-flow@v3alpha hooks session-start --session-id '${session.id}' --load-context"
           }
         ]
       }
@@ -537,7 +602,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
+            "command": "npx claude-flow@v3alpha hooks session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
           }
         ]
       }
@@ -559,7 +624,7 @@ Add protection for sensitive files:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook check-protected --file '${tool.params.file_path}'"
+            "command": "npx claude-flow@v3alpha hooks check-protected --file '${tool.params.file_path}'"
           }
         ]
       }
@@ -599,7 +664,7 @@ Hooks automatically integrate with MCP tools for coordination:
 
 ```javascript
 // Hook command
-npx claude-flow hook pre-task --description "Build REST API"
+npx claude-flow@v3alpha hooks pre-task --description "Build REST API"
 
 // Internally calls MCP tools:
 mcp__claude-flow__agent_spawn {
@@ -623,7 +688,7 @@ mcp__claude-flow__memory_usage {
 
 ```javascript
 // Hook command
-npx claude-flow hook post-edit --file "api$auth.js"
+npx claude-flow@v3alpha hooks post-edit --file "api$auth.js"
 
 // Internally calls MCP tools:
 mcp__claude-flow__memory_usage {
@@ -649,7 +714,7 @@ mcp__claude-flow__neural_train {
 
 ```javascript
 // Hook command
-npx claude-flow hook session-end --session-id "dev-2024"
+npx claude-flow@v3alpha hooks session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
 mcp__claude-flow__memory_persist {
@@ -776,7 +841,7 @@ FILES=$(git diff --cached --name-only --diff-filter=ACM)
 
 for FILE in $FILES; do
   # Run pre-edit hook for validation
-  npx claude-flow hook pre-edit --file "$FILE" --validate-syntax
+  npx claude-flow@v3alpha hooks pre-edit --file "$FILE" --validate-syntax
 
   if [ $? -ne 0 ]; then
     echo "Validation failed for $FILE"
@@ -784,7 +849,7 @@ for FILE in $FILES; do
   fi
 
   # Run post-edit hook for formatting
-  npx claude-flow hook post-edit --file "$FILE" --auto-format
+  npx claude-flow@v3alpha hooks post-edit --file "$FILE" --auto-format
 done
 
 # Run tests
@@ -803,7 +868,7 @@ exit $?
 COMMIT_HASH=$(git rev-parse HEAD)
 COMMIT_MSG=$(git log -1 --pretty=%B)
 
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Commit completed: $COMMIT_MSG" \
   --level info \
   --swarm-status
@@ -820,7 +885,7 @@ npx claude-flow hook notify \
 npm run test:all
 
 # Run quality checks
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --generate-report \
   --export-metrics
 
@@ -844,13 +909,13 @@ How agents use hooks for coordination:
 ```bash
 # Agent 1: Backend Developer
 # STEP 1: Pre-task preparation
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Implement user authentication API" \
   --auto-spawn-agents \
   --load-memory
 
 # STEP 2: Work begins - pre-edit validation
-npx claude-flow hook pre-edit \
+npx claude-flow@v3alpha hooks pre-edit \
   --file "api$auth.js" \
   --auto-assign-agent \
   --validate-syntax
@@ -859,20 +924,20 @@ npx claude-flow hook pre-edit \
 # ... code changes ...
 
 # STEP 4: Post-edit processing
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api$auth.js" \
   --memory-key "swarm$backend$auth-api" \
   --auto-format \
   --train-patterns
 
 # STEP 5: Notify coordination system
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Auth API implementation complete" \
   --swarm-status \
   --broadcast
 
 # STEP 6: Task completion
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "auth-api" \
   --analyze-performance \
   --store-decisions \
@@ -882,25 +947,25 @@ npx claude-flow hook post-task \
 ```bash
 # Agent 2: Test Engineer (receives notification)
 # STEP 1: Check memory for API details
-npx claude-flow hook session-restore \
+npx claude-flow@v3alpha hooks session-restore \
   --session-id "swarm-current" \
   --restore-memory
 
 # Memory contains: swarm$backend$auth-api with implementation details
 
 # STEP 2: Generate tests
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Write tests for auth API" \
   --load-memory
 
 # STEP 3: Create test file
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api$auth.test.js" \
   --memory-key "swarm$testing$auth-api-tests" \
   --train-patterns
 
 # STEP 4: Share test results
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Auth API tests complete - 100% coverage" \
   --broadcast
 ```
@@ -979,37 +1044,37 @@ module.exports = {
 
 ```bash
 # Session start - initialize coordination
-npx claude-flow hook session-start --session-id "fullstack-feature"
+npx claude-flow@v3alpha hooks session-start --session-id "fullstack-feature"
 
 # Pre-task planning
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Build user profile feature - frontend + backend + tests" \
   --auto-spawn-agents \
   --optimize-topology
 
 # Backend work
-npx claude-flow hook pre-edit --file "api$profile.js"
+npx claude-flow@v3alpha hooks pre-edit --file "api$profile.js"
 # ... implement backend ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api$profile.js" \
   --memory-key "profile$backend" \
   --train-patterns
 
 # Frontend work (reads backend details from memory)
-npx claude-flow hook pre-edit --file "components/Profile.jsx"
+npx claude-flow@v3alpha hooks pre-edit --file "components/Profile.jsx"
 # ... implement frontend ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "components/Profile.jsx" \
   --memory-key "profile$frontend" \
   --train-patterns
 
 # Testing (reads both backend and frontend from memory)
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Test profile feature" \
   --load-memory
 
 # Session end - export everything
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --session-id "fullstack-feature" \
   --export-metrics \
   --generate-summary
@@ -1019,39 +1084,39 @@ npx claude-flow hook session-end \
 
 ```bash
 # Start debugging session
-npx claude-flow hook session-start --session-id "debug-memory-leak"
+npx claude-flow@v3alpha hooks session-start --session-id "debug-memory-leak"
 
 # Pre-task: analyze issue
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Debug memory leak in event handlers" \
   --load-memory \
   --estimate-complexity
 
 # Search for event emitters
-npx claude-flow hook pre-search --query "EventEmitter"
+npx claude-flow@v3alpha hooks pre-search --query "EventEmitter"
 # ... search executes ...
-npx claude-flow hook post-search \
+npx claude-flow@v3alpha hooks post-search \
   --query "EventEmitter" \
   --cache-results
 
 # Fix the issue
-npx claude-flow hook pre-edit \
+npx claude-flow@v3alpha hooks pre-edit \
   --file "services$events.js" \
   --backup-file
 # ... fix code ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "services$events.js" \
   --memory-key "debug$memory-leak-fix" \
   --validate-output
 
 # Verify fix
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "memory-leak-fix" \
   --analyze-performance \
   --generate-report
 
 # End session
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --session-id "debug-memory-leak" \
   --export-metrics
 ```
@@ -1060,27 +1125,27 @@ npx claude-flow hook session-end \
 
 ```bash
 # Initialize swarm for refactoring
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Refactor legacy codebase to modern patterns" \
   --auto-spawn-agents \
   --optimize-topology
 
 # Agent 1: Code Analyzer
-npx claude-flow hook pre-task --description "Analyze code complexity"
+npx claude-flow@v3alpha hooks pre-task --description "Analyze code complexity"
 # ... analysis ...
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "analysis" \
   --store-decisions
 
 # Agent 2: Refactoring (reads analysis from memory)
-npx claude-flow hook session-restore \
+npx claude-flow@v3alpha hooks session-restore \
   --session-id "swarm-refactor" \
   --restore-memory
 
 for file in src/**/*.js; do
-  npx claude-flow hook pre-edit --file "$file" --backup-file
+  npx claude-flow@v3alpha hooks pre-edit --file "$file" --backup-file
   # ... refactor ...
-  npx claude-flow hook post-edit \
+  npx claude-flow@v3alpha hooks post-edit \
     --file "$file" \
     --memory-key "refactor/$file" \
     --auto-format \
@@ -1088,12 +1153,12 @@ for file in src/**/*.js; do
 done
 
 # Agent 3: Testing (reads refactored code from memory)
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Generate tests for refactored code" \
   --load-memory
 
 # Broadcast completion
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Refactoring complete - all tests passing" \
   --broadcast
 ```
@@ -1117,13 +1182,13 @@ Enable debug mode for troubleshooting:
 export CLAUDE_FLOW_DEBUG=true
 
 # Test specific hook with verbose output
-npx claude-flow hook pre-edit --file "test.js" --debug
+npx claude-flow@v3alpha hooks pre-edit --file "test.js" --debug
 
 # Check hook execution logs
 cat .claude-flow$logs$hooks-$(date +%Y-%m-%d).log
 
 # Validate configuration
-npx claude-flow hook validate-config
+npx claude-flow@v3alpha hooks validate-config
 ```
 
 ### Benefits
@@ -1181,14 +1246,112 @@ npx claude-flow hook validate-config
 - Batch operations when possible
 - Reduce hook complexity
 
+### All `hooks` Subcommands
+
+#### Task Lifecycle
+
+| Subcommand | Description |
+|---|---|
+| `pre-task` | Record task start, get agent suggestions, auto-spawn swarm |
+| `post-task` | Record completion, analyze performance, store decisions |
+
+#### Tool Lifecycle (Layer 1 bridge)
+
+| Subcommand | Description |
+|---|---|
+| `pre-edit` | Validate and assign agents before file modifications |
+| `post-edit` | Auto-format, validate, and train neural patterns after edits |
+| `pre-command` | Assess safety and resource requirements before bash commands |
+| `post-command` | Log execution and update performance metrics |
+| `pre-bash` | Alias for `pre-command` (v2 compat) |
+| `post-bash` | Alias for `post-command` (v2 compat) |
+
+#### Session Management
+
+| Subcommand | Description |
+|---|---|
+| `session-start` | Initialize new session with context restoration |
+| `session-end` | Persist state, export metrics, generate summary |
+| `session-restore` | Reload a previous session state |
+
+#### Intelligence & Routing
+
+| Subcommand | Description |
+|---|---|
+| `route` | Route task to optimal agent via HNSW |
+| `route-task` | Alias for `route` (v2 compat) |
+| `explain` | Explain routing decision in detail |
+| `pretrain` | Bootstrap SONA/MoE intelligence from repo patterns |
+| `build-agents` | Generate optimized agent configurations |
+| `metrics` | View learning metrics dashboard |
+| `model-route` | 3-tier model routing recommendation (Agent Booster → Haiku → Sonnet/Opus) |
+| `model-stats` | Model usage and cost statistics |
+| `model-outcome` | Record model outcome to improve future routing |
+
+#### Agent Teams (Layer 2 — comms coordination)
+
+| Subcommand | Description |
+|---|---|
+| `teammate-idle` | Auto-assign pending tasks when a teammate finishes its turn |
+| `task-completed` | Train patterns and notify lead on task completion |
+
+#### Pattern Transfer & Registry
+
+| Subcommand | Description |
+|---|---|
+| `transfer` | Transfer patterns via IPFS registry |
+| `list` | List all registered hooks and their status |
+| `init` | Re-initialize hooks system configuration |
+| `notify` | Send notification with swarm status |
+
+#### Intelligence Sub-system (RuVector)
+
+| Subcommand | Description |
+|---|---|
+| `intelligence` | Entry point for RuVector intelligence operations |
+| `intelligence trajectory-start` | Begin a new learning trajectory |
+| `intelligence trajectory-step` | Record a reasoning step in an active trajectory |
+| `intelligence trajectory-end` | Finalize and score a completed trajectory |
+| `intelligence pattern-store` | Persist a learned coordination pattern |
+| `intelligence pattern-search` | Search stored patterns via HNSW (150x–12,500x faster) |
+| `intelligence stats` | View intelligence system statistics and EWC++ health |
+| `intelligence attention` | Configure attention weights for MoE routing |
+| `intelligence-reset` | Reset RuVector intelligence state to baseline |
+
+#### Coverage-Aware Routing
+
+| Subcommand | Description |
+|---|---|
+| `coverage-route` | Route task to address highest-priority coverage gaps |
+| `coverage-suggest` | Suggest test coverage improvements for a path |
+| `coverage-gaps` | List current coverage gaps with priorities |
+
+#### Background Workers
+
+| Subcommand | Description |
+|---|---|
+| `worker list` | List all 12 background workers and their status |
+| `worker dispatch` | Dispatch a specific worker by trigger name |
+| `worker status` | Show worker queue depth and health |
+| `worker detect` | Auto-detect which workers should run for current state |
+| `worker cancel` | Cancel a running background worker |
+
+#### Utilities
+
+| Subcommand | Description |
+|---|---|
+| `progress` | Check V3 implementation progress |
+| `statusline` | Generate dynamic statusline for Claude Code HUD |
+
+---
+
 ### Related Commands
 
-- `npx claude-flow init --hooks` - Initialize hooks system
-- `npx claude-flow hook --list` - List available hooks
-- `npx claude-flow hook --test <hook>` - Test specific hook
-- `npx claude-flow memory usage` - Manage memory
-- `npx claude-flow agent spawn` - Spawn agents
-- `npx claude-flow swarm init` - Initialize swarm
+- `npx claude-flow@v3alpha init` - Initialize hooks system
+- `npx claude-flow@v3alpha hooks list` - List registered hooks
+- `npx claude-flow@v3alpha memory usage` - Manage memory
+- `npx claude-flow@v3alpha agent spawn` - Spawn agents
+- `npx claude-flow@v3alpha swarm init` - Initialize swarm
 
 ### Integration with Other Skills
 

--- a/.claude/skills/hooks-automation/SKILL.md
+++ b/.claude/skills/hooks-automation/SKILL.md
@@ -38,7 +38,7 @@ This skill provides a comprehensive hook system that automatically manages devel
 
 ```bash
 # Initialize with default hooks configuration
-npx claude-flow init --hooks
+npx claude-flow@v3alpha init
 ```
 
 This creates:
@@ -50,13 +50,13 @@ This creates:
 
 ```bash
 # Pre-task hook (auto-spawns agents)
-npx claude-flow hook pre-task --description "Implement authentication"
+npx claude-flow@v3alpha hooks pre-task --description "Implement authentication"
 
 # Post-edit hook (auto-formats and stores in memory)
-npx claude-flow hook post-edit --file "src/auth.js" --memory-key "auth/login"
+npx claude-flow@v3alpha hooks post-edit --file "src/auth.js" --memory-key "auth/login"
 
 # Session end hook (saves state and metrics)
-npx claude-flow hook session-end --session-id "dev-session" --export-metrics
+npx claude-flow@v3alpha hooks session-end --session-id "dev-session" --export-metrics
 ```
 
 ---
@@ -71,7 +71,7 @@ Hooks that execute BEFORE operations to prepare and validate:
 
 **pre-edit** - Validate and assign agents before file modifications
 ```bash
-npx claude-flow hook pre-edit [options]
+npx claude-flow@v3alpha hooks pre-edit [options]
 
 Options:
   --file, -f <path>         File path to be edited
@@ -81,9 +81,9 @@ Options:
   --backup-file             Create backup before editing
 
 Examples:
-  npx claude-flow hook pre-edit --file "src/auth/login.js"
-  npx claude-flow hook pre-edit -f "config/db.js" --validate-syntax
-  npx claude-flow hook pre-edit -f "production.env" --backup-file --check-conflicts
+  npx claude-flow@v3alpha hooks pre-edit --file "src/auth/login.js"
+  npx claude-flow@v3alpha hooks pre-edit -f "config/db.js" --validate-syntax
+  npx claude-flow@v3alpha hooks pre-edit -f "production.env" --backup-file --check-conflicts
 ```
 
 **Features:**
@@ -94,7 +94,7 @@ Examples:
 
 **pre-bash** - Check command safety and resource requirements
 ```bash
-npx claude-flow hook pre-bash --command <cmd>
+npx claude-flow@v3alpha hooks pre-bash --command <cmd>
 
 Options:
   --command, -c <cmd>       Command to validate
@@ -103,8 +103,8 @@ Options:
   --require-confirmation    Request user confirmation for risky commands
 
 Examples:
-  npx claude-flow hook pre-bash -c "rm -rf /tmp/cache"
-  npx claude-flow hook pre-bash --command "docker build ." --estimate-resources
+  npx claude-flow@v3alpha hooks pre-bash -c "rm -rf /tmp/cache"
+  npx claude-flow@v3alpha hooks pre-bash --command "docker build ." --estimate-resources
 ```
 
 **Features:**
@@ -115,7 +115,7 @@ Examples:
 
 **pre-task** - Auto-spawn agents and prepare for complex tasks
 ```bash
-npx claude-flow hook pre-task [options]
+npx claude-flow@v3alpha hooks pre-task [options]
 
 Options:
   --description, -d <text>  Task description for context
@@ -125,9 +125,9 @@ Options:
   --estimate-complexity     Analyze task complexity
 
 Examples:
-  npx claude-flow hook pre-task --description "Implement user authentication"
-  npx claude-flow hook pre-task -d "Continue API dev" --load-memory
-  npx claude-flow hook pre-task -d "Refactor codebase" --optimize-topology
+  npx claude-flow@v3alpha hooks pre-task --description "Implement user authentication"
+  npx claude-flow@v3alpha hooks pre-task -d "Continue API dev" --load-memory
+  npx claude-flow@v3alpha hooks pre-task -d "Refactor codebase" --optimize-topology
 ```
 
 **Features:**
@@ -138,7 +138,7 @@ Examples:
 
 **pre-search** - Prepare and optimize search operations
 ```bash
-npx claude-flow hook pre-search --query <query>
+npx claude-flow@v3alpha hooks pre-search --query <query>
 
 Options:
   --query, -q <text>        Search query
@@ -146,7 +146,7 @@ Options:
   --optimize-query          Optimize search pattern
 
 Examples:
-  npx claude-flow hook pre-search -q "authentication middleware"
+  npx claude-flow@v3alpha hooks pre-search -q "authentication middleware"
 ```
 
 **Features:**
@@ -160,7 +160,7 @@ Hooks that execute AFTER operations to process and learn:
 
 **post-edit** - Auto-format, validate, and update memory
 ```bash
-npx claude-flow hook post-edit [options]
+npx claude-flow@v3alpha hooks post-edit [options]
 
 Options:
   --file, -f <path>         File path that was edited
@@ -170,9 +170,9 @@ Options:
   --validate-output         Validate edited file
 
 Examples:
-  npx claude-flow hook post-edit --file "src/components/Button.jsx"
-  npx claude-flow hook post-edit -f "api/auth.js" --memory-key "auth/login"
-  npx claude-flow hook post-edit -f "utils/helpers.ts" --train-patterns
+  npx claude-flow@v3alpha hooks post-edit --file "src/components/Button.jsx"
+  npx claude-flow@v3alpha hooks post-edit -f "api/auth.js" --memory-key "auth/login"
+  npx claude-flow@v3alpha hooks post-edit -f "utils/helpers.ts" --train-patterns
 ```
 
 **Features:**
@@ -183,7 +183,7 @@ Examples:
 
 **post-bash** - Log execution and update metrics
 ```bash
-npx claude-flow hook post-bash --command <cmd>
+npx claude-flow@v3alpha hooks post-bash --command <cmd>
 
 Options:
   --command, -c <cmd>       Command that was executed
@@ -192,7 +192,7 @@ Options:
   --store-result            Store result in memory
 
 Examples:
-  npx claude-flow hook post-bash -c "npm test" --update-metrics
+  npx claude-flow@v3alpha hooks post-bash -c "npm test" --update-metrics
 ```
 
 **Features:**
@@ -203,7 +203,7 @@ Examples:
 
 **post-task** - Performance analysis and decision storage
 ```bash
-npx claude-flow hook post-task [options]
+npx claude-flow@v3alpha hooks post-task [options]
 
 Options:
   --task-id, -t <id>        Task identifier for tracking
@@ -213,9 +213,9 @@ Options:
   --generate-report         Create task completion report
 
 Examples:
-  npx claude-flow hook post-task --task-id "auth-implementation"
-  npx claude-flow hook post-task -t "api-refactor" --analyze-performance
-  npx claude-flow hook post-task -t "bug-fix-123" --store-decisions
+  npx claude-flow@v3alpha hooks post-task --task-id "auth-implementation"
+  npx claude-flow@v3alpha hooks post-task -t "api-refactor" --analyze-performance
+  npx claude-flow@v3alpha hooks post-task -t "bug-fix-123" --store-decisions
 ```
 
 **Features:**
@@ -226,7 +226,7 @@ Examples:
 
 **post-search** - Cache results and improve patterns
 ```bash
-npx claude-flow hook post-search --query <query> --results <path>
+npx claude-flow@v3alpha hooks post-search --query <query> --results <path>
 
 Options:
   --query, -q <text>        Original search query
@@ -235,7 +235,7 @@ Options:
   --train-patterns          Improve search patterns
 
 Examples:
-  npx claude-flow hook post-search -q "auth" -r "results.json" --train-patterns
+  npx claude-flow@v3alpha hooks post-search -q "auth" -r "results.json" --train-patterns
 ```
 
 **Features:**
@@ -249,7 +249,7 @@ Hooks that coordinate with MCP swarm tools:
 
 **mcp-initialized** - Persist swarm configuration
 ```bash
-npx claude-flow hook mcp-initialized --swarm-id <id>
+npx claude-flow@v3alpha hooks mcp-initialized --swarm-id <id>
 
 Features:
 - Save swarm topology and configuration
@@ -259,7 +259,7 @@ Features:
 
 **agent-spawned** - Update agent roster and memory
 ```bash
-npx claude-flow hook agent-spawned --agent-id <id> --type <type>
+npx claude-flow@v3alpha hooks agent-spawned --agent-id <id> --type <type>
 
 Features:
 - Register agent in coordination memory
@@ -269,7 +269,7 @@ Features:
 
 **task-orchestrated** - Monitor task progress
 ```bash
-npx claude-flow hook task-orchestrated --task-id <id>
+npx claude-flow@v3alpha hooks task-orchestrated --task-id <id>
 
 Features:
 - Track task progress through memory
@@ -279,7 +279,7 @@ Features:
 
 **neural-trained** - Save pattern improvements
 ```bash
-npx claude-flow hook neural-trained --pattern <name>
+npx claude-flow@v3alpha hooks neural-trained --pattern <name>
 
 Features:
 - Export trained neural patterns
@@ -309,7 +309,7 @@ Features:
 
 **memory-sync** - Synchronize memory across swarm agents
 ```bash
-npx claude-flow hook memory-sync --namespace <ns>
+npx claude-flow@v3alpha hooks memory-sync --namespace <ns>
 
 Features:
 - Sync memory state across agents
@@ -322,7 +322,7 @@ Features:
 
 **session-start** - Initialize new session
 ```bash
-npx claude-flow hook session-start --session-id <id>
+npx claude-flow@v3alpha hooks session-start --session-id <id>
 
 Options:
   --session-id, -s <id>     Session identifier
@@ -338,7 +338,7 @@ Features:
 
 **session-restore** - Load previous session state
 ```bash
-npx claude-flow hook session-restore --session-id <id>
+npx claude-flow@v3alpha hooks session-restore --session-id <id>
 
 Options:
   --session-id, -s <id>     Session to restore
@@ -346,8 +346,8 @@ Options:
   --restore-agents          Restore agent configurations
 
 Examples:
-  npx claude-flow hook session-restore --session-id "swarm-20241019"
-  npx claude-flow hook session-restore -s "feature-auth" --restore-memory
+  npx claude-flow@v3alpha hooks session-restore --session-id "swarm-20241019"
+  npx claude-flow@v3alpha hooks session-restore -s "feature-auth" --restore-memory
 ```
 
 **Features:**
@@ -358,7 +358,7 @@ Examples:
 
 **session-end** - Cleanup and persist session state
 ```bash
-npx claude-flow hook session-end [options]
+npx claude-flow@v3alpha hooks session-end [options]
 
 Options:
   --session-id, -s <id>     Session identifier to end
@@ -368,9 +368,9 @@ Options:
   --cleanup-temp            Remove temporary files
 
 Examples:
-  npx claude-flow hook session-end --session-id "dev-session-2024"
-  npx claude-flow hook session-end -s "feature-auth" --export-metrics --generate-summary
-  npx claude-flow hook session-end -s "quick-fix" --cleanup-temp
+  npx claude-flow@v3alpha hooks session-end --session-id "dev-session-2024"
+  npx claude-flow@v3alpha hooks session-end -s "feature-auth" --export-metrics --generate-summary
+  npx claude-flow@v3alpha hooks session-end -s "quick-fix" --cleanup-temp
 ```
 
 **Features:**
@@ -381,7 +381,7 @@ Examples:
 
 **notify** - Custom notifications with swarm status
 ```bash
-npx claude-flow hook notify --message <msg>
+npx claude-flow@v3alpha hooks notify --message <msg>
 
 Options:
   --message, -m <text>      Notification message
@@ -390,8 +390,8 @@ Options:
   --broadcast               Send to all agents
 
 Examples:
-  npx claude-flow hook notify -m "Task completed" --level info
-  npx claude-flow hook notify -m "Critical error" --level error --broadcast
+  npx claude-flow@v3alpha hooks notify -m "Task completed" --level info
+  npx claude-flow@v3alpha hooks notify -m "Critical error" --level error --broadcast
 ```
 
 **Features:**
@@ -400,28 +400,80 @@ Examples:
 - Broadcast to all agents
 - Log important events
 
+### Two-Layer Model
+
+Claude Flow's hook system operates at **two distinct layers**. Understanding the distinction prevents
+misconfiguration.
+
+#### Layer 1 — Claude Code Matcher Hooks (`.claude/settings.json`)
+
+These fire around **Claude Code's own tool calls** (`Write`, `Edit`, `Bash`, `Task`, …). Configured
+under `hooks.PreToolUse` / `hooks.PostToolUse` in `.claude/settings.json`.
+
+**Key characteristic**: Claude Code evaluates these; if the command exits non-zero the tool call is
+blocked. `${tool.params.*}` interpolation is performed by Claude Code's harness, not claude-flow.
+
+#### Layer 2 — claude-flow Internal Hooks (`npx claude-flow@v3alpha hooks <subcommand>`)
+
+These are invoked **by the claude-flow CLI itself** to manage agent coordination, session state,
+learning, and Agent Teams events. They are independent of Claude Code's tool lifecycle and operate
+inside the swarm's orchestration engine.
+
+```bash
+# Agent Teams hooks — fired by the swarm when a teammate finishes or a task completes
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+npx claude-flow@v3alpha hooks task-completed --task-id "my-task" --train-patterns true
+```
+
+---
+
 ### Configuration
 
 #### Basic Configuration
 
-Edit `.claude/settings.json` to configure hooks:
+The full `settings.json` emitted by `npx claude-flow@v3alpha init` activates **both layers** together:
 
 ```json
 {
+  "env": {
+    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "agentTeams": {
+      "hooks": {
+        "teammateIdle": {
+          "autoAssign": true,
+          "notifyLead": true
+        },
+        "taskCompleted": {
+          "trainPatterns": true,
+          "exportLearnings": true
+        }
+      }
+    }
+  },
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --memory-key 'swarm/editor/current'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
         }]
       },
       {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-bash --command '${tool.params.command}'"
+          "command": "npx claude-flow@v3alpha hooks pre-command --command '${tool.params.command}'"
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.prompt}' --load-memory",
+          "async": true
         }]
       }
     ],
@@ -430,20 +482,33 @@ Edit `.claude/settings.json` to configure hooks:
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'swarm/editor/complete' --auto-format --train-patterns"
+          "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns",
+          "async": true
         }]
       },
       {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook post-bash --command '${tool.params.command}' --update-metrics"
+          "command": "npx claude-flow@v3alpha hooks post-command --command '${tool.params.command}' --track-metrics",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --store-decisions",
+          "async": true
         }]
       }
     ]
   }
 }
 ```
+
+**Layer 1 keys** (`hooks.PreToolUse` / `hooks.PostToolUse`) are read by Claude Code.
+**Layer 2 keys** (`env.CLAUDE_FLOW_HOOKS_ENABLED`, `claudeFlow.agentTeams.hooks`) are read by claude-flow.
 
 #### Advanced Configuration
 
@@ -462,7 +527,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
+            "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
             "timeout": 3000,
             "continueOnError": true
           }
@@ -473,7 +538,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
+            "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
             "async": true
           }
         ]
@@ -483,7 +548,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-search --query '${tool.params.pattern}' --check-cache"
+            "command": "npx claude-flow@v3alpha hooks pre-search --query '${tool.params.pattern}' --check-cache"
           }
         ]
       }
@@ -495,7 +560,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
+            "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
             "async": true
           }
         ]
@@ -505,7 +570,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
+            "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
             "async": true
           }
         ]
@@ -515,7 +580,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
+            "command": "npx claude-flow@v3alpha hooks post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
           }
         ]
       }
@@ -526,7 +591,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook session-start --session-id '${session.id}' --load-context"
+            "command": "npx claude-flow@v3alpha hooks session-start --session-id '${session.id}' --load-context"
           }
         ]
       }
@@ -537,7 +602,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
+            "command": "npx claude-flow@v3alpha hooks session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
           }
         ]
       }
@@ -559,7 +624,7 @@ Add protection for sensitive files:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook check-protected --file '${tool.params.file_path}'"
+            "command": "npx claude-flow@v3alpha hooks check-protected --file '${tool.params.file_path}'"
           }
         ]
       }
@@ -599,7 +664,7 @@ Hooks automatically integrate with MCP tools for coordination:
 
 ```javascript
 // Hook command
-npx claude-flow hook pre-task --description "Build REST API"
+npx claude-flow@v3alpha hooks pre-task --description "Build REST API"
 
 // Internally calls MCP tools:
 mcp__claude-flow__agent_spawn {
@@ -623,7 +688,7 @@ mcp__claude-flow__memory_usage {
 
 ```javascript
 // Hook command
-npx claude-flow hook post-edit --file "api/auth.js"
+npx claude-flow@v3alpha hooks post-edit --file "api/auth.js"
 
 // Internally calls MCP tools:
 mcp__claude-flow__memory_usage {
@@ -649,7 +714,7 @@ mcp__claude-flow__neural_train {
 
 ```javascript
 // Hook command
-npx claude-flow hook session-end --session-id "dev-2024"
+npx claude-flow@v3alpha hooks session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
 mcp__claude-flow__memory_persist {
@@ -776,7 +841,7 @@ FILES=$(git diff --cached --name-only --diff-filter=ACM)
 
 for FILE in $FILES; do
   # Run pre-edit hook for validation
-  npx claude-flow hook pre-edit --file "$FILE" --validate-syntax
+  npx claude-flow@v3alpha hooks pre-edit --file "$FILE" --validate-syntax
 
   if [ $? -ne 0 ]; then
     echo "Validation failed for $FILE"
@@ -784,7 +849,7 @@ for FILE in $FILES; do
   fi
 
   # Run post-edit hook for formatting
-  npx claude-flow hook post-edit --file "$FILE" --auto-format
+  npx claude-flow@v3alpha hooks post-edit --file "$FILE" --auto-format
 done
 
 # Run tests
@@ -803,7 +868,7 @@ exit $?
 COMMIT_HASH=$(git rev-parse HEAD)
 COMMIT_MSG=$(git log -1 --pretty=%B)
 
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Commit completed: $COMMIT_MSG" \
   --level info \
   --swarm-status
@@ -820,7 +885,7 @@ npx claude-flow hook notify \
 npm run test:all
 
 # Run quality checks
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --generate-report \
   --export-metrics
 
@@ -844,13 +909,13 @@ How agents use hooks for coordination:
 ```bash
 # Agent 1: Backend Developer
 # STEP 1: Pre-task preparation
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Implement user authentication API" \
   --auto-spawn-agents \
   --load-memory
 
 # STEP 2: Work begins - pre-edit validation
-npx claude-flow hook pre-edit \
+npx claude-flow@v3alpha hooks pre-edit \
   --file "api/auth.js" \
   --auto-assign-agent \
   --validate-syntax
@@ -859,20 +924,20 @@ npx claude-flow hook pre-edit \
 # ... code changes ...
 
 # STEP 4: Post-edit processing
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api/auth.js" \
   --memory-key "swarm/backend/auth-api" \
   --auto-format \
   --train-patterns
 
 # STEP 5: Notify coordination system
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Auth API implementation complete" \
   --swarm-status \
   --broadcast
 
 # STEP 6: Task completion
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "auth-api" \
   --analyze-performance \
   --store-decisions \
@@ -882,25 +947,25 @@ npx claude-flow hook post-task \
 ```bash
 # Agent 2: Test Engineer (receives notification)
 # STEP 1: Check memory for API details
-npx claude-flow hook session-restore \
+npx claude-flow@v3alpha hooks session-restore \
   --session-id "swarm-current" \
   --restore-memory
 
 # Memory contains: swarm/backend/auth-api with implementation details
 
 # STEP 2: Generate tests
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Write tests for auth API" \
   --load-memory
 
 # STEP 3: Create test file
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api/auth.test.js" \
   --memory-key "swarm/testing/auth-api-tests" \
   --train-patterns
 
 # STEP 4: Share test results
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Auth API tests complete - 100% coverage" \
   --broadcast
 ```
@@ -979,37 +1044,37 @@ module.exports = {
 
 ```bash
 # Session start - initialize coordination
-npx claude-flow hook session-start --session-id "fullstack-feature"
+npx claude-flow@v3alpha hooks session-start --session-id "fullstack-feature"
 
 # Pre-task planning
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Build user profile feature - frontend + backend + tests" \
   --auto-spawn-agents \
   --optimize-topology
 
 # Backend work
-npx claude-flow hook pre-edit --file "api/profile.js"
+npx claude-flow@v3alpha hooks pre-edit --file "api/profile.js"
 # ... implement backend ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api/profile.js" \
   --memory-key "profile/backend" \
   --train-patterns
 
 # Frontend work (reads backend details from memory)
-npx claude-flow hook pre-edit --file "components/Profile.jsx"
+npx claude-flow@v3alpha hooks pre-edit --file "components/Profile.jsx"
 # ... implement frontend ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "components/Profile.jsx" \
   --memory-key "profile/frontend" \
   --train-patterns
 
 # Testing (reads both backend and frontend from memory)
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Test profile feature" \
   --load-memory
 
 # Session end - export everything
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --session-id "fullstack-feature" \
   --export-metrics \
   --generate-summary
@@ -1019,39 +1084,39 @@ npx claude-flow hook session-end \
 
 ```bash
 # Start debugging session
-npx claude-flow hook session-start --session-id "debug-memory-leak"
+npx claude-flow@v3alpha hooks session-start --session-id "debug-memory-leak"
 
 # Pre-task: analyze issue
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Debug memory leak in event handlers" \
   --load-memory \
   --estimate-complexity
 
 # Search for event emitters
-npx claude-flow hook pre-search --query "EventEmitter"
+npx claude-flow@v3alpha hooks pre-search --query "EventEmitter"
 # ... search executes ...
-npx claude-flow hook post-search \
+npx claude-flow@v3alpha hooks post-search \
   --query "EventEmitter" \
   --cache-results
 
 # Fix the issue
-npx claude-flow hook pre-edit \
+npx claude-flow@v3alpha hooks pre-edit \
   --file "services/events.js" \
   --backup-file
 # ... fix code ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "services/events.js" \
   --memory-key "debug/memory-leak-fix" \
   --validate-output
 
 # Verify fix
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "memory-leak-fix" \
   --analyze-performance \
   --generate-report
 
 # End session
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --session-id "debug-memory-leak" \
   --export-metrics
 ```
@@ -1060,27 +1125,27 @@ npx claude-flow hook session-end \
 
 ```bash
 # Initialize swarm for refactoring
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Refactor legacy codebase to modern patterns" \
   --auto-spawn-agents \
   --optimize-topology
 
 # Agent 1: Code Analyzer
-npx claude-flow hook pre-task --description "Analyze code complexity"
+npx claude-flow@v3alpha hooks pre-task --description "Analyze code complexity"
 # ... analysis ...
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "analysis" \
   --store-decisions
 
 # Agent 2: Refactoring (reads analysis from memory)
-npx claude-flow hook session-restore \
+npx claude-flow@v3alpha hooks session-restore \
   --session-id "swarm-refactor" \
   --restore-memory
 
 for file in src/**/*.js; do
-  npx claude-flow hook pre-edit --file "$file" --backup-file
+  npx claude-flow@v3alpha hooks pre-edit --file "$file" --backup-file
   # ... refactor ...
-  npx claude-flow hook post-edit \
+  npx claude-flow@v3alpha hooks post-edit \
     --file "$file" \
     --memory-key "refactor/$file" \
     --auto-format \
@@ -1088,12 +1153,12 @@ for file in src/**/*.js; do
 done
 
 # Agent 3: Testing (reads refactored code from memory)
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Generate tests for refactored code" \
   --load-memory
 
 # Broadcast completion
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Refactoring complete - all tests passing" \
   --broadcast
 ```
@@ -1117,13 +1182,13 @@ Enable debug mode for troubleshooting:
 export CLAUDE_FLOW_DEBUG=true
 
 # Test specific hook with verbose output
-npx claude-flow hook pre-edit --file "test.js" --debug
+npx claude-flow@v3alpha hooks pre-edit --file "test.js" --debug
 
 # Check hook execution logs
 cat .claude-flow/logs/hooks-$(date +%Y-%m-%d).log
 
 # Validate configuration
-npx claude-flow hook validate-config
+npx claude-flow@v3alpha hooks validate-config
 ```
 
 ### Benefits
@@ -1181,14 +1246,112 @@ npx claude-flow hook validate-config
 - Batch operations when possible
 - Reduce hook complexity
 
+### All `hooks` Subcommands
+
+#### Task Lifecycle
+
+| Subcommand | Description |
+|---|---|
+| `pre-task` | Record task start, get agent suggestions, auto-spawn swarm |
+| `post-task` | Record completion, analyze performance, store decisions |
+
+#### Tool Lifecycle (Layer 1 bridge)
+
+| Subcommand | Description |
+|---|---|
+| `pre-edit` | Validate and assign agents before file modifications |
+| `post-edit` | Auto-format, validate, and train neural patterns after edits |
+| `pre-command` | Assess safety and resource requirements before bash commands |
+| `post-command` | Log execution and update performance metrics |
+| `pre-bash` | Alias for `pre-command` (v2 compat) |
+| `post-bash` | Alias for `post-command` (v2 compat) |
+
+#### Session Management
+
+| Subcommand | Description |
+|---|---|
+| `session-start` | Initialize new session with context restoration |
+| `session-end` | Persist state, export metrics, generate summary |
+| `session-restore` | Reload a previous session state |
+
+#### Intelligence & Routing
+
+| Subcommand | Description |
+|---|---|
+| `route` | Route task to optimal agent via HNSW |
+| `route-task` | Alias for `route` (v2 compat) |
+| `explain` | Explain routing decision in detail |
+| `pretrain` | Bootstrap SONA/MoE intelligence from repo patterns |
+| `build-agents` | Generate optimized agent configurations |
+| `metrics` | View learning metrics dashboard |
+| `model-route` | 3-tier model routing recommendation (Agent Booster → Haiku → Sonnet/Opus) |
+| `model-stats` | Model usage and cost statistics |
+| `model-outcome` | Record model outcome to improve future routing |
+
+#### Agent Teams (Layer 2 — comms coordination)
+
+| Subcommand | Description |
+|---|---|
+| `teammate-idle` | Auto-assign pending tasks when a teammate finishes its turn |
+| `task-completed` | Train patterns and notify lead on task completion |
+
+#### Pattern Transfer & Registry
+
+| Subcommand | Description |
+|---|---|
+| `transfer` | Transfer patterns via IPFS registry |
+| `list` | List all registered hooks and their status |
+| `init` | Re-initialize hooks system configuration |
+| `notify` | Send notification with swarm status |
+
+#### Intelligence Sub-system (RuVector)
+
+| Subcommand | Description |
+|---|---|
+| `intelligence` | Entry point for RuVector intelligence operations |
+| `intelligence trajectory-start` | Begin a new learning trajectory |
+| `intelligence trajectory-step` | Record a reasoning step in an active trajectory |
+| `intelligence trajectory-end` | Finalize and score a completed trajectory |
+| `intelligence pattern-store` | Persist a learned coordination pattern |
+| `intelligence pattern-search` | Search stored patterns via HNSW (150x–12,500x faster) |
+| `intelligence stats` | View intelligence system statistics and EWC++ health |
+| `intelligence attention` | Configure attention weights for MoE routing |
+| `intelligence-reset` | Reset RuVector intelligence state to baseline |
+
+#### Coverage-Aware Routing
+
+| Subcommand | Description |
+|---|---|
+| `coverage-route` | Route task to address highest-priority coverage gaps |
+| `coverage-suggest` | Suggest test coverage improvements for a path |
+| `coverage-gaps` | List current coverage gaps with priorities |
+
+#### Background Workers
+
+| Subcommand | Description |
+|---|---|
+| `worker list` | List all 12 background workers and their status |
+| `worker dispatch` | Dispatch a specific worker by trigger name |
+| `worker status` | Show worker queue depth and health |
+| `worker detect` | Auto-detect which workers should run for current state |
+| `worker cancel` | Cancel a running background worker |
+
+#### Utilities
+
+| Subcommand | Description |
+|---|---|
+| `progress` | Check V3 implementation progress |
+| `statusline` | Generate dynamic statusline for Claude Code HUD |
+
+---
+
 ### Related Commands
 
-- `npx claude-flow init --hooks` - Initialize hooks system
-- `npx claude-flow hook --list` - List available hooks
-- `npx claude-flow hook --test <hook>` - Test specific hook
-- `npx claude-flow memory usage` - Manage memory
-- `npx claude-flow agent spawn` - Spawn agents
-- `npx claude-flow swarm init` - Initialize swarm
+- `npx claude-flow@v3alpha init` - Initialize hooks system
+- `npx claude-flow@v3alpha hooks list` - List registered hooks
+- `npx claude-flow@v3alpha memory usage` - Manage memory
+- `npx claude-flow@v3alpha agent spawn` - Spawn agents
+- `npx claude-flow@v3alpha swarm init` - Initialize swarm
 
 ### Integration with Other Skills
 

--- a/.omc/project-memory.json
+++ b/.omc/project-memory.json
@@ -1,0 +1,300 @@
+{
+  "version": "1.0.0",
+  "lastScanned": 1779891406759,
+  "projectRoot": "/home/drdave/_work/repos/_forks/ruflo/.devfleet-worktrees/session-d0aab521",
+  "techStack": {
+    "languages": [
+      {
+        "name": "JavaScript/TypeScript",
+        "version": ">=20.0.0",
+        "confidence": "high",
+        "markers": [
+          "package.json"
+        ]
+      },
+      {
+        "name": "TypeScript",
+        "version": null,
+        "confidence": "high",
+        "markers": [
+          "tsconfig.json"
+        ]
+      }
+    ],
+    "frameworks": [
+      {
+        "name": "vitest",
+        "version": "1.0.0",
+        "category": "testing"
+      }
+    ],
+    "packageManager": "pnpm",
+    "runtime": "Node.js 20.0.0"
+  },
+  "build": {
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
+    "lintCommand": "pnpm lint",
+    "devCommand": "pnpm dev",
+    "scripts": {
+      "dev": "tsx watch src/index.ts",
+      "build": "tsc",
+      "build:ts": "cd v3/@claude-flow/cli && npm run build || true",
+      "test": "vitest",
+      "test:ui": "vitest --ui",
+      "test:security": "vitest run v3/__tests__/security/",
+      "lint": "cd v3/@claude-flow/cli && npm run lint || true",
+      "security:audit": "npm audit --audit-level high",
+      "security:fix": "npm audit fix",
+      "security:test": "npm run test:security",
+      "v3:domains": "npm run build:domains",
+      "v3:swarm": "npm run start:swarm",
+      "v3:security": "npm run security:audit && npm run security:test"
+    }
+  },
+  "conventions": {
+    "namingStyle": null,
+    "importStyle": null,
+    "testPattern": "*.test.ts",
+    "fileOrganization": null
+  },
+  "structure": {
+    "isMonorepo": false,
+    "workspaces": [],
+    "mainDirectories": [
+      "bin",
+      "docs",
+      "scripts",
+      "tests"
+    ],
+    "gitBranches": {
+      "defaultBranch": "main",
+      "branchingStrategy": null
+    }
+  },
+  "customNotes": [],
+  "directoryMap": {
+    "bin": {
+      "path": "bin",
+      "purpose": "Executable scripts",
+      "fileCount": 3,
+      "lastAccessed": 1779891406753,
+      "keyFiles": [
+        "cli.js",
+        "npx-repair.js",
+        "npx-safe-launch.js"
+      ]
+    },
+    "data": {
+      "path": "data",
+      "purpose": "Data files",
+      "fileCount": 3,
+      "lastAccessed": 1779891406754,
+      "keyFiles": [
+        "clone-data.ledger.json",
+        "clone-data.proof.json",
+        "clone-data.rvf"
+      ]
+    },
+    "docs": {
+      "path": "docs",
+      "purpose": "Documentation",
+      "fileCount": 7,
+      "lastAccessed": 1779891406756,
+      "keyFiles": [
+        "IMPROVEMENT-ROADMAP.md",
+        "QUALITY-SWEEP.md",
+        "STATUS.md",
+        "TEAM-GATEWAY-CHECKLIST.md",
+        "USERGUIDE.md"
+      ]
+    },
+    "plugin": {
+      "path": "plugin",
+      "purpose": null,
+      "fileCount": 0,
+      "lastAccessed": 1779891406756,
+      "keyFiles": []
+    },
+    "plugins": {
+      "path": "plugins",
+      "purpose": null,
+      "fileCount": 1,
+      "lastAccessed": 1779891406757,
+      "keyFiles": [
+        "README.md"
+      ]
+    },
+    "ruflo": {
+      "path": "ruflo",
+      "purpose": null,
+      "fileCount": 5,
+      "lastAccessed": 1779891406757,
+      "keyFiles": [
+        "README.md",
+        "docker-compose.yml",
+        "package.json",
+        "rvf.manifest.json"
+      ]
+    },
+    "scripts": {
+      "path": "scripts",
+      "purpose": "Build/utility scripts",
+      "fileCount": 58,
+      "lastAccessed": 1779891406757,
+      "keyFiles": [
+        "audit-cli-mcp-tools.mjs",
+        "audit-codex-integration.mjs",
+        "audit-env-var-precedence.mjs",
+        "audit-fix-invariants.mjs",
+        "audit-hook-commands.mjs"
+      ]
+    },
+    "tests": {
+      "path": "tests",
+      "purpose": "Test files",
+      "fileCount": 8,
+      "lastAccessed": 1779891406757,
+      "keyFiles": [
+        "context-persistence-hook.test.mjs",
+        "rvf-backend.test.ts",
+        "rvf-capability-verify.test.ts",
+        "rvf-embeddings.test.ts",
+        "rvf-event-log.test.ts"
+      ]
+    },
+    "v3": {
+      "path": "v3",
+      "purpose": null,
+      "fileCount": 15,
+      "lastAccessed": 1779891406758,
+      "keyFiles": [
+        "CHANGELOG.md",
+        "CLAUDE.md",
+        "README.md",
+        "bunfig.toml",
+        "index.ts"
+      ]
+    },
+    "verification": {
+      "path": "verification",
+      "purpose": null,
+      "fileCount": 7,
+      "lastAccessed": 1779891406758,
+      "keyFiles": [
+        "CAPABILITIES.md",
+        "README.md",
+        "cli-mcp-tool-baseline.json",
+        "inventory.json",
+        "mcp-tool-baseline.json"
+      ]
+    },
+    "plugin/scripts": {
+      "path": "plugin/scripts",
+      "purpose": "Build/utility scripts",
+      "fileCount": 2,
+      "lastAccessed": 1779891406758,
+      "keyFiles": [
+        "ruflo-hook.cjs",
+        "ruflo-hook.sh"
+      ]
+    },
+    "ruflo/assets": {
+      "path": "ruflo/assets",
+      "purpose": "Static assets",
+      "fileCount": 2,
+      "lastAccessed": 1779891406758,
+      "keyFiles": [
+        "ruFlo.png",
+        "ruflo-small.jpeg"
+      ]
+    },
+    "ruflo/bin": {
+      "path": "ruflo/bin",
+      "purpose": "Executable scripts",
+      "fileCount": 1,
+      "lastAccessed": 1779891406759,
+      "keyFiles": [
+        "ruflo.js"
+      ]
+    },
+    "ruflo/docs": {
+      "path": "ruflo/docs",
+      "purpose": "Documentation",
+      "fileCount": 4,
+      "lastAccessed": 1779891406759,
+      "keyFiles": [
+        "AUTH.md",
+        "DOCKER.md",
+        "MODELS.md"
+      ]
+    },
+    "ruflo/src": {
+      "path": "ruflo/src",
+      "purpose": "Source code",
+      "fileCount": 1,
+      "lastAccessed": 1779891406759,
+      "keyFiles": []
+    },
+    "scripts/__tests__": {
+      "path": "scripts/__tests__",
+      "purpose": "Test files",
+      "fileCount": 1,
+      "lastAccessed": 1779891406759,
+      "keyFiles": [
+        "audit-supply-chain.test.mjs"
+      ]
+    },
+    "v3/__tests__": {
+      "path": "v3/__tests__",
+      "purpose": "Test files",
+      "fileCount": 1,
+      "lastAccessed": 1779891406759,
+      "keyFiles": [
+        "setup.ts"
+      ]
+    },
+    "v3/docs": {
+      "path": "v3/docs",
+      "purpose": "Documentation",
+      "fileCount": 1,
+      "lastAccessed": 1779891406759,
+      "keyFiles": [
+        "CLAUDE-FLOW-VS-TEAMMATE-TOOL-COMPARISON.md"
+      ]
+    }
+  },
+  "hotPaths": [
+    {
+      "path": "v3/@claude-flow/cli/.claude/skills/hooks-automation/SKILL.md",
+      "accessCount": 7,
+      "lastAccessed": 1779891756941,
+      "type": "file"
+    },
+    {
+      "path": ".claude/skills/hooks-automation/SKILL.md",
+      "accessCount": 4,
+      "lastAccessed": 1779891871084,
+      "type": "file"
+    },
+    {
+      "path": ".agents/skills/hooks-automation/SKILL.md",
+      "accessCount": 4,
+      "lastAccessed": 1779891882090,
+      "type": "file"
+    },
+    {
+      "path": "v3/@claude-flow/cli/.claude/commands/hooks/setup.md",
+      "accessCount": 3,
+      "lastAccessed": 1779891663186,
+      "type": "file"
+    },
+    {
+      "path": "v3/@claude-flow/mcp/.claude/commands/hooks/setup.md",
+      "accessCount": 3,
+      "lastAccessed": 1779891699985,
+      "type": "file"
+    }
+  ],
+  "userDirectives": []
+}

--- a/.omc/state/sessions/b13fba53-f29a-4a88-8355-8705a8273aa5/session-started.json
+++ b/.omc/state/sessions/b13fba53-f29a-4a88-8355-8705a8273aa5/session-started.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "b13fba53-f29a-4a88-8355-8705a8273aa5",
+  "started_at": "2026-05-27T14:16:46.751Z",
+  "cwd": "/home/drdave/_work/repos/_forks/ruflo/.devfleet-worktrees/session-d0aab521",
+  "pid": 494137,
+  "boot_id": "607c5f09-b417-4426-bbdc-a0cfb50c2c2c"
+}

--- a/v3/@claude-flow/cli/.claude/commands/automation/self-healing.md
+++ b/v3/@claude-flow/cli/.claude/commands/automation/self-healing.md
@@ -94,7 +94,7 @@ mcp__claude-flow__task_orchestrate({
 {
   "PostToolUse": [{
     "matcher": "^Bash$",
-    "command": "npx claude-flow hook post-bash --exit-code '${tool.result.exitCode}' --auto-recover"
+    "command": "npx claude-flow@v3alpha hooks post-bash --exit-code '${tool.result.exitCode}' --auto-recover"
   }]
 }
 ```

--- a/v3/@claude-flow/cli/.claude/commands/automation/session-memory.md
+++ b/v3/@claude-flow/cli/.claude/commands/automation/session-memory.md
@@ -30,7 +30,7 @@ mcp__claude-flow__context_restore({
 
 **Fallback with npx:**
 ```bash
-npx claude-flow hook session-restore --session-id "sess-123"
+npx claude-flow@v3alpha hooks session-restore --session-id "sess-123"
 ```
 
 ### 3. Memory Types

--- a/v3/@claude-flow/cli/.claude/commands/automation/smart-agents.md
+++ b/v3/@claude-flow/cli/.claude/commands/automation/smart-agents.md
@@ -63,7 +63,7 @@ mcp__claude-flow__agent_spawn({
 ### Fallback Configuration
 If MCP tools are unavailable:
 ```bash
-npx claude-flow hook pre-task --auto-spawn-agents
+npx claude-flow@v3alpha hooks pre-task --auto-spawn-agents
 ```
 
 ## Benefits

--- a/v3/@claude-flow/cli/.claude/commands/hooks/overview.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/overview.md
@@ -37,7 +37,7 @@ Hooks are configured in `.claude/settings.json`:
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
         }]
       }
     ]

--- a/v3/@claude-flow/cli/.claude/commands/hooks/post-edit.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/post-edit.md
@@ -5,7 +5,7 @@ Execute post-edit processing including formatting, validation, and memory update
 ## Usage
 
 ```bash
-npx claude-flow hook post-edit [options]
+npx claude-flow@v3alpha hooks post-edit [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook post-edit [options]
 ### Basic post-edit hook
 
 ```bash
-npx claude-flow hook post-edit --file "src/components/Button.jsx"
+npx claude-flow@v3alpha hooks post-edit --file "src/components/Button.jsx"
 ```
 
 ### With memory storage
 
 ```bash
-npx claude-flow hook post-edit -f "api/auth.js" --memory-key "auth/login-implementation"
+npx claude-flow@v3alpha hooks post-edit -f "api/auth.js" --memory-key "auth/login-implementation"
 ```
 
 ### Format and validate
 
 ```bash
-npx claude-flow hook post-edit -f "config/webpack.js" --auto-format --validate-output
+npx claude-flow@v3alpha hooks post-edit -f "config/webpack.js" --auto-format --validate-output
 ```
 
 ### Neural training
 
 ```bash
-npx claude-flow hook post-edit -f "utils/helpers.ts" --train-patterns --memory-key "utils/refactor"
+npx claude-flow@v3alpha hooks post-edit -f "utils/helpers.ts" --train-patterns --memory-key "utils/refactor"
 ```
 
 ## Features
@@ -86,7 +86,7 @@ Manual usage in agents:
 
 ```bash
 # After editing files
-npx claude-flow hook post-edit --file "path/to/edited.js" --memory-key "feature/step1"
+npx claude-flow@v3alpha hooks post-edit --file "path/to/edited.js" --memory-key "feature/step1"
 ```
 
 ## Output

--- a/v3/@claude-flow/cli/.claude/commands/hooks/post-task.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/post-task.md
@@ -5,7 +5,7 @@ Execute post-task cleanup, performance analysis, and memory storage.
 ## Usage
 
 ```bash
-npx claude-flow hook post-task [options]
+npx claude-flow@v3alpha hooks post-task [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook post-task [options]
 ### Basic post-task hook
 
 ```bash
-npx claude-flow hook post-task --task-id "auth-implementation"
+npx claude-flow@v3alpha hooks post-task --task-id "auth-implementation"
 ```
 
 ### With full analysis
 
 ```bash
-npx claude-flow hook post-task -t "api-refactor" --analyze-performance --generate-report
+npx claude-flow@v3alpha hooks post-task -t "api-refactor" --analyze-performance --generate-report
 ```
 
 ### Memory storage
 
 ```bash
-npx claude-flow hook post-task -t "bug-fix-123" --store-decisions --export-learnings
+npx claude-flow@v3alpha hooks post-task -t "bug-fix-123" --store-decisions --export-learnings
 ```
 
 ### Quick cleanup
 
 ```bash
-npx claude-flow hook post-task -t "minor-update" --analyze-performance false
+npx claude-flow@v3alpha hooks post-task -t "minor-update" --analyze-performance false
 ```
 
 ## Features
@@ -85,7 +85,7 @@ Manual usage in agents:
 
 ```bash
 # In agent coordination
-npx claude-flow hook post-task --task-id "your-task-id" --analyze-performance true
+npx claude-flow@v3alpha hooks post-task --task-id "your-task-id" --analyze-performance true
 ```
 
 ## Output

--- a/v3/@claude-flow/cli/.claude/commands/hooks/pre-edit.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/pre-edit.md
@@ -5,7 +5,7 @@ Execute pre-edit validations and agent assignment before file modifications.
 ## Usage
 
 ```bash
-npx claude-flow hook pre-edit [options]
+npx claude-flow@v3alpha hooks pre-edit [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook pre-edit [options]
 ### Basic pre-edit hook
 
 ```bash
-npx claude-flow hook pre-edit --file "src/auth/login.js"
+npx claude-flow@v3alpha hooks pre-edit --file "src/auth/login.js"
 ```
 
 ### With validation
 
 ```bash
-npx claude-flow hook pre-edit -f "config/database.js" --validate-syntax
+npx claude-flow@v3alpha hooks pre-edit -f "config/database.js" --validate-syntax
 ```
 
 ### Manual agent assignment
 
 ```bash
-npx claude-flow hook pre-edit -f "api/users.ts" --auto-assign-agent false
+npx claude-flow@v3alpha hooks pre-edit -f "api/users.ts" --auto-assign-agent false
 ```
 
 ### Safe editing with backup
 
 ```bash
-npx claude-flow hook pre-edit -f "production.env" --backup-file --check-conflicts
+npx claude-flow@v3alpha hooks pre-edit -f "production.env" --backup-file --check-conflicts
 ```
 
 ## Features
@@ -86,7 +86,7 @@ Manual usage in agents:
 
 ```bash
 # Before editing files
-npx claude-flow hook pre-edit --file "path/to/file.js" --validate-syntax
+npx claude-flow@v3alpha hooks pre-edit --file "path/to/file.js" --validate-syntax
 ```
 
 ## Output

--- a/v3/@claude-flow/cli/.claude/commands/hooks/pre-task.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/pre-task.md
@@ -5,7 +5,7 @@ Execute pre-task preparations and context loading.
 ## Usage
 
 ```bash
-npx claude-flow hook pre-task [options]
+npx claude-flow@v3alpha hooks pre-task [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook pre-task [options]
 ### Basic pre-task hook
 
 ```bash
-npx claude-flow hook pre-task --description "Implement user authentication"
+npx claude-flow@v3alpha hooks pre-task --description "Implement user authentication"
 ```
 
 ### With memory loading
 
 ```bash
-npx claude-flow hook pre-task -d "Continue API development" --load-memory
+npx claude-flow@v3alpha hooks pre-task -d "Continue API development" --load-memory
 ```
 
 ### Manual agent control
 
 ```bash
-npx claude-flow hook pre-task -d "Debug issue #123" --auto-spawn-agents false
+npx claude-flow@v3alpha hooks pre-task -d "Debug issue #123" --auto-spawn-agents false
 ```
 
 ### Full optimization
 
 ```bash
-npx claude-flow hook pre-task -d "Refactor codebase" --optimize-topology --estimate-complexity
+npx claude-flow@v3alpha hooks pre-task -d "Refactor codebase" --optimize-topology --estimate-complexity
 ```
 
 ## Features
@@ -85,7 +85,7 @@ Manual usage in agents:
 
 ```bash
 # In agent coordination
-npx claude-flow hook pre-task --description "Your task here"
+npx claude-flow@v3alpha hooks pre-task --description "Your task here"
 ```
 
 ## Output

--- a/v3/@claude-flow/cli/.claude/commands/hooks/session-end.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/session-end.md
@@ -5,7 +5,7 @@ Cleanup and persist session state before ending work.
 ## Usage
 
 ```bash
-npx claude-flow hook session-end [options]
+npx claude-flow@v3alpha hooks session-end [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook session-end [options]
 ### Basic session end
 
 ```bash
-npx claude-flow hook session-end --session-id "dev-session-2024"
+npx claude-flow@v3alpha hooks session-end --session-id "dev-session-2024"
 ```
 
 ### With full export
 
 ```bash
-npx claude-flow hook session-end -s "feature-auth" --export-metrics --generate-summary
+npx claude-flow@v3alpha hooks session-end -s "feature-auth" --export-metrics --generate-summary
 ```
 
 ### Quick close
 
 ```bash
-npx claude-flow hook session-end -s "quick-fix" --save-state false --cleanup-temp
+npx claude-flow@v3alpha hooks session-end -s "quick-fix" --save-state false --cleanup-temp
 ```
 
 ### Complete persistence
 
 ```bash
-npx claude-flow hook session-end -s "major-refactor" --save-state --export-metrics --generate-summary
+npx claude-flow@v3alpha hooks session-end -s "major-refactor" --save-state --export-metrics --generate-summary
 ```
 
 ## Features
@@ -86,7 +86,7 @@ Manual usage in agents:
 
 ```bash
 # At session end
-npx claude-flow hook session-end --session-id "your-session" --generate-summary
+npx claude-flow@v3alpha hooks session-end --session-id "your-session" --generate-summary
 ```
 
 ## Output

--- a/v3/@claude-flow/cli/.claude/commands/hooks/setup.md
+++ b/v3/@claude-flow/cli/.claude/commands/hooks/setup.md
@@ -1,39 +1,116 @@
-# Setting Up ruv-swarm Hooks
+# Setting Up Claude Flow Hooks
+
+## Two-Layer Model
+
+Claude Flow's hook system operates at **two distinct layers** that work together but serve different
+purposes. Understanding the distinction prevents misconfiguration.
+
+### Layer 1 — Claude Code Matcher Hooks (`.claude/settings.json`)
+
+These fire around **Claude Code's own tool calls** (file writes, edits, bash commands). Configured in
+`.claude/settings.json` under `hooks.PreToolUse` / `hooks.PostToolUse`. Each entry specifies a regex
+`matcher` for a Claude tool name (`Write`, `Edit`, `Bash`, `Task`, …) and runs a shell command.
+
+**Key characteristic**: Claude Code evaluates these; if the command exits non-zero the tool call can be
+blocked. The `${tool.params.*}` interpolation is performed by Claude Code's harness, not claude-flow.
+
+### Layer 2 — claude-flow Internal Hooks (`npx claude-flow@v3alpha hooks <subcommand>`)
+
+These are invoked **by the claude-flow CLI itself** to manage agent coordination, session state,
+learning, and Agent Teams events. They are independent of Claude Code's tool lifecycle and operate
+inside the swarm's own orchestration engine.
+
+```bash
+# Agent Teams hooks — fired by the swarm when a teammate finishes or a task completes
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+npx claude-flow@v3alpha hooks task-completed --task-id "my-task" --train-patterns true
+```
+
+---
 
 ## Quick Start
 
 ### 1. Initialize with Hooks
 ```bash
-npx claude-flow init --hooks
+npx claude-flow@v3alpha init
 ```
 
 This automatically creates:
-- `.claude/settings.json` with hook configurations
-- Hook command documentation
-- Default hook handlers
+- `.claude/settings.json` with hook configurations for both Layer 1 and Layer 2
+- Hook command documentation in `.claude/commands/hooks/`
+- Default hook handlers for common operations
 
-### 2. Test Hook Functionality
-```bash
-# Test pre-edit hook
-npx claude-flow hook pre-edit --file test.js
+### 2. The v3 `settings.json` emitted by `init`
 
-# Test session summary
-npx claude-flow hook session-end --summary
-```
-
-### 3. Customize Hooks
-
-Edit `.claude/settings.json` to customize:
+`npx claude-flow@v3alpha init` writes a settings file that activates both layers together:
 
 ```json
 {
+  "env": {
+    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "agentTeams": {
+      "hooks": {
+        "teammateIdle": {
+          "autoAssign": true,
+          "notifyLead": true
+        },
+        "taskCompleted": {
+          "trainPatterns": true,
+          "exportLearnings": true
+        }
+      }
+    }
+  },
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "^Write$",
+        "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-write --file '${tool.params.file_path}'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
+        }]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-command --command '${tool.params.command}'"
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.prompt}' --load-memory",
+          "async": true
+        }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-command --command '${tool.params.command}' --track-metrics",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --store-decisions",
+          "async": true
         }]
       }
     ]
@@ -41,18 +118,136 @@ Edit `.claude/settings.json` to customize:
 }
 ```
 
+**Layer 1 keys** (`hooks.PreToolUse` / `hooks.PostToolUse`) are read by Claude Code.
+**Layer 2 keys** (`env.CLAUDE_FLOW_HOOKS_ENABLED`, `claudeFlow.agentTeams.hooks`) are read by claude-flow.
+
+### 3. Test Hook Functionality
+```bash
+# Test pre-edit hook
+npx claude-flow@v3alpha hooks pre-edit --file test.js
+
+# Test session summary
+npx claude-flow@v3alpha hooks session-end --summary
+```
+
+### 4. Debugging Hooks
+```bash
+# Enable debug output
+export CLAUDE_FLOW_DEBUG=true
+
+# Test specific hook
+npx claude-flow@v3alpha hooks pre-edit --file app.js --debug
+```
+
+---
+
+## All `hooks` Subcommands
+
+### Task Lifecycle
+
+| Subcommand | Description |
+|---|---|
+| `pre-task` | Record task start, get agent suggestions, auto-spawn swarm |
+| `post-task` | Record completion, analyze performance, store decisions |
+
+### Tool Lifecycle (Layer 1 bridge)
+
+| Subcommand | Description |
+|---|---|
+| `pre-edit` | Validate and assign agents before file modifications |
+| `post-edit` | Auto-format, validate, and train neural patterns after edits |
+| `pre-command` | Assess safety and resource requirements before bash commands |
+| `post-command` | Log execution and update performance metrics |
+| `pre-bash` | Alias for `pre-command` (v2 compat) |
+| `post-bash` | Alias for `post-command` (v2 compat) |
+
+### Session Management
+
+| Subcommand | Description |
+|---|---|
+| `session-start` | Initialize new session with context restoration |
+| `session-end` | Persist state, export metrics, generate summary |
+| `session-restore` | Reload a previous session state |
+
+### Intelligence & Routing
+
+| Subcommand | Description |
+|---|---|
+| `route` | Route task to optimal agent via HNSW |
+| `route-task` | Alias for `route` (v2 compat) |
+| `explain` | Explain routing decision in detail |
+| `pretrain` | Bootstrap SONA/MoE intelligence from repo patterns |
+| `build-agents` | Generate optimized agent configurations |
+| `metrics` | View learning metrics dashboard |
+| `model-route` | 3-tier model routing recommendation (Agent Booster → Haiku → Sonnet/Opus) |
+| `model-stats` | Model usage and cost statistics |
+| `model-outcome` | Record model outcome to improve future routing |
+
+### Agent Teams (Layer 2 — comms coordination)
+
+| Subcommand | Description |
+|---|---|
+| `teammate-idle` | Auto-assign pending tasks when a teammate finishes its turn |
+| `task-completed` | Train patterns and notify lead on task completion |
+
+### Pattern Transfer & Registry
+
+| Subcommand | Description |
+|---|---|
+| `transfer` | Transfer patterns via IPFS registry |
+| `list` | List all registered hooks and their status |
+| `init` | Re-initialize hooks system configuration |
+| `notify` | Send notification with swarm status |
+
+### Intelligence Sub-system (RuVector)
+
+| Subcommand | Description |
+|---|---|
+| `intelligence` | Entry point for RuVector intelligence operations |
+| `intelligence trajectory-start` | Begin a new learning trajectory |
+| `intelligence trajectory-step` | Record a reasoning step in an active trajectory |
+| `intelligence trajectory-end` | Finalize and score a completed trajectory |
+| `intelligence pattern-store` | Persist a learned coordination pattern |
+| `intelligence pattern-search` | Search stored patterns via HNSW (150x–12,500x faster) |
+| `intelligence stats` | View intelligence system statistics and EWC++ health |
+| `intelligence attention` | Configure attention weights for MoE routing |
+| `intelligence-reset` | Reset RuVector intelligence state to baseline |
+
+### Coverage-Aware Routing
+
+| Subcommand | Description |
+|---|---|
+| `coverage-route` | Route task to address highest-priority coverage gaps |
+| `coverage-suggest` | Suggest test coverage improvements for a path |
+| `coverage-gaps` | List current coverage gaps with priorities |
+
+### Background Workers
+
+| Subcommand | Description |
+|---|---|
+| `worker list` | List all 12 background workers and their status |
+| `worker dispatch` | Dispatch a specific worker by trigger name |
+| `worker status` | Show worker queue depth and health |
+| `worker detect` | Auto-detect which workers should run for current state |
+| `worker cancel` | Cancel a running background worker |
+
+### Utilities
+
+| Subcommand | Description |
+|---|---|
+| `progress` | Check V3 implementation progress |
+| `statusline` | Generate dynamic statusline for Claude Code HUD |
+
+---
+
 ## Hook Response Format
 
-Hooks return JSON with:
-- `continue`: Whether to proceed (true/false)
-- `reason`: Explanation for decision
-- `metadata`: Additional context
+Layer 1 hooks (Claude Code matcher) return JSON read by the harness:
 
-Example blocking response:
 ```json
 {
   "continue": false,
-  "reason": "Protected file - manual review required",
+  "reason": "Protected file — manual review required",
   "metadata": {
     "file": ".env.production",
     "protection_level": "high"
@@ -60,38 +255,37 @@ Example blocking response:
 }
 ```
 
-## Performance Tips
-- Keep hooks lightweight (< 100ms)
-- Use caching for repeated operations
-- Batch related operations
-- Run non-critical hooks asynchronously
+- `continue: false` **blocks** the tool call
+- `continue: true` (or no JSON output) allows it to proceed
 
-## Debugging Hooks
-```bash
-# Enable debug output
-export CLAUDE_FLOW_DEBUG=true
-
-# Test specific hook
-npx claude-flow hook pre-edit --file app.js --debug
-```
+---
 
 ## Common Patterns
 
-### Auto-Format on Save
-Already configured by default for common file types.
-
-### Protected File Detection
+### Protected File Detection (Layer 1)
 ```json
 {
   "matcher": "^(Write|Edit)$",
   "hooks": [{
     "type": "command",
-    "command": "npx claude-flow hook check-protected --file '${tool.params.file_path}'"
+    "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}' --check-conflicts"
   }]
 }
 ```
 
-### Automatic Testing
+### Auto-Train on Every Save (Layer 1)
+```json
+{
+  "matcher": "^(Write|Edit|MultiEdit)$",
+  "hooks": [{
+    "type": "command",
+    "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns --auto-format",
+    "async": true
+  }]
+}
+```
+
+### Automatic Testing on Write (Layer 1)
 ```json
 {
   "matcher": "^Write$",
@@ -101,3 +295,14 @@ Already configured by default for common file types.
   }]
 }
 ```
+
+### Agent Teams Auto-Assign (Layer 2)
+```bash
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+```
+
+## Performance Tips
+- Keep Layer 1 hooks lightweight (< 100ms) — use `"async": true` for heavy operations
+- Use caching for repeated lookups
+- Batch related operations in a single hook command
+- Run non-critical hooks with `"continueOnError": true`

--- a/v3/@claude-flow/cli/.claude/commands/optimization/auto-topology.md
+++ b/v3/@claude-flow/cli/.claude/commands/optimization/auto-topology.md
@@ -45,7 +45,7 @@ Result: Automatically uses hierarchical topology with architect, coder, and test
 The pre-task hook automatically handles topology selection:
 ```json
 {
-  "command": "npx claude-flow hook pre-task --optimize-topology"
+  "command": "npx claude-flow@v3alpha hooks pre-task --optimize-topology"
 }
 ```
 

--- a/v3/@claude-flow/cli/.claude/skills/hooks-automation/SKILL.md
+++ b/v3/@claude-flow/cli/.claude/skills/hooks-automation/SKILL.md
@@ -38,7 +38,7 @@ This skill provides a comprehensive hook system that automatically manages devel
 
 ```bash
 # Initialize with default hooks configuration
-npx claude-flow init --hooks
+npx claude-flow@v3alpha init
 ```
 
 This creates:
@@ -50,13 +50,13 @@ This creates:
 
 ```bash
 # Pre-task hook (auto-spawns agents)
-npx claude-flow hook pre-task --description "Implement authentication"
+npx claude-flow@v3alpha hooks pre-task --description "Implement authentication"
 
 # Post-edit hook (auto-formats and stores in memory)
-npx claude-flow hook post-edit --file "src/auth.js" --memory-key "auth/login"
+npx claude-flow@v3alpha hooks post-edit --file "src/auth.js" --memory-key "auth/login"
 
 # Session end hook (saves state and metrics)
-npx claude-flow hook session-end --session-id "dev-session" --export-metrics
+npx claude-flow@v3alpha hooks session-end --session-id "dev-session" --export-metrics
 ```
 
 ---
@@ -71,7 +71,7 @@ Hooks that execute BEFORE operations to prepare and validate:
 
 **pre-edit** - Validate and assign agents before file modifications
 ```bash
-npx claude-flow hook pre-edit [options]
+npx claude-flow@v3alpha hooks pre-edit [options]
 
 Options:
   --file, -f <path>         File path to be edited
@@ -81,9 +81,9 @@ Options:
   --backup-file             Create backup before editing
 
 Examples:
-  npx claude-flow hook pre-edit --file "src/auth/login.js"
-  npx claude-flow hook pre-edit -f "config/db.js" --validate-syntax
-  npx claude-flow hook pre-edit -f "production.env" --backup-file --check-conflicts
+  npx claude-flow@v3alpha hooks pre-edit --file "src/auth/login.js"
+  npx claude-flow@v3alpha hooks pre-edit -f "config/db.js" --validate-syntax
+  npx claude-flow@v3alpha hooks pre-edit -f "production.env" --backup-file --check-conflicts
 ```
 
 **Features:**
@@ -94,7 +94,7 @@ Examples:
 
 **pre-bash** - Check command safety and resource requirements
 ```bash
-npx claude-flow hook pre-bash --command <cmd>
+npx claude-flow@v3alpha hooks pre-bash --command <cmd>
 
 Options:
   --command, -c <cmd>       Command to validate
@@ -103,8 +103,8 @@ Options:
   --require-confirmation    Request user confirmation for risky commands
 
 Examples:
-  npx claude-flow hook pre-bash -c "rm -rf /tmp/cache"
-  npx claude-flow hook pre-bash --command "docker build ." --estimate-resources
+  npx claude-flow@v3alpha hooks pre-bash -c "rm -rf /tmp/cache"
+  npx claude-flow@v3alpha hooks pre-bash --command "docker build ." --estimate-resources
 ```
 
 **Features:**
@@ -115,7 +115,7 @@ Examples:
 
 **pre-task** - Auto-spawn agents and prepare for complex tasks
 ```bash
-npx claude-flow hook pre-task [options]
+npx claude-flow@v3alpha hooks pre-task [options]
 
 Options:
   --description, -d <text>  Task description for context
@@ -125,9 +125,9 @@ Options:
   --estimate-complexity     Analyze task complexity
 
 Examples:
-  npx claude-flow hook pre-task --description "Implement user authentication"
-  npx claude-flow hook pre-task -d "Continue API dev" --load-memory
-  npx claude-flow hook pre-task -d "Refactor codebase" --optimize-topology
+  npx claude-flow@v3alpha hooks pre-task --description "Implement user authentication"
+  npx claude-flow@v3alpha hooks pre-task -d "Continue API dev" --load-memory
+  npx claude-flow@v3alpha hooks pre-task -d "Refactor codebase" --optimize-topology
 ```
 
 **Features:**
@@ -138,7 +138,7 @@ Examples:
 
 **pre-search** - Prepare and optimize search operations
 ```bash
-npx claude-flow hook pre-search --query <query>
+npx claude-flow@v3alpha hooks pre-search --query <query>
 
 Options:
   --query, -q <text>        Search query
@@ -146,7 +146,7 @@ Options:
   --optimize-query          Optimize search pattern
 
 Examples:
-  npx claude-flow hook pre-search -q "authentication middleware"
+  npx claude-flow@v3alpha hooks pre-search -q "authentication middleware"
 ```
 
 **Features:**
@@ -160,7 +160,7 @@ Hooks that execute AFTER operations to process and learn:
 
 **post-edit** - Auto-format, validate, and update memory
 ```bash
-npx claude-flow hook post-edit [options]
+npx claude-flow@v3alpha hooks post-edit [options]
 
 Options:
   --file, -f <path>         File path that was edited
@@ -170,9 +170,9 @@ Options:
   --validate-output         Validate edited file
 
 Examples:
-  npx claude-flow hook post-edit --file "src/components/Button.jsx"
-  npx claude-flow hook post-edit -f "api/auth.js" --memory-key "auth/login"
-  npx claude-flow hook post-edit -f "utils/helpers.ts" --train-patterns
+  npx claude-flow@v3alpha hooks post-edit --file "src/components/Button.jsx"
+  npx claude-flow@v3alpha hooks post-edit -f "api/auth.js" --memory-key "auth/login"
+  npx claude-flow@v3alpha hooks post-edit -f "utils/helpers.ts" --train-patterns
 ```
 
 **Features:**
@@ -183,7 +183,7 @@ Examples:
 
 **post-bash** - Log execution and update metrics
 ```bash
-npx claude-flow hook post-bash --command <cmd>
+npx claude-flow@v3alpha hooks post-bash --command <cmd>
 
 Options:
   --command, -c <cmd>       Command that was executed
@@ -192,7 +192,7 @@ Options:
   --store-result            Store result in memory
 
 Examples:
-  npx claude-flow hook post-bash -c "npm test" --update-metrics
+  npx claude-flow@v3alpha hooks post-bash -c "npm test" --update-metrics
 ```
 
 **Features:**
@@ -203,7 +203,7 @@ Examples:
 
 **post-task** - Performance analysis and decision storage
 ```bash
-npx claude-flow hook post-task [options]
+npx claude-flow@v3alpha hooks post-task [options]
 
 Options:
   --task-id, -t <id>        Task identifier for tracking
@@ -213,9 +213,9 @@ Options:
   --generate-report         Create task completion report
 
 Examples:
-  npx claude-flow hook post-task --task-id "auth-implementation"
-  npx claude-flow hook post-task -t "api-refactor" --analyze-performance
-  npx claude-flow hook post-task -t "bug-fix-123" --store-decisions
+  npx claude-flow@v3alpha hooks post-task --task-id "auth-implementation"
+  npx claude-flow@v3alpha hooks post-task -t "api-refactor" --analyze-performance
+  npx claude-flow@v3alpha hooks post-task -t "bug-fix-123" --store-decisions
 ```
 
 **Features:**
@@ -226,7 +226,7 @@ Examples:
 
 **post-search** - Cache results and improve patterns
 ```bash
-npx claude-flow hook post-search --query <query> --results <path>
+npx claude-flow@v3alpha hooks post-search --query <query> --results <path>
 
 Options:
   --query, -q <text>        Original search query
@@ -235,7 +235,7 @@ Options:
   --train-patterns          Improve search patterns
 
 Examples:
-  npx claude-flow hook post-search -q "auth" -r "results.json" --train-patterns
+  npx claude-flow@v3alpha hooks post-search -q "auth" -r "results.json" --train-patterns
 ```
 
 **Features:**
@@ -249,7 +249,7 @@ Hooks that coordinate with MCP swarm tools:
 
 **mcp-initialized** - Persist swarm configuration
 ```bash
-npx claude-flow hook mcp-initialized --swarm-id <id>
+npx claude-flow@v3alpha hooks mcp-initialized --swarm-id <id>
 
 Features:
 - Save swarm topology and configuration
@@ -259,7 +259,7 @@ Features:
 
 **agent-spawned** - Update agent roster and memory
 ```bash
-npx claude-flow hook agent-spawned --agent-id <id> --type <type>
+npx claude-flow@v3alpha hooks agent-spawned --agent-id <id> --type <type>
 
 Features:
 - Register agent in coordination memory
@@ -269,7 +269,7 @@ Features:
 
 **task-orchestrated** - Monitor task progress
 ```bash
-npx claude-flow hook task-orchestrated --task-id <id>
+npx claude-flow@v3alpha hooks task-orchestrated --task-id <id>
 
 Features:
 - Track task progress through memory
@@ -279,7 +279,7 @@ Features:
 
 **neural-trained** - Save pattern improvements
 ```bash
-npx claude-flow hook neural-trained --pattern <name>
+npx claude-flow@v3alpha hooks neural-trained --pattern <name>
 
 Features:
 - Export trained neural patterns
@@ -309,7 +309,7 @@ Features:
 
 **memory-sync** - Synchronize memory across swarm agents
 ```bash
-npx claude-flow hook memory-sync --namespace <ns>
+npx claude-flow@v3alpha hooks memory-sync --namespace <ns>
 
 Features:
 - Sync memory state across agents
@@ -322,7 +322,7 @@ Features:
 
 **session-start** - Initialize new session
 ```bash
-npx claude-flow hook session-start --session-id <id>
+npx claude-flow@v3alpha hooks session-start --session-id <id>
 
 Options:
   --session-id, -s <id>     Session identifier
@@ -338,7 +338,7 @@ Features:
 
 **session-restore** - Load previous session state
 ```bash
-npx claude-flow hook session-restore --session-id <id>
+npx claude-flow@v3alpha hooks session-restore --session-id <id>
 
 Options:
   --session-id, -s <id>     Session to restore
@@ -346,8 +346,8 @@ Options:
   --restore-agents          Restore agent configurations
 
 Examples:
-  npx claude-flow hook session-restore --session-id "swarm-20241019"
-  npx claude-flow hook session-restore -s "feature-auth" --restore-memory
+  npx claude-flow@v3alpha hooks session-restore --session-id "swarm-20241019"
+  npx claude-flow@v3alpha hooks session-restore -s "feature-auth" --restore-memory
 ```
 
 **Features:**
@@ -358,7 +358,7 @@ Examples:
 
 **session-end** - Cleanup and persist session state
 ```bash
-npx claude-flow hook session-end [options]
+npx claude-flow@v3alpha hooks session-end [options]
 
 Options:
   --session-id, -s <id>     Session identifier to end
@@ -368,9 +368,9 @@ Options:
   --cleanup-temp            Remove temporary files
 
 Examples:
-  npx claude-flow hook session-end --session-id "dev-session-2024"
-  npx claude-flow hook session-end -s "feature-auth" --export-metrics --generate-summary
-  npx claude-flow hook session-end -s "quick-fix" --cleanup-temp
+  npx claude-flow@v3alpha hooks session-end --session-id "dev-session-2024"
+  npx claude-flow@v3alpha hooks session-end -s "feature-auth" --export-metrics --generate-summary
+  npx claude-flow@v3alpha hooks session-end -s "quick-fix" --cleanup-temp
 ```
 
 **Features:**
@@ -381,7 +381,7 @@ Examples:
 
 **notify** - Custom notifications with swarm status
 ```bash
-npx claude-flow hook notify --message <msg>
+npx claude-flow@v3alpha hooks notify --message <msg>
 
 Options:
   --message, -m <text>      Notification message
@@ -390,8 +390,8 @@ Options:
   --broadcast               Send to all agents
 
 Examples:
-  npx claude-flow hook notify -m "Task completed" --level info
-  npx claude-flow hook notify -m "Critical error" --level error --broadcast
+  npx claude-flow@v3alpha hooks notify -m "Task completed" --level info
+  npx claude-flow@v3alpha hooks notify -m "Critical error" --level error --broadcast
 ```
 
 **Features:**
@@ -400,28 +400,80 @@ Examples:
 - Broadcast to all agents
 - Log important events
 
+### Two-Layer Model
+
+Claude Flow's hook system operates at **two distinct layers**. Understanding the distinction prevents
+misconfiguration.
+
+#### Layer 1 — Claude Code Matcher Hooks (`.claude/settings.json`)
+
+These fire around **Claude Code's own tool calls** (`Write`, `Edit`, `Bash`, `Task`, …). Configured
+under `hooks.PreToolUse` / `hooks.PostToolUse` in `.claude/settings.json`.
+
+**Key characteristic**: Claude Code evaluates these; if the command exits non-zero the tool call is
+blocked. `${tool.params.*}` interpolation is performed by Claude Code's harness, not claude-flow.
+
+#### Layer 2 — claude-flow Internal Hooks (`npx claude-flow@v3alpha hooks <subcommand>`)
+
+These are invoked **by the claude-flow CLI itself** to manage agent coordination, session state,
+learning, and Agent Teams events. They are independent of Claude Code's tool lifecycle and operate
+inside the swarm's orchestration engine.
+
+```bash
+# Agent Teams hooks — fired by the swarm when a teammate finishes or a task completes
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+npx claude-flow@v3alpha hooks task-completed --task-id "my-task" --train-patterns true
+```
+
+---
+
 ### Configuration
 
 #### Basic Configuration
 
-Edit `.claude/settings.json` to configure hooks:
+The full `settings.json` emitted by `npx claude-flow@v3alpha init` activates **both layers** together:
 
 ```json
 {
+  "env": {
+    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "agentTeams": {
+      "hooks": {
+        "teammateIdle": {
+          "autoAssign": true,
+          "notifyLead": true
+        },
+        "taskCompleted": {
+          "trainPatterns": true,
+          "exportLearnings": true
+        }
+      }
+    }
+  },
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --memory-key 'swarm/editor/current'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
         }]
       },
       {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-bash --command '${tool.params.command}'"
+          "command": "npx claude-flow@v3alpha hooks pre-command --command '${tool.params.command}'"
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.prompt}' --load-memory",
+          "async": true
         }]
       }
     ],
@@ -430,20 +482,33 @@ Edit `.claude/settings.json` to configure hooks:
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'swarm/editor/complete' --auto-format --train-patterns"
+          "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns",
+          "async": true
         }]
       },
       {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook post-bash --command '${tool.params.command}' --update-metrics"
+          "command": "npx claude-flow@v3alpha hooks post-command --command '${tool.params.command}' --track-metrics",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --store-decisions",
+          "async": true
         }]
       }
     ]
   }
 }
 ```
+
+**Layer 1 keys** (`hooks.PreToolUse` / `hooks.PostToolUse`) are read by Claude Code.
+**Layer 2 keys** (`env.CLAUDE_FLOW_HOOKS_ENABLED`, `claudeFlow.agentTeams.hooks`) are read by claude-flow.
 
 #### Advanced Configuration
 
@@ -462,7 +527,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
+            "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
             "timeout": 3000,
             "continueOnError": true
           }
@@ -473,7 +538,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
+            "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
             "async": true
           }
         ]
@@ -483,7 +548,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook pre-search --query '${tool.params.pattern}' --check-cache"
+            "command": "npx claude-flow@v3alpha hooks pre-search --query '${tool.params.pattern}' --check-cache"
           }
         ]
       }
@@ -495,7 +560,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
+            "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
             "async": true
           }
         ]
@@ -505,7 +570,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
+            "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
             "async": true
           }
         ]
@@ -515,7 +580,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
+            "command": "npx claude-flow@v3alpha hooks post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
           }
         ]
       }
@@ -526,7 +591,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook session-start --session-id '${session.id}' --load-context"
+            "command": "npx claude-flow@v3alpha hooks session-start --session-id '${session.id}' --load-context"
           }
         ]
       }
@@ -537,7 +602,7 @@ Complete hook configuration with all features:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
+            "command": "npx claude-flow@v3alpha hooks session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
           }
         ]
       }
@@ -559,7 +624,7 @@ Add protection for sensitive files:
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow hook check-protected --file '${tool.params.file_path}'"
+            "command": "npx claude-flow@v3alpha hooks check-protected --file '${tool.params.file_path}'"
           }
         ]
       }
@@ -599,7 +664,7 @@ Hooks automatically integrate with MCP tools for coordination:
 
 ```javascript
 // Hook command
-npx claude-flow hook pre-task --description "Build REST API"
+npx claude-flow@v3alpha hooks pre-task --description "Build REST API"
 
 // Internally calls MCP tools:
 mcp__claude-flow__agent_spawn {
@@ -623,7 +688,7 @@ mcp__claude-flow__memory_usage {
 
 ```javascript
 // Hook command
-npx claude-flow hook post-edit --file "api/auth.js"
+npx claude-flow@v3alpha hooks post-edit --file "api/auth.js"
 
 // Internally calls MCP tools:
 mcp__claude-flow__memory_usage {
@@ -649,7 +714,7 @@ mcp__claude-flow__neural_train {
 
 ```javascript
 // Hook command
-npx claude-flow hook session-end --session-id "dev-2024"
+npx claude-flow@v3alpha hooks session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
 mcp__claude-flow__memory_persist {
@@ -776,7 +841,7 @@ FILES=$(git diff --cached --name-only --diff-filter=ACM)
 
 for FILE in $FILES; do
   # Run pre-edit hook for validation
-  npx claude-flow hook pre-edit --file "$FILE" --validate-syntax
+  npx claude-flow@v3alpha hooks pre-edit --file "$FILE" --validate-syntax
 
   if [ $? -ne 0 ]; then
     echo "Validation failed for $FILE"
@@ -784,7 +849,7 @@ for FILE in $FILES; do
   fi
 
   # Run post-edit hook for formatting
-  npx claude-flow hook post-edit --file "$FILE" --auto-format
+  npx claude-flow@v3alpha hooks post-edit --file "$FILE" --auto-format
 done
 
 # Run tests
@@ -803,7 +868,7 @@ exit $?
 COMMIT_HASH=$(git rev-parse HEAD)
 COMMIT_MSG=$(git log -1 --pretty=%B)
 
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Commit completed: $COMMIT_MSG" \
   --level info \
   --swarm-status
@@ -820,7 +885,7 @@ npx claude-flow hook notify \
 npm run test:all
 
 # Run quality checks
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --generate-report \
   --export-metrics
 
@@ -844,13 +909,13 @@ How agents use hooks for coordination:
 ```bash
 # Agent 1: Backend Developer
 # STEP 1: Pre-task preparation
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Implement user authentication API" \
   --auto-spawn-agents \
   --load-memory
 
 # STEP 2: Work begins - pre-edit validation
-npx claude-flow hook pre-edit \
+npx claude-flow@v3alpha hooks pre-edit \
   --file "api/auth.js" \
   --auto-assign-agent \
   --validate-syntax
@@ -859,20 +924,20 @@ npx claude-flow hook pre-edit \
 # ... code changes ...
 
 # STEP 4: Post-edit processing
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api/auth.js" \
   --memory-key "swarm/backend/auth-api" \
   --auto-format \
   --train-patterns
 
 # STEP 5: Notify coordination system
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Auth API implementation complete" \
   --swarm-status \
   --broadcast
 
 # STEP 6: Task completion
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "auth-api" \
   --analyze-performance \
   --store-decisions \
@@ -882,25 +947,25 @@ npx claude-flow hook post-task \
 ```bash
 # Agent 2: Test Engineer (receives notification)
 # STEP 1: Check memory for API details
-npx claude-flow hook session-restore \
+npx claude-flow@v3alpha hooks session-restore \
   --session-id "swarm-current" \
   --restore-memory
 
 # Memory contains: swarm/backend/auth-api with implementation details
 
 # STEP 2: Generate tests
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Write tests for auth API" \
   --load-memory
 
 # STEP 3: Create test file
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api/auth.test.js" \
   --memory-key "swarm/testing/auth-api-tests" \
   --train-patterns
 
 # STEP 4: Share test results
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Auth API tests complete - 100% coverage" \
   --broadcast
 ```
@@ -979,37 +1044,37 @@ module.exports = {
 
 ```bash
 # Session start - initialize coordination
-npx claude-flow hook session-start --session-id "fullstack-feature"
+npx claude-flow@v3alpha hooks session-start --session-id "fullstack-feature"
 
 # Pre-task planning
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Build user profile feature - frontend + backend + tests" \
   --auto-spawn-agents \
   --optimize-topology
 
 # Backend work
-npx claude-flow hook pre-edit --file "api/profile.js"
+npx claude-flow@v3alpha hooks pre-edit --file "api/profile.js"
 # ... implement backend ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "api/profile.js" \
   --memory-key "profile/backend" \
   --train-patterns
 
 # Frontend work (reads backend details from memory)
-npx claude-flow hook pre-edit --file "components/Profile.jsx"
+npx claude-flow@v3alpha hooks pre-edit --file "components/Profile.jsx"
 # ... implement frontend ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "components/Profile.jsx" \
   --memory-key "profile/frontend" \
   --train-patterns
 
 # Testing (reads both backend and frontend from memory)
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Test profile feature" \
   --load-memory
 
 # Session end - export everything
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --session-id "fullstack-feature" \
   --export-metrics \
   --generate-summary
@@ -1019,39 +1084,39 @@ npx claude-flow hook session-end \
 
 ```bash
 # Start debugging session
-npx claude-flow hook session-start --session-id "debug-memory-leak"
+npx claude-flow@v3alpha hooks session-start --session-id "debug-memory-leak"
 
 # Pre-task: analyze issue
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Debug memory leak in event handlers" \
   --load-memory \
   --estimate-complexity
 
 # Search for event emitters
-npx claude-flow hook pre-search --query "EventEmitter"
+npx claude-flow@v3alpha hooks pre-search --query "EventEmitter"
 # ... search executes ...
-npx claude-flow hook post-search \
+npx claude-flow@v3alpha hooks post-search \
   --query "EventEmitter" \
   --cache-results
 
 # Fix the issue
-npx claude-flow hook pre-edit \
+npx claude-flow@v3alpha hooks pre-edit \
   --file "services/events.js" \
   --backup-file
 # ... fix code ...
-npx claude-flow hook post-edit \
+npx claude-flow@v3alpha hooks post-edit \
   --file "services/events.js" \
   --memory-key "debug/memory-leak-fix" \
   --validate-output
 
 # Verify fix
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "memory-leak-fix" \
   --analyze-performance \
   --generate-report
 
 # End session
-npx claude-flow hook session-end \
+npx claude-flow@v3alpha hooks session-end \
   --session-id "debug-memory-leak" \
   --export-metrics
 ```
@@ -1060,27 +1125,27 @@ npx claude-flow hook session-end \
 
 ```bash
 # Initialize swarm for refactoring
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Refactor legacy codebase to modern patterns" \
   --auto-spawn-agents \
   --optimize-topology
 
 # Agent 1: Code Analyzer
-npx claude-flow hook pre-task --description "Analyze code complexity"
+npx claude-flow@v3alpha hooks pre-task --description "Analyze code complexity"
 # ... analysis ...
-npx claude-flow hook post-task \
+npx claude-flow@v3alpha hooks post-task \
   --task-id "analysis" \
   --store-decisions
 
 # Agent 2: Refactoring (reads analysis from memory)
-npx claude-flow hook session-restore \
+npx claude-flow@v3alpha hooks session-restore \
   --session-id "swarm-refactor" \
   --restore-memory
 
 for file in src/**/*.js; do
-  npx claude-flow hook pre-edit --file "$file" --backup-file
+  npx claude-flow@v3alpha hooks pre-edit --file "$file" --backup-file
   # ... refactor ...
-  npx claude-flow hook post-edit \
+  npx claude-flow@v3alpha hooks post-edit \
     --file "$file" \
     --memory-key "refactor/$file" \
     --auto-format \
@@ -1088,12 +1153,12 @@ for file in src/**/*.js; do
 done
 
 # Agent 3: Testing (reads refactored code from memory)
-npx claude-flow hook pre-task \
+npx claude-flow@v3alpha hooks pre-task \
   --description "Generate tests for refactored code" \
   --load-memory
 
 # Broadcast completion
-npx claude-flow hook notify \
+npx claude-flow@v3alpha hooks notify \
   --message "Refactoring complete - all tests passing" \
   --broadcast
 ```
@@ -1117,13 +1182,13 @@ Enable debug mode for troubleshooting:
 export CLAUDE_FLOW_DEBUG=true
 
 # Test specific hook with verbose output
-npx claude-flow hook pre-edit --file "test.js" --debug
+npx claude-flow@v3alpha hooks pre-edit --file "test.js" --debug
 
 # Check hook execution logs
 cat .claude-flow/logs/hooks-$(date +%Y-%m-%d).log
 
 # Validate configuration
-npx claude-flow hook validate-config
+npx claude-flow@v3alpha hooks validate-config
 ```
 
 ### Benefits
@@ -1181,14 +1246,112 @@ npx claude-flow hook validate-config
 - Batch operations when possible
 - Reduce hook complexity
 
+### All `hooks` Subcommands
+
+#### Task Lifecycle
+
+| Subcommand | Description |
+|---|---|
+| `pre-task` | Record task start, get agent suggestions, auto-spawn swarm |
+| `post-task` | Record completion, analyze performance, store decisions |
+
+#### Tool Lifecycle (Layer 1 bridge)
+
+| Subcommand | Description |
+|---|---|
+| `pre-edit` | Validate and assign agents before file modifications |
+| `post-edit` | Auto-format, validate, and train neural patterns after edits |
+| `pre-command` | Assess safety and resource requirements before bash commands |
+| `post-command` | Log execution and update performance metrics |
+| `pre-bash` | Alias for `pre-command` (v2 compat) |
+| `post-bash` | Alias for `post-command` (v2 compat) |
+
+#### Session Management
+
+| Subcommand | Description |
+|---|---|
+| `session-start` | Initialize new session with context restoration |
+| `session-end` | Persist state, export metrics, generate summary |
+| `session-restore` | Reload a previous session state |
+
+#### Intelligence & Routing
+
+| Subcommand | Description |
+|---|---|
+| `route` | Route task to optimal agent via HNSW |
+| `route-task` | Alias for `route` (v2 compat) |
+| `explain` | Explain routing decision in detail |
+| `pretrain` | Bootstrap SONA/MoE intelligence from repo patterns |
+| `build-agents` | Generate optimized agent configurations |
+| `metrics` | View learning metrics dashboard |
+| `model-route` | 3-tier model routing recommendation (Agent Booster → Haiku → Sonnet/Opus) |
+| `model-stats` | Model usage and cost statistics |
+| `model-outcome` | Record model outcome to improve future routing |
+
+#### Agent Teams (Layer 2 — comms coordination)
+
+| Subcommand | Description |
+|---|---|
+| `teammate-idle` | Auto-assign pending tasks when a teammate finishes its turn |
+| `task-completed` | Train patterns and notify lead on task completion |
+
+#### Pattern Transfer & Registry
+
+| Subcommand | Description |
+|---|---|
+| `transfer` | Transfer patterns via IPFS registry |
+| `list` | List all registered hooks and their status |
+| `init` | Re-initialize hooks system configuration |
+| `notify` | Send notification with swarm status |
+
+#### Intelligence Sub-system (RuVector)
+
+| Subcommand | Description |
+|---|---|
+| `intelligence` | Entry point for RuVector intelligence operations |
+| `intelligence trajectory-start` | Begin a new learning trajectory |
+| `intelligence trajectory-step` | Record a reasoning step in an active trajectory |
+| `intelligence trajectory-end` | Finalize and score a completed trajectory |
+| `intelligence pattern-store` | Persist a learned coordination pattern |
+| `intelligence pattern-search` | Search stored patterns via HNSW (150x–12,500x faster) |
+| `intelligence stats` | View intelligence system statistics and EWC++ health |
+| `intelligence attention` | Configure attention weights for MoE routing |
+| `intelligence-reset` | Reset RuVector intelligence state to baseline |
+
+#### Coverage-Aware Routing
+
+| Subcommand | Description |
+|---|---|
+| `coverage-route` | Route task to address highest-priority coverage gaps |
+| `coverage-suggest` | Suggest test coverage improvements for a path |
+| `coverage-gaps` | List current coverage gaps with priorities |
+
+#### Background Workers
+
+| Subcommand | Description |
+|---|---|
+| `worker list` | List all 12 background workers and their status |
+| `worker dispatch` | Dispatch a specific worker by trigger name |
+| `worker status` | Show worker queue depth and health |
+| `worker detect` | Auto-detect which workers should run for current state |
+| `worker cancel` | Cancel a running background worker |
+
+#### Utilities
+
+| Subcommand | Description |
+|---|---|
+| `progress` | Check V3 implementation progress |
+| `statusline` | Generate dynamic statusline for Claude Code HUD |
+
+---
+
 ### Related Commands
 
-- `npx claude-flow init --hooks` - Initialize hooks system
-- `npx claude-flow hook --list` - List available hooks
-- `npx claude-flow hook --test <hook>` - Test specific hook
-- `npx claude-flow memory usage` - Manage memory
-- `npx claude-flow agent spawn` - Spawn agents
-- `npx claude-flow swarm init` - Initialize swarm
+- `npx claude-flow@v3alpha init` - Initialize hooks system
+- `npx claude-flow@v3alpha hooks list` - List registered hooks
+- `npx claude-flow@v3alpha memory usage` - Manage memory
+- `npx claude-flow@v3alpha agent spawn` - Spawn agents
+- `npx claude-flow@v3alpha swarm init` - Initialize swarm
 
 ### Integration with Other Skills
 

--- a/v3/@claude-flow/mcp/.claude/commands/automation/self-healing.md
+++ b/v3/@claude-flow/mcp/.claude/commands/automation/self-healing.md
@@ -94,7 +94,7 @@ mcp__claude-flow__task_orchestrate({
 {
   "PostToolUse": [{
     "matcher": "^Bash$",
-    "command": "npx claude-flow hook post-bash --exit-code '${tool.result.exitCode}' --auto-recover"
+    "command": "npx claude-flow@v3alpha hooks post-bash --exit-code '${tool.result.exitCode}' --auto-recover"
   }]
 }
 ```

--- a/v3/@claude-flow/mcp/.claude/commands/automation/session-memory.md
+++ b/v3/@claude-flow/mcp/.claude/commands/automation/session-memory.md
@@ -30,7 +30,7 @@ mcp__claude-flow__context_restore({
 
 **Fallback with npx:**
 ```bash
-npx claude-flow hook session-restore --session-id "sess-123"
+npx claude-flow@v3alpha hooks session-restore --session-id "sess-123"
 ```
 
 ### 3. Memory Types

--- a/v3/@claude-flow/mcp/.claude/commands/automation/smart-agents.md
+++ b/v3/@claude-flow/mcp/.claude/commands/automation/smart-agents.md
@@ -63,7 +63,7 @@ mcp__claude-flow__agent_spawn({
 ### Fallback Configuration
 If MCP tools are unavailable:
 ```bash
-npx claude-flow hook pre-task --auto-spawn-agents
+npx claude-flow@v3alpha hooks pre-task --auto-spawn-agents
 ```
 
 ## Benefits

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/overview.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/overview.md
@@ -37,7 +37,7 @@ Hooks are configured in `.claude/settings.json`:
         "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
         }]
       }
     ]

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/post-edit.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/post-edit.md
@@ -5,7 +5,7 @@ Execute post-edit processing including formatting, validation, and memory update
 ## Usage
 
 ```bash
-npx claude-flow hook post-edit [options]
+npx claude-flow@v3alpha hooks post-edit [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook post-edit [options]
 ### Basic post-edit hook
 
 ```bash
-npx claude-flow hook post-edit --file "src/components/Button.jsx"
+npx claude-flow@v3alpha hooks post-edit --file "src/components/Button.jsx"
 ```
 
 ### With memory storage
 
 ```bash
-npx claude-flow hook post-edit -f "api/auth.js" --memory-key "auth/login-implementation"
+npx claude-flow@v3alpha hooks post-edit -f "api/auth.js" --memory-key "auth/login-implementation"
 ```
 
 ### Format and validate
 
 ```bash
-npx claude-flow hook post-edit -f "config/webpack.js" --auto-format --validate-output
+npx claude-flow@v3alpha hooks post-edit -f "config/webpack.js" --auto-format --validate-output
 ```
 
 ### Neural training
 
 ```bash
-npx claude-flow hook post-edit -f "utils/helpers.ts" --train-patterns --memory-key "utils/refactor"
+npx claude-flow@v3alpha hooks post-edit -f "utils/helpers.ts" --train-patterns --memory-key "utils/refactor"
 ```
 
 ## Features
@@ -86,7 +86,7 @@ Manual usage in agents:
 
 ```bash
 # After editing files
-npx claude-flow hook post-edit --file "path/to/edited.js" --memory-key "feature/step1"
+npx claude-flow@v3alpha hooks post-edit --file "path/to/edited.js" --memory-key "feature/step1"
 ```
 
 ## Output

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/post-task.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/post-task.md
@@ -5,7 +5,7 @@ Execute post-task cleanup, performance analysis, and memory storage.
 ## Usage
 
 ```bash
-npx claude-flow hook post-task [options]
+npx claude-flow@v3alpha hooks post-task [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook post-task [options]
 ### Basic post-task hook
 
 ```bash
-npx claude-flow hook post-task --task-id "auth-implementation"
+npx claude-flow@v3alpha hooks post-task --task-id "auth-implementation"
 ```
 
 ### With full analysis
 
 ```bash
-npx claude-flow hook post-task -t "api-refactor" --analyze-performance --generate-report
+npx claude-flow@v3alpha hooks post-task -t "api-refactor" --analyze-performance --generate-report
 ```
 
 ### Memory storage
 
 ```bash
-npx claude-flow hook post-task -t "bug-fix-123" --store-decisions --export-learnings
+npx claude-flow@v3alpha hooks post-task -t "bug-fix-123" --store-decisions --export-learnings
 ```
 
 ### Quick cleanup
 
 ```bash
-npx claude-flow hook post-task -t "minor-update" --analyze-performance false
+npx claude-flow@v3alpha hooks post-task -t "minor-update" --analyze-performance false
 ```
 
 ## Features
@@ -85,7 +85,7 @@ Manual usage in agents:
 
 ```bash
 # In agent coordination
-npx claude-flow hook post-task --task-id "your-task-id" --analyze-performance true
+npx claude-flow@v3alpha hooks post-task --task-id "your-task-id" --analyze-performance true
 ```
 
 ## Output

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/pre-edit.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/pre-edit.md
@@ -5,7 +5,7 @@ Execute pre-edit validations and agent assignment before file modifications.
 ## Usage
 
 ```bash
-npx claude-flow hook pre-edit [options]
+npx claude-flow@v3alpha hooks pre-edit [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook pre-edit [options]
 ### Basic pre-edit hook
 
 ```bash
-npx claude-flow hook pre-edit --file "src/auth/login.js"
+npx claude-flow@v3alpha hooks pre-edit --file "src/auth/login.js"
 ```
 
 ### With validation
 
 ```bash
-npx claude-flow hook pre-edit -f "config/database.js" --validate-syntax
+npx claude-flow@v3alpha hooks pre-edit -f "config/database.js" --validate-syntax
 ```
 
 ### Manual agent assignment
 
 ```bash
-npx claude-flow hook pre-edit -f "api/users.ts" --auto-assign-agent false
+npx claude-flow@v3alpha hooks pre-edit -f "api/users.ts" --auto-assign-agent false
 ```
 
 ### Safe editing with backup
 
 ```bash
-npx claude-flow hook pre-edit -f "production.env" --backup-file --check-conflicts
+npx claude-flow@v3alpha hooks pre-edit -f "production.env" --backup-file --check-conflicts
 ```
 
 ## Features
@@ -86,7 +86,7 @@ Manual usage in agents:
 
 ```bash
 # Before editing files
-npx claude-flow hook pre-edit --file "path/to/file.js" --validate-syntax
+npx claude-flow@v3alpha hooks pre-edit --file "path/to/file.js" --validate-syntax
 ```
 
 ## Output

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/pre-task.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/pre-task.md
@@ -5,7 +5,7 @@ Execute pre-task preparations and context loading.
 ## Usage
 
 ```bash
-npx claude-flow hook pre-task [options]
+npx claude-flow@v3alpha hooks pre-task [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook pre-task [options]
 ### Basic pre-task hook
 
 ```bash
-npx claude-flow hook pre-task --description "Implement user authentication"
+npx claude-flow@v3alpha hooks pre-task --description "Implement user authentication"
 ```
 
 ### With memory loading
 
 ```bash
-npx claude-flow hook pre-task -d "Continue API development" --load-memory
+npx claude-flow@v3alpha hooks pre-task -d "Continue API development" --load-memory
 ```
 
 ### Manual agent control
 
 ```bash
-npx claude-flow hook pre-task -d "Debug issue #123" --auto-spawn-agents false
+npx claude-flow@v3alpha hooks pre-task -d "Debug issue #123" --auto-spawn-agents false
 ```
 
 ### Full optimization
 
 ```bash
-npx claude-flow hook pre-task -d "Refactor codebase" --optimize-topology --estimate-complexity
+npx claude-flow@v3alpha hooks pre-task -d "Refactor codebase" --optimize-topology --estimate-complexity
 ```
 
 ## Features
@@ -85,7 +85,7 @@ Manual usage in agents:
 
 ```bash
 # In agent coordination
-npx claude-flow hook pre-task --description "Your task here"
+npx claude-flow@v3alpha hooks pre-task --description "Your task here"
 ```
 
 ## Output

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/session-end.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/session-end.md
@@ -5,7 +5,7 @@ Cleanup and persist session state before ending work.
 ## Usage
 
 ```bash
-npx claude-flow hook session-end [options]
+npx claude-flow@v3alpha hooks session-end [options]
 ```
 
 ## Options
@@ -21,25 +21,25 @@ npx claude-flow hook session-end [options]
 ### Basic session end
 
 ```bash
-npx claude-flow hook session-end --session-id "dev-session-2024"
+npx claude-flow@v3alpha hooks session-end --session-id "dev-session-2024"
 ```
 
 ### With full export
 
 ```bash
-npx claude-flow hook session-end -s "feature-auth" --export-metrics --generate-summary
+npx claude-flow@v3alpha hooks session-end -s "feature-auth" --export-metrics --generate-summary
 ```
 
 ### Quick close
 
 ```bash
-npx claude-flow hook session-end -s "quick-fix" --save-state false --cleanup-temp
+npx claude-flow@v3alpha hooks session-end -s "quick-fix" --save-state false --cleanup-temp
 ```
 
 ### Complete persistence
 
 ```bash
-npx claude-flow hook session-end -s "major-refactor" --save-state --export-metrics --generate-summary
+npx claude-flow@v3alpha hooks session-end -s "major-refactor" --save-state --export-metrics --generate-summary
 ```
 
 ## Features
@@ -86,7 +86,7 @@ Manual usage in agents:
 
 ```bash
 # At session end
-npx claude-flow hook session-end --session-id "your-session" --generate-summary
+npx claude-flow@v3alpha hooks session-end --session-id "your-session" --generate-summary
 ```
 
 ## Output

--- a/v3/@claude-flow/mcp/.claude/commands/hooks/setup.md
+++ b/v3/@claude-flow/mcp/.claude/commands/hooks/setup.md
@@ -1,39 +1,116 @@
-# Setting Up ruv-swarm Hooks
+# Setting Up Claude Flow Hooks
+
+## Two-Layer Model
+
+Claude Flow's hook system operates at **two distinct layers** that work together but serve different
+purposes. Understanding the distinction prevents misconfiguration.
+
+### Layer 1 — Claude Code Matcher Hooks (`.claude/settings.json`)
+
+These fire around **Claude Code's own tool calls** (file writes, edits, bash commands). Configured in
+`.claude/settings.json` under `hooks.PreToolUse` / `hooks.PostToolUse`. Each entry specifies a regex
+`matcher` for a Claude tool name (`Write`, `Edit`, `Bash`, `Task`, …) and runs a shell command.
+
+**Key characteristic**: Claude Code evaluates these; if the command exits non-zero the tool call can be
+blocked. The `${tool.params.*}` interpolation is performed by Claude Code's harness, not claude-flow.
+
+### Layer 2 — claude-flow Internal Hooks (`npx claude-flow@v3alpha hooks <subcommand>`)
+
+These are invoked **by the claude-flow CLI itself** to manage agent coordination, session state,
+learning, and Agent Teams events. They are independent of Claude Code's tool lifecycle and operate
+inside the swarm's own orchestration engine.
+
+```bash
+# Agent Teams hooks — fired by the swarm when a teammate finishes or a task completes
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+npx claude-flow@v3alpha hooks task-completed --task-id "my-task" --train-patterns true
+```
+
+---
 
 ## Quick Start
 
 ### 1. Initialize with Hooks
 ```bash
-npx claude-flow init --hooks
+npx claude-flow@v3alpha init
 ```
 
 This automatically creates:
-- `.claude/settings.json` with hook configurations
-- Hook command documentation
-- Default hook handlers
+- `.claude/settings.json` with hook configurations for both Layer 1 and Layer 2
+- Hook command documentation in `.claude/commands/hooks/`
+- Default hook handlers for common operations
 
-### 2. Test Hook Functionality
-```bash
-# Test pre-edit hook
-npx claude-flow hook pre-edit --file test.js
+### 2. The v3 `settings.json` emitted by `init`
 
-# Test session summary
-npx claude-flow hook session-end --summary
-```
-
-### 3. Customize Hooks
-
-Edit `.claude/settings.json` to customize:
+`npx claude-flow@v3alpha init` writes a settings file that activates both layers together:
 
 ```json
 {
+  "env": {
+    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "agentTeams": {
+      "hooks": {
+        "teammateIdle": {
+          "autoAssign": true,
+          "notifyLead": true
+        },
+        "taskCompleted": {
+          "trainPatterns": true,
+          "exportLearnings": true
+        }
+      }
+    }
+  },
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "^Write$",
+        "matcher": "^(Write|Edit|MultiEdit)$",
         "hooks": [{
           "type": "command",
-          "command": "npx claude-flow hook pre-write --file '${tool.params.file_path}'"
+          "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}'"
+        }]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-command --command '${tool.params.command}'"
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks pre-task --description '${tool.params.prompt}' --load-memory",
+          "async": true
+        }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-command --command '${tool.params.command}' --track-metrics",
+          "async": true
+        }]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow@v3alpha hooks post-task --task-id '${result.task_id}' --store-decisions",
+          "async": true
         }]
       }
     ]
@@ -41,18 +118,136 @@ Edit `.claude/settings.json` to customize:
 }
 ```
 
+**Layer 1 keys** (`hooks.PreToolUse` / `hooks.PostToolUse`) are read by Claude Code.
+**Layer 2 keys** (`env.CLAUDE_FLOW_HOOKS_ENABLED`, `claudeFlow.agentTeams.hooks`) are read by claude-flow.
+
+### 3. Test Hook Functionality
+```bash
+# Test pre-edit hook
+npx claude-flow@v3alpha hooks pre-edit --file test.js
+
+# Test session summary
+npx claude-flow@v3alpha hooks session-end --summary
+```
+
+### 4. Debugging Hooks
+```bash
+# Enable debug output
+export CLAUDE_FLOW_DEBUG=true
+
+# Test specific hook
+npx claude-flow@v3alpha hooks pre-edit --file app.js --debug
+```
+
+---
+
+## All `hooks` Subcommands
+
+### Task Lifecycle
+
+| Subcommand | Description |
+|---|---|
+| `pre-task` | Record task start, get agent suggestions, auto-spawn swarm |
+| `post-task` | Record completion, analyze performance, store decisions |
+
+### Tool Lifecycle (Layer 1 bridge)
+
+| Subcommand | Description |
+|---|---|
+| `pre-edit` | Validate and assign agents before file modifications |
+| `post-edit` | Auto-format, validate, and train neural patterns after edits |
+| `pre-command` | Assess safety and resource requirements before bash commands |
+| `post-command` | Log execution and update performance metrics |
+| `pre-bash` | Alias for `pre-command` (v2 compat) |
+| `post-bash` | Alias for `post-command` (v2 compat) |
+
+### Session Management
+
+| Subcommand | Description |
+|---|---|
+| `session-start` | Initialize new session with context restoration |
+| `session-end` | Persist state, export metrics, generate summary |
+| `session-restore` | Reload a previous session state |
+
+### Intelligence & Routing
+
+| Subcommand | Description |
+|---|---|
+| `route` | Route task to optimal agent via HNSW |
+| `route-task` | Alias for `route` (v2 compat) |
+| `explain` | Explain routing decision in detail |
+| `pretrain` | Bootstrap SONA/MoE intelligence from repo patterns |
+| `build-agents` | Generate optimized agent configurations |
+| `metrics` | View learning metrics dashboard |
+| `model-route` | 3-tier model routing recommendation (Agent Booster → Haiku → Sonnet/Opus) |
+| `model-stats` | Model usage and cost statistics |
+| `model-outcome` | Record model outcome to improve future routing |
+
+### Agent Teams (Layer 2 — comms coordination)
+
+| Subcommand | Description |
+|---|---|
+| `teammate-idle` | Auto-assign pending tasks when a teammate finishes its turn |
+| `task-completed` | Train patterns and notify lead on task completion |
+
+### Pattern Transfer & Registry
+
+| Subcommand | Description |
+|---|---|
+| `transfer` | Transfer patterns via IPFS registry |
+| `list` | List all registered hooks and their status |
+| `init` | Re-initialize hooks system configuration |
+| `notify` | Send notification with swarm status |
+
+### Intelligence Sub-system (RuVector)
+
+| Subcommand | Description |
+|---|---|
+| `intelligence` | Entry point for RuVector intelligence operations |
+| `intelligence trajectory-start` | Begin a new learning trajectory |
+| `intelligence trajectory-step` | Record a reasoning step in an active trajectory |
+| `intelligence trajectory-end` | Finalize and score a completed trajectory |
+| `intelligence pattern-store` | Persist a learned coordination pattern |
+| `intelligence pattern-search` | Search stored patterns via HNSW (150x–12,500x faster) |
+| `intelligence stats` | View intelligence system statistics and EWC++ health |
+| `intelligence attention` | Configure attention weights for MoE routing |
+| `intelligence-reset` | Reset RuVector intelligence state to baseline |
+
+### Coverage-Aware Routing
+
+| Subcommand | Description |
+|---|---|
+| `coverage-route` | Route task to address highest-priority coverage gaps |
+| `coverage-suggest` | Suggest test coverage improvements for a path |
+| `coverage-gaps` | List current coverage gaps with priorities |
+
+### Background Workers
+
+| Subcommand | Description |
+|---|---|
+| `worker list` | List all 12 background workers and their status |
+| `worker dispatch` | Dispatch a specific worker by trigger name |
+| `worker status` | Show worker queue depth and health |
+| `worker detect` | Auto-detect which workers should run for current state |
+| `worker cancel` | Cancel a running background worker |
+
+### Utilities
+
+| Subcommand | Description |
+|---|---|
+| `progress` | Check V3 implementation progress |
+| `statusline` | Generate dynamic statusline for Claude Code HUD |
+
+---
+
 ## Hook Response Format
 
-Hooks return JSON with:
-- `continue`: Whether to proceed (true/false)
-- `reason`: Explanation for decision
-- `metadata`: Additional context
+Layer 1 hooks (Claude Code matcher) return JSON read by the harness:
 
-Example blocking response:
 ```json
 {
   "continue": false,
-  "reason": "Protected file - manual review required",
+  "reason": "Protected file — manual review required",
   "metadata": {
     "file": ".env.production",
     "protection_level": "high"
@@ -60,38 +255,37 @@ Example blocking response:
 }
 ```
 
-## Performance Tips
-- Keep hooks lightweight (< 100ms)
-- Use caching for repeated operations
-- Batch related operations
-- Run non-critical hooks asynchronously
+- `continue: false` **blocks** the tool call
+- `continue: true` (or no JSON output) allows it to proceed
 
-## Debugging Hooks
-```bash
-# Enable debug output
-export CLAUDE_FLOW_DEBUG=true
-
-# Test specific hook
-npx claude-flow hook pre-edit --file app.js --debug
-```
+---
 
 ## Common Patterns
 
-### Auto-Format on Save
-Already configured by default for common file types.
-
-### Protected File Detection
+### Protected File Detection (Layer 1)
 ```json
 {
   "matcher": "^(Write|Edit)$",
   "hooks": [{
     "type": "command",
-    "command": "npx claude-flow hook check-protected --file '${tool.params.file_path}'"
+    "command": "npx claude-flow@v3alpha hooks pre-edit --file '${tool.params.file_path}' --check-conflicts"
   }]
 }
 ```
 
-### Automatic Testing
+### Auto-Train on Every Save (Layer 1)
+```json
+{
+  "matcher": "^(Write|Edit|MultiEdit)$",
+  "hooks": [{
+    "type": "command",
+    "command": "npx claude-flow@v3alpha hooks post-edit --file '${tool.params.file_path}' --train-patterns --auto-format",
+    "async": true
+  }]
+}
+```
+
+### Automatic Testing on Write (Layer 1)
 ```json
 {
   "matcher": "^Write$",
@@ -101,3 +295,14 @@ Already configured by default for common file types.
   }]
 }
 ```
+
+### Agent Teams Auto-Assign (Layer 2)
+```bash
+npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
+```
+
+## Performance Tips
+- Keep Layer 1 hooks lightweight (< 100ms) — use `"async": true` for heavy operations
+- Use caching for repeated lookups
+- Batch related operations in a single hook command
+- Run non-critical hooks with `"continueOnError": true`

--- a/v3/@claude-flow/mcp/.claude/commands/optimization/auto-topology.md
+++ b/v3/@claude-flow/mcp/.claude/commands/optimization/auto-topology.md
@@ -45,7 +45,7 @@ Result: Automatically uses hierarchical topology with architect, coder, and test
 The pre-task hook automatically handles topology selection:
 ```json
 {
-  "command": "npx claude-flow hook pre-task --optimize-topology"
+  "command": "npx claude-flow@v3alpha hooks pre-task --optimize-topology"
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR corrects the hooks skill documentation across all 23 affected files in `v3/@claude-flow/{cli,mcp}/` plus the root skill copies (`.agents/skills/` and `.claude/skills/`).

### Plural subcommand fix

All documentation examples previously used the **singular** `claude-flow hook <subcommand>` form (e.g., `npx claude-flow hook pre-task`). The v3 CLI registers the command as **`hooks`** (plural). Every affected file has been updated:

```
# Before (broken in v3)
npx claude-flow hook pre-task --description "..."

# After (correct v3 form)
npx claude-flow@v3alpha hooks pre-task --description "..."
```

This touched 23 markdown files: `pre-task.md`, `post-task.md`, `pre-edit.md`, `post-edit.md`, `session-end.md`, `overview.md`, `auto-topology.md`, `self-healing.md`, `session-memory.md`, `smart-agents.md` (both `cli` and `mcp` copies) plus the root `SKILL.md` copies.

### Schema rewrite (4 files)

`setup.md` (cli + mcp) and `SKILL.md` (cli + root agents/skills) received a full schema rewrite:

- **Stale flag removed:** `npx claude-flow init --hooks` → `npx claude-flow@v3alpha init` (the `--hooks` flag was removed in v3)
- **Heading corrected:** `# Setting Up ruv-swarm Hooks` → `# Setting Up Claude Flow Hooks`
- **Two-Layer Model added:** distinguishes
  - *Layer 1* — Claude Code matcher hooks (`PreToolUse`/`PostToolUse` in `.claude/settings.json`)
  - *Layer 2* — claude-flow internal hooks (`npx claude-flow@v3alpha hooks <subcommand>`)
- **Full `init` output schema:** replaced the misleading single-layer `PreToolUse` snippet with the complete v3 emission including `env.CLAUDE_FLOW_HOOKS_ENABLED=true`, `claudeFlow.agentTeams.hooks` block (`teammateIdle`/`taskCompleted`), and all six `PreToolUse`/`PostToolUse` entries for `Write`, `Bash`, and `Task`
- **30+ hooks subcommands table:** added reference grouped by lifecycle — task, tool, session, intelligence/routing, agent-teams, transfer/registry, RuVector intelligence, coverage-aware routing, background workers, utilities

---

## Wire-Up Report

Full feature verification: [`.omc/ruflo-wireup-report.md`](.omc/ruflo-wireup-report.md)

13/15 rows PASS. The hooks surface (Row 3) verified **38 total hookable subcommands** (33 direct + 5 `worker` sub-subcommands), confirming the plural `hooks` command is the canonical entrypoint.

---

## Smoke-Test Commands (M4 passing)

The following commands exercise the corrected v3 plural form and all passed in the M4 verification run:

```bash
# Layer 2 — internal hook subcommands (plural form)
npx claude-flow@v3alpha hooks pre-task --description "Implement user authentication"
npx claude-flow@v3alpha hooks pre-task -d "Continue API development" --load-memory
npx claude-flow@v3alpha hooks pre-task -d "Debug issue #123" --auto-spawn-agents false
npx claude-flow@v3alpha hooks pre-task -d "Refactor codebase" --optimize-topology --estimate-complexity
npx claude-flow@v3alpha hooks pre-edit --file test.js
npx claude-flow@v3alpha hooks pre-edit --file app.js --debug
npx claude-flow@v3alpha hooks post-edit --file app.js --train-patterns
npx claude-flow@v3alpha hooks session-end --summary
npx claude-flow@v3alpha hooks teammate-idle --auto-assign true
npx claude-flow@v3alpha hooks task-completed --task-id "my-task" --train-patterns true

# Init (stale --hooks flag removed)
npx claude-flow@v3alpha init
```

---

> **Note:** This PR is documentation-only — no TypeScript source files were modified. CI should be green; no label changes requested.
