### PR TITLE
fix(init): correct MCP allow rule mcp__claude-flow__:* -> mcp__claude-flow__*  Fixes #2302

### DIFF
--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -33,7 +33,7 @@ export function generateSettings(options: InitOptions): object {
       'Bash(npx @claude-flow*)',
       'Bash(npx claude-flow*)',
       'Bash(node .claude/*)',
-      'mcp__claude-flow__:*',
+      'mcp__claude-flow__*',
     ],
     deny: [
       'Read(./.env)',


### PR DESCRIPTION
Fixes #2302. One-character fix in settings-generator.ts: removes stray colon from mcp__claude-flow__:* -> mcp__claude-flow__*. No other occurrences in codebase (verified via GitNexus Cypher). No tests affected.