### PR TITLE
fix(security): declare ed25519 runtime dependency

### DIFF
--- a/v3/@claude-flow/security/package.json
+++ b/v3/@claude-flow/security/package.json
@@ -14,6 +14,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@noble/ed25519": "^2.0.0",
     "bcryptjs": "^3.0.3",
     "zod": "^3.22.0"
   },

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -520,6 +520,9 @@ importers:
 
   '@claude-flow/security':
     dependencies:
+      '@noble/ed25519':
+        specifier: ^2.0.0
+        version: 2.3.0
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3


### PR DESCRIPTION
Closes #2311.

`v3/@claude-flow/security/src/plugins/integrity-verifier.ts` dynamically imports `@noble/ed25519`, but the `@claude-flow/security` package did not declare that dependency itself. Root-level dependencies do not make the package self-contained for workspace/source-only builds, and the current CI failure is TS2307 from the security package build.

This declares `@noble/ed25519` directly in `v3/@claude-flow/security/package.json` and syncs the `v3/pnpm-lock.yaml` importer entry to the already-resolved `2.3.0` package. This should also address the dependency-search-path portion of #2313.

Validation:
- Parsed the updated `v3/@claude-flow/security/package.json` as JSON.
- Verified `v3/pnpm-lock.yaml` now lists `@noble/ed25519` under the `@claude-flow/security` importer with specifier `^2.0.0` and version `2.3.0`.
- Confirmed current main imports `@noble/ed25519` from `integrity-verifier.ts` while the package only declared `bcryptjs` and `zod` before this change.