### PR TITLE
feat(router): #2334 Phase 1 — tiny-dancer neural seam + trajectory collection (flagged off)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/router-neural-phase1.test.ts
+++ b/v3/@claude-flow/cli/__tests__/router-neural-phase1.test.ts
@@ -1,0 +1,207 @@
+/**
+ * #2334 Phase 1 — neural seam + trajectory collection tests.
+ *
+ * What this proves:
+ *  1. DEFAULT UNCHANGED — with both env gates off, route() reports
+ *     routedBy: 'heuristic' and behaves exactly like the pre-#2334 router
+ *     (no sidecar file, no neural import).
+ *  2. SEAM IS LIVE — an embedding passed through EnhancedModelRouter.route()
+ *     reaches computeSemanticDepth (complexity shifts with embedding
+ *     variance), closing the unreachable-branch finding from #2329.
+ *  3. GRACEFUL DEGRADATION — neural gate open but artifact missing →
+ *     routedBy: 'bandit-fallback', valid decision, no throw (ADR-124).
+ *  4. TRAJECTORY COLLECTION — flag on → decision + outcome JSONL rows in
+ *     .swarm/model-router-trajectories.jsonl, joined on taskHash; flag off →
+ *     no file (privacy default).
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ModelRouter } from '../src/ruvector/model-router.js';
+import { createEnhancedModelRouter } from '../src/ruvector/enhanced-model-router.js';
+import { resetNeuralRouter } from '../src/ruvector/neural-router.js';
+import { TRAJECTORY_FILE, taskHash } from '../src/ruvector/router-trajectory.js';
+
+let cwdRestore: string;
+let tmpDir: string;
+const ENV_KEYS = [
+  'CLAUDE_FLOW_ROUTER_NEURAL',
+  'CLAUDE_FLOW_ROUTER_MODEL_PATH',
+  'CLAUDE_FLOW_ROUTER_TRAJECTORY',
+] as const;
+let envRestore: Record<string, string | undefined>;
+
+beforeEach(() => {
+  cwdRestore = process.cwd();
+  tmpDir = mkdtempSync(join(tmpdir(), 'router-neural-p1-'));
+  process.chdir(tmpDir);
+  envRestore = {};
+  for (const k of ENV_KEYS) {
+    envRestore[k] = process.env[k];
+    delete process.env[k];
+  }
+  resetNeuralRouter();
+});
+
+afterEach(() => {
+  process.chdir(cwdRestore);
+  rmSync(tmpDir, { recursive: true, force: true });
+  for (const k of ENV_KEYS) {
+    if (envRestore[k] === undefined) delete process.env[k];
+    else process.env[k] = envRestore[k];
+  }
+  resetNeuralRouter();
+});
+
+function trajectoryRows(): Array<Record<string, unknown>> {
+  const p = join(tmpDir, TRAJECTORY_FILE);
+  if (!existsSync(p)) return [];
+  return readFileSync(p, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+describe('#2334 P1 — default behavior unchanged (gates off)', () => {
+  it("reports routedBy: 'heuristic' with no env gates set", async () => {
+    const router = new ModelRouter();
+    const result = await router.route('fix a typo in the readme');
+    expect(result.routedBy).toBe('heuristic');
+    expect(['haiku', 'sonnet', 'opus']).toContain(result.model);
+  });
+
+  it('writes no trajectory sidecar when the flag is off', async () => {
+    const router = new ModelRouter();
+    await router.route('implement a small feature');
+    router.recordOutcome('implement a small feature', 'haiku', 'success');
+    expect(existsSync(join(tmpDir, TRAJECTORY_FILE))).toBe(false);
+  });
+
+  it("does not append '| RoutedBy:' to reasoning on the default path", async () => {
+    const router = new ModelRouter();
+    const result = await router.route('rename a variable');
+    expect(result.reasoning).not.toContain('RoutedBy:');
+  });
+});
+
+describe('#2334 P1 — the embedding seam is live end-to-end', () => {
+  it('embedding changes complexity via computeSemanticDepth (base router)', async () => {
+    const router = new ModelRouter();
+    const task = 'implement the feature';
+    const flat = new Array(384).fill(0.001); // ~zero variance
+    const spiky = Array.from({ length: 384 }, (_, i) => (i % 2 === 0 ? 0.9 : -0.9)); // high variance
+
+    const withoutEmbedding = await router.route(task);
+    const withSpiky = await router.route(task, spiky);
+    const withFlat = await router.route(task, flat);
+
+    // The embedding branch blends variance into semanticDepth — a
+    // high-variance embedding must produce a different complexity than a
+    // near-zero-variance one, proving the branch executed.
+    expect(withSpiky.complexity).not.toBeCloseTo(withFlat.complexity, 10);
+    // And high variance pushes semantic depth (and so complexity) UP
+    // relative to the no-embedding baseline of the same task.
+    expect(withSpiky.complexity).toBeGreaterThan(withoutEmbedding.complexity - 1e-9);
+  });
+
+  it('EnhancedModelRouter threads context.embedding to the base router', async () => {
+    const enhanced = createEnhancedModelRouter({ agentBoosterEnabled: false });
+    const task = 'update the helper function'; // no tier-3 keywords, no codemod intent
+    const spiky = Array.from({ length: 384 }, (_, i) => (i % 2 === 0 ? 0.9 : -0.9));
+
+    const withEmbedding = await enhanced.route(task, { embedding: spiky });
+    const withoutEmbedding = await enhanced.route(task);
+
+    // routedBy surfaces from the base router on tier-2/3 results — proves
+    // the call path went through baseRouter.route (not a shortcut).
+    expect(withEmbedding.routedBy).toBe('heuristic');
+    expect(withoutEmbedding.routedBy).toBe('heuristic');
+    // Embedding variance shifts the blended complexity.
+    expect(withEmbedding.complexity).not.toBeCloseTo(withoutEmbedding.complexity!, 10);
+  });
+});
+
+describe('#2334 P1 — graceful degradation (ADR-124)', () => {
+  it("gate open + artifact missing → routedBy: 'bandit-fallback', no throw", async () => {
+    process.env.CLAUDE_FLOW_ROUTER_NEURAL = '1';
+    process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH = join(tmpDir, 'does-not-exist.safetensors');
+    resetNeuralRouter();
+
+    const router = new ModelRouter();
+    const embedding = new Array(384).fill(0.1);
+    const result = await router.route('implement the feature', embedding);
+
+    expect(result.routedBy).toBe('bandit-fallback');
+    expect(['haiku', 'sonnet', 'opus']).toContain(result.model);
+    expect(result.reasoning).toContain('RoutedBy: bandit-fallback');
+  });
+
+  it('gate open but NO embedding → stays heuristic (neural never consulted)', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_NEURAL = '1';
+    process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH = join(tmpDir, 'does-not-exist.safetensors');
+    resetNeuralRouter();
+
+    const router = new ModelRouter();
+    const result = await router.route('implement the feature');
+    expect(result.routedBy).toBe('heuristic');
+  });
+});
+
+describe('#2334 P1 — trajectory collection (flag on)', () => {
+  it('writes decision + outcome rows joined on taskHash', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY = '1';
+    const router = new ModelRouter();
+    const task = 'implement the user-profile feature with tests';
+    const embedding = new Array(8).fill(0.25);
+
+    const decision = await router.route(task, embedding);
+    router.recordOutcome(task, decision.model, 'success');
+
+    const rows = trajectoryRows();
+    const decisions = rows.filter((r) => r.type === 'decision');
+    const outcomes = rows.filter((r) => r.type === 'outcome');
+    expect(decisions).toHaveLength(1);
+    expect(outcomes).toHaveLength(1);
+
+    const d = decisions[0] as Record<string, any>;
+    const o = outcomes[0] as Record<string, any>;
+    // Join key
+    expect(d.taskHash).toBe(taskHash(task));
+    expect(o.taskHash).toBe(d.taskHash);
+    // Training features present
+    expect(d.embedding).toEqual(embedding);
+    expect(typeof d.complexity).toBe('number');
+    expect(d.features).toMatchObject({
+      lexicalComplexity: expect.any(Number),
+      semanticDepth: expect.any(Number),
+      taskScope: expect.any(Number),
+      uncertaintyLevel: expect.any(Number),
+    });
+    expect(d.model).toBe(decision.model);
+    expect(d.routedBy).toBe('heuristic');
+    // Outcome label
+    expect(o.outcome).toBe('success');
+    expect(o.model).toBe(decision.model);
+  });
+
+  it('omits the embedding field when route() received none', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY = '1';
+    const router = new ModelRouter();
+    await router.route('fix the bug');
+    const d = trajectoryRows().find((r) => r.type === 'decision') as Record<string, any>;
+    expect(d).toBeDefined();
+    expect('embedding' in d).toBe(false);
+  });
+
+  it('keeps full task text up to 500 chars (vs learningHistory 100)', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY = '1';
+    const router = new ModelRouter();
+    const longTask = 'implement '.repeat(80); // 800 chars
+    await router.route(longTask);
+    const d = trajectoryRows().find((r) => r.type === 'decision') as Record<string, any>;
+    expect((d.task as string).length).toBe(500);
+    expect(d.taskHash).toBe(taskHash(longTask)); // hash of FULL text, not truncation
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -120,6 +120,7 @@
     "@ruvector/ruvllm-wasm": "^2.0.2",
     "@ruvector/rvagent-wasm": "^0.1.0",
     "@ruvector/sona": "^0.1.6",
+    "@ruvector/tiny-dancer": "^0.1.18",
     "agentdb": "^3.0.0-alpha.16",
     "agentic-flow": "^3.0.0-alpha.1",
     "ruvector": "^0.2.27"

--- a/v3/@claude-flow/cli/src/ruvector/enhanced-model-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/enhanced-model-router.ts
@@ -11,7 +11,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { extname, isAbsolute, resolve as resolvePath } from 'path';
-import { ClaudeModel, getModelRouter, ModelRouter, ModelRoutingResult } from './model-router.js';
+import { ClaudeModel, getModelRouter, ModelRouter, ModelRoutingResult, RoutedBy } from './model-router.js';
 import { applyCodemod, isDeterministicCodemod, type CodemodLanguage } from './codemods/engine.js';
 
 /** Map a file path to the codemod engine's language, falling back to a hint. */
@@ -72,6 +72,12 @@ export interface EnhancedRouteResult {
   canSkipLLM?: boolean;
   estimatedLatencyMs: number;
   estimatedCost: number;
+  /**
+   * Which mechanism produced the text-routing decision (#2334). Absent on
+   * paths that never reach the base router (Tier-1 codemod, Tier-3 keyword
+   * shortcut).
+   */
+  routedBy?: RoutedBy;
 }
 
 /**
@@ -368,9 +374,17 @@ export class EnhancedModelRouter {
   }
 
   /**
-   * Route a task to the optimal tier and handler
+   * Route a task to the optimal tier and handler.
+   *
+   * `context.embedding` (#2334) threads a task embedding through to the base
+   * router's `route(task, embedding)` seam — feeding the embedding branch of
+   * `computeSemanticDepth` and, when the neural gate is open, the FastGRNN
+   * path. Optional; omitting it preserves pre-#2334 behavior exactly.
    */
-  async route(task: string, context?: { filePath?: string }): Promise<EnhancedRouteResult> {
+  async route(
+    task: string,
+    context?: { filePath?: string; embedding?: number[] }
+  ): Promise<EnhancedRouteResult> {
     // Step 1: Deterministic codemod detection (ADR-143).
     // Only intents that a codemod can apply *deterministically and safely* skip
     // the LLM. Intents that need inference (add-types, add-error-handling,
@@ -456,8 +470,10 @@ export class EnhancedModelRouter {
       }
     }
 
-    // Step 4: Text-based complexity via the local heuristic + bandit router.
-    const baseResult = await this.baseRouter.route(task);
+    // Step 4: Text-based complexity via the base router. With an embedding
+    // threaded through (#2334) the semantic-depth embedding branch is live,
+    // and the neural path is consulted when its env gate is open.
+    const baseResult = await this.baseRouter.route(task, context?.embedding);
 
     // Step 5: Combine AST complexity with the text-routing result.
     // Also boost if a single tier3 keyword is found.
@@ -484,6 +500,7 @@ export class EnhancedModelRouter {
         canSkipLLM: false,
         estimatedLatencyMs: 500,
         estimatedCost: 0.0002,
+        routedBy: baseResult.routedBy,
       };
     }
 
@@ -498,6 +515,7 @@ export class EnhancedModelRouter {
         canSkipLLM: false,
         estimatedLatencyMs: 2000,
         estimatedCost: 0.003,
+        routedBy: baseResult.routedBy,
       };
     }
 
@@ -511,6 +529,7 @@ export class EnhancedModelRouter {
       canSkipLLM: false,
       estimatedLatencyMs: 5000,
       estimatedCost: 0.015,
+      routedBy: baseResult.routedBy,
     };
   }
 
@@ -679,7 +698,7 @@ export function createEnhancedModelRouter(
  */
 export async function enhancedRouteToModel(
   task: string,
-  context?: { filePath?: string }
+  context?: { filePath?: string; embedding?: number[] }
 ): Promise<EnhancedRouteResult> {
   const router = getEnhancedModelRouter();
   return router.route(task, context);

--- a/v3/@claude-flow/cli/src/ruvector/model-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/model-router.ts
@@ -20,20 +20,28 @@
  * - Sonnet: medium confidence, moderate complexity (balanced)
  * - Opus: low confidence, high complexity (most capable)
  *
- * Note (#2329): An earlier design (ADR-026 + this file's previous header)
- * described a Tiny-Dancer / FastGRNN neural router with embedding-based
- * complexity scoring. That path was never wired in — `@ruvector/tiny-dancer`
- * is not imported here and the `embedding`-consuming branch in
- * `computeSemanticDepth` is only reachable via the externally-callable
- * `routeToModelFull(task, embedding)` wrapper (no internal callers). The
- * shipped router is the heuristic + bandit described above; the neural
- * path remains a future direction tracked in #2329.
+ * Neural path (#2334 Phase 1): the `@ruvector/tiny-dancer` FastGRNN seam is
+ * now wired through `route(task, embedding?)` behind a double env gate
+ * (CLAUDE_FLOW_ROUTER_NEURAL=1 + CLAUDE_FLOW_ROUTER_MODEL_PATH) that is OFF
+ * by default — see `neural-router.ts`. Every routing result reports which
+ * path produced it via `routedBy: 'fastgrnn' | 'bandit-fallback' |
+ * 'heuristic'` (ADR-086/074: observable, not inferred). Until a trained
+ * FastGRNN safetensors artifact ships (the Phase 2 gate in #2334), the
+ * default behavior is byte-identical to the heuristic + bandit described
+ * above. Opt-in trajectory collection for Phase 2 training lives in
+ * `router-trajectory.ts` (CLAUDE_FLOW_ROUTER_TRAJECTORY=1).
+ *
+ * History (#2329): an earlier design (ADR-026 + this file's previous header)
+ * described this neural router as already shipped; it never was. #2330 made
+ * the docs honest, #2334 is wiring the real thing through the seam.
  *
  * @module model-router
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
+import { neuralRoutingEnabled, tryNeuralRoute } from './neural-router.js';
+import { recordTrajectoryDecision, recordTrajectoryOutcome } from './router-trajectory.js';
 
 // ============================================================================
 // Types & Constants
@@ -121,6 +129,16 @@ export interface ModelRouterConfig {
 }
 
 /**
+ * Which mechanism produced a routing decision (#2334, ADR-086/074 —
+ * observable, never inferred from import success):
+ * - 'fastgrnn'        — the @ruvector/tiny-dancer neural path routed it
+ * - 'bandit-fallback' — neural was enabled but unavailable/failed; the
+ *                       heuristic + Thompson bandit routed it instead
+ * - 'heuristic'       — neural not enabled (default); heuristic + bandit
+ */
+export type RoutedBy = 'fastgrnn' | 'bandit-fallback' | 'heuristic';
+
+/**
  * Routing decision result
  */
 export interface ModelRoutingResult {
@@ -140,6 +158,8 @@ export interface ModelRoutingResult {
   inferenceTimeUs: number;
   /** Estimated cost multiplier */
   costMultiplier: number;
+  /** Which mechanism produced this decision (#2334). */
+  routedBy: RoutedBy;
 }
 
 /**
@@ -390,7 +410,13 @@ export class ModelRouter {
   }
 
   /**
-   * Route a task to the optimal model
+   * Route a task to the optimal model.
+   *
+   * `embedding` is the #2334 neural seam: when provided it (a) feeds the
+   * `computeSemanticDepth` embedding branch, and (b) — only when the neural
+   * gate is open (see neural-router.ts) — is offered to the FastGRNN router
+   * first, with the heuristic + bandit as fallback. With the gate closed
+   * (default) behavior is identical to the pre-#2334 router.
    */
   async route(task: string, embedding?: number[]): Promise<ModelRoutingResult> {
     const startTime = performance.now();
@@ -398,14 +424,24 @@ export class ModelRouter {
     // Analyze task complexity
     const complexity = this.analyzeComplexity(task, embedding);
 
+    // #2334 — neural-first when the gate is open. tryNeuralRoute never
+    // throws; null means unavailable/failed → bandit fallback below.
+    let routedBy: RoutedBy = 'heuristic';
+    let neuralDecision: { model: ClaudeModel; confidence: number; uncertainty: number } | null = null;
+    if (embedding && embedding.length > 0 && neuralRoutingEnabled()) {
+      neuralDecision = await tryNeuralRoute(embedding);
+      routedBy = neuralDecision ? 'fastgrnn' : 'bandit-fallback';
+    }
+
     // Compute base model scores
     const scores = this.computeModelScores(complexity);
 
     // Apply circuit breaker adjustments
     const adjustedScores = this.applyCircuitBreaker(scores);
 
-    // Select best model
-    const { model, confidence, uncertainty } = this.selectModel(adjustedScores, complexity.score);
+    // Select best model (neural decision wins when present)
+    const { model, confidence, uncertainty } = neuralDecision
+      ?? this.selectModel(adjustedScores, complexity.score);
 
     const inferenceTimeUs = (performance.now() - startTime) * 1000;
 
@@ -415,17 +451,28 @@ export class ModelRouter {
       confidence,
       uncertainty,
       complexity: complexity.score,
-      reasoning: this.buildReasoning(model, complexity, confidence),
+      reasoning: this.buildReasoning(model, complexity, confidence)
+        + (routedBy !== 'heuristic' ? ` | RoutedBy: ${routedBy}` : ''),
       alternatives: Object.entries(adjustedScores)
         .filter(([m]) => m !== model)
         .map(([m, score]) => ({ model: m as ClaudeModel, score }))
         .sort((a, b) => b.score - a.score),
       inferenceTimeUs,
       costMultiplier: MODEL_CAPABILITIES[model].costMultiplier,
+      routedBy,
     };
 
     // Track decision
     this.trackDecision(task, result);
+
+    // #2334 Phase 1 — opt-in per-decision dataset row for Phase 2 training
+    // (no-op unless CLAUDE_FLOW_ROUTER_TRAJECTORY=1).
+    recordTrajectoryDecision(
+      task,
+      embedding,
+      { score: complexity.score, ...complexity.features },
+      { model, confidence, uncertainty, routedBy },
+    );
 
     return result;
   }
@@ -757,6 +804,10 @@ export class ModelRouter {
     const reward = BANDIT_REWARDS[model]?.[outcome] ?? 0.5;
     bp[model].alpha += reward;
     bp[model].beta += 1 - reward;
+
+    // #2334 Phase 1 — opt-in outcome row, joined to the decision row on
+    // taskHash for offline Phase 2 training (no-op unless enabled).
+    recordTrajectoryOutcome(task, model, outcome);
 
     this.saveState();
   }

--- a/v3/@claude-flow/cli/src/ruvector/neural-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/neural-router.ts
@@ -1,0 +1,172 @@
+/**
+ * Neural routing scaffold — `@ruvector/tiny-dancer` FastGRNN seam (#2334 Phase 1)
+ *
+ * Wires the optional neural path that ADR-026 originally described, behind a
+ * double gate that is OFF by default:
+ *
+ *   CLAUDE_FLOW_ROUTER_NEURAL=1                      — opt in to the neural path
+ *   CLAUDE_FLOW_ROUTER_MODEL_PATH=<x.safetensors>    — trained FastGRNN artifact
+ *
+ * Both must be set; otherwise `tryNeuralRoute` returns `null` immediately and
+ * the caller stays on the shipped heuristic + Thompson-bandit path. When the
+ * gate is open but anything fails (package not installed — it is an
+ * optionalDependency per ADR-124 — artifact missing/incompatible, runtime
+ * error), this module degrades gracefully: it returns `null`, never throws,
+ * and the caller reports `routedBy: 'bandit-fallback'` so the active path is
+ * observable rather than inferred from import success (ADR-086/074).
+ *
+ * Candidate modeling (#2334 Q3, provisional): the 3 model tiers are encoded as
+ * fixed candidates with deterministic placeholder embeddings (orthogonal-ish
+ * one-hot-block vectors). This is explicitly provisional — the trained Phase 2
+ * artifact defines what candidate embeddings mean, and this encoding is the
+ * scaffolding default until the maintainers answer #2334's candidate-modeling
+ * question. Until a real artifact exists the gate stays closed in practice, so
+ * the placeholder never influences routing.
+ *
+ * @module neural-router
+ */
+
+import { existsSync } from 'fs';
+
+// ============================================================================
+// Types (local mirror of the @ruvector/tiny-dancer surface we consume)
+// ============================================================================
+
+/** The three routable tiers — 'inherit' is never a neural candidate. */
+export type NeuralRoutableModel = 'haiku' | 'sonnet' | 'opus';
+
+export interface NeuralRouteDecision {
+  model: NeuralRoutableModel;
+  confidence: number;
+  uncertainty: number;
+  inferenceTimeUs: number;
+}
+
+interface TinyDancerRoutingDecision {
+  candidateId: string;
+  confidence: number;
+  useLightweight: boolean;
+  uncertainty: number;
+}
+
+interface TinyDancerRouter {
+  route(request: {
+    queryEmbedding: Float32Array | number[];
+    candidates: Array<{ id: string; embedding: Float32Array | number[]; metadata?: string }>;
+    metadata?: string;
+  }): Promise<{
+    decisions: TinyDancerRoutingDecision[];
+    inferenceTimeUs: number;
+    candidatesProcessed: number;
+  }>;
+}
+
+// ============================================================================
+// Gate & lifecycle
+// ============================================================================
+
+/** True when the user has opted in AND pointed at a model artifact. */
+export function neuralRoutingEnabled(): boolean {
+  return process.env.CLAUDE_FLOW_ROUTER_NEURAL === '1'
+    && !!process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH;
+}
+
+// Cached router instance + a sticky failure latch so a broken install/artifact
+// costs one failed load, not one per routing call.
+let routerInstance: TinyDancerRouter | null = null;
+let loadFailed = false;
+
+/** Reset cached state — for tests. */
+export function resetNeuralRouter(): void {
+  routerInstance = null;
+  loadFailed = false;
+}
+
+async function loadRouter(): Promise<TinyDancerRouter | null> {
+  if (routerInstance) return routerInstance;
+  if (loadFailed) return null;
+
+  const modelPath = process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH;
+  if (!modelPath || !existsSync(modelPath)) {
+    loadFailed = true;
+    return null;
+  }
+
+  try {
+    // Dynamic import of an optionalDependency (ADR-124): absent on installs
+    // where the native binding failed or was skipped — degrade, don't throw.
+    const mod = await import('@ruvector/tiny-dancer');
+    const RouterCtor = (mod as { Router?: new (cfg: { modelPath: string }) => TinyDancerRouter }).Router;
+    if (!RouterCtor) {
+      loadFailed = true;
+      return null;
+    }
+    routerInstance = new RouterCtor({ modelPath });
+    return routerInstance;
+  } catch {
+    loadFailed = true;
+    return null;
+  }
+}
+
+// ============================================================================
+// Candidate encoding (provisional — see header + #2334 Q3)
+// ============================================================================
+
+const TIER_ORDER: NeuralRoutableModel[] = ['haiku', 'sonnet', 'opus'];
+
+/**
+ * Deterministic placeholder embedding for a tier candidate: a block one-hot
+ * over the embedding dimensionality. Replaced by whatever the Phase 2 trained
+ * artifact defines as candidate space.
+ */
+function tierCandidateEmbedding(tierIndex: number, dim: number): number[] {
+  const v = new Array<number>(dim).fill(0);
+  const block = Math.max(1, Math.floor(dim / TIER_ORDER.length));
+  const start = tierIndex * block;
+  for (let i = start; i < Math.min(start + block, dim); i++) v[i] = 1 / Math.sqrt(block);
+  return v;
+}
+
+// ============================================================================
+// Routing
+// ============================================================================
+
+/**
+ * Attempt a neural routing decision for the given task embedding.
+ *
+ * Returns `null` (never throws) when the gate is closed, the package or
+ * artifact is unavailable, or inference fails — callers fall back to the
+ * bandit and report `routedBy: 'bandit-fallback'` (when the gate was open)
+ * or `'heuristic'` (when it never was).
+ */
+export async function tryNeuralRoute(embedding: number[]): Promise<NeuralRouteDecision | null> {
+  if (!neuralRoutingEnabled()) return null;
+  if (!embedding || embedding.length === 0) return null;
+
+  const router = await loadRouter();
+  if (!router) return null;
+
+  try {
+    const response = await router.route({
+      queryEmbedding: embedding,
+      candidates: TIER_ORDER.map((tier, i) => ({
+        id: tier,
+        embedding: tierCandidateEmbedding(i, embedding.length),
+        metadata: JSON.stringify({ tier }),
+      })),
+    });
+
+    const best = response.decisions?.[0];
+    if (!best || !TIER_ORDER.includes(best.candidateId as NeuralRoutableModel)) return null;
+
+    return {
+      model: best.candidateId as NeuralRoutableModel,
+      confidence: best.confidence,
+      uncertainty: best.uncertainty,
+      inferenceTimeUs: response.inferenceTimeUs,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/v3/@claude-flow/cli/src/ruvector/router-trajectory.ts
+++ b/v3/@claude-flow/cli/src/ruvector/router-trajectory.ts
@@ -1,0 +1,130 @@
+/**
+ * Router trajectory collection (#2334 Phase 1)
+ *
+ * Opt-in per-decision dataset collection for the model router. The persisted
+ * bandit state (`.swarm/model-router-state.json`) keeps only aggregates —
+ * 9 Beta(α,β) cells and a capped/truncated history — which is not trainable
+ * material for the Phase 2 FastGRNN tier-classifier. This sidecar captures
+ * the per-example rows that training needs:
+ *
+ *   decision rows: { taskHash, task, embedding?, complexity, features,
+ *                    model, confidence, uncertainty, routedBy, ts }
+ *   outcome rows:  { taskHash, model, outcome, ts }
+ *
+ * joined offline on `taskHash` (sha256-16 of the task text).
+ *
+ * OFF by default. Enable with CLAUDE_FLOW_ROUTER_TRAJECTORY=1. Rows append to
+ * `.swarm/model-router-trajectories.jsonl` — local-only, same trust domain as
+ * the existing state file, but unlike it the rows contain full task text (up
+ * to 500 chars) and raw embeddings, which is why this is opt-in rather than
+ * always-on.
+ *
+ * Writes are best-effort: any fs error is swallowed (collection must never
+ * break routing), matching the state-file behavior in model-router.ts.
+ *
+ * @module router-trajectory
+ */
+
+import { createHash } from 'crypto';
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+
+export const TRAJECTORY_FILE = '.swarm/model-router-trajectories.jsonl';
+
+/** Schema version stamped on every row so offline training can dispatch. */
+const ROW_VERSION = 1;
+
+export function trajectoryCollectionEnabled(): boolean {
+  return process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY === '1';
+}
+
+/** Join key: first 16 hex chars of sha256(task). */
+export function taskHash(task: string): string {
+  return createHash('sha256').update(task).digest('hex').slice(0, 16);
+}
+
+export interface TrajectoryDecisionRow {
+  v: number;
+  type: 'decision';
+  ts: string;
+  taskHash: string;
+  /** Task text, capped at 500 chars (cf. learningHistory's 100). */
+  task: string;
+  /** Raw embedding when one was threaded through route(); else omitted. */
+  embedding?: number[];
+  complexity: number;
+  features: {
+    lexicalComplexity: number;
+    semanticDepth: number;
+    taskScope: number;
+    uncertaintyLevel: number;
+  };
+  model: string;
+  confidence: number;
+  uncertainty: number;
+  routedBy: string;
+}
+
+export interface TrajectoryOutcomeRow {
+  v: number;
+  type: 'outcome';
+  ts: string;
+  taskHash: string;
+  model: string;
+  outcome: 'success' | 'failure' | 'escalated';
+}
+
+function appendRow(row: TrajectoryDecisionRow | TrajectoryOutcomeRow): void {
+  try {
+    const fullPath = join(process.cwd(), TRAJECTORY_FILE);
+    const dir = dirname(fullPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    appendFileSync(fullPath, JSON.stringify(row) + '\n');
+  } catch {
+    // Best-effort: collection must never break routing.
+  }
+}
+
+export function recordTrajectoryDecision(
+  task: string,
+  embedding: number[] | undefined,
+  complexity: TrajectoryDecisionRow['features'] & { score: number },
+  decision: { model: string; confidence: number; uncertainty: number; routedBy: string },
+): void {
+  if (!trajectoryCollectionEnabled()) return;
+  appendRow({
+    v: ROW_VERSION,
+    type: 'decision',
+    ts: new Date().toISOString(),
+    taskHash: taskHash(task),
+    task: task.slice(0, 500),
+    ...(embedding && embedding.length > 0 ? { embedding } : {}),
+    complexity: complexity.score,
+    features: {
+      lexicalComplexity: complexity.lexicalComplexity,
+      semanticDepth: complexity.semanticDepth,
+      taskScope: complexity.taskScope,
+      uncertaintyLevel: complexity.uncertaintyLevel,
+    },
+    model: decision.model,
+    confidence: decision.confidence,
+    uncertainty: decision.uncertainty,
+    routedBy: decision.routedBy,
+  });
+}
+
+export function recordTrajectoryOutcome(
+  task: string,
+  model: string,
+  outcome: 'success' | 'failure' | 'escalated',
+): void {
+  if (!trajectoryCollectionEnabled()) return;
+  appendRow({
+    v: ROW_VERSION,
+    type: 'outcome',
+    ts: new Date().toISOString(),
+    taskHash: taskHash(task),
+    model,
+    outcome,
+  });
+}

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@ruvector/sona':
         specifier: ^0.1.6
         version: 0.1.6
+      '@ruvector/tiny-dancer':
+        specifier: ^0.1.18
+        version: 0.1.18
       agentdb:
         specifier: ^3.0.0-alpha.16
         version: 3.0.0-alpha.16(@types/node@20.19.27)(zod@3.25.76)
@@ -5789,15 +5792,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@ruvector/tiny-dancer-linux-arm64-gnu@0.1.15:
-    resolution: {integrity: sha512-HwduiK4dJj5x3hcKdHSgYksEssJFc7pNkg+ENyrlN1kIOyfCAQ76mx3uu+Hhg55hX6HbZEloXQcVG0jn4VM2uw==}
-    engines: {node: '>=18.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@ruvector/tiny-dancer-linux-arm64-gnu@0.1.17:
     resolution: {integrity: sha512-bvjYL0/tyonot6KFQPAbtOdw3TGL6fIxakmn8ED6gRRcwPJ3V6VZ0WgLZfOlXiWc4I/eQvcNldgJ+3QOXurgMw==}
     engines: {node: '>=18.0.0'}
@@ -5821,17 +5815,6 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
-
-  /@ruvector/tiny-dancer@0.1.15:
-    resolution: {integrity: sha512-Gl+eHhenRHVpyeqjJJBa2RL1HbXC+WNr8caEcEfNdODFKlKaicOPDaujUHAG3tEMZzeT3564eqPWu+ZiA+wxKQ==}
-    engines: {node: '>=18.0.0'}
-    optionalDependencies:
-      '@ruvector/tiny-dancer-darwin-arm64': 0.1.15
-      '@ruvector/tiny-dancer-darwin-x64': 0.1.15
-      '@ruvector/tiny-dancer-linux-arm64-gnu': 0.1.15
-      '@ruvector/tiny-dancer-linux-x64-gnu': 0.1.15
-      '@ruvector/tiny-dancer-win32-x64-msvc': 0.1.15
-    dev: false
 
   /@ruvector/tiny-dancer@0.1.18:
     resolution: {integrity: sha512-rgkHJl/RIwIuFc+kYV8eULY+N/cDsEcxseURRcPA4vfU8TUKca0e3ENN8Fuc8Vm/bka8tzyY1TF8G2/DvFQAPA==}
@@ -7151,7 +7134,7 @@ packages:
       '@ruvector/edge-full': 0.1.0
       '@ruvector/router': 0.1.26
       '@ruvector/ruvllm': 0.2.4
-      '@ruvector/tiny-dancer': 0.1.15
+      '@ruvector/tiny-dancer': 0.1.18
       '@supabase/supabase-js': 2.89.0
       '@xenova/transformers': 2.17.2
       axios: 1.13.2


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #2334 (Option B follow-up to #2329): wire the `@ruvector/tiny-dancer` FastGRNN seam and collect the per-decision dataset Phase 2 training needs — with **default behavior byte-identical** to the shipped heuristic + Thompson-bandit router.

### What's in

| Piece | File | Gate |
|---|---|---|
| FastGRNN scaffold (dynamic import, graceful degradation per ADR-124) | `src/ruvector/neural-router.ts` (new) | `CLAUDE_FLOW_ROUTER_NEURAL=1` **and** `CLAUDE_FLOW_ROUTER_MODEL_PATH=<safetensors>` |
| Trajectory JSONL sidecar (decision + outcome rows joined on `taskHash`) | `src/ruvector/router-trajectory.ts` (new) | `CLAUDE_FLOW_ROUTER_TRAJECTORY=1` |
| `routedBy: 'fastgrnn' \| 'bandit-fallback' \| 'heuristic'` observable on every result (ADR-086/074) | `model-router.ts` | always reported |
| Embedding threaded through `EnhancedModelRouter.route(task, {embedding})` → `baseRouter.route(task, embedding)` — the `computeSemanticDepth` embedding branch is now reachable from internal call sites | `enhanced-model-router.ts` | none (optional param) |
| `@ruvector/tiny-dancer ^0.1.18` | `package.json` `optionalDependencies` | install-optional |

### What's deliberately NOT in (per #2334 phasing)

- No trained artifact — Phase 2, gated on the maintainer answers in #2334 (safetensors tensor layout, artifact strategy, candidate modeling, ADR, acceptance bar).
- Routing recommendation stays **advisory** (no consumer-side binding change).
- Tier-1 codemods and the Thompson bandit untouched — bandit remains the decision-maker by default and the fallback when neural is gated on but unavailable.
- Tier-candidate embedding encoding in `neural-router.ts` is a documented placeholder pending Q3.

### Trajectory row shape (v1)

```jsonc
{"v":1,"type":"decision","ts":"…","taskHash":"sha256-16","task":"<=500ch","embedding":[…],"complexity":0.42,"features":{"lexicalComplexity":…,"semanticDepth":…,"taskScope":…,"uncertaintyLevel":…},"model":"sonnet","confidence":0.71,"uncertainty":0.2,"routedBy":"heuristic"}
{"v":1,"type":"outcome","ts":"…","taskHash":"sha256-16","model":"sonnet","outcome":"success"}
```

Opt-in because rows carry full task text (500ch vs learningHistory's 100) + raw embeddings.

## Testing

- 10 new tests in `__tests__/router-neural-phase1.test.ts`: default-unchanged (3), seam-live end-to-end (2), graceful degradation (2), trajectory collection (3)
- Existing `router-bandit` / `codemod-routing` / `issue-2250-2251-regression` / `mcp-tools-deep` suites: green (16 + 107)
- `tsc` clean, package build clean

Closes nothing — #2334 stays open for the Phase 2 design questions.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)