### PR TITLE
fix(ruvocal): faithful RvfGridFSBucket GridFS shim + allow wasm: scheme in isValidUrl

### DIFF
--- a/ruflo/src/ruvocal/src/lib/server/database/rvf.ts
+++ b/ruflo/src/ruvocal/src/lib/server/database/rvf.ts
@@ -16,6 +16,7 @@
 import { randomUUID } from "crypto";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
+import { Readable, Writable } from "stream";
 
 // ---------------------------------------------------------------------------
 // ObjectId compatibility
@@ -1022,41 +1023,59 @@ export class RvfGridFSBucket {
 		options?: { metadata?: Record<string, unknown>; contentType?: string }
 	) {
 		const id = randomUUID();
-		const chunks: string[] = [];
+		const chunks: Buffer[] = [];
+		const files = this.files;
 
-		return {
-			id: new ObjectId(id),
-			write(chunk: Buffer | string) {
-				chunks.push(
-					typeof chunk === "string" ? chunk : chunk.toString("base64")
-				);
+		// objectMode so callers may pass ArrayBuffer/Uint8Array/Buffer/string
+		// (uploadFile.ts hands us an ArrayBuffer cast to Buffer).
+		const stream = new Writable({
+			objectMode: true,
+			write(chunk, _enc, cb) {
+				try {
+					chunks.push(
+						typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk as ArrayBufferLike)
+					);
+					cb();
+				} catch (e) {
+					cb(e as Error);
+				}
 			},
-			end: async () => {
-				const data = chunks.join("");
-				this.files.set(id, {
-					_id: id,
-					filename,
-					contentType: options?.contentType ?? "application/octet-stream",
-					length: data.length,
-					data,
-					metadata: options?.metadata ?? {},
-					createdAt: new Date(),
-				});
-				scheduleSave();
+			final(cb) {
+				try {
+					const data = Buffer.concat(chunks).toString("base64");
+					files.set(id, {
+						_id: id,
+						filename,
+						contentType: options?.contentType ?? "application/octet-stream",
+						length: data.length,
+						data,
+						metadata: options?.metadata ?? {},
+						createdAt: new Date(),
+					});
+					scheduleSave();
+					cb();
+				} catch (e) {
+					cb(e as Error);
+				}
 			},
-		};
+		});
+		(stream as unknown as { id: ObjectId }).id = new ObjectId(id);
+		return stream;
 	}
 
 	openDownloadStream(id: ObjectId | string) {
 		const fileId = typeof id === "string" ? id : id.toString();
-		const files = this.files;
-		return {
-			async toArray(): Promise<Buffer[]> {
-				const file = files.get(fileId);
-				if (!file) throw new Error("File not found");
-				return [Buffer.from(file.data as string, "base64")];
-			},
-		};
+		const file = this.files.get(fileId);
+		if (!file) {
+			// Match MongoDB GridFS (and the prior shim): a missing file is an
+			// error. Surface it on the stream so callers see it via either
+			// .on("error") or a rejected .toArray(), rather than silently
+			// yielding zero bytes.
+			const missing = new Readable({ read() {} });
+			missing.destroy(new Error("File not found"));
+			return missing;
+		}
+		return Readable.from([Buffer.from(file.data as string, "base64")]);
 	}
 
 	async delete(id: ObjectId | string) {
@@ -1065,7 +1084,7 @@ export class RvfGridFSBucket {
 		scheduleSave();
 	}
 
-	async find(filter: Record<string, unknown> = {}) {
+	find(filter: Record<string, unknown> = {}) {
 		const results: Record<string, unknown>[] = [];
 		for (const doc of this.files.values()) {
 			if (matchesFilter(doc, filter)) {
@@ -1073,6 +1092,10 @@ export class RvfGridFSBucket {
 				results.push(meta);
 			}
 		}
-		return { toArray: async () => results };
+		let i = 0;
+		return {
+			next: async () => (i < results.length ? results[i++] : null),
+			toArray: async () => results,
+		};
 	}
 }

--- a/ruflo/src/ruvocal/src/lib/server/urlSafety.ts
+++ b/ruflo/src/ruvocal/src/lib/server/urlSafety.ts
@@ -37,6 +37,7 @@ function isUnsafeIp(address: string): boolean {
 export function isValidUrl(urlString: string): boolean {
 	try {
 		const url = new URL(urlString.trim());
+		if (url.protocol === "wasm:") return true;
 		const hostname = url.hostname.toLowerCase();
 		// Allow HTTP for localhost/loopback/Docker-internal (dev & local MCP bridge)
 		if (


### PR DESCRIPTION
## Summary

Two independent fixes to the RVF-backed ChatUI (ruvocal), both currently carried as out-of-tree patches in our deployment. They're unrelated and a reviewer can take either on its own; happy to split into two PRs if you'd prefer.

### 1. `RvfGridFSBucket` is an incomplete GridFS shim → file upload/download/fork all 500

`src/lib/server/database.ts` hardcodes the RVF backend (`new RvfGridFSBucket()`), and that class is a shim mimicking MongoDB's `GridFSBucket` so the chat-ui file callers keep compiling. The mimicry is incomplete in three ways, and every Mongo-era caller breaks at runtime:

1. **`openUploadStream` was not a `Writable`** — it returned `{ id, write, end }`. `files/uploadFile.ts` does `upload.once("finish"/"error", …)` → `TypeError: upload.once is not a function` → HTTP 500 on every attachment upload.
2. **Silent corruption** — `uploadFile.ts` passes an `ArrayBuffer` (cast to `Buffer`). The old `write()` did `chunk.toString("base64")` on it, persisting the literal string `"[object ArrayBuffer]"`. (A naïve default-mode `Writable` would instead throw `ERR_INVALID_ARG_TYPE` on the `ArrayBuffer`.)
3. **`openDownloadStream` was not a `Readable`, `find()` was mis-shaped** — `openDownloadStream` returned `{ toArray }` (no `.on`/`.pipe`); `find()` was `async` returning `{ toArray }` with no `.next()`. `files/downloadFile.ts` and `routes/conversation` (copy-on-fork) call these as real streams/cursors *without awaiting `find`*, so reading a file back and forking a shared conversation with attachments each 500 independently.

(2) and (3) were latent because those paths only run once files exist, and uploads never succeeded — so fixing only `openUploadStream` surfaces the next crash rather than working.

**Fix** (one file, zero caller changes):
- `openUploadStream` returns a real **objectMode** `Writable` that coerces each chunk via `Buffer.from` (absorbs `ArrayBuffer`/`Uint8Array`/`Buffer`/`string`), persists on `final`, and carries `.id` — so `.once("finish")`, `.write()`, `.end()`, and `.pipe()` all work.
- `openDownloadStream` returns a real `Readable` via `Readable.from`.
- `find()` is synchronous and returns a cursor exposing both `next()` and `toArray()`.

Storage stays base64 (download decodes → `downloadFile` re-encodes for its `{type:"base64"}` return; round-trip preserved). Verified end-to-end against a live deployment: `ArrayBuffer` upload → `finish` → byte-exact base64 round-trip → `.pipe()` copy-on-fork, plus an HTTP multipart upload + `downloadFile()` read-back.

### 2. `isValidUrl` rejects the `wasm:` scheme → browser-local MCP silently soft-bricks autopilot

ruvocal advertises an in-browser WASM MCP server ("RVAgent Local") to clients as `url: "wasm://local"`, and the SPA selects it by default when no other MCP is configured. On every chat submit the server runs each selected MCP URL through `isValidUrl()`, which only permits http/https against safe hostnames — correct SSRF prevention for HTTP MCPs, but wrong for a scheme the server never fetches (the browser hosts the module). `wasm://local` is rejected, `runMcpFlow` strips it, sees zero valid servers, returns `"not_applicable"`; with autopilot ON the client then silently refuses to fire the POST — pick a model, type, hit send, nothing happens, no 4xx/5xx, no toast.

**Fix:** early-return `true` for `url.protocol === "wasm:"`. HTTP/HTTPS SSRF checks unchanged.

## Test plan

- Attach an image in the ChatUI with a multimodal model → response, **no 500**, no `upload.once`/`ERR_INVALID_ARG_TYPE` in the server log; re-open the conversation and confirm the image renders (exercises the read path).
- Fork/continue from a shared conversation that has a file attachment (exercises the `.pipe()` copy path).
- With only the WASM MCP selected + autopilot on, a chat submit no longer silently no-ops; no `rejected … wasm` / `all selected MCP servers rejected` warnings.


### Existing test compatibility
The repo's `src/lib/server/database/__tests__/rvf.spec.ts` `RvfGridFSBucket` block passes unchanged on Node 22:
- `upload and download` — `openUploadStream` is now a real `Writable`; `await stream.end()` settles before the subsequent `openDownloadStream(...).toArray()`.
- `delete file` — `openDownloadStream` on a missing file surfaces a `"File not found"` error on the stream (GridFS semantics, as the prior shim did via `toArray()`), so `.rejects.toThrow("File not found")` still holds. (It does **not** silently return an empty stream.)
