### PR TITLE
feat(gaia): #2156 iter 54 — smolagents-style CodeAgent harness (ADR-138)

### DIFF
--- a/plugins/ruflo-workflows/commands/gaia-run.md
+++ b/plugins/ruflo-workflows/commands/gaia-run.md
@@ -1,7 +1,7 @@
 ---
 name: gaia-run
 description: Execute a GAIA benchmark run — shells out to gaia-bench run, streams progress, and writes JSON results
-argument-hint: "[--level=1] [--limit=53] [--models=haiku,sonnet] [--concurrency=3] [--voting-attempts=1] [--hardness-routing] [--enable-critic] [--decompose] [--planning-interval=4]"
+argument-hint: "[--level=1] [--limit=53] [--models=haiku,sonnet] [--concurrency=3] [--voting-attempts=1] [--hardness-routing] [--enable-critic] [--decompose] [--planning-interval=4] [--mode=toolcalling|codeagent]"
 ---
 
 # /gaia run
@@ -18,6 +18,9 @@ Run GAIA benchmark questions through the ruflo agent loop.
 
 # Recommended config (~$2/run, all active tracks):
 /gaia run --level=1 --models=claude-sonnet-4-6 --hardness-routing --enable-critic --planning-interval=4
+
+# ADR-138 iter 54 — CodeAgent mode (smolagents-style Python code blocks):
+/gaia run --level=1 --models=claude-sonnet-4-6 --mode=codeagent
 ```
 
 ## Options
@@ -34,6 +37,7 @@ Run GAIA benchmark questions through the ruflo agent loop.
 | `--enable-critic` | off | Track D: adversarial critic reviews answer before submission (+3-5pp; skipped when voting-attempts > 1) |
 | `--decompose` | off | Track E: decompose multi-step questions into sub-questions (+5-10pp on ~30-40% of L1 set) |
 | `--planning-interval` | `4` | Track B: inject planning checkpoint every N turns (0=disable; based on smolagents finding) |
+| `--mode` | `toolcalling` | Agent mode: `toolcalling` (default, JSON tool_use) or `codeagent` (ADR-138 iter 54 — Python code blocks, targets HAL accuracy) |
 | `--max-turns` | `12` | Max agent turns per question (overridden by hardness router) |
 | `--judge-model` | `claude-sonnet-4-6` | Model used for LLM-as-judge scoring |
 | `--smoke-only` | off | Use 5-question fixture (CI / no HF token) |

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -81,7 +81,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node -e \"const{cpSync,mkdirSync}=require('fs');mkdirSync('dist/src/benchmarks',{recursive:true});cpSync('src/benchmarks/gaia-codeagent-runner.py','dist/src/benchmarks/gaia-codeagent-runner.py')\"",
     "test": "vitest run",
     "test:plugin-store": "npx tsx src/plugins/tests/standalone-test.ts",
     "test:pattern-store": "npx tsx src/transfer/store/tests/standalone-test.ts",

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-agent.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-agent.ts
@@ -29,10 +29,22 @@
  *   to prevent tunnel-vision on bad strategies. Adds ~80 tokens per
  *   replan event (~$0.0001 each), negligible cost.
  *
- * Refs: ADR-133, ADR-135, iter 30, #2156
+ * Iter 53a T2 narrowing:
+ *   Three precise changes from iter 52 T2 (which had net -1q: +6 recoveries, -7 regressions):
+ *   1. extractFinalAnswer uses Stage 1 only (no Stage 2/3 prose fallback).
+ *      Stage 2/3 fired too aggressively: overwriting correct Stage 1 answers and
+ *      extracting wrong prose fragments. Now Stage 1 is the only extraction path.
+ *   2. System prompt removes surrender instruction ("FINAL_ANSWER: unknown / I don't know").
+ *      That instruction caused the agent to give up on questions it would have figured out.
+ *      Replaced with: "When you reach a final answer, output FINAL_ANSWER: <value>."
+ *   3. Reversed-text preprocessor is preserved (iter 52 T2 finding: 2d83110e has reversed text).
+ *
+ * Refs: ADR-133, ADR-135, iter 30, iter 52, iter 53a, #2156
  */
 
 import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   GaiaQuestion,
   SMOKE_FIXTURE,
@@ -183,17 +195,125 @@ function buildSystemPrompt(): string {
     '',
     'RULES:',
     '1. Use tools when you need information you do not have with certainty.',
-    '2. When you are confident in the answer, output it on its own line in this exact format:',
+    '2. When you reach a final answer, output it on its own line in this EXACT format:',
     '   FINAL_ANSWER: <your answer here>',
     '3. Keep answers concise.  For numbers, give just the number.  For names, give just the name.',
     '4. Do not include units unless the question specifically asks for them.',
-    '5. If after all tool calls you still cannot determine the answer, output:',
-    '   FINAL_ANSWER: I don\'t know',
+    '5. MANDATORY: You MUST ALWAYS end your final response with a FINAL_ANSWER line.',
+    '   NEVER end your reasoning without committing to a specific answer.',
+    '6. IMPORTANT: If the question text appears garbled, reversed, or encoded, try to interpret it',
+    '   (e.g. reverse it, decode it) before concluding you cannot answer.',
   ].join('\n');
 }
 
+/**
+ * Detect whether a string looks like reversed English text.
+ *
+ * Heuristic: if reversing the string makes it parse as more-English than the
+ * original (measured by the ratio of common English words present), flag it.
+ */
+const ENGLISH_MARKERS = [
+  'the', 'and', 'for', 'are', 'but', 'not', 'you', 'all', 'can', 'was',
+  'her', 'his', 'they', 'this', 'with', 'have', 'from', 'what', 'that',
+  'write', 'word', 'answer', 'sentence', 'understand', 'left', 'right',
+];
+
+function countEnglishMarkers(text: string): number {
+  const lower = text.toLowerCase();
+  return ENGLISH_MARKERS.filter((w) => lower.includes(w)).length;
+}
+
+/**
+ * If the question text appears to be reversed English, prepend a de-reversed
+ * version so the agent sees both the original and the decoded form.
+ *
+ * Iter 52 T2 — gate 1 finding: task 2d83110e has a reversed sentence.
+ * Kept in iter 53a (this is not the source of the iter 52 regressions).
+ */
 function buildUserMessage(question: string): string {
+  const reversed = question.split('').reverse().join('');
+  const origScore = countEnglishMarkers(question);
+  const revScore = countEnglishMarkers(reversed);
+
+  if (revScore >= origScore + 3 && revScore >= 4) {
+    return (
+      `[NOTE: The following question text appears to be written in reverse. ` +
+      `Decoded: "${reversed}"]\n\n${question}`
+    );
+  }
+
   return question;
+}
+
+/** Anthropic image content block for vision API. */
+interface ImageContentBlock {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: string;
+    data: string;
+  };
+}
+
+/**
+ * Parse an IMAGE_BASE64 marker returned by file_read's extractImage().
+ * Returns an Anthropic image content block, or null if the marker is invalid.
+ *
+ * Marker format: [IMAGE_BASE64:{"mediaType":"image/png","base64":"...","path":"..."}]
+ */
+export function parseImageMarker(marker: string): ImageContentBlock | null {
+  const match = /^\[IMAGE_BASE64:(\{.*\})\]$/.exec(marker.trim());
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1]) as { mediaType: string; base64: string };
+    if (!parsed.mediaType || !parsed.base64) return null;
+    return {
+      type: 'image',
+      source: { type: 'base64', media_type: parsed.mediaType, data: parsed.base64 },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the initial user-turn content for a GAIA question.
+ *
+ * - Image attachment: returns content array with text block + inline base64 image block
+ *   so Claude can see the image on turn 0 without a file_read call.
+ * - Non-image attachment: appends a path hint to the question text so Claude knows
+ *   to call file_read.
+ * - No attachment: returns the question as plain text.
+ */
+function buildInitialContent(question: GaiaQuestion): ContentBlock[] | string {
+  const questionText = buildUserMessage(question.question);
+
+  if (!question.file_path) return questionText;
+
+  const ext = path.extname(question.file_path).toLowerCase();
+  const imageExts = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+
+  if (imageExts.includes(ext)) {
+    let buf: Buffer;
+    try {
+      buf = fs.readFileSync(question.file_path);
+    } catch {
+      return questionText + `\n\nNote: Attached image at path: ${question.file_path}\nCall file_read to get the IMAGE_BASE64 marker.`;
+    }
+    const mediaTypeMap: Record<string, string> = {
+      '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+      '.gif': 'image/gif', '.webp': 'image/webp',
+    };
+    return [
+      { type: 'text', text: questionText } as ContentBlock,
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: mediaTypeMap[ext] ?? 'image/png', data: buf.toString('base64') },
+      } as unknown as ContentBlock,
+    ];
+  }
+
+  return questionText + `\n\nThis question has an attached file. Call file_read with path="${question.file_path}" to read it, then answer the question.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -214,7 +334,8 @@ interface AnthropicResponse {
 
 interface MessageParam {
   role: 'user' | 'assistant';
-  content: ContentBlock[] | string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: ContentBlock[] | string | any[];
 }
 
 async function callAnthropicWithTools(
@@ -282,8 +403,24 @@ function extractFinalAnswer(resp: AnthropicResponse): string | null {
 interface ToolResultMessageContent {
   type: 'tool_result';
   tool_use_id: string;
-  content: string;
+  content: string | unknown[];
   is_error?: boolean;
+}
+
+/**
+ * If a tool output string is entirely an IMAGE_BASE64 marker, convert it to
+ * a mixed content array [text_hint, image_block] for the Anthropic vision API.
+ * Otherwise return the string unchanged.
+ */
+function wrapToolOutput(output: string): string | unknown[] {
+  const imageBlock = parseImageMarker(output);
+  if (imageBlock) {
+    return [
+      { type: 'text', text: 'Image file contents:' },
+      imageBlock,
+    ];
+  }
+  return output;
 }
 
 async function executeToolCalls(
@@ -310,7 +447,7 @@ async function executeToolCalls(
         return {
           type: 'tool_result',
           tool_use_id: block.id,
-          content: output,
+          content: wrapToolOutput(output),
         };
       } catch (err) {
         return {
@@ -361,7 +498,7 @@ export async function runGaiaAgent(
   let replanCount = 0;
 
   const messages: MessageParam[] = [
-    { role: 'user', content: buildUserMessage(question.question) },
+    { role: 'user', content: buildInitialContent(question) },
   ];
 
   let turns = 0;
@@ -436,15 +573,15 @@ export async function runGaiaAgent(
       if (shouldReplan) {
         replanCount++;
         const checkpoint = buildPlanningCheckpoint(turns, maxTurns);
-        messages.push({
-          role: 'user',
-          content: [
-            ...toolResults,
-            { type: 'text', text: checkpoint } as ContentBlock,
-          ],
-        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const content: any[] = [
+          ...toolResults,
+          { type: 'text', text: checkpoint } as ContentBlock,
+        ];
+        messages.push({ role: 'user', content });
       } else {
-        messages.push({ role: 'user', content: toolResults });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        messages.push({ role: 'user', content: toolResults as any[] });
       }
 
       continue;
@@ -641,3 +778,14 @@ if (process.argv.includes('--smoke')) {
       process.exit(2);
     });
 }
+
+// ---------------------------------------------------------------------------
+// Test-only exports (iter 53a — gaia-extract.smoke.ts)
+// These expose private functions for unit testing without polluting the
+// public API.  Named with a leading underscore to signal test-only use.
+// ---------------------------------------------------------------------------
+
+export {
+  extractFinalAnswer as _extractFinalAnswerForTest,
+  buildUserMessage as _buildUserMessageForTest,
+};

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-codeagent-runner.py
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-codeagent-runner.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""
+GAIA CodeAgent Python Step Runner — ADR-138 iter 54
+
+This script is invoked by gaia-codeagent.ts for each agent step.
+It pre-defines tool functions as Python callables, then exec()s the agent's
+code in that context.
+
+Protocol (via environment variables):
+  GAIA_CODE_FILE     : path to a temp file containing the agent's Python code
+  GAIA_RESULT_FILE   : path where this runner writes final_answer JSON sentinel
+  ANTHROPIC_API_KEY  : passed through to claude -p tool backends
+  GAIA_ATTACHMENT_PATH: optional attachment file path for this question
+
+Tool dispatch strategy:
+  web_search(query)       -> claude -p with WebSearch (best web coverage)
+  visit_webpage(url)      -> requests + bs4 HTML extraction (no claude -p overhead)
+  grounded_query(query)   -> ruflo TS grounded_query via node subprocess
+  read_file(path)         -> direct Python (text/csv/json/xlsx/pptx) or requests+bs4 for PDF
+  describe_image(path)    -> claude -p with --allowedTools Read (Claude vision)
+  final_answer(answer)    -> writes GAIA_RESULT_FILE JSON and sys.exit(0)
+
+Authorized imports (pre-loaded):
+  math, re, json, datetime, collections, itertools, statistics,
+  fractions, decimal, string, unicodedata, operator, sys, os, pathlib,
+  urllib.parse, pandas (optional), numpy (optional), sympy (optional),
+  requests (optional), bs4 (optional), openpyxl (optional)
+
+Refs: ADR-138, HAL-DEEP-STUDY.md, #2156, iter 54
+"""
+
+import sys
+import os
+import json
+import subprocess
+import tempfile
+import math
+import re
+import datetime
+from datetime import date, timedelta
+from collections import Counter, defaultdict, OrderedDict
+import itertools
+import statistics
+import fractions
+import decimal
+import operator
+import string
+import unicodedata
+from urllib.parse import urlparse, quote, unquote
+from pathlib import Path
+
+# Optional heavy imports — graceful fallback
+try:
+    import pandas as pd
+    import numpy as np
+except ImportError:
+    pd = None
+    np = None
+
+try:
+    import sympy
+except ImportError:
+    sympy = None
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+    HAS_REQUESTS = True
+except ImportError:
+    requests = None
+    BeautifulSoup = None
+    HAS_REQUESTS = False
+
+try:
+    import openpyxl
+    HAS_OPENPYXL = True
+except ImportError:
+    HAS_OPENPYXL = False
+
+try:
+    from pptx import Presentation as PptxPresentation
+    HAS_PPTX = True
+except ImportError:
+    HAS_PPTX = False
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+GAIA_RESULT_FILE = os.environ.get("GAIA_RESULT_FILE", "")
+GAIA_CODE_FILE = os.environ.get("GAIA_CODE_FILE", "")
+GAIA_ATTACHMENT_PATH = os.environ.get("GAIA_ATTACHMENT_PATH", "")
+
+CLAUDE_CMD = "claude"
+TOOL_TIMEOUT = 30  # seconds per tool call
+
+
+# ---------------------------------------------------------------------------
+# Tool: web_search
+# Dispatches to claude -p with WebSearch for best web coverage
+# ---------------------------------------------------------------------------
+
+def web_search(query: str) -> str:
+    """Search the web and return relevant snippets."""
+    if not query or not query.strip():
+        return "[web_search: empty query]"
+    try:
+        result = subprocess.run(
+            [
+                CLAUDE_CMD, "-p",
+                "--allowedTools", "WebSearch",
+                "--output-format", "text",
+                f"Search the web for: {query}\n\nReturn the top results with titles, URLs, and key snippets. Be concise.",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=TOOL_TIMEOUT,
+            env={**os.environ, "ANTHROPIC_API_KEY": ANTHROPIC_API_KEY},
+        )
+        output = result.stdout.strip()
+        if output:
+            return output[:4000]
+        if result.stderr:
+            return f"[web_search: {result.stderr.strip()[:200]}]"
+        return "[web_search: no results]"
+    except subprocess.TimeoutExpired:
+        return f"[web_search: timed out after {TOOL_TIMEOUT}s]"
+    except FileNotFoundError:
+        # claude CLI not available — fall back to DuckDuckGo scraping
+        return _ddg_fallback(query)
+    except Exception as e:
+        return f"[web_search error: {e}]"
+
+
+def _ddg_fallback(query: str) -> str:
+    """Fallback web search via DuckDuckGo HTML scraping."""
+    if not HAS_REQUESTS:
+        return "[web_search: requests not available]"
+    try:
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; ruflo-gaia/1.0)"}
+        resp = requests.post(
+            "https://html.duckduckgo.com/html/",
+            data={"q": query},
+            headers=headers,
+            timeout=15,
+        )
+        soup = BeautifulSoup(resp.text, "html.parser")
+        results = []
+        for r in soup.select(".result")[:5]:
+            title_el = r.select_one(".result__title")
+            snip_el = r.select_one(".result__snippet")
+            title = title_el.get_text(strip=True) if title_el else ""
+            snip = snip_el.get_text(strip=True) if snip_el else ""
+            if title:
+                results.append(f"{title}: {snip}")
+        return "\n".join(results) if results else "[web_search: no results]"
+    except Exception as e:
+        return f"[web_search: {e}]"
+
+
+# ---------------------------------------------------------------------------
+# Tool: visit_webpage
+# Fetches full page content via requests + bs4
+# ---------------------------------------------------------------------------
+
+def visit_webpage(url: str) -> str:
+    """Fetch the full text content of a webpage."""
+    if not url or not url.strip():
+        return "[visit_webpage: empty URL]"
+    url = url.strip()
+    if not url.startswith("http"):
+        url = "https://" + url
+    if HAS_REQUESTS:
+        return _visit_with_requests(url)
+    else:
+        return _visit_with_claude(url)
+
+
+def _visit_with_requests(url: str) -> str:
+    """Fetch page via requests + bs4 text extraction."""
+    try:
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; ruflo-gaia/1.0)"}
+        resp = requests.get(url, headers=headers, timeout=20, allow_redirects=True)
+        if resp.status_code != 200:
+            return f"[visit_webpage: HTTP {resp.status_code} for {url}]"
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        # Remove noise
+        for tag in soup(["script", "style", "nav", "footer", "header", "aside", "noscript"]):
+            tag.decompose()
+
+        # Extract main content
+        text = soup.get_text(separator="\n", strip=True)
+        # Collapse blank lines
+        lines = [l.strip() for l in text.splitlines() if l.strip()]
+        content = "\n".join(lines)
+
+        if len(content) > 8000:
+            content = content[:8000] + "\n[... truncated ...]"
+        return content if content else "[visit_webpage: no text content extracted]"
+    except requests.exceptions.Timeout:
+        return f"[visit_webpage: timed out fetching {url}]"
+    except Exception as e:
+        return f"[visit_webpage error: {e}]"
+
+
+def _visit_with_claude(url: str) -> str:
+    """Fallback: fetch webpage via claude -p with WebFetch."""
+    try:
+        result = subprocess.run(
+            [
+                CLAUDE_CMD, "-p",
+                "--allowedTools", "WebFetch",
+                "--output-format", "text",
+                f"Fetch the content of this URL and return the full text: {url}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=TOOL_TIMEOUT,
+            env={**os.environ, "ANTHROPIC_API_KEY": ANTHROPIC_API_KEY},
+        )
+        output = result.stdout.strip()
+        return output[:8000] if output else f"[visit_webpage: no content from {url}]"
+    except Exception as e:
+        return f"[visit_webpage: {e}]"
+
+
+# ---------------------------------------------------------------------------
+# Tool: grounded_query
+# Calls Gemini with Google Search grounding (ruflo's unique advantage)
+# ---------------------------------------------------------------------------
+
+def grounded_query(query: str) -> str:
+    """Ask Gemini with Google Search grounding — returns synthesized answer with citations."""
+    if not query or not query.strip():
+        return "[grounded_query: empty query]"
+
+    google_key = os.environ.get("GOOGLE_AI_API_KEY", "")
+    if not google_key:
+        # Fall back to web_search if no Google key
+        return web_search(query)
+
+    try:
+        import urllib.request
+        import urllib.error
+
+        url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+        payload = {
+            "contents": [{"parts": [{"text": query}]}],
+            "tools": [{"google_search": {}}],
+            "generationConfig": {"maxOutputTokens": 1024},
+        }
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            f"{url}?key={google_key}",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+
+        # Extract text
+        candidates = body.get("candidates", [])
+        if not candidates:
+            return "[grounded_query: no candidates]"
+        parts = candidates[0].get("content", {}).get("parts", [])
+        text = " ".join(p.get("text", "") for p in parts).strip()
+
+        # Extract sources
+        sources = []
+        grounding = candidates[0].get("groundingMetadata", {})
+        for chunk in grounding.get("groundingChunks", [])[:4]:
+            web = chunk.get("web", {})
+            title = web.get("title", "")
+            src_uri = web.get("uri", "")
+            if title and src_uri:
+                sources.append(f"- {title}: {src_uri}")
+
+        result = text
+        if sources:
+            result += "\n\nSources:\n" + "\n".join(sources)
+        return result[:4000] if result else "[grounded_query: empty response]"
+
+    except Exception as e:
+        # Fall back to web_search
+        return web_search(query)
+
+
+# ---------------------------------------------------------------------------
+# Tool: read_file
+# Supports: txt, csv, json, xlsx, pptx, pdf (via pdfminer.six if available)
+# ---------------------------------------------------------------------------
+
+def read_file(path: str) -> str:
+    """Read a file and return its text content."""
+    if not path or not path.strip():
+        return "[read_file: empty path]"
+    path = path.strip()
+    if not os.path.exists(path):
+        return f"[read_file: file not found: {path}]"
+
+    ext = Path(path).suffix.lower()
+
+    # Text-based formats — direct read
+    if ext in (".txt", ".md", ".log", ".xml", ".html", ".htm"):
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                content = f.read(50_000)
+            return content if content else "[read_file: empty file]"
+        except Exception as e:
+            return f"[read_file: {e}]"
+
+    # JSON
+    if ext == ".json":
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return json.dumps(data, indent=2)[:8000]
+        except Exception as e:
+            return f"[read_file json: {e}]"
+
+    # CSV
+    if ext == ".csv":
+        if pd is not None:
+            try:
+                df = pd.read_csv(path)
+                return f"Shape: {df.shape}\nColumns: {list(df.columns)}\n\nFirst rows:\n{df.head(10).to_string()}"
+            except Exception as e:
+                return f"[read_file csv: {e}]"
+        else:
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    return f.read(8000)
+            except Exception as e:
+                return f"[read_file csv: {e}]"
+
+    # Excel
+    if ext in (".xlsx", ".xls"):
+        if pd is not None:
+            try:
+                df = pd.read_excel(path, sheet_name=None)
+                parts = []
+                for sheet_name, sheet_df in df.items():
+                    parts.append(f"Sheet: {sheet_name}")
+                    parts.append(sheet_df.head(20).to_string())
+                return "\n\n".join(parts)[:8000]
+            except Exception as e:
+                return f"[read_file excel: {e}]"
+        elif HAS_OPENPYXL:
+            try:
+                wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+                parts = []
+                for ws in wb.worksheets:
+                    rows = []
+                    for row in ws.iter_rows(max_row=20, values_only=True):
+                        rows.append("\t".join(str(c) if c is not None else "" for c in row))
+                    parts.append(f"Sheet: {ws.title}\n" + "\n".join(rows))
+                return "\n\n".join(parts)[:8000]
+            except Exception as e:
+                return f"[read_file excel: {e}]"
+        return "[read_file: pandas/openpyxl not available for Excel]"
+
+    # PPTX
+    if ext == ".pptx":
+        if HAS_PPTX:
+            try:
+                prs = PptxPresentation(path)
+                parts = []
+                for i, slide in enumerate(prs.slides):
+                    texts = [shape.text for shape in slide.shapes if shape.has_text_frame]
+                    parts.append(f"Slide {i+1}: " + " | ".join(texts))
+                return "\n".join(parts)[:8000]
+            except Exception as e:
+                return f"[read_file pptx: {e}]"
+        return "[read_file: python-pptx not available]"
+
+    # PDF — try pdfminer.six, then fallback to pdftotext subprocess
+    if ext == ".pdf":
+        return _read_pdf(path)
+
+    # Images — use describe_image
+    if ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff"):
+        return describe_image(path)
+
+    # Unknown — try as text
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read(8000)
+    except Exception as e:
+        return f"[read_file: unsupported format {ext}: {e}]"
+
+
+def _read_pdf(path: str) -> str:
+    """Extract text from a PDF file."""
+    # Try pdfminer.six
+    try:
+        from pdfminer.high_level import extract_text as pdfminer_extract
+        text = pdfminer_extract(path)
+        if text and text.strip():
+            return text.strip()[:8000]
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    # Try pdftotext subprocess
+    try:
+        result = subprocess.run(
+            ["pdftotext", path, "-"],
+            capture_output=True, text=True, timeout=15
+        )
+        if result.stdout.strip():
+            return result.stdout.strip()[:8000]
+    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+        pass
+
+    # Last resort: claude -p with Read (vision for scanned PDFs)
+    if ANTHROPIC_API_KEY:
+        try:
+            result = subprocess.run(
+                [
+                    CLAUDE_CMD, "-p",
+                    "--allowedTools", "Read",
+                    "--output-format", "text",
+                    f"Read and extract all text from this file: {path}",
+                ],
+                capture_output=True, text=True, timeout=30,
+                env={**os.environ, "ANTHROPIC_API_KEY": ANTHROPIC_API_KEY},
+            )
+            if result.stdout.strip():
+                return result.stdout.strip()[:8000]
+        except Exception:
+            pass
+
+    return f"[read_file: could not extract text from PDF at {path}]"
+
+
+# ---------------------------------------------------------------------------
+# Tool: describe_image
+# Uses claude -p with vision capability
+# ---------------------------------------------------------------------------
+
+def describe_image(path: str) -> str:
+    """Describe the contents of an image using Claude vision."""
+    if not path or not os.path.exists(path):
+        return f"[describe_image: file not found: {path}]"
+    if not ANTHROPIC_API_KEY:
+        return "[describe_image: ANTHROPIC_API_KEY not set]"
+    try:
+        result = subprocess.run(
+            [
+                CLAUDE_CMD, "-p",
+                "--allowedTools", "Read",
+                "--output-format", "text",
+                f"Describe this image in detail, including any text, numbers, charts, or data visible: {path}",
+            ],
+            capture_output=True, text=True, timeout=30,
+            env={**os.environ, "ANTHROPIC_API_KEY": ANTHROPIC_API_KEY},
+        )
+        output = result.stdout.strip()
+        return output[:4000] if output else "[describe_image: no description generated]"
+    except Exception as e:
+        return f"[describe_image: {e}]"
+
+
+# ---------------------------------------------------------------------------
+# Tool: final_answer
+# Writes sentinel JSON and exits
+# ---------------------------------------------------------------------------
+
+def final_answer(answer) -> None:
+    """Submit the final answer. This ends the agent loop."""
+    answer_str = str(answer).strip()
+
+    # Write sentinel JSON
+    if GAIA_RESULT_FILE:
+        try:
+            with open(GAIA_RESULT_FILE, "w", encoding="utf-8") as f:
+                json.dump({"answer": answer_str}, f)
+        except Exception as e:
+            print(f"[final_answer: could not write result file: {e}]", file=sys.stderr)
+
+    print(f"[GAIA_FINAL_ANSWER]: {answer_str}")
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Main execution
+# ---------------------------------------------------------------------------
+
+def main():
+    # Read agent code
+    if not GAIA_CODE_FILE or not os.path.exists(GAIA_CODE_FILE):
+        print("[CodeAgent runner: GAIA_CODE_FILE not set or not found]", file=sys.stderr)
+        sys.exit(1)
+
+    with open(GAIA_CODE_FILE, "r", encoding="utf-8") as f:
+        agent_code = f.read()
+
+    # Build execution globals with all tool functions pre-defined
+    exec_globals = {
+        "__builtins__": __builtins__,
+        # Math / standard lib
+        "math": math,
+        "re": re,
+        "json": json,
+        "datetime": datetime,
+        "date": date,
+        "timedelta": timedelta,
+        "Counter": Counter,
+        "defaultdict": defaultdict,
+        "OrderedDict": OrderedDict,
+        "itertools": itertools,
+        "statistics": statistics,
+        "fractions": fractions,
+        "decimal": decimal,
+        "operator": operator,
+        "string": string,
+        "unicodedata": unicodedata,
+        "urlparse": urlparse,
+        "quote": quote,
+        "unquote": unquote,
+        "Path": Path,
+        "os": os,
+        "sys": sys,
+        "pd": pd,
+        "np": np,
+        "sympy": sympy,
+        "requests": requests,
+        # Tool functions
+        "web_search": web_search,
+        "visit_webpage": visit_webpage,
+        "grounded_query": grounded_query,
+        "read_file": read_file,
+        "describe_image": describe_image,
+        "final_answer": final_answer,
+        # Attachment path hint
+        "ATTACHMENT_PATH": GAIA_ATTACHMENT_PATH,
+    }
+
+    # Execute
+    try:
+        exec(agent_code, exec_globals)
+    except SystemExit:
+        # final_answer() calls sys.exit(0) — expected
+        raise
+    except Exception as e:
+        import traceback
+        print(f"[CodeAgent execution error]\n{traceback.format_exc()}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-codeagent.smoke.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-codeagent.smoke.ts
@@ -1,0 +1,287 @@
+/**
+ * GAIA CodeAgent Smoke Tests — ADR-138 iter 54 (FINAL design)
+ *
+ * 5 tests validating the CodeAgent harness end-to-end.
+ * Tests 1-4 are unit-level (no API calls). Test 5 uses 1 API call.
+ *
+ * Tests:
+ *   T1: Code block extraction — parser correctness (no subprocess)
+ *   T2: Python runner — simple math (subprocess, no API)
+ *   T3: Python runner — file read via ATTACHMENT_PATH
+ *   T4: Python runner — code error recovery (traceback returned as obs)
+ *   T5: End-to-end — simple factual question (1 API call, ~$0.01)
+ *
+ * Pass criteria: 5/5. Gate before iter 55 5Q run.
+ *
+ * Run: npx tsx gaia-codeagent.smoke.ts
+ *      or: node dist/src/benchmarks/gaia-codeagent.smoke.js
+ *
+ * Refs: ADR-138, #2156, iter 54
+ */
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  extractCodeBlock,
+  runCodeAgentStep,
+  runGaiaCodeAgent,
+  isAnswerCorrect,
+} from './gaia-codeagent.js';
+import type { GaiaQuestion } from './gaia-loader.js';
+import { resolveAnthropicApiKey } from './gaia-agent.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  message: string;
+  durationMs: number;
+}
+
+function makeQ(overrides: Partial<GaiaQuestion> = {}): GaiaQuestion {
+  return {
+    task_id: 'smoke-test',
+    level: 1 as const,
+    question: 'What is 2 + 2?',
+    final_answer: '4',
+    file_name: null,
+    file_path: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// T1: Code block extraction (no subprocess, no API)
+// ---------------------------------------------------------------------------
+
+function testCodeBlockExtraction(): TestResult {
+  const name = 'T1: Code block extraction';
+  const start = Date.now();
+
+  const cases: Array<{ input: string; expected: string | null }> = [
+    { input: '```python\nprint(2+2)\n```', expected: 'print(2+2)' },
+    { input: '```py\nresult = 42\n```', expected: 'result = 42' },
+    { input: '```\nfinal_answer("test")\n```', expected: 'final_answer("test")' },
+    { input: 'No code block here', expected: null },
+    {
+      input: 'Reasoning...\n```python\nweb_search("q")\nprint(r)\n```\nMore',
+      expected: 'web_search("q")\nprint(r)',
+    },
+  ];
+
+  for (const { input, expected } of cases) {
+    const result = extractCodeBlock(input);
+    if (result !== expected) {
+      return {
+        name,
+        passed: false,
+        message: `Case "${input.slice(0, 40)}": got "${result}", expected "${expected}"`,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+  return { name, passed: true, message: `${cases.length}/5 cases passed`, durationMs: Date.now() - start };
+}
+
+// ---------------------------------------------------------------------------
+// T2: Python runner — simple math (subprocess, no API)
+// ---------------------------------------------------------------------------
+
+function testPythonRunnerMath(): TestResult {
+  const name = 'T2: Python runner — simple math';
+  const start = Date.now();
+
+  const apiKey = process.env.ANTHROPIC_API_KEY ?? 'test-key';
+  const code = `result = 2 + 2\nprint(result)\nfinal_answer(str(result))`;
+  const stepResult = runCodeAgentStep(code, null, 15_000, apiKey);
+
+  if (stepResult.finalAnswer !== '4') {
+    return {
+      name,
+      passed: false,
+      message: `Expected finalAnswer "4", got "${stepResult.finalAnswer ?? 'null'}". Obs: ${stepResult.observation.slice(0, 200)}`,
+      durationMs: Date.now() - start,
+    };
+  }
+  return { name, passed: true, message: `finalAnswer="4" as expected`, durationMs: Date.now() - start };
+}
+
+// ---------------------------------------------------------------------------
+// T3: Python runner — file read via ATTACHMENT_PATH
+// ---------------------------------------------------------------------------
+
+function testPythonRunnerFileRead(): TestResult {
+  const name = 'T3: Python runner — file read';
+  const start = Date.now();
+  const tmpFile = path.join(os.tmpdir(), `gaia-smoke-${Date.now()}.txt`);
+  fs.writeFileSync(tmpFile, 'The magic number is forty-two (42).', 'utf-8');
+
+  try {
+    const apiKey = process.env.ANTHROPIC_API_KEY ?? 'test-key';
+    const code = `content = read_file(ATTACHMENT_PATH)\nprint("Read:", content[:80])\nfinal_answer("42")`;
+    const stepResult = runCodeAgentStep(code, tmpFile, 15_000, apiKey);
+
+    if (stepResult.finalAnswer !== '42') {
+      return {
+        name, passed: false,
+        message: `Expected finalAnswer "42", got "${stepResult.finalAnswer ?? 'null'}". Obs: ${stepResult.observation.slice(0, 200)}`,
+        durationMs: Date.now() - start,
+      };
+    }
+    if (!stepResult.observation.includes('forty-two') && !stepResult.observation.includes('42')) {
+      return {
+        name, passed: false,
+        message: `File content not in observation. Obs: ${stepResult.observation.slice(0, 200)}`,
+        durationMs: Date.now() - start,
+      };
+    }
+    return { name, passed: true, message: `File read OK, finalAnswer="42"`, durationMs: Date.now() - start };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T4: Python runner — code error recovery
+// ---------------------------------------------------------------------------
+
+function testPythonRunnerErrorRecovery(): TestResult {
+  const name = 'T4: Python runner — error recovery';
+  const start = Date.now();
+
+  const apiKey = process.env.ANTHROPIC_API_KEY ?? 'test-key';
+  const badCode = `result = undefined_variable_xyz + 1\nprint(result)`;
+  const stepResult = runCodeAgentStep(badCode, null, 15_000, apiKey);
+
+  if (stepResult.finalAnswer !== null) {
+    return {
+      name, passed: false,
+      message: `Expected no finalAnswer from errored code, got "${stepResult.finalAnswer}"`,
+      durationMs: Date.now() - start,
+    };
+  }
+  const obs = stepResult.observation.toLowerCase();
+  if (!obs.includes('error') && !obs.includes('nameerror')) {
+    return {
+      name, passed: false,
+      message: `Observation should contain error info, got: ${stepResult.observation.slice(0, 200)}`,
+      durationMs: Date.now() - start,
+    };
+  }
+  return {
+    name, passed: true,
+    message: `Error returned as observation: "${stepResult.observation.slice(0, 60)}..."`,
+    durationMs: Date.now() - start,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// T5: End-to-end — simple factual question (1 API call)
+// ---------------------------------------------------------------------------
+
+async function testEndToEndSimple(): Promise<TestResult> {
+  const name = 'T5: End-to-end — simple factual (1 API call)';
+  const start = Date.now();
+
+  let apiKey: string;
+  try {
+    apiKey = resolveAnthropicApiKey();
+  } catch (err) {
+    return {
+      name, passed: false,
+      message: `No API key: ${String(err)}`,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const q = makeQ({
+    task_id: 'smoke-e2e-01',
+    question: 'What is 6 multiplied by 7? Answer as a number.',
+    final_answer: '42',
+  });
+
+  try {
+    const result = await runGaiaCodeAgent(q, {
+      model: 'claude-sonnet-4-6',
+      maxTurns: 5,
+      apiKey,
+    });
+
+    if (result.error && !result.finalAnswer) {
+      return { name, passed: false, message: `Agent error: ${result.error}`, durationMs: Date.now() - start };
+    }
+    if (result.finalAnswer === null) {
+      return { name, passed: false, message: `No final answer (timedOut=${result.timedOut})`, durationMs: Date.now() - start };
+    }
+    const num = parseFloat(result.finalAnswer.replace(/,/g, ''));
+    if (Math.abs(num - 42) > 0.01) {
+      return {
+        name, passed: false,
+        message: `Expected "42", got "${result.finalAnswer}" (turns=${result.turns})`,
+        durationMs: Date.now() - start,
+      };
+    }
+    const estCost = (result.totalInputTokens / 1e6) * 3.0 + (result.totalOutputTokens / 1e6) * 15.0;
+    return {
+      name, passed: true,
+      message: `finalAnswer="${result.finalAnswer}" turns=${result.turns} cost~=$${estCost.toFixed(4)}`,
+      durationMs: Date.now() - start,
+    };
+  } catch (err) {
+    return { name, passed: false, message: `Exception: ${String(err)}`, durationMs: Date.now() - start };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log('\n=== GAIA CodeAgent Smoke Tests (ADR-138 iter 54) ===\n');
+
+  const results: TestResult[] = [
+    testCodeBlockExtraction(),
+    testPythonRunnerMath(),
+    testPythonRunnerFileRead(),
+    testPythonRunnerErrorRecovery(),
+    await testEndToEndSimple(),
+  ];
+
+  let passed = 0;
+  for (const r of results) {
+    const status = r.passed ? 'PASS' : 'FAIL';
+    console.log(`[${status}] ${r.name} (${r.durationMs}ms)`);
+    console.log(`       ${r.message}`);
+    if (r.passed) passed++;
+  }
+
+  console.log(`\n=== ${passed}/${results.length} passed ===`);
+  if (passed === results.length) {
+    console.log('All smoke tests passed. CodeAgent harness ready for 1Q sanity check.\n');
+    process.exit(0);
+  } else {
+    console.log(`SMOKE FAILED — ${results.length - passed} test(s) failed.\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Smoke test crashed:', err);
+  process.exit(2);
+});
+
+export {
+  testCodeBlockExtraction,
+  testPythonRunnerMath,
+  testPythonRunnerFileRead,
+  testPythonRunnerErrorRecovery,
+  testEndToEndSimple,
+};

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-codeagent.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-codeagent.ts
@@ -1,0 +1,774 @@
+/**
+ * GAIA CodeAgent — ADR-138 iter 54 (FINAL design)
+ *
+ * smolagents-style CodeAgent harness for the GAIA L1 benchmark.
+ * NOT the smolagents library — this is the PATTERN implemented natively in ruflo TS.
+ *
+ * Architecture (HAL replication):
+ *   Instead of Anthropic native tool_use blocks (JSON → execute → repeat),
+ *   the agent writes Python code that calls tools as functions.  The code is
+ *   parsed from markdown code blocks, executed in gaia-codeagent-runner.py,
+ *   and the stdout is fed back as the next user turn.  The agent commits its
+ *   answer by calling final_answer("value") in Python.
+ *
+ * Why this beats ToolCallingAgent on GAIA (from HAL-DEEP-STUDY.md):
+ *   - 30% fewer steps for the same task (Python is more expressive than JSON)
+ *   - Variables persist across steps in the agent's mental model
+ *   - Complex control flow (loops, try/except) is native
+ *   - final_answer() is deterministic — no regex extraction fragility
+ *
+ * Loop algorithm:
+ *   1. Build system prompt with tool signatures and GAIA instruction template.
+ *   2. Call Anthropic Messages API (text-in / text-out — NO tools array).
+ *   3. Parse the response for a ```python ... ``` code block.
+ *   4. If code block found: run gaia-codeagent-runner.py subprocess.
+ *      - Runner pre-defines tool functions (web_search, visit_webpage, etc.)
+ *      - If final_answer("X") is called in the code: extract X, return result.
+ *      - Otherwise: feed stdout back as user turn, continue.
+ *   5. If no code block: prompt agent to produce one (max 3 retries).
+ *   6. If maxTurns exceeded: return timedOut=true.
+ *   7. Every planningInterval turns: inject a planning checkpoint.
+ *
+ * Tool routing (via gaia-codeagent-runner.py):
+ *   web_search(query)      → claude -p with WebSearch (best web coverage)
+ *   visit_webpage(url)     → requests + bs4 HTML extraction
+ *   grounded_query(query)  → Gemini with Google Search grounding (ruflo unique)
+ *   read_file(path)        → Python direct (text/csv/json/xlsx) or subprocess
+ *   describe_image(path)   → claude -p with vision
+ *   final_answer(x)        → writes sentinel JSON and exits runner
+ *
+ * Key parameters:
+ *   model:            claude-sonnet-4-6 (default; ADR-138 targets Sonnet 4.5+)
+ *   maxTurns:         20 (HAL uses 200; 20 is cost-controlled for L1)
+ *   planningInterval: 4 (match HAL's planning_interval=4)
+ *   maxTokensPerTurn: 4096 (code generation needs more space than ToolCalling)
+ *
+ * Refs: ADR-138, HAL-DEEP-STUDY.md, smolagents CodeAgent, #2156, iter 54
+ */
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  GaiaQuestion,
+  SMOKE_FIXTURE,
+} from './gaia-loader.js';
+import { resolveAnthropicApiKey, isAnswerCorrect } from './gaia-agent.js';
+
+// ---------------------------------------------------------------------------
+// Re-export for callers
+// ---------------------------------------------------------------------------
+
+export { isAnswerCorrect };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_API_VERSION = '2023-06-01';
+
+/** Default model: Sonnet 4.6 (ADR-138 targets Sonnet 4.5+; 4.6 is available). */
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_MAX_TURNS = 20;
+const DEFAULT_MAX_TOKENS_PER_TURN = 4096;
+const DEFAULT_PER_TURN_TIMEOUT_MS = 90_000;
+const DEFAULT_PLANNING_INTERVAL = 4;
+const DEFAULT_PER_STEP_TIMEOUT_MS = 30_000;
+const MAX_OBSERVATION_CHARS = 6_000;
+const MAX_NO_CODE_RETRIES = 3;
+
+/** Pattern for final_answer in text output (GAIA format, fallback). */
+const FINAL_ANSWER_TEXT_RE = /FINAL_ANSWER:\s*(.+)/i;
+
+/** Path to the Python runner script — co-located with this file. */
+function getRunnerPath(): string {
+  const RUNNER_NAME = 'gaia-codeagent-runner.py';
+
+  // Primary: resolve relative to this compiled JS file (dist/src/benchmarks/)
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const candidate = path.join(path.dirname(thisFile), RUNNER_NAME);
+    if (fs.existsSync(candidate)) return candidate;
+  } catch { /* ESM URL resolution failed */ }
+
+  // Secondary: look for the Python runner next to the current file via __dirname-style
+  // heuristic — for Jest/ts-node contexts where import.meta.url is file://...src/...
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    // Walk up the dist/ tree to find src/benchmarks/ sibling
+    const distBenchmarks = path.dirname(thisFile);
+    const srcBenchmarks = distBenchmarks.replace(
+      path.join('dist', 'src', 'benchmarks'),
+      path.join('src', 'benchmarks'),
+    );
+    const srcCandidate = path.join(srcBenchmarks, RUNNER_NAME);
+    if (fs.existsSync(srcCandidate)) return srcCandidate;
+  } catch { /* ignore */ }
+
+  // Tertiary: CJS fallback (process.argv[1] path)
+  const fallback = path.join(path.dirname(process.argv[1] ?? '.'), RUNNER_NAME);
+  return fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CodeAgentResult {
+  questionId: string;
+  finalAnswer: string | null;
+  turns: number;
+  toolCallsByName: Record<string, number>;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  wallMs: number;
+  replanCount: number;
+  timedOut?: boolean;
+  error?: string;
+  /** Steps log for debugging — each entry is one turn's code + output. */
+  steps?: Array<{ code: string; output: string }>;
+}
+
+export interface CodeAgentOptions {
+  model?: string;
+  maxTurns?: number;
+  maxTokensPerTurn?: number;
+  perTurnTimeoutMs?: number;
+  /** Timeout for each Python step execution (default: 30s). */
+  perStepTimeoutMs?: number;
+  planningInterval?: number;
+  apiKey?: string;
+  /** If true, include step-by-step code/output log in the result. */
+  verbose?: boolean;
+  /**
+   * Optional tool catalogue override — used by unit tests to inject mock tools.
+   * In production (Python runner mode) this is ignored; the runner defines its own tools.
+   */
+  catalogue?: unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// Message types
+// ---------------------------------------------------------------------------
+
+interface MessageParam {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface AnthropicTextResponse {
+  id: string;
+  model: string;
+  stop_reason: 'end_turn' | 'max_tokens' | string;
+  content: Array<{ type: 'text'; text: string }>;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+// ---------------------------------------------------------------------------
+// System prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the CodeAgent system prompt.
+ *
+ * The prompt explains the coding loop to the model and lists all available
+ * tools with their signatures.  This mirrors HAL's CodeAgent system prompt
+ * format as documented in HAL-DEEP-STUDY.md.
+ */
+function buildCodeAgentSystemPrompt(): string {
+  const toolDocs = [
+    '  web_search(query: str) -> str',
+    '    Search the web and return snippets. Use for factual lookups.',
+    '',
+    '  visit_webpage(url: str) -> str',
+    '    Fetch full text content of a webpage. Use after web_search to read a page.',
+    '',
+    '  grounded_query(query: str) -> str',
+    '    Ask Gemini with Google grounding — returns synthesized answer with citations.',
+    '    Best for factoid questions. Use this OR web_search (not both for same query).',
+    '',
+    '  read_file(path: str) -> str',
+    '    Read a file — supports txt, csv, json, xlsx, pptx, pdf, images.',
+    '    Use the ATTACHMENT_PATH variable if a file was provided with the question.',
+    '',
+    '  describe_image(path: str) -> str',
+    '    Describe an image using Claude vision.',
+    '',
+    '  final_answer(answer) -> never',
+    '    Submit your final answer. This ENDS the loop immediately.',
+  ].join('\n');
+
+  return [
+    'You are a Python-capable agent solving GAIA benchmark questions.',
+    'To use tools, write Python code in ```python blocks and call tool functions directly.',
+    'After each code block, you will receive the output. Continue until you have the answer.',
+    '',
+    'TOOL FUNCTIONS AVAILABLE (call these in your Python code):',
+    toolDocs,
+    '',
+    'GLOBAL VARIABLES:',
+    '  ATTACHMENT_PATH: str  (path to attached file, or empty string if no attachment)',
+    '',
+    'PRE-IMPORTED: math, re, json, datetime, collections, itertools, statistics,',
+    '  fractions, decimal, string, unicodedata, urllib.parse, pathlib.Path,',
+    '  pandas as pd (optional), numpy as np (optional), sympy (optional)',
+    '',
+    'CODING RULES:',
+    '1. Write Python code in ```python\\n...\\n``` blocks.',
+    '2. Use print() to see tool outputs and intermediate results.',
+    '3. Call final_answer("your answer here") when you are certain of the answer.',
+    '4. Handle errors with try/except — do not crash on tool failures.',
+    '5. Use ATTACHMENT_PATH to access attached files when provided.',
+    '',
+    'GAIA ANSWER FORMAT (CRITICAL — follow exactly):',
+    'Return only the answer, which should be:',
+    '- A number: no commas, no units unless specified. Do not round unless asked.',
+    '- A string: no articles (a/an/the), no abbreviations. Spell out digits unless specified.',
+    '- A comma-separated list: apply the above per element.',
+    '',
+    'IMPORTANT: Do not include extra explanation in final_answer(). Just the bare answer.',
+    'Example: final_answer("3") or final_answer("Paris") or final_answer("2, 4, 6")',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Planning checkpoint
+// ---------------------------------------------------------------------------
+
+function buildCodeAgentPlanningCheckpoint(turn: number, maxTurns: number): string {
+  return (
+    `[PLANNING CHECKPOINT — step ${turn}/${maxTurns}]\n` +
+    `You have used ${turn} steps so far. Before continuing:\n` +
+    `1. Briefly summarize what you have learned from tool calls so far.\n` +
+    `2. State explicitly: is your current approach making progress toward the answer?\n` +
+    `3. If NOT making progress: switch strategy. Different tool, different query, different approach.\n` +
+    `4. If you are confident in an answer: call final_answer("your answer") now.\n` +
+    `Continue with your next Python code block.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Code block parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the first ```python ... ``` code block from assistant output.
+ * Returns null if no code block is found.
+ *
+ * Exported for use in unit tests (gaia-codeagent.smoke.ts T1).
+ */
+export function extractCodeBlock(text: string): string | null {
+  // Match ```python or ```py (with optional language tag) then newline then content
+  const withLangMatch = /```(?:python|py)\s*\n([\s\S]*?)```/.exec(text);
+  if (withLangMatch) return withLangMatch[1].trim();
+
+  // Bare ``` with no language tag
+  const lenientMatch = /```\s*\n([\s\S]*?)```/.exec(text);
+  if (lenientMatch) return lenientMatch[1].trim();
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Python execution via gaia-codeagent-runner.py subprocess
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute one step of agent code via gaia-codeagent-runner.py.
+ *
+ * The runner:
+ * 1. Pre-defines tool functions (web_search, visit_webpage, grounded_query,
+ *    read_file, describe_image, final_answer)
+ * 2. exec()s the agent's code in that context
+ * 3. If final_answer() is called: writes GAIA_RESULT_FILE JSON and exits 0
+ * 4. stdout is captured as the observation for the next turn
+ *
+ * Returns { output, finalAnswer }.
+ */
+function executeAgentCodeStep(
+  code: string,
+  attachmentPath: string | null,
+  stepTimeoutMs: number,
+  apiKey: string,
+  toolCallsByName: Record<string, number>,
+): { output: string; finalAnswer: string | null } {
+  const runnerPath = getRunnerPath();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gaia-ca-'));
+  const codeFile = path.join(tmpDir, 'agent_code.py');
+  const resultFile = path.join(tmpDir, 'final_answer.json');
+
+  try {
+    fs.writeFileSync(codeFile, code, 'utf-8');
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PYTHONIOENCODING: 'utf-8',
+      GAIA_CODE_FILE: codeFile,
+      GAIA_RESULT_FILE: resultFile,
+      ANTHROPIC_API_KEY: apiKey,
+    };
+    if (attachmentPath) {
+      env.GAIA_ATTACHMENT_PATH = attachmentPath;
+    }
+
+    const result = spawnSync('python3', [runnerPath], {
+      encoding: 'utf-8',
+      timeout: stepTimeoutMs,
+      env,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    // Count tool calls detected in stdout (heuristic from output markers)
+    const stdout = result.stdout ?? '';
+    const toolPatterns = ['web_search', 'visit_webpage', 'grounded_query', 'read_file', 'describe_image'];
+    for (const toolName of toolPatterns) {
+      // Rough heuristic: count function calls in agent code
+      const count = (code.match(new RegExp(`\\b${toolName}\\s*\\(`, 'g')) ?? []).length;
+      if (count > 0) {
+        toolCallsByName[toolName] = (toolCallsByName[toolName] ?? 0) + count;
+      }
+    }
+
+    // Check for final_answer sentinel
+    let finalAnswer: string | null = null;
+    if (fs.existsSync(resultFile)) {
+      try {
+        const sentinel = JSON.parse(fs.readFileSync(resultFile, 'utf-8'));
+        finalAnswer = String(sentinel.answer ?? '').trim();
+      } catch { /* ignore */ }
+    }
+
+    const stdoutTrimmed = stdout.trim();
+    const stderr = (result.stderr ?? '').trim();
+
+    if ((result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT') {
+      return { output: `[Execution timed out after ${stepTimeoutMs / 1000}s]`, finalAnswer: null };
+    }
+
+    // Filter out non-critical warnings from stderr
+    const stderrClean = stderr
+      ? stderr.split('\n').filter(l =>
+          !l.includes('UserWarning') && !l.includes('DeprecationWarning') && l.trim()
+        ).slice(0, 5).join('\n')
+      : '';
+
+    let observation = stdoutTrimmed;
+    if (stderrClean) {
+      observation = observation
+        ? `${observation}\n[stderr]: ${stderrClean.slice(0, 500)}`
+        : `[stderr]: ${stderrClean.slice(0, 500)}`;
+    }
+    if (!observation && finalAnswer !== null) {
+      observation = `[Code executed — final_answer captured: ${finalAnswer}]`;
+    }
+    if (!observation) {
+      observation = '[Code executed — no output]';
+    }
+
+    if (observation.length > MAX_OBSERVATION_CHARS) {
+      observation = observation.slice(0, MAX_OBSERVATION_CHARS) + '\n[... truncated ...]';
+    }
+
+    return { output: observation, finalAnswer };
+  } catch (err) {
+    return { output: `[Execution error: ${String(err)}]`, finalAnswer: null };
+  } finally {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public step runner (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single Python code step via the gaia-codeagent-runner.py subprocess.
+ *
+ * This is a thin public wrapper around `executeAgentCodeStep` that:
+ * - Exposes a clean typed signature for unit tests (gaia-codeagent.smoke.ts T2-T4)
+ * - Renames `output` → `observation` to match the smolagents naming convention
+ *
+ * @param code       Python code to execute
+ * @param attachmentPath  Path to attached file, or null
+ * @param timeoutMs  Subprocess timeout in ms (default: 30s)
+ * @param apiKey     Anthropic API key (passed to runner for claude -p tool calls)
+ */
+export function runCodeAgentStep(
+  code: string,
+  attachmentPath: string | null,
+  timeoutMs = DEFAULT_PER_STEP_TIMEOUT_MS,
+  apiKey = '',
+): { observation: string; finalAnswer: string | null } {
+  const toolCallsByName: Record<string, number> = {};
+  const { output, finalAnswer } = executeAgentCodeStep(code, attachmentPath, timeoutMs, apiKey, toolCallsByName);
+  return { observation: output, finalAnswer };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic Messages API call (text-only — no tools array)
+// ---------------------------------------------------------------------------
+
+async function callAnthropicTextOnly(
+  apiKey: string,
+  model: string,
+  systemPrompt: string,
+  messages: MessageParam[],
+  maxTokens: number,
+  timeoutMs: number,
+): Promise<AnthropicTextResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let res: Response;
+  try {
+    res = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_API_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens,
+        system: systemPrompt,
+        messages,
+      }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '<unreadable>');
+    throw new Error(`Anthropic API error ${res.status}: ${errText.slice(0, 400)}`);
+  }
+
+  return (await res.json()) as AnthropicTextResponse;
+}
+
+// ---------------------------------------------------------------------------
+// Main CodeAgent loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a GAIA question through the smolagents-style CodeAgent harness.
+ *
+ * The agent writes Python code, we execute it with tool stubs, and feed
+ * the output back.  The loop continues until final_answer() is called
+ * or maxTurns is exhausted.
+ */
+export async function runGaiaCodeAgent(
+  question: GaiaQuestion,
+  options: CodeAgentOptions = {},
+): Promise<CodeAgentResult> {
+  const {
+    model = DEFAULT_MODEL,
+    maxTurns = DEFAULT_MAX_TURNS,
+    maxTokensPerTurn = DEFAULT_MAX_TOKENS_PER_TURN,
+    perTurnTimeoutMs = DEFAULT_PER_TURN_TIMEOUT_MS,
+    perStepTimeoutMs = DEFAULT_PER_STEP_TIMEOUT_MS,
+    planningInterval = DEFAULT_PLANNING_INTERVAL,
+    apiKey: suppliedKey,
+    verbose = false,
+  } = options;
+
+  const wallStart = Date.now();
+  const apiKey = resolveAnthropicApiKey(suppliedKey);
+  const attachmentPath = question.file_path ?? null;
+
+  const toolCallsByName: Record<string, number> = {};
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let replanCount = 0;
+  let noCodeRetries = 0;
+  const steps: Array<{ code: string; output: string }> = [];
+
+  const systemPrompt = buildCodeAgentSystemPrompt();
+
+  // Build the initial user message following the GAIA instruction template
+  // (exact format from HAL-DEEP-STUDY.md §4)
+  const questionText = buildGaiaQuestionMessage(question);
+  const messages: MessageParam[] = [
+    { role: 'user', content: questionText },
+  ];
+
+  let turns = 0;
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    turns = turn + 1;
+
+    // Call the model (text only — no tools array)
+    let resp: AnthropicTextResponse;
+    try {
+      resp = await callAnthropicTextOnly(
+        apiKey,
+        model,
+        systemPrompt,
+        messages,
+        maxTokensPerTurn,
+        perTurnTimeoutMs,
+      );
+    } catch (err) {
+      return {
+        questionId: question.task_id,
+        finalAnswer: null,
+        turns,
+        toolCallsByName,
+        totalInputTokens,
+        totalOutputTokens,
+        wallMs: Date.now() - wallStart,
+        replanCount,
+        error: err instanceof Error ? err.message : String(err),
+        steps: verbose ? steps : undefined,
+      };
+    }
+
+    totalInputTokens += resp.usage.input_tokens;
+    totalOutputTokens += resp.usage.output_tokens;
+
+    // Extract text content
+    const assistantText = resp.content
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n')
+      .trim();
+
+    // Append assistant turn to messages
+    messages.push({ role: 'assistant', content: assistantText });
+
+    // --- Check for final_answer in TEXT output (before code execution) ---
+    // Sometimes the agent commits in prose without a code block
+    const textFinalMatch = FINAL_ANSWER_TEXT_RE.exec(assistantText);
+    if (textFinalMatch) {
+      const finalAnswer = textFinalMatch[1].trim();
+      return {
+        questionId: question.task_id,
+        finalAnswer,
+        turns,
+        toolCallsByName,
+        totalInputTokens,
+        totalOutputTokens,
+        wallMs: Date.now() - wallStart,
+        replanCount,
+        steps: verbose ? steps : undefined,
+      };
+    }
+
+    // --- Extract code block ---
+    const codeBlock = extractCodeBlock(assistantText);
+
+    if (!codeBlock) {
+      noCodeRetries++;
+      if (noCodeRetries >= MAX_NO_CODE_RETRIES) {
+        // Give up on prompting — try to extract answer from prose
+        const textMatch = FINAL_ANSWER_TEXT_RE.exec(assistantText);
+        if (textMatch) {
+          return {
+            questionId: question.task_id,
+            finalAnswer: textMatch[1].trim(),
+            turns,
+            toolCallsByName,
+            totalInputTokens,
+            totalOutputTokens,
+            wallMs: Date.now() - wallStart,
+            replanCount,
+            steps: verbose ? steps : undefined,
+          };
+        }
+        break;
+      }
+      // Prompt agent to produce a code block
+      messages.push({
+        role: 'user',
+        content: 'Please write a Python code block. Use ```python\\n...\\n``` format. Call final_answer("your answer") when done.',
+      });
+      continue;
+    }
+
+    noCodeRetries = 0;
+
+    // --- Execute the code via the Python runner ---
+    const { output, finalAnswer: execFinalAnswer } = executeAgentCodeStep(
+      codeBlock,
+      attachmentPath,
+      perStepTimeoutMs,
+      apiKey,
+      toolCallsByName,
+    );
+
+    if (verbose) {
+      steps.push({ code: codeBlock, output });
+    }
+
+    // If execution produced a final_answer, return it
+    if (execFinalAnswer !== null) {
+      return {
+        questionId: question.task_id,
+        finalAnswer: execFinalAnswer,
+        turns,
+        toolCallsByName,
+        totalInputTokens,
+        totalOutputTokens,
+        wallMs: Date.now() - wallStart,
+        replanCount,
+        steps: verbose ? steps : undefined,
+      };
+    }
+
+    // --- Build next user turn (observation) ---
+    // Every planningInterval turns, inject a planning checkpoint
+    const shouldReplan =
+      planningInterval > 0 && turns > 0 && turns % planningInterval === 0;
+
+    let observationText = `\`\`\`output\n${output}\n\`\`\``;
+    if (shouldReplan) {
+      replanCount++;
+      observationText += `\n\n${buildCodeAgentPlanningCheckpoint(turns, maxTurns)}`;
+    }
+
+    messages.push({ role: 'user', content: observationText });
+  }
+
+  // Exhausted maxTurns
+  return {
+    questionId: question.task_id,
+    finalAnswer: null,
+    turns,
+    toolCallsByName,
+    totalInputTokens,
+    totalOutputTokens,
+    wallMs: Date.now() - wallStart,
+    replanCount,
+    timedOut: true,
+    steps: verbose ? steps : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GAIA question message builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the user message for a GAIA question.
+ * Follows the HAL instruction template exactly (HAL-DEEP-STUDY.md §4).
+ */
+function buildGaiaQuestionMessage(question: GaiaQuestion): string {
+  const gaiaPreamble = [
+    'Please answer the question below. You should:',
+    '- Return only your answer, which should be a number, or a short phrase with as few words as possible, or a comma separated list.',
+    '- If you are asked for a number, don\'t use commas to write your number neither use units such as $ or percent sign unless specified otherwise. Don\'t round numbers unless specified.',
+    '- If you are asked for a string, don\'t use articles, neither abbreviations (e.g. for cities), and write the digits in full unless specified otherwise.',
+    '- If you are asked for a comma separated list, apply the above rules depending on whether the element to be put in the list is a number or a string.',
+    '',
+    'To submit your answer, use: final_answer("your answer here")',
+    '',
+  ].join('\n');
+
+  let questionText = question.question;
+
+  // Attachment hint
+  if (question.file_path) {
+    const ext = question.file_path.split('.').pop()?.toLowerCase() ?? '';
+    const toolHint = ext === 'pdf'
+      ? `Use pdf_read(path="${question.file_path}") to read the attached PDF.`
+      : ext === 'xlsx' || ext === 'csv'
+      ? `Use file_read(path="${question.file_path}") to read the attached spreadsheet.`
+      : `Use file_read(path="${question.file_path}") to read the attached file.`;
+
+    questionText += `\n\n[ATTACHMENT: ${question.file_name ?? question.file_path}]\n${toolHint}`;
+  }
+
+  return gaiaPreamble + questionText;
+}
+
+// ---------------------------------------------------------------------------
+// Smoke runner
+// ---------------------------------------------------------------------------
+
+const SONNET_INPUT_COST_PER_M = 3.0;
+const SONNET_OUTPUT_COST_PER_M = 15.0;
+
+/**
+ * Run all 5 SMOKE_FIXTURE questions through the CodeAgent harness.
+ * Pass criteria: ≥3/5 correct (60%).
+ */
+export async function runCodeAgentSmokeTest(opts: {
+  verbose?: boolean;
+  apiKey?: string;
+  model?: string;
+} = {}): Promise<{ passRate: number; passed: number; total: number }> {
+  const { verbose = true, apiKey, model = DEFAULT_MODEL } = opts;
+
+  if (verbose) {
+    console.log('\n=== GAIA CodeAgent Smoke Test (ADR-138 iter 54) ===');
+    console.log(`Model: ${model}`);
+    console.log(`Questions: ${SMOKE_FIXTURE.length}\n`);
+  }
+
+  let passed = 0;
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+
+  for (const question of SMOKE_FIXTURE) {
+    const result = await runGaiaCodeAgent(question, { model, apiKey, verbose });
+
+    const correct =
+      result.finalAnswer !== null &&
+      isAnswerCorrect(result.finalAnswer, question.final_answer);
+
+    if (correct) passed++;
+    totalInputTokens += result.totalInputTokens;
+    totalOutputTokens += result.totalOutputTokens;
+
+    if (verbose) {
+      const status = correct ? 'PASS' : 'FAIL';
+      console.log(`[${status}] ${question.task_id}: ${question.question.slice(0, 60)}`);
+      console.log(
+        `       Expected: "${question.final_answer}" | Got: "${result.finalAnswer ?? 'null'}"`,
+      );
+      console.log(
+        `       Turns: ${result.turns} | Replans: ${result.replanCount} ` +
+        `| Tools: ${JSON.stringify(result.toolCallsByName)} | Wall: ${result.wallMs}ms`,
+      );
+      if (result.error) console.log(`       Error: ${result.error}`);
+      console.log();
+    }
+  }
+
+  const passRate = passed / SMOKE_FIXTURE.length;
+  const estCost =
+    (totalInputTokens / 1_000_000) * SONNET_INPUT_COST_PER_M +
+    (totalOutputTokens / 1_000_000) * SONNET_OUTPUT_COST_PER_M;
+
+  if (verbose) {
+    console.log('=== Summary ===');
+    console.log(`Pass rate: ${passed}/${SMOKE_FIXTURE.length} (${(passRate * 100).toFixed(0)}%)`);
+    console.log(`Status:    ${passed >= 3 ? 'SMOKE PASSED' : 'SMOKE FAILED'}`);
+    console.log(`Tokens in: ${totalInputTokens.toLocaleString()}`);
+    console.log(`Tokens out: ${totalOutputTokens.toLocaleString()}`);
+    console.log(`Est. cost: $${estCost.toFixed(4)} (Sonnet pricing)`);
+    console.log();
+  }
+
+  return { passRate, passed, total: SMOKE_FIXTURE.length };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+
+if (process.argv.includes('--smoke')) {
+  runCodeAgentSmokeTest({ verbose: true })
+    .then(({ passed }) => {
+      process.exit(passed >= 3 ? 0 : 1);
+    })
+    .catch((err) => {
+      console.error('CodeAgent smoke test crashed:', err);
+      process.exit(2);
+    });
+}

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-loader.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-loader.ts
@@ -22,6 +22,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as https from 'node:https';
+import * as url from 'node:url';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -94,6 +95,13 @@ export function resolveHfToken(): string {
 
 function defaultCacheDir(): string {
   return path.join(os.homedir(), '.cache', 'ruflo', 'gaia');
+}
+
+/**
+ * Export the default cache directory path (no side effects).
+ */
+export function getDefaultCacheDir(): string {
+  return defaultCacheDir();
 }
 
 function ensureDir(dir: string): void {
@@ -272,6 +280,101 @@ async function downloadGaiaLevel(
 }
 
 // ---------------------------------------------------------------------------
+// Attachment download (iter-53b)
+// ---------------------------------------------------------------------------
+
+/**
+ * Base URL for GAIA validation attachment files.
+ * Individual files are at: HF_FILE_BASE/<task_id>/<file_name>
+ *
+ * HF now serves files through the Xet storage layer; requests will redirect
+ * (301/302/303) to a Xet download URL that requires NO auth header.
+ * We only send the Authorization header to requests targeting huggingface.co.
+ */
+const HF_FILE_BASE =
+  'https://huggingface.co/datasets/gaia-benchmark/GAIA/resolve/main/2023/validation';
+
+/**
+ * Download a single GAIA attachment file to the cache directory.
+ * Follows HTTP redirects, sending auth only to huggingface.co domains.
+ * Returns the local file path on success, or null on any error.
+ */
+async function downloadAttachment(
+  taskId: string,
+  fileName: string,
+  token: string,
+  cacheDir: string,
+): Promise<string | null> {
+  const destPath = path.join(cacheDir, fileName);
+  if (fs.existsSync(destPath)) return destPath; // already cached
+
+  const fileUrl = `${HF_FILE_BASE}/${taskId}/${encodeURIComponent(fileName)}`;
+  ensureDir(cacheDir);
+
+  return new Promise((resolve) => {
+    function doGet(requestUrl: string, depth: number): void {
+      if (depth > 5) { resolve(null); return; }
+
+      const parsed = new url.URL(requestUrl);
+      const headers: Record<string, string> = {
+        'User-Agent': 'ruflo-gaia-loader/1.0',
+      };
+      if (parsed.hostname.includes('huggingface.co')) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      const req = https.get(requestUrl, { headers }, (res) => {
+        if (res.statusCode && [301, 302, 303, 307, 308].includes(res.statusCode)) {
+          const loc = res.headers['location'];
+          res.resume();
+          if (loc) doGet(loc, depth + 1);
+          else resolve(null);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          resolve(null);
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          try {
+            fs.writeFileSync(destPath, Buffer.concat(chunks));
+            resolve(destPath);
+          } catch {
+            resolve(null);
+          }
+        });
+        res.on('error', () => resolve(null));
+      });
+      req.on('error', () => resolve(null));
+      req.setTimeout(60_000, () => { req.destroy(); resolve(null); });
+    }
+    doGet(fileUrl, 0);
+  });
+}
+
+/**
+ * Download all attachment files referenced by the questions list.
+ * Mutates each question's `file_path` field in place.
+ * Skips questions without a file_name.
+ */
+export async function resolveAttachments(
+  questions: GaiaQuestion[],
+  token: string,
+  cacheDir: string,
+): Promise<void> {
+  const withFiles = questions.filter((q) => q.file_name);
+  await Promise.all(
+    withFiles.map(async (q) => {
+      const localPath = await downloadAttachment(q.task_id, q.file_name!, token, cacheDir);
+      q.file_path = localPath;
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -294,6 +397,8 @@ export async function loadGaia(options: LoadGaiaOptions = {}): Promise<GaiaQuest
 
   const token = resolveHfToken();
   const questions = await downloadGaiaLevel(level, token, cacheDir);
+  // Resolve attachment files in parallel (iter-53b: populates file_path on each question)
+  await resolveAttachments(questions, token, cacheDir);
   return limit !== undefined ? questions.slice(0, limit) : questions;
 }
 

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-tools/file_read.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-tools/file_read.ts
@@ -1,37 +1,46 @@
 /**
- * GAIA Tool: file_read — ADR-133-PR2
+ * GAIA Tool: file_read — ADR-133-PR2 / iter-53b attachment-tools
  *
  * Reads a file from the local filesystem and returns its contents as a
- * UTF-8 string.  Performs a content-type sniff based on extension +
- * magic bytes so Claude knows what it received.
+ * UTF-8 string.  Performs content-type dispatch based on extension +
+ * magic bytes:
  *
- * Design notes:
- * - Supported formats (PR-2): plain text, JSON, CSV, XML, HTML, Markdown,
- *   JavaScript, TypeScript, Python, shell scripts, YAML.
- * - Binary formats (PDF, DOCX, XLSX, images): returns a descriptive stub
- *   rather than raw bytes.  Full PDF text extraction is tracked for PR-4.
- * - Maximum file size: 1 MB (avoids blowing the context window).
- * - Path must be absolute to prevent directory traversal from relative paths
- *   embedded in GAIA attachment filenames.
+ * Supported extraction formats (iter-53b):
+ *   - Plain text, JSON, CSV, XML, HTML, Markdown, JS/TS, Python, shell, YAML
+ *   - XLSX  — openpyxl subprocess (cell values + fill colours)
+ *   - PPTX  — python-pptx subprocess (per-slide text)
+ *   - PNG / JPEG / GIF / WebP — returns IMAGE_BASE64 marker for vision API
+ *   - MP3 / WAV — OpenAI Whisper (tiny model) subprocess transcript
+ *   - .py source file — returned as UTF-8 text (no execution)
  *
- * Refs: ADR-133, #2156
+ * For PDF / DOCX / other binary: descriptive stub (PR-4 deferred).
+ *
+ * IMAGE_BASE64 marker format:
+ *   [IMAGE_BASE64:{"mediaType":"image/png","base64":"...","path":"/abs/path"}]
+ *
+ * The agent loop in gaia-agent.ts must parse this marker when it appears
+ * in a tool_result and convert it to an Anthropic vision content block.
+ *
+ * Maximum file size: 5 MB.  Paths must be absolute.
+ *
+ * Refs: ADR-133, #2156, iter-53b
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { GaiaTool, ToolDefinition } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const MAX_FILE_BYTES = 1 * 1024 * 1024; // 1 MB
+const MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MB
 
 // ---------------------------------------------------------------------------
 // Content-type detection
 // ---------------------------------------------------------------------------
 
-/** Map of file extension → human-readable media type label. */
 const EXT_TO_TYPE: Record<string, string> = {
   '.txt': 'text/plain',
   '.md': 'text/markdown',
@@ -48,10 +57,9 @@ const EXT_TO_TYPE: Record<string, string> = {
   '.sh': 'application/x-sh',
   '.bash': 'application/x-sh',
   '.zsh': 'application/x-sh',
-  // Binary / deferred
-  '.pdf': 'application/pdf',
-  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  // Handled binary (extraction implemented)
   '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -59,35 +67,37 @@ const EXT_TO_TYPE: Record<string, string> = {
   '.webp': 'image/webp',
   '.mp3': 'audio/mpeg',
   '.wav': 'audio/wav',
+  // Stub binary (deferred)
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   '.mp4': 'video/mp4',
 };
 
-/** Set of extension types that are binary / deferred and cannot be returned as text. */
-const BINARY_TYPES = new Set([
-  'application/pdf',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+/** Binary types for which we have extraction logic in iter-53b. */
+const HANDLED_BINARY_TYPES = new Set([
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   'image/png',
   'image/jpeg',
   'image/gif',
   'image/webp',
   'audio/mpeg',
   'audio/wav',
+]);
+
+/** Binary types for which we return a stub (no extraction yet). */
+const STUB_BINARY_TYPES = new Set([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   'video/mp4',
 ]);
 
-/**
- * Detect content type from extension.  Falls back to 'application/octet-stream'.
- */
 function detectContentType(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
   return EXT_TO_TYPE[ext] ?? 'application/octet-stream';
 }
 
-/**
- * Quick magic-byte check to catch binary files even when the extension is wrong.
- * Only checks the first 4 bytes.
- */
+/** Quick magic-byte check for common binary signatures. */
 function hasBinaryMagic(buf: Buffer): boolean {
   if (buf.length < 4) return false;
   // PDF: %PDF
@@ -98,7 +108,7 @@ function hasBinaryMagic(buf: Buffer): boolean {
   if (buf[0] === 0xff && buf[1] === 0xd8) return true;
   // GIF: GIF8
   if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) return true;
-  // ZIP (DOCX/XLSX are ZIP): PK\x03\x04
+  // ZIP (DOCX/XLSX/PPTX): PK\x03\x04
   if (buf[0] === 0x50 && buf[1] === 0x4b && buf[2] === 0x03 && buf[3] === 0x04) return true;
   return false;
 }
@@ -107,14 +117,6 @@ function hasBinaryMagic(buf: Buffer): boolean {
 // Path validation
 // ---------------------------------------------------------------------------
 
-/**
- * Validate that `filePath` is safe to read:
- * - Must be a non-empty string
- * - Must be an absolute path (caller must have resolved GAIA attachment paths)
- * - Must not contain null bytes
- *
- * Does NOT check if the file exists (let the OS return ENOENT).
- */
 function validatePath(filePath: string): void {
   if (!filePath || typeof filePath !== 'string') {
     throw new Error('file_read: `path` must be a non-empty string.');
@@ -131,6 +133,185 @@ function validatePath(filePath: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Python subprocess helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a Python script passed via stdin, with optional positional args.
+ * Uses execFileSync with stdin input to avoid shell-escaping issues.
+ */
+function runPython(script: string, args: string[], timeoutMs: number): string {
+  return execFileSync('python3', ['-', ...args], {
+    input: script,
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+  }).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Extraction helpers
+// ---------------------------------------------------------------------------
+
+/** Map an ARGB/RGB integer or tuple to a human-readable colour name. */
+function colorName(r: number, g: number, b: number): string {
+  if (r < 40 && g < 40 && b < 40) return 'black';
+  if (r > 215 && g > 215 && b > 215) return 'white';
+  if (r > 200 && g < 80 && b < 80) return 'red';
+  if (r < 80 && g > 150 && b < 80) return 'green';
+  if (r < 80 && g < 80 && b > 200) return 'blue';
+  if (r > 200 && g > 200 && b < 80) return 'yellow';
+  if (r > 200 && g > 100 && b < 80) return 'orange';
+  if (r > 130 && g < 80 && b > 130) return 'purple';
+  if (r < 80 && g > 150 && b > 150) return 'teal';
+  if (r > 150 && g < 100 && b < 100) return 'dark-red';
+  if (r > 150 && g > 150 && b > 150) return 'light-gray';
+  if (r < 100 && g < 100 && b < 100) return 'dark-gray';
+  return `rgb(${r},${g},${b})`;
+}
+
+/**
+ * Extract XLSX content via openpyxl Python subprocess.
+ * Returns cell values + fill colours as structured text.
+ */
+function extractXlsx(filePath: string): string {
+  const script = [
+    'import sys, json',
+    'from openpyxl import load_workbook',
+    'wb = load_workbook(sys.argv[1])',
+    'out = []',
+    'for ws in wb.worksheets:',
+    "    sheet = {'sheet': ws.title, 'cells': []}",
+    '    for row in ws.iter_rows():',
+    '        for cell in row:',
+    '            fill = cell.fill',
+    '            color = None',
+    "            if fill and fill.fill_type == 'solid':",
+    '                fg = fill.fgColor',
+    "                if fg.type == 'rgb' and fg.rgb not in ('00000000', 'FFFFFFFF', '00FFFFFF', 'FF000000', 'FFFFFFFF'):",
+    '                    color = fg.rgb',
+    '            # Include cell if it has a value OR a color',
+    '            if cell.value is None and color is None:',
+    '                continue',
+    "            entry = {'coord': cell.coordinate, 'value': str(cell.value) if cell.value is not None else ''}",
+    '            if color:',
+    "                entry['color'] = color",
+    "            sheet['cells'].append(entry)",
+    '    out.append(sheet)',
+    'print(json.dumps(out))',
+  ].join('\n');
+
+  let raw: string;
+  try {
+    raw = runPython(script, [filePath], 30_000);
+  } catch (err) {
+    throw new Error(`XLSX extraction failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  let parsed: Array<{ sheet: string; cells: Array<{ coord: string; value: string; color?: string }> }>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return `[XLSX parse error]\nRaw output:\n${raw.slice(0, 2000)}`;
+  }
+
+  const lines: string[] = [`[XLSX: ${path.basename(filePath)} — ${parsed.length} sheet(s)]`];
+  for (const ws of parsed) {
+    lines.push(`\n--- Sheet: ${ws.sheet} ---`);
+    for (const cell of ws.cells) {
+      const colorPart = cell.color
+        ? (() => {
+            const hex = cell.color.slice(-6);
+            const r = parseInt(hex.slice(0, 2), 16);
+            const g = parseInt(hex.slice(2, 4), 16);
+            const b = parseInt(hex.slice(4, 6), 16);
+            return ` [fill:${colorName(r, g, b)}]`;
+          })()
+        : '';
+      lines.push(`  ${cell.coord}: ${cell.value}${colorPart}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Extract PPTX content via python-pptx Python subprocess.
+ * Returns per-slide text.
+ */
+function extractPptx(filePath: string): string {
+  const script = [
+    'import sys, json',
+    'from pptx import Presentation',
+    'prs = Presentation(sys.argv[1])',
+    'out = []',
+    'for i, slide in enumerate(prs.slides):',
+    '    texts = []',
+    '    for shape in slide.shapes:',
+    '        if not shape.has_text_frame:',
+    '            continue',
+    '        for para in shape.text_frame.paragraphs:',
+    "            t = ''.join(run.text for run in para.runs).strip()",
+    '            if t:',
+    '                texts.append(t)',
+    "    out.append({'slide': i + 1, 'texts': texts})",
+    'print(json.dumps(out))',
+  ].join('\n');
+
+  let raw: string;
+  try {
+    raw = runPython(script, [filePath], 30_000);
+  } catch (err) {
+    throw new Error(`PPTX extraction failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  let parsed: Array<{ slide: number; texts: string[] }>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return `[PPTX parse error]\nRaw output:\n${raw.slice(0, 2000)}`;
+  }
+
+  const lines: string[] = [`[PPTX: ${path.basename(filePath)} — ${parsed.length} slide(s)]`];
+  for (const s of parsed) {
+    lines.push(`\n--- Slide ${s.slide} ---`);
+    for (const t of s.texts) lines.push(`  ${t}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Encode image as base64 and return the IMAGE_BASE64 marker.
+ * The agent loop will convert this to an Anthropic vision content block.
+ */
+function extractImage(filePath: string, contentType: string): string {
+  const buf = fs.readFileSync(filePath);
+  const b64 = buf.toString('base64');
+  const marker = JSON.stringify({ mediaType: contentType, base64: b64, path: filePath });
+  return `[IMAGE_BASE64:${marker}]`;
+}
+
+/**
+ * Transcribe audio via OpenAI Whisper (tiny model) Python subprocess.
+ */
+function extractAudio(filePath: string): string {
+  const script = [
+    'import sys',
+    'import whisper',
+    'model = whisper.load_model("tiny")',
+    'result = model.transcribe(sys.argv[1])',
+    "print(result['text'].strip())",
+  ].join('\n');
+
+  let transcript: string;
+  try {
+    transcript = runPython(script, [filePath], 120_000);
+  } catch (err) {
+    throw new Error(`Audio transcription failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return `[Audio transcript: ${path.basename(filePath)}]\n\n${transcript}`;
+}
+
+// ---------------------------------------------------------------------------
 // GaiaTool implementation
 // ---------------------------------------------------------------------------
 
@@ -141,9 +322,13 @@ export class FileReadTool implements GaiaTool {
     name: 'file_read',
     description:
       'Read the contents of a local file and return them as text. ' +
-      'The path must be absolute. For PDF, DOCX, and image files a descriptive ' +
-      'stub is returned instead of raw bytes (full extraction coming in PR-4). ' +
-      `Maximum file size: ${MAX_FILE_BYTES / 1024} KB.`,
+      'The path must be absolute. ' +
+      'For XLSX files: returns cell values and fill colours. ' +
+      'For PPTX files: returns per-slide text. ' +
+      'For image files (PNG/JPEG/GIF/WebP): returns an IMAGE_BASE64 marker for vision API use. ' +
+      'For audio files (MP3/WAV): returns a Whisper transcript. ' +
+      'For Python source files (.py): returns the source code as text. ' +
+      `Maximum file size: ${MAX_FILE_BYTES / 1024 / 1024} MB.`,
     input_schema: {
       type: 'object',
       properties: {
@@ -160,7 +345,6 @@ export class FileReadTool implements GaiaTool {
     const filePath = String(input['path'] ?? '').trim();
     validatePath(filePath);
 
-    // Check file exists
     let stat: fs.Stats;
     try {
       stat = fs.statSync(filePath);
@@ -182,25 +366,51 @@ export class FileReadTool implements GaiaTool {
       );
     }
 
-    // Read the file
-    const buf = fs.readFileSync(filePath);
-
-    // Content-type detection: extension first, then magic bytes
     const contentType = detectContentType(filePath);
-    const isBinaryByType = BINARY_TYPES.has(contentType);
-    const isBinaryByMagic = hasBinaryMagic(buf);
 
-    if (isBinaryByType || isBinaryByMagic) {
+    // --- HANDLED binary types: extraction implemented ---
+    if (HANDLED_BINARY_TYPES.has(contentType)) {
+      if (
+        contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      ) {
+        return extractXlsx(filePath);
+      }
+      if (
+        contentType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+      ) {
+        return extractPptx(filePath);
+      }
+      if (contentType.startsWith('image/')) {
+        return extractImage(filePath, contentType);
+      }
+      if (contentType.startsWith('audio/')) {
+        return extractAudio(filePath);
+      }
+    }
+
+    // --- STUB binary types: no extraction yet ---
+    if (STUB_BINARY_TYPES.has(contentType)) {
       return (
         `[Binary file: ${contentType}]\n` +
         `Path: ${filePath}\n` +
         `Size: ${stat.size} bytes\n` +
-        `Note: Text extraction for this format is not yet implemented (ADR-133 PR-4). ` +
-        `If this is a GAIA attachment, describe what you expect the file to contain based on context.`
+        `Note: Text extraction for this format is not yet implemented. ` +
+        `Describe what you expect the file to contain based on context.`
       );
     }
 
-    // Decode as UTF-8 with a fallback to latin-1 for slightly misencoded text files.
+    // --- Read full file for magic-byte check ---
+    const buf = fs.readFileSync(filePath);
+    if (hasBinaryMagic(buf)) {
+      return (
+        `[Binary file — magic bytes detected]\n` +
+        `Path: ${filePath}\n` +
+        `Size: ${stat.size} bytes\n` +
+        `Detected content-type: ${contentType}`
+      );
+    }
+
+    // --- Plain text ---
     let text: string;
     try {
       text = buf.toString('utf-8');

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-tools/index.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-tools/index.ts
@@ -1,34 +1,39 @@
 /**
- * gaia-tools barrel — ADR-133-PR2
+ * gaia-tools barrel — ADR-133-PR2 / ADR-138 iter 54
  *
  * Exports all tool implementations + shared types so that gaia-agent.ts
- * (PR-3) and future tools (PR-4: python_exec, PR-5: web_browse) can import
- * from a single entry point.
+ * (PR-3) and gaia-codeagent.ts (ADR-138) can import from a single entry point.
  *
  * iter-47 fix: re-added grounded_query which was absent from the integration
  * branch because feat/adr-135-grounded-query-gemini was never cherry-picked
  * during Track A/B/D/E/Q integration (iter-42 measured −36pp / 13.2%).
  *
- * Refs: ADR-133, ADR-135, #2156
+ * iter-54 adds: visit_webpage, python_exec, pdf_read (HAL tool parity).
+ *
+ * Refs: ADR-133, ADR-135, ADR-138, #2156
  */
 
 export * from './types.js';
 export * from './web_search.js';
 export * from './file_read.js';
 export * from './grounded_query.js';
+export * from './visit_webpage.js';
+export * from './python_exec.js';
+export * from './pdf_read.js';
 
 import { createWebSearchTool } from './web_search.js';
 import { createFileReadTool } from './file_read.js';
 import { createGroundedQueryTool } from './grounded_query.js';
+import { createVisitWebpageTool } from './visit_webpage.js';
+import { createPythonExecTool } from './python_exec.js';
+import { createPdfReadTool } from './pdf_read.js';
 import type { GaiaToolCatalogue } from './types.js';
 
 /**
- * Returns the default tool catalogue for a GAIA Level-1 run.
+ * Returns the default tool catalogue for a GAIA Level-1 run (ToolCallingAgent).
  *
  * PR-2 catalogue: web_search + file_read
  * iter-33 adds:   grounded_query (Gemini 2.5 Flash grounding — pre-synthesised answer + citations)
- * PR-4 will add:  python_exec (E2B sandbox)
- * PR-5 will add:  web_browse, image_describe
  *
  * Both web_search and grounded_query are registered so the agent can choose:
  *   - grounded_query: for factoid questions needing a clean answer with citations (1 call)
@@ -36,4 +41,23 @@ import type { GaiaToolCatalogue } from './types.js';
  */
 export function createDefaultToolCatalogue(): GaiaToolCatalogue {
   return [createWebSearchTool(), createFileReadTool(), createGroundedQueryTool()];
+}
+
+/**
+ * Returns the extended tool catalogue for CodeAgent (ADR-138 iter 54).
+ *
+ * Adds visit_webpage, python_exec, and pdf_read on top of the default set.
+ * These tools are consumed by gaia-codeagent-runner.py, not the TypeScript
+ * agent loop directly — the catalogue is registered so the system prompt
+ * can enumerate them.
+ */
+export function createCodeAgentToolCatalogue(): GaiaToolCatalogue {
+  return [
+    createWebSearchTool(),
+    createGroundedQueryTool(),
+    createVisitWebpageTool(),
+    createFileReadTool(),
+    createPythonExecTool(),
+    createPdfReadTool(),
+  ];
 }

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-tools/pdf_read.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-tools/pdf_read.ts
@@ -1,0 +1,245 @@
+/**
+ * GAIA Tool: pdf_read — ADR-138 iter 54
+ *
+ * Extracts text content from a PDF file using a Python subprocess.
+ * GAIA L1 has ~20-30% of questions with PDF attachments; without this,
+ * ruflo is functionally blind on those questions.
+ *
+ * Extraction chain (tries in order, returns first success):
+ *   1. pdfminer.six  — best quality, handles most text PDFs
+ *   2. pdfplumber    — good alternative, especially for tables
+ *   3. PyPDF2/pypdf  — fallback, lower quality but widely available
+ *   4. pdftotext     — CLI tool (poppler-utils), if installed
+ *   5. Stub          — returns a note that extraction failed
+ *
+ * For image-only (scanned) PDFs, all text extractors return empty.
+ * In that case we return a note so the agent can try describe_image.
+ *
+ * Refs: ADR-138, #2156, iter 54
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { GaiaTool, ToolDefinition } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EXEC_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_CHARS = 8_000;
+
+// ---------------------------------------------------------------------------
+// Extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to extract PDF text using Python pdfminer.six (best quality).
+ */
+function extractViaPdfminer(filePath: string): string {
+  const script = `
+import sys
+try:
+    from pdfminer.high_level import extract_text
+    text = extract_text(sys.argv[1])
+    print(text[:12000] if text else '')
+except ImportError:
+    print('[pdfminer_not_installed]')
+except Exception as e:
+    print('[pdfminer_error:' + str(e) + ']')
+`.trim();
+
+  try {
+    const out = execFileSync('python3', ['-', filePath], {
+      input: script,
+      encoding: 'utf-8',
+      timeout: EXEC_TIMEOUT_MS,
+    }).trim();
+    if (out && !out.startsWith('[pdfminer_not_installed]') && !out.startsWith('[pdfminer_error:')) {
+      return out;
+    }
+  } catch { /* fall through */ }
+  return '';
+}
+
+/**
+ * Try to extract PDF text using pdfplumber (good for tables).
+ */
+function extractViaPdfplumber(filePath: string): string {
+  const script = `
+import sys
+try:
+    import pdfplumber
+    with pdfplumber.open(sys.argv[1]) as pdf:
+        texts = []
+        for page in pdf.pages:
+            t = page.extract_text()
+            if t:
+                texts.append(t)
+        print('\\n\\n'.join(texts)[:12000])
+except ImportError:
+    print('[pdfplumber_not_installed]')
+except Exception as e:
+    print('[pdfplumber_error:' + str(e) + ']')
+`.trim();
+
+  try {
+    const out = execFileSync('python3', ['-', filePath], {
+      input: script,
+      encoding: 'utf-8',
+      timeout: EXEC_TIMEOUT_MS,
+    }).trim();
+    if (out && !out.startsWith('[pdfplumber_not_installed]') && !out.startsWith('[pdfplumber_error:')) {
+      return out;
+    }
+  } catch { /* fall through */ }
+  return '';
+}
+
+/**
+ * Try to extract PDF text using pypdf (widely available, lower quality).
+ */
+function extractViaPypdf(filePath: string): string {
+  const script = `
+import sys
+try:
+    try:
+        import pypdf as pdf_lib
+    except ImportError:
+        import PyPDF2 as pdf_lib
+    with open(sys.argv[1], 'rb') as f:
+        reader = pdf_lib.PdfReader(f)
+        texts = []
+        for page in reader.pages:
+            t = page.extract_text()
+            if t:
+                texts.append(t)
+        print('\\n\\n'.join(texts)[:12000])
+except ImportError:
+    print('[pypdf_not_installed]')
+except Exception as e:
+    print('[pypdf_error:' + str(e) + ']')
+`.trim();
+
+  try {
+    const out = execFileSync('python3', ['-', filePath], {
+      input: script,
+      encoding: 'utf-8',
+      timeout: EXEC_TIMEOUT_MS,
+    }).trim();
+    if (out && !out.startsWith('[pypdf_not_installed]') && !out.startsWith('[pypdf_error:')) {
+      return out;
+    }
+  } catch { /* fall through */ }
+  return '';
+}
+
+/**
+ * Try to extract PDF text using the `pdftotext` CLI tool (poppler-utils).
+ */
+function extractViaPdftotext(filePath: string): string {
+  try {
+    const out = execFileSync('pdftotext', [filePath, '-'], {
+      encoding: 'utf-8',
+      timeout: EXEC_TIMEOUT_MS,
+    }).trim();
+    return out.slice(0, 12000);
+  } catch { /* fall through */ }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Path validation (mirrors file_read.ts)
+// ---------------------------------------------------------------------------
+
+function validatePdfPath(filePath: string): void {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new Error('pdf_read: `path` must be a non-empty string.');
+  }
+  if (!path.isAbsolute(filePath)) {
+    throw new Error(`pdf_read: path must be absolute. Got: "${filePath}".`);
+  }
+  if (filePath.includes('\0')) {
+    throw new Error('pdf_read: path contains null byte — rejected.');
+  }
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext !== '.pdf') {
+    throw new Error(`pdf_read: expected a .pdf file, got extension "${ext}". Use file_read for other formats.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GaiaTool implementation
+// ---------------------------------------------------------------------------
+
+export class PdfReadTool implements GaiaTool {
+  readonly name = 'pdf_read';
+
+  readonly definition: ToolDefinition = {
+    name: 'pdf_read',
+    description:
+      'Extract text content from a PDF file. ' +
+      'Path must be absolute. ' +
+      'Tries pdfminer.six, pdfplumber, pypdf, and pdftotext in order. ' +
+      'Returns extracted text or a note if the PDF is image-only (scanned). ' +
+      `Output truncated to ${MAX_OUTPUT_CHARS} characters.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute path to the PDF file.',
+        },
+      },
+      required: ['path'],
+    },
+  };
+
+  async execute(input: Record<string, unknown>): Promise<string> {
+    const filePath = String(input['path'] ?? '').trim();
+    validatePdfPath(filePath);
+
+    // Check existence
+    try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile()) throw new Error(`pdf_read: "${filePath}" is not a regular file.`);
+    } catch (e: unknown) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') throw new Error(`pdf_read: file not found: ${filePath}`);
+      throw e;
+    }
+
+    const filename = path.basename(filePath);
+
+    // Try extractors in order
+    let text = extractViaPdfminer(filePath);
+    if (!text) text = extractViaPdfplumber(filePath);
+    if (!text) text = extractViaPypdf(filePath);
+    if (!text) text = extractViaPdftotext(filePath);
+
+    if (!text || text.length < 20) {
+      return (
+        `[PDF: ${filename}]\n` +
+        `Text extraction returned no content. This may be a scanned/image-only PDF.\n` +
+        `If the PDF contains images, consider using describe_image on specific pages.\n` +
+        `File: ${filePath}`
+      );
+    }
+
+    const truncated = text.length > MAX_OUTPUT_CHARS;
+    const output = text.slice(0, MAX_OUTPUT_CHARS);
+    return (
+      `[PDF: ${filename}]\n\n${output}` +
+      (truncated ? `\n\n[... truncated at ${MAX_OUTPUT_CHARS} chars ...]` : '')
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience factory
+// ---------------------------------------------------------------------------
+
+export function createPdfReadTool(): PdfReadTool {
+  return new PdfReadTool();
+}

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-tools/python_exec.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-tools/python_exec.ts
@@ -1,0 +1,154 @@
+/**
+ * GAIA Tool: python_exec — ADR-138 iter 54
+ *
+ * Executes a Python code snippet in a constrained subprocess and returns
+ * stdout. This is the second-highest-leverage missing tool — HAL's
+ * python_interpreter covers computation, data manipulation, and string
+ * processing that the LLM cannot reliably do in prose.
+ *
+ * Design:
+ * - Runs `python3 -c "..."` via execFileSync (NOT shell=true — avoids injection)
+ * - The agent's code is injected directly; stdout is captured and returned.
+ * - Pre-amble imports: math, datetime, json, re, collections, itertools,
+ *   statistics, urllib.parse, fractions, decimal, operator — no requests/bs4
+ *   (those are for visit_webpage, not computation).
+ * - Timeout: 30s
+ * - Output capped at 4000 chars.
+ *
+ * Security note: This runs in our controlled benchmark environment against
+ * known GAIA questions. We accept the subprocess risk in that context.
+ * For production agent sandboxing, use a proper E2B/Firecracker sandbox.
+ *
+ * Refs: ADR-138, #2156, iter 54
+ */
+
+import { execFileSync } from 'node:child_process';
+import { GaiaTool, ToolDefinition } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EXEC_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_CHARS = 4_000;
+
+/**
+ * Authorized imports pre-loaded into the execution preamble.
+ * Mirrors HAL's additional_authorized_imports list (HAL-DEEP-STUDY.md §3.2).
+ */
+const PREAMBLE = `
+import math
+import re
+import json
+import datetime
+from datetime import date, timedelta
+from collections import Counter, defaultdict, OrderedDict
+import itertools
+import statistics
+import fractions
+import decimal
+import operator
+from urllib.parse import urlparse, quote, unquote
+import string
+import unicodedata
+import sys
+import os.path
+
+# pandas/scipy/sympy optional — handle ImportError gracefully
+try:
+    import pandas as pd
+    import numpy as np
+except ImportError:
+    pd = None
+    np = None
+
+try:
+    import sympy
+except ImportError:
+    sympy = None
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Execution helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a Python snippet and return its stdout.
+ * The preamble is prepended so agent code can use math/datetime/etc directly.
+ */
+export function runPythonSnippet(code: string): string {
+  const fullCode = `${PREAMBLE}\n\n${code}`;
+
+  let stdout: string;
+  try {
+    stdout = execFileSync('python3', ['-c', fullCode], {
+      encoding: 'utf-8',
+      timeout: EXEC_TIMEOUT_MS,
+      env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error && 'stderr' in err) {
+      const execErr = err as { stderr?: string; message: string };
+      const stderr = (execErr.stderr ?? '').trim();
+      const msg = err.message ?? '';
+      // Timeout
+      if (msg.includes('ETIMEDOUT') || msg.includes('timed out')) {
+        return `[python_exec: timed out after ${EXEC_TIMEOUT_MS / 1000}s]`;
+      }
+      if (stderr) {
+        return `[python_exec error]\n${stderr.slice(0, 1000)}`;
+      }
+    }
+    return `[python_exec error: ${String(err)}]`;
+  }
+
+  const result = stdout.trim();
+  if (result.length > MAX_OUTPUT_CHARS) {
+    return result.slice(0, MAX_OUTPUT_CHARS) + `\n[... truncated at ${MAX_OUTPUT_CHARS} chars ...]`;
+  }
+  return result || '[python_exec: no output]';
+}
+
+// ---------------------------------------------------------------------------
+// GaiaTool implementation
+// ---------------------------------------------------------------------------
+
+export class PythonExecTool implements GaiaTool {
+  readonly name = 'python_exec';
+
+  readonly definition: ToolDefinition = {
+    name: 'python_exec',
+    description:
+      'Execute a Python code snippet and return the stdout output. ' +
+      'Use for: arithmetic, date calculations, string manipulation, list operations, ' +
+      'statistical computations, data conversions, unit conversions. ' +
+      'Pre-imported: math, datetime, re, json, collections, itertools, statistics, fractions, ' +
+      'decimal, string, unicodedata, urllib.parse. ' +
+      'pandas/numpy/sympy available if installed. ' +
+      'Use print() to output results. Timeout: 30s.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description: 'Python code to execute. Use print() to produce output.',
+        },
+      },
+      required: ['code'],
+    },
+  };
+
+  async execute(input: Record<string, unknown>): Promise<string> {
+    const code = String(input['code'] ?? '').trim();
+    if (!code) throw new Error('python_exec: `code` input is required and must be non-empty.');
+    return runPythonSnippet(code);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience factory
+// ---------------------------------------------------------------------------
+
+export function createPythonExecTool(): PythonExecTool {
+  return new PythonExecTool();
+}

--- a/v3/@claude-flow/cli/src/benchmarks/gaia-tools/visit_webpage.ts
+++ b/v3/@claude-flow/cli/src/benchmarks/gaia-tools/visit_webpage.ts
@@ -1,0 +1,186 @@
+/**
+ * GAIA Tool: visit_webpage — ADR-138 iter 54
+ *
+ * Fetches a URL and returns the full page content as clean plain text.
+ * This is the highest-leverage missing tool — HAL's visit_webpage is responsible
+ * for ~25-35% of L1 question coverage (Wikipedia, government sites, reference pages).
+ *
+ * Implementation:
+ * - Uses Node.js built-in fetch (Node 22 — no external dep)
+ * - Strips HTML tags via a Python subprocess (requests + bs4.get_text) which
+ *   handles encoding properly and is already available in the benchmark env.
+ * - Falls back to pure-regex HTML stripping if Python subprocess fails.
+ * - Truncates output to 8000 chars (enough for most reference articles;
+ *   prevents context overflow).
+ *
+ * Refs: ADR-138, #2156, iter 54
+ */
+
+import { execFileSync } from 'node:child_process';
+import { GaiaTool, ToolDefinition } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_CHARS = 8_000;
+const UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+// ---------------------------------------------------------------------------
+// HTML extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract readable text from HTML using Python bs4.
+ * bs4.get_text() handles encoding, strips scripts/styles, respects structure.
+ */
+function extractTextViaPython(html: string): string {
+  const script = `
+import sys, re
+from bs4 import BeautifulSoup
+
+html = sys.stdin.read()
+soup = BeautifulSoup(html, 'html.parser')
+
+# Remove scripts, styles, nav, footer
+for tag in soup(['script', 'style', 'nav', 'footer', 'header', 'aside']):
+    tag.decompose()
+
+text = soup.get_text(separator='\\n', strip=True)
+# Collapse multiple blank lines
+text = re.sub(r'\\n{3,}', '\\n\\n', text)
+print(text[:12000])
+`.trim();
+
+  try {
+    return execFileSync('python3', ['-'], {
+      input: script + '\n',
+      encoding: 'utf-8',
+      timeout: 15_000,
+      env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fallback: strip HTML tags with regex (no external dep, less accurate).
+ */
+function extractTextViaRegex(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#x27;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Page fetcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a URL and return the response HTML as a string.
+ * Uses Node.js built-in fetch (Node 18+).
+ */
+async function fetchPage(url: string): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: {
+        'User-Agent': UA,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    throw new Error(`visit_webpage: HTTP ${res.status} for ${url}`);
+  }
+
+  // Guard against non-HTML content types (PDFs, binary files)
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/pdf')) {
+    throw new Error(
+      `visit_webpage: URL returns a PDF. Use file_read with the downloaded path instead. URL: ${url}`,
+    );
+  }
+
+  return await res.text();
+}
+
+// ---------------------------------------------------------------------------
+// GaiaTool implementation
+// ---------------------------------------------------------------------------
+
+export class VisitWebpageTool implements GaiaTool {
+  readonly name = 'visit_webpage';
+
+  readonly definition: ToolDefinition = {
+    name: 'visit_webpage',
+    description:
+      'Fetch the full text content of a webpage URL. ' +
+      'Returns the readable text stripped of HTML, scripts, and navigation. ' +
+      'Use after web_search to read the full content of a promising result. ' +
+      `Output is truncated to ${MAX_OUTPUT_CHARS} characters.`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The full URL to fetch (must start with http:// or https://).',
+        },
+      },
+      required: ['url'],
+    },
+  };
+
+  async execute(input: Record<string, unknown>): Promise<string> {
+    const url = String(input['url'] ?? '').trim();
+    if (!url) throw new Error('visit_webpage: `url` input is required.');
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      throw new Error(`visit_webpage: URL must start with http:// or https://. Got: "${url}"`);
+    }
+
+    const html = await fetchPage(url);
+
+    // Try Python extraction first (better quality), fall back to regex
+    let text = extractTextViaPython(html);
+    if (!text || text.length < 50) {
+      text = extractTextViaRegex(html);
+    }
+
+    if (!text || text.length < 20) {
+      return `[visit_webpage: page at ${url} returned no readable text content]`;
+    }
+
+    const truncated = text.length > MAX_OUTPUT_CHARS;
+    const output = text.slice(0, MAX_OUTPUT_CHARS);
+    return `[Page: ${url}]\n\n${output}${truncated ? `\n\n[... truncated at ${MAX_OUTPUT_CHARS} chars ...]` : ''}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience factory
+// ---------------------------------------------------------------------------
+
+export function createVisitWebpageTool(): VisitWebpageTool {
+  return new VisitWebpageTool();
+}

--- a/v3/@claude-flow/cli/src/commands/gaia-bench.ts
+++ b/v3/@claude-flow/cli/src/commands/gaia-bench.ts
@@ -204,6 +204,12 @@ const runCommand: Command = {
       description: 'ADR-135 Track B: inject a planning checkpoint every N tool_use turns (default: 4, set 0 to disable). Based on smolagents finding — prevents tunnel-vision on bad strategies.',
       default: '4',
     },
+    {
+      name: 'mode',
+      type: 'string',
+      description: 'Agent mode: "toolcalling" (default, ADR-133 JSON tool_use) or "codeagent" (ADR-138 iter 54 — smolagents-style Python code blocks).',
+      default: 'toolcalling',
+    },
   ],
   examples: [
     {
@@ -238,6 +244,10 @@ const runCommand: Command = {
       command: 'claude-flow gaia-bench run --level 1 --models claude-sonnet-4-6 --hardness-routing --enable-critic --planning-interval 4',
       description: 'Recommended config: hardness routing + critic + planning checkpoints (~$2/run est.)',
     },
+    {
+      command: 'claude-flow gaia-bench run --level 1 --models claude-sonnet-4-6 --mode codeagent',
+      description: 'ADR-138 iter 54: CodeAgent (smolagents-style Python code blocks) — targets HAL-level accuracy',
+    },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const level = parseInt(String(ctx.flags.level ?? '1'), 10) as 1 | 2 | 3;
@@ -271,6 +281,11 @@ const runCommand: Command = {
     const enableDecompose = ctx.flags['decompose'] === true || ctx.flags['decompose'] === 'true';
     // ADR-135 Track B: planning interval (passed through to runGaiaAgent via agentOpts).
     const planningInterval = parseInt(String(ctx.flags['planningInterval'] ?? ctx.flags['planning-interval'] ?? '4'), 10);
+    // ADR-138 iter 54: CodeAgent mode.
+    const agentModeRaw = String(ctx.flags['mode'] ?? 'toolcalling');
+    // 'agent' is a backward-compat alias for 'toolcalling'
+    const agentMode = agentModeRaw === 'agent' ? 'toolcalling' : agentModeRaw;
+    const useCodeAgent = agentMode === 'codeagent';
 
     // Dynamic imports to avoid loading at startup.
     // NOTE: gaia-*.ts sources are pre-compiled under dist/src/benchmarks/ only --
@@ -281,6 +296,12 @@ const runCommand: Command = {
     const benchmarksBase = new URL('../benchmarks/', import.meta.url).href;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { loadGaia } = (await import(benchmarksBase + 'gaia-loader.js')) as any;
+    // ADR-138 iter 54: CodeAgent — only imported when --mode codeagent.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { runGaiaCodeAgent } = useCodeAgent
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ? ((await import(benchmarksBase + 'gaia-codeagent.js')) as any)
+      : { runGaiaCodeAgent: null };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { runGaiaAgent } = (await import(benchmarksBase + 'gaia-agent.js')) as any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -338,6 +359,7 @@ const runCommand: Command = {
     log(output.bold(`GAIA Benchmark -- Level ${level}${smokeOnly ? ' [SMOKE]' : ''}`));
     log(output.dim('-'.repeat(60)));
     log(`Models  : ${models.join(', ')}`);
+    log(`Mode    : ${agentMode}${useCodeAgent ? ' (ADR-138 iter 54 — CodeAgent harness)' : ''}`);
     log(`Limit   : ${limit ?? 'all'}`);
     log(`Concurrency: ${concurrency}`);
     if (useVoting && !hardnessRouting) {
@@ -481,7 +503,16 @@ const runCommand: Command = {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               let agentResult: any;
               try {
-                if (useThisVoting && runGaiaAgentWithVoting) {
+                if (useCodeAgent && runGaiaCodeAgent) {
+                  // ADR-138 iter 54: smolagents-style CodeAgent (Python code blocks, not JSON tool_use).
+                  const codeAgentMaxTurns = effectiveMaxTurns === 12 ? 20 : effectiveMaxTurns;
+                  agentResult = await runGaiaCodeAgent(sq, {
+                    model: effectiveModel,
+                    maxTurns: codeAgentMaxTurns,
+                    planningInterval,
+                    apiKey,
+                  });
+                } else if (useThisVoting && runGaiaAgentWithVoting) {
                   // ADR-135 Track A: multi-attempt majority voting.
                   agentResult = await runGaiaAgentWithVoting(sq, {
                     ...agentOpts,


### PR DESCRIPTION
## Summary

- Implements the HAL-replication **CodeAgent pattern** natively in ruflo TypeScript (ADR-138 iter 54). Instead of JSON `tool_use` blocks, the agent writes Python code that calls tools as functions — the single largest gap between ruflo (45.3% L1) and HAL (82.07% L1).
- Adds Python step runner (`gaia-codeagent-runner.py`, 556 LOC) that pre-defines all tools as Python callables and `exec()`s agent code in that context; `final_answer("x")` writes a sentinel JSON file and exits — deterministic answer capture.
- Wires `--mode=codeagent` flag into `gaia-bench run` — default remains `toolcalling` for full backward compatibility.

## Files changed

| File | Change |
|------|--------|
| `gaia-codeagent.ts` | New — 774 LOC main harness |
| `gaia-codeagent-runner.py` | New — 556 LOC Python step runner |
| `gaia-codeagent.smoke.ts` | New — 5 smoke tests |
| `gaia-tools/visit_webpage.ts` | New — HAL tool parity |
| `gaia-tools/python_exec.ts` | New — HAL tool parity |
| `gaia-tools/pdf_read.ts` | New — HAL tool parity |
| `gaia-tools/index.ts` | Updated — `createCodeAgentToolCatalogue()` (6 tools) |
| `gaia-bench.ts` | Updated — `--mode` flag (toolcalling\|codeagent) |
| `gaia-run.md` | Updated — `--mode` docs |
| `package.json` | Updated — postbuild copies runner to dist/ |

## Build & smoke

- `npm run build`: **zero TypeScript errors**
- Smoke: **5/5 pass** (T1=code-block-parser, T2=math-subprocess, T3=file-read, T4=error-recovery, T5=end-to-end factual question `6×7=42`)

## Key parameters

| Param | Value | Source |
|-------|-------|--------|
| model | `claude-sonnet-4-6` | ADR-138 (vs HAL `claude-sonnet-4-5`) |
| maxTurns | `20` | ADR-138 (HAL uses 200; 20 is cost-controlled) |
| planningInterval | `4` | HAL `planning_interval=4` |
| maxTokensPerTurn | `4096` | code generation headroom |

## Expected impact

Per HAL-DEEP-STUDY.md, CodeAgent alone accounts for +15-20pp on GAIA L1 over ToolCallingAgent. Combined with Sonnet upgrade (+10-15pp) and step budget increase (+8-12pp), target is to exceed 65% on the 5Q smoke run and push toward HAL's 82.07%.

## Test plan

- [x] `npm run build` — zero errors
- [x] Smoke: `node dist/src/benchmarks/gaia-codeagent.smoke.js` — 5/5 pass
- [ ] Single-Q sanity: `gaia-bench run --mode=codeagent --limit 1 --models claude-sonnet-4-6`
- [ ] 5Q smoke run: `gaia-bench run --smoke-only --mode=codeagent --models claude-sonnet-4-6`
- [ ] 53Q L1 run: `gaia-bench run --level=1 --mode=codeagent --models claude-sonnet-4-6`

Refs: ADR-138, HAL-DEEP-STUDY.md, #2156

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

Co-Authored-By: RuFlo <ruv@ruv.net>