### PR TITLE
fix(statusline): resolve globally-installed ruflo CLI version (Homebrew-aware)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/bug-cluster-2219-2226.test.ts
+++ b/v3/@claude-flow/cli/__tests__/bug-cluster-2219-2226.test.ts
@@ -45,6 +45,23 @@ describe('#2221 — statusline version probe covers global npm installs', () => 
     expect(SCRIPT).toContain("'marketplaces', 'ruflo', 'package.json'");
     expect(SCRIPT).toContain("'node_modules', 'ruflo', 'package.json'");
   });
+
+  // process.execPath is the *resolved* node path; on Homebrew it points into the
+  // versioned Cellar, not the prefix where global packages live — so the
+  // execPath-relative probe alone misses `npm i -g ruflo`. Probe known prefixes.
+  it('probes well-known global prefixes so Homebrew/global installs resolve', () => {
+    expect(SCRIPT).toContain('/opt/homebrew/lib/node_modules');
+    expect(SCRIPT).toContain('/usr/local/lib/node_modules');
+  });
+
+  // The installed CLI is what the user actually runs and upgrades via `npm i -g`;
+  // the marketplace checkout lags releases, so it must be a fallback, not first.
+  it('prefers an installed CLI over the lagging plugin marketplace checkout', () => {
+    const localProbe = SCRIPT.indexOf("'node_modules', 'ruflo', 'package.json'");
+    const marketProbe = SCRIPT.indexOf("'marketplaces', 'ruflo', 'package.json'");
+    expect(localProbe).toBeGreaterThanOrEqual(0);
+    expect(marketProbe).toBeGreaterThan(localProbe);
+  });
 });
 
 describe('#2215 — system_info and hooks_intelligence agree on flashAttention', () => {

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -362,30 +362,48 @@ function getCostFromStdin() {
 }
 
 // Read package version from the first package.json we find.
+// Precedence: the ruflo the user actually runs (project-local install, then a
+// global 'npm i -g' install) wins over the plugin marketplace checkout, which
+// lags npm releases and only refreshes on 'claude plugin marketplace update'.
 function getPkgVersion() {
   let ver = '3.6';
   try {
     const home = os.homedir();
     const pkgPaths = [
-      path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
+      // 1. Project-local install — what THIS project resolves.
       path.join(CWD, 'node_modules', '@claude-flow', 'cli', 'package.json'),
       path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
-      path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
     ];
-    // #2221: global installs (npm i -g ruflo) live outside CWD/node_modules, so the
-    // probes above all miss and the version falls back to the hard-coded default.
-    // Derive the global node_modules dir from the running node binary (no npm spawn —
-    // statusline renders often). Covers nvm/mise (bin/../lib/node_modules) and Windows
-    // (bin/node_modules) layouts.
+    // 2. Global install (npm i -g ruflo) — lives outside CWD/node_modules. Probe
+    // known global roots without spawning npm (statusline renders often). #2221
+    // probed only execPath-relative dirs, but process.execPath is the *resolved*
+    // node path, so on Homebrew it points into the versioned Cellar
+    // (…/Cellar/node/<v>/bin) while global packages live at the prefix
+    // (/opt/homebrew/lib/node_modules). List the well-known prefixes explicitly in
+    // addition to the execPath-relative layouts (nvm/mise/asdf/volta, Windows).
     try {
       const binDir = path.dirname(process.execPath);
-      for (const gm of [path.join(binDir, '..', 'lib', 'node_modules'), path.join(binDir, 'node_modules')]) {
+      const globalRoots = [
+        path.join(binDir, '..', 'lib', 'node_modules'), // *nix prefix (nvm/mise/asdf/volta/linux)
+        path.join(binDir, 'node_modules'),              // Windows
+        '/opt/homebrew/lib/node_modules',               // Homebrew (Apple Silicon)
+        '/usr/local/lib/node_modules',                  // Homebrew (Intel) / common Unix
+        '/usr/lib/node_modules',                        // some Linux distros
+      ];
+      if (process.env.npm_config_prefix) globalRoots.push(path.join(process.env.npm_config_prefix, 'lib', 'node_modules'));
+      if (process.env.APPDATA) globalRoots.push(path.join(process.env.APPDATA, 'npm', 'node_modules')); // Windows npm prefix
+      for (const gm of globalRoots) {
         pkgPaths.push(
           path.join(gm, 'ruflo', 'package.json'),
           path.join(gm, '@claude-flow', 'cli', 'package.json'),
         );
       }
     } catch { /* ignore */ }
+    // 3. Fallbacks: plugin marketplace checkout, then in-repo source checkout.
+    pkgPaths.push(
+      path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'package.json'),
+      path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
+    );
     for (const p of pkgPaths) {
       if (!fs.existsSync(p)) continue;
       try {


### PR DESCRIPTION
## Problem

The generated statusline shows a stale `RuFlo V…` number: after `npm i -g ruflo@latest`, the version in the bar doesn't change. It reads the version from the first `package.json` it finds in `getPkgVersion()` (`src/init/statusline-generator.ts`), and two issues compound:

1. **Homebrew (and any symlinked-node setup) is invisible to the global probe.** The `#2221` probe derives the global modules dir from `process.execPath`, but `process.execPath` is the *resolved* node path. On Homebrew, node lives in a versioned Cellar (`/opt/homebrew/Cellar/node/<v>/bin/node`), so `binDir/../lib/node_modules` points **inside the Cellar**, where global packages aren't. The actual global install lives at the prefix (`/opt/homebrew/lib/node_modules`), which was never probed. So a `npm i -g ruflo` install is never found on the most common macOS setup.

2. **The plugin marketplace checkout is probed first and wins.** `~/.claude/plugins/marketplaces/ruflo/package.json` is the first entry, and it's found first. That checkout lags npm releases and only refreshes on `claude plugin marketplace update` — so even when a newer global CLI is installed, the bar shows the older marketplace version.

Real-world repro (Homebrew, ARM): global CLI at `3.10.36`, marketplace checkout at `3.10.33` → bar shows `RuFlo V3.10.33`.

## Fix

In `getPkgVersion()`:

- **Probe the actually-installed CLI first** — project-local `node_modules`, then a global install. Global roots now list well-known prefixes explicitly (`/opt/homebrew/lib/node_modules`, `/usr/local/lib/node_modules`, `/usr/lib/node_modules`) **in addition to** the `execPath`-relative layouts (nvm/mise/asdf/volta on \*nix, Windows), plus optional `npm_config_prefix`/`APPDATA`. No `npm` spawn — the statusline renders frequently, so this stays a set of cheap `fs.existsSync` checks.
- **Demote the marketplace checkout to a fallback** (after local + global), with the in-repo `v3/@claude-flow/cli` source checkout last. This keeps plugin-only installs working (no CLI present → marketplace version shown) while making the bar reflect the CLI the user actually runs and upgrades.

## Design note for reviewers

The one behavioral change is **precedence**: the marketplace checkout is no longer probed first. This is deliberate and is the part that actually fixes the reported symptom — the header reads "RuFlo V…", which users expect to track the CLI they install/upgrade, and the marketplace checkout is the *least* up-to-date version source (lags releases, manual refresh). Happy to adjust ordering if maintainers prefer a different policy.

## Verification

- Ran the **real generator** through `tsx` and confirmed the emitted script contains `process.execPath`, the `'lib', 'node_modules'` layout, the marketplace probe, the local `ruflo` probe, **and** the new `/opt/homebrew/lib/node_modules` + `/usr/local/lib/node_modules` prefixes, with the local probe ordered before the marketplace probe.
- **End-to-end:** generated the `statusline.cjs` and ran it from a directory with no local install on Homebrew/ARM → now renders `RuFlo V3.10.36`, matching the installed global CLI.
- Extended `__tests__/bug-cluster-2219-2226.test.ts` (the `#2221` block) with two assertions: well-known global prefixes are probed, and an installed CLI is preferred over the marketplace checkout. The existing `#2221` assertions remain green (they're `toContain` checks; all four probed substrings are still present).

## Out of scope (follow-up)

The repo ships several **drifted** statusline copies — `v3/@claude-flow/cli/.claude/helpers/statusline.cjs` (and the published npm bundle) still use an older `RUFLO_VERSION` block with **no global probe at all**, while the generator has the `getPkgVersion` logic. They should be regenerated from the generator (or a build step enforced) so they don't diverge. Kept out of this PR to keep the review focused on the generator — the user-facing source of truth.
