### PR TITLE
feat(statusline): configurable cost symbol + hide toggle

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -28,6 +28,15 @@ const os = require('os');
 // Configuration
 const CONFIG = {
   maxAgents: 15,
+  // Session-cost display. Claude Code's cost.total_cost_usd is a client-side
+  // estimate that "may differ from your actual bill" and reads as misleading on
+  // subscription plans, where token usage is not billed per dollar. These let
+  // each user pick what the segment means to them without changing the default.
+  //   RUFLO_STATUSLINE_COST_SYMBOL  override the leading '$' (e.g. ⚡, €, 🌱);
+  //                                 set to an empty string for the number alone.
+  //   RUFLO_STATUSLINE_HIDE_COST    1/true/yes/on removes the segment entirely.
+  costSymbol: process.env.RUFLO_STATUSLINE_COST_SYMBOL ?? '$',
+  hideCost: /^(1|true|yes|on)$/i.test(process.env.RUFLO_STATUSLINE_HIDE_COST || ''),
 };
 
 const CWD = process.cwd();
@@ -420,8 +429,8 @@ function generateStatusline() {
     const ctxColor = ctxInfo.usedPct >= 90 ? c.brightRed : ctxInfo.usedPct >= 70 ? c.brightYellow : c.brightGreen;
     header += '  ' + c.dim + '│' + c.reset + '  ' + ctxColor + '● ' + ctxInfo.usedPct + '% ctx' + c.reset;
   }
-  if (costInfo && costInfo.costUsd > 0) {
-    header += '  ' + c.dim + '│' + c.reset + '  ' + c.brightYellow + '$' + costInfo.costUsd.toFixed(2) + c.reset;
+  if (!CONFIG.hideCost && costInfo && costInfo.costUsd > 0) {
+    header += '  ' + c.dim + '│' + c.reset + '  ' + c.brightYellow + CONFIG.costSymbol + costInfo.costUsd.toFixed(2) + c.reset;
   }
   lines.push(header);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Ruflo project (formerly Claude Flow) are documented h
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Configurable statusline cost segment via two environment variables (defaults unchanged):
+  - `RUFLO_STATUSLINE_COST_SYMBOL` — override the leading `$` (e.g. `⚡`, `€`, `🌱`); empty string shows the number alone.
+  - `RUFLO_STATUSLINE_HIDE_COST` — `1`/`true`/`yes`/`on` hides the segment. `cost.total_cost_usd` is a client-side estimate that may differ from the actual bill and is misleading on subscription plans.
+
 ## [3.5.0] - 2026-02-27
 
 ### Ruflo v3.5 — First Major Stable Release

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -2586,6 +2586,30 @@ Claude Code pipes JSON session data via **stdin** to the statusline script after
 | `🧠 15%` | Intelligence score | Pattern count from AgentDB |
 | `📦 AgentDB ●1.2K` | AgentDB vector count | File size estimate (`size / 2KB`) |
 
+**Customizing the cost segment:**
+
+`cost.total_cost_usd` is a client-side estimate from Claude Code that *may differ from your actual bill* and, on subscription plans, does not reflect out-of-pocket spend. Two environment variables let you relabel or remove the segment (the default is unchanged):
+
+| Variable | Effect | Example |
+|----------|--------|---------|
+| `RUFLO_STATUSLINE_COST_SYMBOL` | Overrides the leading `$`. Set to an empty string to show the number alone. | `RUFLO_STATUSLINE_COST_SYMBOL=⚡` → `⚡1.30` |
+| `RUFLO_STATUSLINE_HIDE_COST` | `1`/`true`/`yes`/`on` removes the segment entirely. | `RUFLO_STATUSLINE_HIDE_COST=1` |
+
+Set them in the `env` block of `.claude/settings.json` — Claude Code applies it to every session and to the statusline subprocess, and unlike hand-editing the helper it survives `npx ruflo@latest init --update`:
+
+```json
+{
+  "statusLine": { "type": "command", "command": "node .claude/helpers/statusline.cjs" },
+  "env": { "RUFLO_STATUSLINE_COST_SYMBOL": "⚡" }
+}
+```
+
+Or export them in your shell profile before launching Claude Code:
+
+```bash
+export RUFLO_STATUSLINE_COST_SYMBOL=⚡   # or: export RUFLO_STATUSLINE_HIDE_COST=1
+```
+
 **Setup (Automatic):**
 
 Run `npx ruflo@latest init` — this generates `.claude/settings.json` with the correct statusline config and creates the helper script at `.claude/helpers/statusline.cjs`.

--- a/v3/@claude-flow/cli/__tests__/statusline-cost-display.test.ts
+++ b/v3/@claude-flow/cli/__tests__/statusline-cost-display.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Statusline session-cost display configuration.
+ *
+ * Claude Code's `cost.total_cost_usd` is documented as a client-side estimate
+ * that "may differ from your actual bill", and on subscription plans it reads as
+ * misleading (token usage is not billed per dollar). The statusline therefore
+ * lets each user relabel or hide the cost segment without changing the default:
+ *
+ *   RUFLO_STATUSLINE_COST_SYMBOL  override the leading '$' ('' => number alone)
+ *   RUFLO_STATUSLINE_HIDE_COST    1/true/yes/on => omit the segment
+ *
+ * These tests cover three layers:
+ *   1. Generator contract — the emitted script wires the env vars and keeps '$'
+ *      as the default, so the customization can never silently regress.
+ *   2. Runtime behavior — the generated script renders the right thing for each
+ *      configuration when fed a Claude Code stdin payload.
+ *   3. Drift guard — the committed `.claude/helpers/statusline.cjs` artifact stays
+ *      byte-identical to the generator output for the default options.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { generateStatuslineScript } from '../src/init/statusline-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+const SCRIPT = generateStatuslineScript(DEFAULT_INIT_OPTIONS);
+
+const stripAnsi = (s: string): string =>
+  // eslint-disable-next-line no-control-regex
+  s.replace(/\x1b\[[0-9;]*m/g, '');
+
+/**
+ * Run the generated statusline against a Claude Code stdin payload. PATH is
+ * neutered so the script's `npx`/`git` probes fail instantly and fall back to
+ * local data — the cost segment comes purely from stdin, so this stays offline
+ * and deterministic. Returns the first (header) line with ANSI stripped.
+ */
+function renderHeader(env: Record<string, string> = {}): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-'));
+  const scriptPath = path.join(dir, 'statusline.cjs');
+  writeFileSync(scriptPath, SCRIPT, 'utf-8');
+  const payload = JSON.stringify({
+    model: { display_name: 'Opus 4.8' },
+    context_window: { used_percentage: 34 },
+    cost: { total_cost_usd: 1.3, total_duration_ms: 376000 },
+  });
+  try {
+    const out = execFileSync(process.execPath, [scriptPath], {
+      input: payload,
+      encoding: 'utf-8',
+      env: { PATH: '/nonexistent', HOME: dir, ...env },
+      timeout: 15000,
+    });
+    return stripAnsi(out).split('\n')[0];
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('statusline cost display — generator contract', () => {
+  it('reads both env vars and keeps "$" as the default', () => {
+    expect(SCRIPT).toContain('RUFLO_STATUSLINE_COST_SYMBOL');
+    expect(SCRIPT).toContain('RUFLO_STATUSLINE_HIDE_COST');
+    // Default must be the dollar sign (?? '$') so existing setups are unchanged.
+    expect(SCRIPT).toContain("process.env.RUFLO_STATUSLINE_COST_SYMBOL ?? '$'");
+  });
+
+  it('renders the cost via the configurable symbol, not a hardcoded "$"', () => {
+    expect(SCRIPT).toContain('CONFIG.costSymbol + costInfo.costUsd.toFixed(2)');
+    // The literal `'$' + costInfo.costUsd` render must be gone.
+    expect(SCRIPT).not.toContain("'$' + costInfo.costUsd.toFixed(2)");
+  });
+
+  it('guards the cost segment with the hide toggle', () => {
+    expect(SCRIPT).toContain('!CONFIG.hideCost && costInfo && costInfo.costUsd > 0');
+  });
+});
+
+describe('statusline cost display — runtime behavior', () => {
+  it('shows "$1.30" by default (backward compatible)', () => {
+    expect(renderHeader()).toContain('$1.30');
+  });
+
+  it('replaces the symbol when RUFLO_STATUSLINE_COST_SYMBOL is set', () => {
+    const header = renderHeader({ RUFLO_STATUSLINE_COST_SYMBOL: '⚡' });
+    expect(header).toContain('⚡1.30');
+    expect(header).not.toContain('$1.30');
+  });
+
+  it('omits the segment when RUFLO_STATUSLINE_HIDE_COST is truthy', () => {
+    const header = renderHeader({ RUFLO_STATUSLINE_HIDE_COST: '1' });
+    expect(header).not.toContain('1.30');
+  });
+
+  it('shows the number alone when the symbol is an empty string', () => {
+    const header = renderHeader({ RUFLO_STATUSLINE_COST_SYMBOL: '' });
+    expect(header).toContain('1.30');
+    expect(header).not.toContain('$1.30');
+  });
+});
+
+describe('statusline cost display — committed artifact drift guard', () => {
+  it('matches the generator output for default options', () => {
+    const artifact = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../../../.claude/helpers/statusline.cjs',
+    );
+    if (!existsSync(artifact)) return; // package tested in isolation; nothing to guard
+    expect(readFileSync(artifact, 'utf-8')).toBe(SCRIPT);
+  });
+});

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -55,6 +55,15 @@ const os = require('os');
 // Configuration
 const CONFIG = {
   maxAgents: ${maxAgents},
+  // Session-cost display. Claude Code's cost.total_cost_usd is a client-side
+  // estimate that "may differ from your actual bill" and reads as misleading on
+  // subscription plans, where token usage is not billed per dollar. These let
+  // each user pick what the segment means to them without changing the default.
+  //   RUFLO_STATUSLINE_COST_SYMBOL  override the leading '$' (e.g. ⚡, €, 🌱);
+  //                                 set to an empty string for the number alone.
+  //   RUFLO_STATUSLINE_HIDE_COST    1/true/yes/on removes the segment entirely.
+  costSymbol: process.env.RUFLO_STATUSLINE_COST_SYMBOL ?? '$',
+  hideCost: /^(1|true|yes|on)$/i.test(process.env.RUFLO_STATUSLINE_HIDE_COST || ''),
 };
 
 const CWD = process.cwd();
@@ -447,8 +456,8 @@ function generateStatusline() {
     const ctxColor = ctxInfo.usedPct >= 90 ? c.brightRed : ctxInfo.usedPct >= 70 ? c.brightYellow : c.brightGreen;
     header += '  ' + c.dim + '│' + c.reset + '  ' + ctxColor + '● ' + ctxInfo.usedPct + '% ctx' + c.reset;
   }
-  if (costInfo && costInfo.costUsd > 0) {
-    header += '  ' + c.dim + '│' + c.reset + '  ' + c.brightYellow + '$' + costInfo.costUsd.toFixed(2) + c.reset;
+  if (!CONFIG.hideCost && costInfo && costInfo.costUsd > 0) {
+    header += '  ' + c.dim + '│' + c.reset + '  ' + c.brightYellow + CONFIG.costSymbol + costInfo.costUsd.toFixed(2) + c.reset;
   }
   lines.push(header);
 


### PR DESCRIPTION
## What

The statusline's session-cost segment was hardcoded to a `$` prefix. This adds two opt-in environment variables to relabel or hide it. **Default behavior is unchanged** (`$1.30`).

| Variable | Effect | Example |
|---|---|---|
| `RUFLO_STATUSLINE_COST_SYMBOL` | Override the leading `$` (empty string = number alone) | `RUFLO_STATUSLINE_COST_SYMBOL=⚡` → `⚡1.30` |
| `RUFLO_STATUSLINE_HIDE_COST` | `1`/`true`/`yes`/`on` hides the segment | `RUFLO_STATUSLINE_HIDE_COST=1` |

Set in the `env` block of `.claude/settings.json` (or a shell export):

```json
"env": { "RUFLO_STATUSLINE_COST_SYMBOL": "⚡" }
```

## Why

`cost.total_cost_usd` is documented by Claude Code as a client-side estimate that "may differ from your actual bill." On subscription plans it does not track out-of-pocket spend, so a `$` prefix misrepresents it. These let each user pick a unit that matches their mental model, or hide it, without changing the default.

Doing this via environment variables (rather than hand-editing the helper) is also durable: the setting survives `npx ruflo@latest init --update` regenerating `.claude/helpers/statusline.cjs`.

Note on scope: the only spend-related fields Claude Code passes to a statusline are `cost.total_cost_usd` and durations; payload token counts are a context-window snapshot, not cumulative session totals. So this is honest relabeling, not a derived energy/CO₂ figure.

## How

- The change lives in the generator `v3/@claude-flow/cli/src/init/statusline-generator.ts` (the source of truth `npx ruflo init` emits). The committed `.claude/helpers/statusline.cjs` is regenerated so the two stay byte-identical.
- Other statusline files are untouched — they don't render the cost segment.

## Tests

`v3/@claude-flow/cli/__tests__/statusline-cost-display.test.ts`:

- **Generator contract** — emitted script wires both env vars and keeps `$` as the default.
- **Runtime** — feeds a Claude Code stdin payload to the generated script and asserts `$1.30` (default), `⚡1.30` (symbol), hidden (toggle), and bare `1.30` (empty symbol).
- **Drift guard** — committed artifact equals generator output for default options.

---
*AI (Claude) supported my development of this PR.*
