### PR TITLE
fix: community bug batch — session atomic writes (#2307), hive-mind await (#2297), statusline storm (#2337)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -42,10 +42,51 @@ const CONFIG = {
 const CWD = process.cwd();
 
 // ─── Delegation cache ───────────────────────────────────────────
-// Cache the CLI JSON result for 10s so rapid prompt re-renders
-// (e.g. every keypress in some shells) don't re-invoke npx each time.
+// Cache the CLI JSON result for 60s so rapid prompt re-renders
+// (Claude Code refreshes the statusline several times a second while
+// streaming) don't re-invoke the CLI each time. #2337: bumped 10s→60s
+// because 10s was far too short for how often Claude Code re-renders.
 const CACHE_FILE = path.join(os.tmpdir(), 'ruflo-statusline-cache-' + require('crypto').createHash('md5').update(CWD).digest('hex').slice(0, 8) + '.json');
-const CACHE_TTL_MS = 10000;
+const CACHE_TTL_MS = 60000;
+
+// #2337: resolve an already-installed @claude-flow/cli (or ruflo) bin so we
+// can invoke it directly via `node`. The previous version called
+// `npx --yes @claude-flow/cli@latest` on every uncached render, which forces
+// a registry resolution + cold-start of the entire CLI per render. With
+// multiple concurrent Claude Code sessions this storms the host (reporter
+// saw load average 40-65 on a 12-core box).
+//
+// Returns the absolute path to bin/cli.js or null. Mirrors getPkgVersion()'s
+// path probing (project, monorepo, plugin marketplace, global node_modules
+// including custom-prefix layouts like ~/.npm-global).
+function resolveCliBin() {
+  try {
+    const home = os.homedir();
+    const candidates = [
+      path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'bin', 'cli.js'),
+      path.join(CWD, 'node_modules', '@claude-flow', 'cli', 'bin', 'cli.js'),
+      path.join(CWD, 'node_modules', 'ruflo', 'bin', 'cli.js'),
+      path.join(CWD, 'v3', '@claude-flow', 'cli', 'bin', 'cli.js'),
+    ];
+    try {
+      const binDir = path.dirname(process.execPath);
+      const globalModuleDirs = [path.join(binDir, '..', 'lib', 'node_modules'), path.join(binDir, 'node_modules')];
+      for (const prefix of [process.env.npm_config_prefix, process.env.PREFIX, path.join(home, '.npm-global')]) {
+        if (prefix) globalModuleDirs.push(path.join(prefix, 'lib', 'node_modules'));
+      }
+      for (const gm of globalModuleDirs) {
+        candidates.push(
+          path.join(gm, 'ruflo', 'bin', 'cli.js'),
+          path.join(gm, '@claude-flow', 'cli', 'bin', 'cli.js'),
+        );
+      }
+    } catch { /* ignore */ }
+    for (const p of candidates) {
+      if (fs.existsSync(p)) return p;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
 
 function readCache() {
   try {
@@ -76,8 +117,16 @@ function getStatuslineData() {
   if (cached) return cached;
 
   try {
+    // #2337: prefer an already-installed CLI bin via direct `node` invocation
+    // — no npx, no registry round-trip, no @latest re-resolve per render.
+    // Fall back to `npx --prefer-offline @claude-flow/cli` (no @latest) only
+    // when nothing is installed locally, so a cold environment still works.
+    const cliBin = resolveCliBin();
+    const cmd = cliBin
+      ? '"' + process.execPath + '" "' + cliBin + '" hooks statusline --json 2>/dev/null'
+      : 'npx --prefer-offline @claude-flow/cli hooks statusline --json 2>/dev/null';
     const raw = execSync(
-      'npx --yes @claude-flow/cli@latest hooks statusline --json 2>/dev/null',
+      cmd,
       { encoding: 'utf-8', timeout: 8000, stdio: ['pipe', 'pipe', 'pipe'], cwd: CWD }
     ).trim();
     // The CLI may emit preamble lines before the JSON — find the first '{'.

--- a/v3/@claude-flow/cli/.claude/helpers/session.js
+++ b/v3/@claude-flow/cli/.claude/helpers/session.js
@@ -10,6 +10,20 @@ const path = require('path');
 const SESSION_DIR = path.join(process.cwd(), '.claude-flow', 'sessions');
 const SESSION_FILE = path.join(SESSION_DIR, 'current.json');
 
+// #2307: Atomic write — serialize to a per-process temp file, then rename()
+// into place. rename() is atomic on the same filesystem, so concurrent writers
+// (session-restore, metric, daemon workers, teammates) can't interleave partial
+// content. Without this, two non-atomic writeFileSync calls can race so that a
+// shorter payload overwrites a longer one in place, leaving the longer payload's
+// tail dangling past the end (valid JSON + trailing garbage = parse error).
+// Temp name includes process.pid so concurrent writers don't collide on it.
+// Same class as #1707 (metrics) / #1637 (daemon-state) — session.js was missed.
+function atomicWrite(file, data) {
+  const tmp = `${file}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, file);
+}
+
 const commands = {
   start: () => {
     const sessionId = `session-${Date.now()}`;
@@ -27,7 +41,7 @@ const commands = {
     };
 
     fs.mkdirSync(SESSION_DIR, { recursive: true });
-    fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+    atomicWrite(SESSION_FILE, JSON.stringify(session, null, 2));
 
     console.log(`Session started: ${sessionId}`);
     return session;
@@ -39,9 +53,17 @@ const commands = {
       return null;
     }
 
-    const session = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
+    let session;
+    try {
+      session = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
+    } catch (e) {
+      // #2307: corrupted session file (e.g. from a pre-atomic-write race).
+      // Don't throw — start a fresh session so the hook recovers cleanly.
+      console.log(`Session file corrupted (${e.message}); starting fresh`);
+      return commands.start();
+    }
     session.restoredAt = new Date().toISOString();
-    fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+    atomicWrite(SESSION_FILE, JSON.stringify(session, null, 2));
 
     console.log(`Session restored: ${session.id}`);
     return session;
@@ -59,7 +81,7 @@ const commands = {
 
     // Archive session
     const archivePath = path.join(SESSION_DIR, `${session.id}.json`);
-    fs.writeFileSync(archivePath, JSON.stringify(session, null, 2));
+    atomicWrite(archivePath, JSON.stringify(session, null, 2));
     fs.unlinkSync(SESSION_FILE);
 
     console.log(`Session ended: ${session.id}`);
@@ -95,7 +117,7 @@ const commands = {
     const session = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
     session.context[key] = value;
     session.updatedAt = new Date().toISOString();
-    fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+    atomicWrite(SESSION_FILE, JSON.stringify(session, null, 2));
 
     return session;
   },
@@ -116,7 +138,7 @@ const commands = {
     const session = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
     if (session.metrics[name] !== undefined) {
       session.metrics[name]++;
-      fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+      atomicWrite(SESSION_FILE, JSON.stringify(session, null, 2));
     }
 
     return session;

--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -363,7 +363,21 @@ async function spawnClaudeCodeInstance(
       output.printInfo('The Queen coordinator will orchestrate all worker agents');
       output.writeln(output.dim(`Prompt file saved at: ${promptFile}`));
 
-      return { success: true, promptFile };
+      // #2297: await child exit before returning. Without this, the CLI
+      // process resolves immediately, finishes, and the still-initializing
+      // `claude` child loses its controlling terminal and is killed mid-launch
+      // — visible as a stray XTVERSION reply leaking onto the next shell
+      // prompt (the terminal queried for capabilities, but the child died
+      // before reading the answer). Awaiting also makes the existing
+      // claudeProcess.on('exit', ...) log lines actually print, and lets the
+      // non-interactive (-p / --non-interactive) path complete only after
+      // Claude Code finishes.
+      const claudeExitCode = await new Promise<number>((resolve) => {
+        claudeProcess.on('exit', (c) => resolve(c ?? 0));
+        claudeProcess.on('error', () => resolve(1));
+      });
+
+      return { success: claudeExitCode === 0, promptFile };
     } else if (dryRun) {
       output.writeln();
       output.printInfo('Dry run - would execute Claude Code with prompt:');

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -69,10 +69,51 @@ const CONFIG = {
 const CWD = process.cwd();
 
 // ─── Delegation cache ───────────────────────────────────────────
-// Cache the CLI JSON result for 10s so rapid prompt re-renders
-// (e.g. every keypress in some shells) don't re-invoke npx each time.
+// Cache the CLI JSON result for 60s so rapid prompt re-renders
+// (Claude Code refreshes the statusline several times a second while
+// streaming) don't re-invoke the CLI each time. #2337: bumped 10s→60s
+// because 10s was far too short for how often Claude Code re-renders.
 const CACHE_FILE = path.join(os.tmpdir(), 'ruflo-statusline-cache-' + require('crypto').createHash('md5').update(CWD).digest('hex').slice(0, 8) + '.json');
-const CACHE_TTL_MS = 10000;
+const CACHE_TTL_MS = 60000;
+
+// #2337: resolve an already-installed @claude-flow/cli (or ruflo) bin so we
+// can invoke it directly via \`node\`. The previous version called
+// \`npx --yes @claude-flow/cli@latest\` on every uncached render, which forces
+// a registry resolution + cold-start of the entire CLI per render. With
+// multiple concurrent Claude Code sessions this storms the host (reporter
+// saw load average 40-65 on a 12-core box).
+//
+// Returns the absolute path to bin/cli.js or null. Mirrors getPkgVersion()'s
+// path probing (project, monorepo, plugin marketplace, global node_modules
+// including custom-prefix layouts like ~/.npm-global).
+function resolveCliBin() {
+  try {
+    const home = os.homedir();
+    const candidates = [
+      path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'bin', 'cli.js'),
+      path.join(CWD, 'node_modules', '@claude-flow', 'cli', 'bin', 'cli.js'),
+      path.join(CWD, 'node_modules', 'ruflo', 'bin', 'cli.js'),
+      path.join(CWD, 'v3', '@claude-flow', 'cli', 'bin', 'cli.js'),
+    ];
+    try {
+      const binDir = path.dirname(process.execPath);
+      const globalModuleDirs = [path.join(binDir, '..', 'lib', 'node_modules'), path.join(binDir, 'node_modules')];
+      for (const prefix of [process.env.npm_config_prefix, process.env.PREFIX, path.join(home, '.npm-global')]) {
+        if (prefix) globalModuleDirs.push(path.join(prefix, 'lib', 'node_modules'));
+      }
+      for (const gm of globalModuleDirs) {
+        candidates.push(
+          path.join(gm, 'ruflo', 'bin', 'cli.js'),
+          path.join(gm, '@claude-flow', 'cli', 'bin', 'cli.js'),
+        );
+      }
+    } catch { /* ignore */ }
+    for (const p of candidates) {
+      if (fs.existsSync(p)) return p;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
 
 function readCache() {
   try {
@@ -103,8 +144,16 @@ function getStatuslineData() {
   if (cached) return cached;
 
   try {
+    // #2337: prefer an already-installed CLI bin via direct \`node\` invocation
+    // — no npx, no registry round-trip, no @latest re-resolve per render.
+    // Fall back to \`npx --prefer-offline @claude-flow/cli\` (no @latest) only
+    // when nothing is installed locally, so a cold environment still works.
+    const cliBin = resolveCliBin();
+    const cmd = cliBin
+      ? '"' + process.execPath + '" "' + cliBin + '" hooks statusline --json 2>/dev/null'
+      : 'npx --prefer-offline @claude-flow/cli hooks statusline --json 2>/dev/null';
     const raw = execSync(
-      'npx --yes @claude-flow/cli@latest hooks statusline --json 2>/dev/null',
+      cmd,
       { encoding: 'utf-8', timeout: 8000, stdio: ['pipe', 'pipe', 'pipe'], cwd: CWD }
     ).trim();
     // The CLI may emit preamble lines before the JSON — find the first '{'.


### PR DESCRIPTION
Three community-reported bug fixes, each applying the reporter's recommended patch with credit. All three reporters provided detailed diagnoses (and #2307 included a full diff applied verbatim).

## Commits

### `fix(session): atomic writes to current.json + corrupted-file self-heal (#2307)`
**Reporter:** @BIWizzard · **Bug:** `session-restore` hook throws on a `current.json` corrupted by racing non-atomic `writeFileSync` calls — same class as #1707 / #1637 which were fixed elsewhere with atomic writes; `session.js` was missed.
**Fix:** new `atomicWrite()` helper (temp file + `rename()`) used by all 5 session-file writes; `restore()` self-heals on `JSON.parse` failure by starting a fresh session instead of throwing.

### `fix(hive-mind): await spawned claude before returning (#2297)`
**Reporter:** @clement-livdeo · **Bug:** `hive-mind spawn --claude` prints success messages, returns to shell instantly, and `claude` dies mid-init. The signature tell — a stray XTVERSION reply leaking onto the next shell prompt — confirmed the child was killed mid-startup because the parent exited.
**Fix:** await `claudeProcess.on('exit'|'error')` before returning from `spawnClaudeCodeInstance()`. Also makes the existing exit-handler log lines (\"completed successfully\" / \"exited with code N\") actually print.

### `fix(statusline): resolve installed CLI bin + bump cache TTL 10s→60s (#2337)`
**Reporter:** @shaal · **Bug:** statusline ran `npx --yes @claude-flow/cli@latest hooks statusline --json` per render with a 10 s cache. The `@latest` tag forces npm registry re-resolution on every uncached call; Claude Code refreshes the statusline several times a second while streaming. With ~6 concurrent sessions: load average 40-65 on a 12-core box, each `npm exec` consuming 55-90 % of a core.
**Fix:** new `resolveCliBin()` finds an installed `bin/cli.js` (same path-probing as `getPkgVersion()` — project / monorepo / plugin marketplace / global node_modules, incl. custom-prefix layouts). Invokes directly via `process.execPath` — no npx, no registry, no @latest. Falls back to `npx --prefer-offline @claude-flow/cli` (no @latest) when nothing's installed. Cache TTL 10 s → 60 s. Applied to both the committed dogfood helper AND the init generator template so existing + future installs both benefit.

## Closes
- Closes #2307
- Closes #2297
- Closes #2337

## Out of this PR (separate work)

Two more community bugs from the same triage pass that need bigger fixes:
- **#2305** (sparkling — embedding model ignored at runtime) — architectural: needs a shared zero-dep config-chain package; reporter even outlined the design from their private fork. Will reply on the issue with a status + plan.
- **#2296** (Liohtml — 7 controllers null after #1611) — cross-package version skew between `@claude-flow/memory@3.0.0-alpha.19` and `agentdb@3.0.0-alpha.16`; needs coordinated republish of the sub-packages. Will reply with the path forward.

## Verification

- `node -c .claude/helpers/statusline.cjs` → parses OK
- Existing test suites untouched (no test file changes; the changed files have no existing unit-test fixtures — `session.js` is the runtime helper shipped via init, `hive-mind.ts` is a CLI command, `statusline.cjs` is generated)
- Each commit is independently revertable if anything regresses

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)