### PR TITLE
fix(memory): auto-memory cluster — frontmatter, _ paths, plugin lookup, embed default (#2281–#2285)

### DIFF
--- a/.claude/helpers/auto-memory-hook.mjs
+++ b/.claude/helpers/auto-memory-hook.mjs
@@ -130,16 +130,77 @@ class JsonFileBackend {
 // Resolve memory package path (local dev or npm installed)
 // ============================================================================
 
+/**
+ * Resolve a bundled package file (`<pkg>/<relativeFile>`) by trying, in order:
+ *   1. PROJECT_ROOT/v3/<pkg>/<relativeFile>           (monorepo dev layout)
+ *   2. CWD/node_modules/<pkg>/<relativeFile>          (user's project deps)
+ *   3. node_modules walk-up from PROJECT_ROOT
+ *   4. node_modules walk-up from CWD
+ *   5. Global npm prefix — checks the ruflo / claude-flow / @claude-flow/cli
+ *      bundles, AND the package installed globally on its own
+ *
+ * Returns the resolved absolute path, or null. See issue #2285.
+ */
+async function resolveBundledFile(pkg, relativeFile) {
+  const monorepo = join(PROJECT_ROOT, 'v3', pkg, relativeFile);
+  if (existsSync(monorepo)) return monorepo;
+
+  const cwd = process.env.CLAUDE_FLOW_CWD || process.cwd();
+  const inCwd = join(cwd, 'node_modules', pkg, relativeFile);
+  if (existsSync(inCwd)) return inCwd;
+
+  const walkUp = (start) => {
+    let dir = start;
+    while (dir && dir !== dirname(dir)) {
+      const candidate = join(dir, 'node_modules', pkg, relativeFile);
+      if (existsSync(candidate)) return candidate;
+      dir = dirname(dir);
+    }
+    return null;
+  };
+
+  const fromProject = walkUp(PROJECT_ROOT);
+  if (fromProject) return fromProject;
+
+  const fromCwd = walkUp(cwd);
+  if (fromCwd) return fromCwd;
+
+  // Global npm prefix fallback — handles `npm i -g ruflo` and friends, where
+  // the marketplace clone (PROJECT_ROOT) has no access to the bundled deps.
+  try {
+    const { execSync } = await import('child_process');
+    const npmPrefix = execSync('npm prefix -g', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (npmPrefix) {
+      // Both Unix (<prefix>/lib/node_modules) and Windows (<prefix>/node_modules)
+      const roots = [join(npmPrefix, 'lib', 'node_modules'), join(npmPrefix, 'node_modules')];
+      const wrappers = ['ruflo', 'claude-flow', join('@claude-flow', 'cli')];
+      for (const root of roots) {
+        for (const wrapper of wrappers) {
+          const candidate = join(root, wrapper, 'node_modules', pkg, relativeFile);
+          if (existsSync(candidate)) return candidate;
+        }
+        const direct = join(root, pkg, relativeFile);
+        if (existsSync(direct)) return direct;
+      }
+    }
+  } catch { /* npm not on PATH or no global install */ }
+
+  return null;
+}
+
 async function loadMemoryPackage() {
-  // Strategy 1: Local dev (built dist)
-  const localDist = join(PROJECT_ROOT, 'v3/@claude-flow/memory/dist/index.js');
-  if (existsSync(localDist)) {
+  // Strategy 1-5: locate dist/index.js across dev/installed/global layouts
+  const resolved = await resolveBundledFile('@claude-flow/memory', 'dist/index.js');
+  if (resolved) {
     try {
-      return await import(`file://${localDist}`);
+      return await import(`file://${resolved}`);
     } catch { /* fall through */ }
   }
 
-  // Strategy 2: Use createRequire for CJS-style resolution (handles nested node_modules
+  // Strategy 6: Use createRequire for CJS-style resolution (handles nested node_modules
   // when installed as a transitive dependency via npx ruflo / npx claude-flow)
   try {
     const { createRequire } = await import('module');
@@ -147,23 +208,10 @@ async function loadMemoryPackage() {
     return require('@claude-flow/memory');
   } catch { /* fall through */ }
 
-  // Strategy 3: ESM import (works when @claude-flow/memory is a direct dependency)
+  // Strategy 7: ESM import (works when @claude-flow/memory is a direct dependency)
   try {
     return await import('@claude-flow/memory');
   } catch { /* fall through */ }
-
-  // Strategy 4: Walk up from PROJECT_ROOT looking for @claude-flow/memory in any node_modules
-  let searchDir = PROJECT_ROOT;
-  const { parse } = await import('path');
-  while (searchDir !== parse(searchDir).root) {
-    const candidate = join(searchDir, 'node_modules', '@claude-flow', 'memory', 'dist', 'index.js');
-    if (existsSync(candidate)) {
-      try {
-        return await import(`file://${candidate}`);
-      } catch { /* fall through */ }
-    }
-    searchDir = dirname(searchDir);
-  }
 
   return null;
 }
@@ -223,7 +271,10 @@ async function doImport() {
   await backend.initialize();
 
   const bridgeConfig = {
-    workingDir: PROJECT_ROOT,
+    // Use Claude Code's invocation cwd (the user's project), not PROJECT_ROOT
+    // — PROJECT_ROOT resolves to the plugin clone when this hook runs from
+    // ~/.claude/plugins/marketplaces/ruflo/. See issue #2284.
+    workingDir: process.env.CLAUDE_FLOW_CWD || process.cwd(),
     syncMode: 'on-session-end',
   };
 
@@ -259,8 +310,8 @@ async function doImport() {
     // Bridge to AgentDB: store entries with ONNX vector embeddings for semantic search
     let vectorized = 0;
     try {
-      const cliDistPath = join(PROJECT_ROOT, 'v3/@claude-flow/cli/dist/src/memory/memory-initializer.js');
-      if (existsSync(cliDistPath)) {
+      const cliDistPath = await resolveBundledFile('@claude-flow/cli', 'dist/src/memory/memory-initializer.js');
+      if (cliDistPath) {
         const memInit = await import(`file://${cliDistPath}`);
         await memInit.initializeMemoryDatabase({ force: false, verbose: false });
 
@@ -313,7 +364,8 @@ async function doSync() {
   }
 
   const bridgeConfig = {
-    workingDir: PROJECT_ROOT,
+    // See doImport — must reflect the user's project, not PROJECT_ROOT (#2284)
+    workingDir: process.env.CLAUDE_FLOW_CWD || process.cwd(),
     syncMode: 'on-session-end',
   };
 
@@ -346,8 +398,8 @@ async function doSync() {
 
     // Flush intelligence patterns to disk (SONA + ReasoningBank)
     try {
-      const intPath = join(PROJECT_ROOT, 'v3/@claude-flow/cli/dist/src/memory/intelligence.js');
-      if (existsSync(intPath)) {
+      const intPath = await resolveBundledFile('@claude-flow/cli', 'dist/src/memory/intelligence.js');
+      if (intPath) {
         const intelligence = await import(`file://${intPath}`);
         if (intelligence.flushPatterns) {
           intelligence.flushPatterns();
@@ -391,8 +443,8 @@ async function doStatus() {
     const hasDb = existsSync(dbPath) || existsSync(swarmDbPath);
     console.log(`  AgentDB:        ${hasDb ? '✅ sql.js database exists' : '⏸ Not initialized'}`);
 
-    const intPath = join(PROJECT_ROOT, 'v3/@claude-flow/cli/dist/src/memory/intelligence.js');
-    if (existsSync(intPath)) {
+    const intPath = await resolveBundledFile('@claude-flow/cli', 'dist/src/memory/intelligence.js');
+    if (intPath) {
       const intelligence = await import(`file://${intPath}`);
       const stats = intelligence.getIntelligenceStats?.();
       if (stats) {
@@ -454,8 +506,8 @@ async function doImportAll() {
   // Load memory-initializer for vectorized storage
   let memInit = null;
   try {
-    const cliDistPath = join(PROJECT_ROOT, 'v3/@claude-flow/cli/dist/src/memory/memory-initializer.js');
-    if (existsSync(cliDistPath)) {
+    const cliDistPath = await resolveBundledFile('@claude-flow/cli', 'dist/src/memory/memory-initializer.js');
+    if (cliDistPath) {
       memInit = await import(`file://${cliDistPath}`);
       await memInit.initializeMemoryDatabase({ force: false, verbose: false });
     }

--- a/v3/@claude-flow/cli/src/commands/embeddings.ts
+++ b/v3/@claude-flow/cli/src/commands/embeddings.ts
@@ -708,7 +708,7 @@ const initCommand: Command = {
   name: 'init',
   description: 'Initialize embedding subsystem with ONNX model and hyperbolic config',
   options: [
-    { name: 'model', short: 'm', type: 'string', description: 'ONNX model ID', default: 'Xenova/all-MiniLM-L6-v2' },
+    { name: 'model', short: 'm', type: 'string', description: 'ONNX model ID', default: 'all-MiniLM-L6-v2' },
     { name: 'hyperbolic', type: 'boolean', description: 'Enable hyperbolic (Poincaré ball) embeddings', default: 'true' },
     { name: 'curvature', short: 'c', type: 'string', description: 'Poincaré ball curvature (use --curvature=-1 for negative)', default: '-1' },
     { name: 'download', short: 'd', type: 'boolean', description: 'Download model during init', default: 'true' },
@@ -717,13 +717,13 @@ const initCommand: Command = {
   ],
   examples: [
     { command: 'claude-flow embeddings init', description: 'Initialize with defaults' },
-    { command: 'claude-flow embeddings init --model Xenova/all-mpnet-base-v2', description: 'Use higher quality model' },
+    { command: 'claude-flow embeddings init --model all-mpnet-base-v2', description: 'Use higher quality model' },
     { command: 'claude-flow embeddings init --no-hyperbolic', description: 'Euclidean only' },
     { command: 'claude-flow embeddings init --curvature=-0.5', description: 'Custom curvature (use = for negative)' },
     { command: 'claude-flow embeddings init --force', description: 'Overwrite existing config' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const model = ctx.flags.model as string || 'Xenova/all-MiniLM-L6-v2';
+    const model = ctx.flags.model as string || 'all-MiniLM-L6-v2';
     const hyperbolic = ctx.flags.hyperbolic !== false;
     const download = ctx.flags.download !== false;
     const force = ctx.flags.force === true;

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -96,6 +96,15 @@ describe('resolveAutoMemoryDir', () => {
     expect(result).toContain('workspaces-my-project');
   });
 
+  it('should normalize underscores to dashes (issue #2282)', () => {
+    // Claude Code normalizes both `/` and `_` to `-` when computing the
+    // project key, so paths like /home/phil/A-Project/RX_ERP/ map to
+    // -home-phil-A-Project-RX-ERP, not -home-phil-A-Project-RX_ERP.
+    const result = resolveAutoMemoryDir('/home/phil/A-Project/RX_ERP');
+    expect(result).toContain('A-Project-RX-ERP');
+    expect(result).not.toContain('RX_ERP');
+  });
+
   it('should produce consistent paths for same input', () => {
     const a = resolveAutoMemoryDir('/workspaces/my-project');
     const b = resolveAutoMemoryDir('/workspaces/my-project');
@@ -148,8 +157,64 @@ Content of section two.
     expect(entries[1].heading).toBe('Section Two');
   });
 
-  it('should return empty array for content without ## headings', () => {
+  it('should fall back to single untitled entry when no ## headings or frontmatter (issue #2283)', () => {
+    // Pre-fix behavior was to return [] — we now emit one entry with the
+    // body as content so files without ## subheadings still import.
     const content = '# Only h1 heading\nSome text\n';
+    const entries = parseMarkdownEntries(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].heading).toBe('(untitled)');
+    expect(entries[0].content).toContain('# Only h1 heading');
+    expect(entries[0].content).toContain('Some text');
+  });
+
+  it('should parse YAML frontmatter + body as a single entry (issue #2283)', () => {
+    // Claude Code's auto-memory format: YAML frontmatter + free-text body,
+    // no ## sub-headings. Pre-fix this returned [] silently.
+    const content = `---
+name: GitHub identity for RX Platform
+description: Phil uses PrimitiveOne / one@primitive1.com for...
+type: user
+originSessionId: 753b313d-3414-abcd
+---
+For the RX Platform / RX_ERP project specifically:
+
+- **GitHub login**: \`PrimitiveOne\`
+- **GitHub email**: \`one@primitive1.com\`
+`;
+    const entries = parseMarkdownEntries(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].heading).toBe('GitHub identity for RX Platform');
+    expect(entries[0].content).toContain('GitHub login');
+    expect(entries[0].content).toContain('PrimitiveOne');
+    expect(entries[0].metadata.type).toBe('user');
+    expect(entries[0].metadata.description).toContain('Phil uses PrimitiveOne');
+    expect(entries[0].metadata.originSessionId).toBe('753b313d-3414-abcd');
+  });
+
+  it('should prefer ## headings over frontmatter fallback when both present', () => {
+    const content = `---
+name: Should be ignored when ## headings exist
+type: user
+---
+## Real Section
+Section content
+`;
+    const entries = parseMarkdownEntries(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].heading).toBe('Real Section');
+    expect(entries[0].content).toContain('Section content');
+  });
+
+  it('should return empty array for empty content', () => {
+    expect(parseMarkdownEntries('')).toHaveLength(0);
+  });
+
+  it('should return empty array when frontmatter has no body', () => {
+    const content = `---
+name: Frontmatter only
+---
+`;
     const entries = parseMarkdownEntries(content);
     expect(entries).toHaveLength(0);
   });
@@ -171,10 +236,6 @@ Line 3
     const content = '## Padded\n\n  Text here  \n\n';
     const entries = parseMarkdownEntries(content);
     expect(entries[0].content).toBe('Text here');
-  });
-
-  it('should handle empty content', () => {
-    expect(parseMarkdownEntries('')).toHaveLength(0);
   });
 });
 
@@ -927,7 +988,9 @@ Already in DB
       }));
     });
 
-    it('should handle files with no ## headings', async () => {
+    it('should import files with no ## headings as a single untitled entry (issue #2283)', async () => {
+      // Pre-#2283 the parser dropped these silently. Now a file with body but
+      // no sub-headings imports as one entry with the full body as content.
       fsSync.writeFileSync(
         path.join(testDir, 'empty.md'),
         '# Just a title\nSome text without sections\n',
@@ -935,7 +998,7 @@ Already in DB
       );
 
       const result = await bridge.importFromAutoMemory();
-      expect(result.imported).toBe(0);
+      expect(result.imported).toBe(1);
       expect(result.files).toContain('empty.md');
     });
   });

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -762,10 +762,11 @@ export function resolveAutoMemoryDir(workingDir: string): string {
   const gitRoot = findGitRoot(workingDir);
   const basePath = gitRoot || workingDir;
 
-  // Claude Code normalizes to forward slashes then replaces with dashes
-  // The leading dash IS preserved (e.g. /workspaces/foo -> -workspaces-foo)
+  // Claude Code normalizes to forward slashes then replaces both `/` and `_`
+  // with dashes (e.g. /workspaces/RX_ERP -> -workspaces-RX-ERP). The leading
+  // dash IS preserved.
   const normalized = basePath.split(path.sep).join('/');
-  const projectKey = normalized.replace(/\//g, '-');
+  const projectKey = normalized.replace(/[\/_]/g, '-');
 
   return path.join(
     process.env.HOME || process.env.USERPROFILE || '~',
@@ -795,17 +796,43 @@ export function findGitRoot(dir: string): string | null {
 
 /**
  * Parse markdown content into structured entries.
- * Splits on ## headings and extracts content under each.
+ *
+ * Three-tier strategy to handle both legacy topic files and Claude Code's
+ * native auto-memory format:
+ *  1. Strip YAML frontmatter if present and capture name/description/type.
+ *  2. Split body on `## ` headings (legacy MEMORY.md-style topic files).
+ *  3. If no `## ` headings were found, fall back to a single entry per file
+ *     using frontmatter.name as the heading (or `(untitled)`), the
+ *     post-frontmatter body as content, and frontmatter fields as metadata.
+ *
+ * Without (3), files like Claude Code's `~/.claude/projects/<key>/memory/*.md`
+ * (frontmatter + free-text body, no `## ` sub-headings) parse to zero entries
+ * and silently drop on import. See issue #2283.
  */
 export function parseMarkdownEntries(content: string): ParsedEntry[] {
   const entries: ParsedEntry[] = [];
-  const lines = content.split('\n');
+
+  // Strip YAML frontmatter and capture key fields.
+  const frontmatter: Record<string, string> = {};
+  let body = content;
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (fmMatch) {
+    body = fmMatch[2];
+    for (const fmLine of fmMatch[1].split(/\r?\n/)) {
+      const kv = fmLine.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+      if (kv) frontmatter[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, '');
+    }
+  }
+
+  const lines = body.split('\n');
   let currentHeading = '';
   let currentLines: string[] = [];
+  let sawHeading = false;
 
   for (const line of lines) {
     const headingMatch = line.match(/^##\s+(.+)/);
     if (headingMatch) {
+      sawHeading = true;
       if (currentHeading && currentLines.length > 0) {
         entries.push({
           heading: currentHeading,
@@ -826,6 +853,18 @@ export function parseMarkdownEntries(content: string): ParsedEntry[] {
       content: currentLines.join('\n').trim(),
       metadata: {},
     });
+  }
+
+  if (!sawHeading) {
+    const trimmedBody = body.trim();
+    if (trimmedBody) {
+      const heading = frontmatter.name || frontmatter.description || '(untitled)';
+      const metadata: Record<string, string> = {};
+      if (frontmatter.type) metadata.type = frontmatter.type;
+      if (frontmatter.description) metadata.description = frontmatter.description;
+      if (frontmatter.originSessionId) metadata.originSessionId = frontmatter.originSessionId;
+      entries.push({ heading, content: trimmedBody, metadata });
+    }
   }
 
   return entries;


### PR DESCRIPTION
## Summary

Fixes 5 related bugs in the SessionStart auto-memory pipeline, all filed by @PrimitiveOne on 2026-06-03. Each issue included a vetted patch — this PR applies them.

| Issue | Site | Fix |
|---|---|---|
| #2281 | `embeddings.ts` | Default model ID `Xenova/all-MiniLM-L6-v2` → `all-MiniLM-L6-v2` to match MODEL_REGISTRY keys and pass VALID_MODEL_ID_PATTERN |
| #2282 | `auto-memory-bridge.ts` | `resolveAutoMemoryDir` now strips `_` too (`RX_ERP` → `RX-ERP`), matching Claude Code's project-key normalization |
| #2283 | `auto-memory-bridge.ts` | `parseMarkdownEntries` now parses YAML frontmatter and falls back to single-entry-per-file, so Claude Code's native `frontmatter+body` format imports instead of dropping silently |
| #2284 | `auto-memory-hook.mjs` | `workingDir` now uses `CLAUDE_FLOW_CWD \|\| cwd()` instead of `PROJECT_ROOT` (which pointed at the plugin clone, not the user's project) |
| #2285 | `auto-memory-hook.mjs` | New `resolveBundledFile()` helper with global-npm-prefix fallback for `ruflo`, `claude-flow`, and `@claude-flow/cli` wrappers in both Unix and Windows layouts. Applied to all 4 `PROJECT_ROOT`-anchored package lookups |

## Files changed (4 files, +198/−44)

- `.claude/helpers/auto-memory-hook.mjs` — workingDir + lookup helper
- `v3/@claude-flow/memory/src/auto-memory-bridge.ts` — regex + parser
- `v3/@claude-flow/memory/src/auto-memory-bridge.test.ts` — 4 new tests, 2 updated (frontmatter, `_` normalization, fallback)
- `v3/@claude-flow/cli/src/commands/embeddings.ts` — default model ID (3 lines)

## Test plan

- [x] `npx vitest run src/auto-memory-bridge.test.ts` in `v3/@claude-flow/memory`: **77/78 pass** (1 pre-existing Windows-only `path.join` failure from `01efa7e0c8`, 2026-02-08, unrelated)
- [x] `node --check` on the modified hook: clean
- [x] No new errors at the changed lines in `embeddings.ts` (existing repo-wide TS errors are pre-existing dep-resolution issues unrelated to this 3-line edit)
- [ ] CI on Linux (where the Windows-portability test passes)
- [ ] Manual repro: after publish, `ruflo embeddings init` succeeds with no flags, SessionStart import finds memory files in a project path containing `_`, marketplace clone resolves bundled packages via `npm prefix -g`

## After-merge release plan

Per CLAUDE.md publishing rules, bumps + publishes will be:
- `@claude-flow/memory`: 3.0.0-alpha.18 → 3.0.0-alpha.19
- `@claude-flow/cli`: 3.10.33 → 3.10.37
- `claude-flow`: 3.10.33 → 3.10.37
- `ruflo`: 3.10.33 → 3.10.37

Closes #2281
Closes #2282
Closes #2283
Closes #2284
Closes #2285

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)