### PR TITLE
chore(deps): sync package-lock.json via npm install --ignore-scripts on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.7.0-alpha.25",
+  "version": "3.7.0-alpha.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.7.0-alpha.25",
+      "version": "3.7.0-alpha.30",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "^3.7.0-alpha.5",


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` using `npm install --ignore-scripts`, bumping the recorded version from `3.7.0-alpha.25` to `3.7.0-alpha.30` to match the current `package.json`.
- Uses npm rather than pnpm, consistent with the npm-native `overrides` field already declared in `package.json`.
- `--ignore-scripts` skips native compilation of `better-sqlite3` (the Windows machine where this was run is missing the Python build toolchain). This is a lockfile-only change — no dependency versions, ranges, or resolutions were modified.

## Why
On this Windows environment, a vanilla `npm install` fails at the `better-sqlite3` node-gyp step, leaving the lockfile drifting from the current `3.7.0-alpha.30` release. Re-running with `--ignore-scripts` lets the lockfile resync so contributors on Windows can install dependencies without the native build prerequisite.

## Test plan
- [ ] CI green on `npm install` / `npm ci`
- [ ] No diff outside `package-lock.json`
- [ ] Reviewer confirms the version bump matches `package.json` (`3.7.0-alpha.30`)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)