### PR TITLE
fix(vector-db): pass unique storagePath to VectorDB to prevent daemon lock conflict

### DIFF
--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.7.0-alpha.24",
+  "version": "3.7.0-alpha.82",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/ruvector/vector-db.ts
+++ b/v3/@claude-flow/cli/src/ruvector/vector-db.ts
@@ -147,6 +147,16 @@ let ruvectorModule: RuVectorModule | null = null;
 let loadAttempted = false;
 let isAvailable = false;
 
+function uniqueStoragePath(): string {
+  // Use os.tmpdir() so each adapter instance gets its own file and never
+  // contends with daemons that hold a lock on the default "agentdb.rvf" path.
+  const os = require('os');
+  const path = require('path');
+  const crypto = require('crypto');
+  const rand = crypto.randomBytes(8).toString('hex');
+  return path.join(os.tmpdir(), `ruvector-${process.pid}-${rand}.rvf`);
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -172,7 +182,7 @@ export async function loadRuVector(): Promise<boolean> {
       const VectorDBClass = ruvector.VectorDB || ruvector.VectorDb;
       ruvectorModule = {
         createVectorDB: async (dimensions: number): Promise<VectorDB> => {
-          const db = new VectorDBClass({ dimensions });
+          const db = new VectorDBClass({ dimensions, storagePath: uniqueStoragePath() });
           // Wrap ruvector's VectorDB to match our interface
           return {
             insert: (embedding: Float32Array, id: string, metadata?: Record<string, unknown>) => {
@@ -248,8 +258,8 @@ export async function createVectorDB(dimensions: number = 768): Promise<VectorDB
   if (ruvectorModule && typeof ruvectorModule.createVectorDB === 'function') {
     try {
       return await ruvectorModule.createVectorDB(dimensions);
-    } catch {
-      // Fall back to simple implementation
+    } catch (err) {
+      console.warn('[vector-db] HNSW init failed, using brute-force fallback:', (err as Error).message);
     }
   }
 


### PR DESCRIPTION
## Summary

- HNSW was silently degrading to brute-force `FallbackVectorDB` on every startup
- Root cause: `new VectorDBClass({ dimensions })` — no `storagePath` — so the native binding defaulted to `agentdb.rvf` in CWD, which running daemons hold exclusively
- The constructor threw `"Database already open. Cannot acquire lock"`, the silent `catch {}` swallowed the error, and every search ran O(n) brute-force instead of HNSW
- The benchmark's `~1.0× speedup` and `recall@10 = 1.0` at every N were the signature of brute-force vs brute-force

## Fix (`v3/@claude-flow/cli/src/ruvector/vector-db.ts`)

1. Added `uniqueStoragePath()` — generates `os.tmpdir()/ruvector-<pid>-<rand>.rvf` so each adapter instance owns its own file and never contends with the daemon lock
2. Changed `new VectorDBClass({ dimensions })` → `new VectorDBClass({ dimensions, storagePath: uniqueStoragePath() })`
3. Made the fallback `catch {}` emit `console.warn` so any future HNSW init failure is visible

## Published

`@claude-flow/cli@3.7.0-alpha.82` and `claude-flow@3.7.0-alpha.82` shipped to npm with this fix.

## Test plan

- [ ] `npx @claude-flow/cli@latest` — HNSW activates (no `[vector-db] HNSW init failed` warning)
- [ ] Benchmark at N=5000 shows ≥2× speedup vs brute-force baseline

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)