### PR TITLE
Add project memory, PR template, and eval smoke tests

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -1,0 +1,29 @@
+# Project Memory — Ruflo (claude-flow)
+
+## Architecture
+- **Monorepo**: CLI + MCP server + plugins in one package
+- **Stack**: TypeScript, Vitest, Node.js
+- **Package names**: `@claude-flow/cli`, `claude-flow`, `ruflo` (all same package)
+- **Entry**: `src/index.ts` → compiled via `tsc`
+
+## Key Patterns
+- Domain-Driven Design with bounded contexts
+- Event sourcing for state changes
+- Hierarchical-mesh topology for swarm coordination
+- AgentDB with HNSW indexing for vector search
+- ONNX embeddings (all-MiniLM-L6-v2, 384 dims)
+
+## Agent Roles (16 typed + custom)
+- Core: coder, reviewer, tester, planner, researcher
+- Specialized: security-architect, security-auditor, memory-specialist, performance-engineer
+- Coordination: hierarchical-coordinator, mesh-coordinator, adaptive-coordinator
+- GitHub: pr-manager, code-review-swarm, issue-tracker, release-manager
+
+## MCP Tools
+- 314 tools across memory, swarm, agents, hive-mind, hooks, workers, security, neural
+
+## Testing
+- Framework: Vitest
+- Security tests: `v3/__tests__/security/`
+- Integration tests: `tests/`
+- Run: `npm test`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What does this PR do? Keep it to 1-3 sentences. -->
+
+## Changes
+
+<!-- Bullet list of key changes -->
+
+-
+
+## Test Plan
+
+<!-- How was this tested? -->
+
+- [ ] `npm test` passes
+- [ ] `npm run build` succeeds
+- [ ] Manual verification completed
+
+## Security
+
+<!-- Any security implications? -->
+
+- [ ] No secrets or credentials in diff
+- [ ] Input validation at system boundaries
+- [ ] No new dependencies with known CVEs

--- a/evals/smoke.test.ts
+++ b/evals/smoke.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+
+describe('CLI smoke tests', () => {
+  it('should show version', () => {
+    const output = execSync('npx @claude-flow/cli@latest --version', {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    expect(output).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it('should show help', () => {
+    const output = execSync('npx @claude-flow/cli@latest --help', {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    expect(output).toContain('claude-flow');
+  });
+});
+
+describe('MCP tool surface', () => {
+  it('should have memory tools registered', () => {
+    const output = execSync('npx @claude-flow/cli@latest memory --help', {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    expect(output).toContain('store');
+    expect(output).toContain('search');
+  });
+});
+
+describe('Security eval', () => {
+  it('should not contain hardcoded secrets in source', () => {
+    const result = execSync(
+      'grep -rn "AKIA\\|sk-[a-zA-Z0-9]\\{20,\\}\\|password\\s*=\\s*[\"\\x27][^\"\\x27]\\{8,\\}" src/ || true',
+      { encoding: 'utf-8', timeout: 10000 }
+    ).trim();
+    expect(result).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes 3 failing ECC harness audit checks, improving score from 29/39 to 35/39 (90%).

## Changes
- **Memory Persistence**: Add `.claude/memory.md` with architecture, patterns, agent roles
- **GitHub Integration**: Add `.github/PULL_REQUEST_TEMPLATE.md` with test plan and security checklist
- **Eval Coverage**: Add `evals/smoke.test.ts` with CLI smoke tests and secret-scan eval

## Test plan
- [x] ECC harness audit passes (35/39)
- [x] No secrets in diff (ggshield passed)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)