### PR TITLE
fix(arena): post-merge review patches for #2315 (5 items)

### DIFF
--- a/plugins/ruflo-arena/src/engine/evolution.ts
+++ b/plugins/ruflo-arena/src/engine/evolution.ts
@@ -67,19 +67,25 @@ export function coevolve(game: GameSpec, opts: CoevolveOptions = {}): Coevolutio
 
   let a = randomFSM(game, rng, startStates, 'A');
   let b = randomFSM(game, rng, startStates, 'B');
-  const h2hA = () => meanPayoff(game, a, b, rounds, evalSeed);
 
-  const curve: CoevolutionResult['curve'] = [{ gen: 0, side: 'init', payoffA: h2hA() }];
+  // Cache the current (A vs B) baseline so each generation runs ONE match
+  // (the candidate's), not three (candidate + old baseline + curve sample).
+  // Numerically identical — the seed is fixed — but ~3x fewer matches per gen.
+  let baseline = meanPayoff(game, a, b, rounds, evalSeed);
+
+  const curve: CoevolutionResult['curve'] = [{ gen: 0, side: 'init', payoffA: baseline }];
   for (let g = 1; g <= generations; g++) {
     if (g % 2 === 1) {
       const cand = mutate(a, game, rng);
-      if (meanPayoff(game, cand, b, rounds, evalSeed) >= meanPayoff(game, a, b, rounds, evalSeed)) a = cand;
+      const candFit = meanPayoff(game, cand, b, rounds, evalSeed);
+      if (candFit >= baseline) { a = cand; baseline = candFit; }
     } else {
       const cand = mutate(b, game, rng);
-      // B wants to minimise A's payoff (equivalently maximise its own in a 2-player game)
-      if (meanPayoff(game, a, cand, rounds, evalSeed) <= meanPayoff(game, a, b, rounds, evalSeed)) b = cand;
+      // B wants to MINIMISE A's payoff (zero-sum in a 2-player setting).
+      const candFit = meanPayoff(game, a, cand, rounds, evalSeed);
+      if (candFit <= baseline) { b = cand; baseline = candFit; }
     }
-    curve.push({ gen: g, side: g % 2 === 1 ? 'A' : 'B', payoffA: h2hA() });
+    curve.push({ gen: g, side: g % 2 === 1 ? 'A' : 'B', payoffA: baseline });
   }
   return { a, b, curve, generations };
 }

--- a/plugins/ruflo-arena/src/engine/tournament.ts
+++ b/plugins/ruflo-arena/src/engine/tournament.ts
@@ -15,9 +15,14 @@ export function runTournament(game: GameSpec, roster: Strategy[], opts: Tourname
   const names = roster.map((s) => s.name);
   const n = roster.length;
 
+  // Self-matches (i === j) are skipped when `includeSelf=false` — they're
+  // also excluded from `meanVsField` below, so computing them would just be
+  // wasted work. The diagonal stays at 0 in that mode (consumers can rely
+  // on `includeSelf` to interpret it).
   const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
   for (let i = 0; i < n; i++) {
     for (let j = 0; j < n; j++) {
+      if (!includeSelf && i === j) continue;
       matrix[i][j] = meanPayoff(game, roster[i], roster[j], rounds, seed);
     }
   }

--- a/plugins/ruflo-arena/src/mcp-tools/index.ts
+++ b/plugins/ruflo-arena/src/mcp-tools/index.ts
@@ -195,9 +195,16 @@ export function createArenaTools(store: RunStore): MCPTool[] {
             startStates: args.startStates,
           });
           const payoffs = r.curve.map((c) => c.payoffA);
+          // Single-pass scan avoids Math.min/max(...spread) — the spread
+          // form hits V8's argument-count limit (~16k) for long curves.
+          let minP = Infinity, maxP = -Infinity;
+          for (const p of payoffs) {
+            if (p < minP) minP = p;
+            if (p > maxP) maxP = p;
+          }
           const summary = {
             generations: r.generations,
-            payoffRange: [Math.min(...payoffs), Math.max(...payoffs)] as [number, number],
+            payoffRange: [minP, maxP] as [number, number],
             finalPayoffA: payoffs[payoffs.length - 1],
           };
           const result = { game: game.name, ...summary, sparkline: sparkline(payoffs) };
@@ -243,7 +250,14 @@ export function createArenaTools(store: RunStore): MCPTool[] {
   ];
 }
 
-/** Default tool set, persisting to `.ruflo/arena/` on disk. */
+/**
+ * Default tool set, persisting to `.ruflo/arena/` under the process CWD.
+ *
+ * For hosts that need to control the on-disk location (test sandboxes, multi-tenant
+ * runtimes, in-memory only), prefer the {@link createArenaTools} factory with an
+ * explicit {@link RunStore} — e.g. `createArenaTools(new InMemoryRunStore())` for
+ * tests, or `createArenaTools(new FileRunStore('/custom/path'))` for relocation.
+ */
 export const arenaTools: MCPTool[] = createArenaTools(new FileRunStore());
 
 // Re-export Zod schemas so hosts can introspect/validate independently.

--- a/plugins/ruflo-arena/src/persistence/run-store.ts
+++ b/plugins/ruflo-arena/src/persistence/run-store.ts
@@ -101,17 +101,27 @@ export class FileRunStore implements RunStore {
  * Shape a run for AgentDB persistence via `mcp__claude-flow__memory_store`.
  * The command layer calls the MCP tool with this payload so runs become semantically
  * searchable ("tournaments where grim dominated") and feed the RuVector data layer later.
+ *
+ * `kind`, `game`, and `seed` are lifted to top-level fields (parallel to `tags`)
+ * so RuVector ADR-197 indexers can filter without re-parsing `value`. `value`
+ * itself still carries the full summary for body-level semantic search.
  */
 export function agentdbRecord(record: RunRecord): {
   namespace: string;
   key: string;
+  kind: RunKind;
+  game: string;
+  seed: number;
   value: string;
   tags: string[];
 } {
   return {
     namespace: 'arena',
     key: record.runId,
-    value: JSON.stringify({ kind: record.kind, game: record.game, seed: record.seed, ...record.summary }),
+    kind: record.kind,
+    game: record.game,
+    seed: record.seed,
+    value: JSON.stringify(record.summary),
     tags: ['ruliology', 'competition', record.kind, record.game],
   };
 }


### PR DESCRIPTION
Follow-up to Ofer's ruflo-arena merge (#2315). Applies the 5 review items posted at https://github.com/ruvnet/ruflo/pull/2315#issuecomment-4650114965.

## Summary

| # | File | Change |
|---|---|---|
| 1 | \`src/engine/evolution.ts\` | \`coevolve\` caches the (A vs B) baseline → 1 match/gen instead of 3 (numerically identical, deterministic seed) |
| 2 | \`src/engine/tournament.ts\` | Skip the n self-matches when \`includeSelf=false\`; diagonal stays at 0 in that mode |
| 3 | \`src/mcp-tools/index.ts\` | \`Math.min/max(...payoffs)\` → single-pass scan (avoids V8 spread-args cap on long curves) |
| 4 | \`src/mcp-tools/index.ts\` | JSDoc on the \`arenaTools\` singleton calling out \`createArenaTools(store)\` for hosts that need to control persistence |
| 5 | \`src/persistence/run-store.ts\` | \`agentdbRecord()\` lifts \`kind\`/\`game\`/\`seed\` to top-level so RuVector ADR-197 indexers can filter without parsing \`value\` |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — 4 suites / 23 tests pass
- [x] \`npm run lint\` clean

Stats: 4 files · +44 −9 lines.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)