### PR TITLE
docs: fix typo "ruvflo" -> "ruflo" in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Orchestrate 100+ specialized AI agents across machines, teams, and trust boundar
 
 ### What Ruflo Does
 
-One `npx ruvflo init` gives Claude Code a nervous system: agents self-organize into swarms, learn from every task, remember across sessions, and — with federation — securely talk to agents on other machines without leaking data. You keep writing code. Ruflo handles the coordination.
+One `npx ruflo init` gives Claude Code a nervous system: agents self-organize into swarms, learn from every task, remember across sessions, and — with federation — securely talk to agents on other machines without leaking data. You keep writing code. Ruflo handles the coordination.
 
 ```
 Self-Learning / Self-Optimizing Agent Architecture

--- a/ruflo/README.md
+++ b/ruflo/README.md
@@ -35,7 +35,7 @@ Orchestrate 100+ specialized AI agents across machines, teams, and trust boundar
 
 ### What Ruflo Does
 
-One `npx ruvflo init` gives Claude Code a nervous system: agents self-organize into swarms, learn from every task, remember across sessions, and — with federation — securely talk to agents on other machines without leaking data. You keep writing code. Ruflo handles the coordination.
+One `npx ruflo init` gives Claude Code a nervous system: agents self-organize into swarms, learn from every task, remember across sessions, and — with federation — securely talk to agents on other machines without leaking data. You keep writing code. Ruflo handles the coordination.
 
 ```
 Self-Learning / Self-Optimizing Agent Architecture

--- a/v3/@claude-flow/cli/README.md
+++ b/v3/@claude-flow/cli/README.md
@@ -35,7 +35,7 @@ Orchestrate 100+ specialized AI agents across machines, teams, and trust boundar
 
 ### What Ruflo Does
 
-One `npx ruvflo init` gives Claude Code a nervous system: agents self-organize into swarms, learn from every task, remember across sessions, and — with federation — securely talk to agents on other machines without leaking data. You keep writing code. Ruflo handles the coordination.
+One `npx ruflo init` gives Claude Code a nervous system: agents self-organize into swarms, learn from every task, remember across sessions, and — with federation — securely talk to agents on other machines without leaking data. You keep writing code. Ruflo handles the coordination.
 
 ```
 Self-Learning / Self-Optimizing Agent Architecture


### PR DESCRIPTION
## Summary

- The intro paragraph in three READMEs referenced the package as `npx ruvflo init`, but the correct command is `npx ruflo init` (used in the very next section of the same file).
- Single-character fix in three locations — no functional changes.

## Files changed

- `README.md`
- `ruflo/README.md`
- `v3/@claude-flow/cli/README.md`

## Test plan

- [x] Confirmed `ruvflo` no longer appears in repository READMEs (`grep -rn 'ruvflo' --include='*.md'` returns only ADR-047 mentions of `ruvflow` with a `w`, which is a different keyword and left untouched)
- [x] Confirmed `npx ruflo init` is the form used elsewhere in the same files

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)