### PR TITLE
fix(memory): #2312 — break embedder-rescue recursion that OOM'd CI at 4GB

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -2322,13 +2322,14 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm -r build
       - name: Run trajectory graph edges smoke
-        # #2312 — TEST 2 (post-task → reinforced-by edge) OOMs at 6 GB+ inside
-        # the SONA endTrajectory + distillLearning chain (EWCConsolidator init
-        # is the likely allocator). The graph-edge contract being asserted is
-        # orthogonal to that path. Gate the step non-blocking until the real
-        # allocation profile is fixed; TEST 1 (trajectory-step → trajectory-
-        # caused edge) still runs and gates the same contract.
-        continue-on-error: true
+        # #2312 root cause (fixed): memory-bridge's rescueAgentdbEmbedder
+        # patched agentdb.embedder.embed to delegate to generateEmbedding —
+        # which is bridge-first, so the patched embed re-entered itself via
+        # bridgeGenerateEmbedding in an unbounded async cycle (heap OOM at
+        # the V8 limit, SIGABRT 134; SONA/EWC were innocent). The rescue now
+        # delegates to generateLocalEmbedding (a bridge-free leaf), so this
+        # smoke gates again at default heap — verified green in a node:22
+        # Linux container at 512 MB with a cold model cache.
         run: node scripts/smoke-trajectory-graph-edges.mjs
 
   graph-plugin-adapter-smoke:

--- a/scripts/smoke-trajectory-graph-edges.mjs
+++ b/scripts/smoke-trajectory-graph-edges.mjs
@@ -9,7 +9,7 @@
  * Usage: node scripts/smoke-trajectory-graph-edges.mjs
  */
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -17,6 +17,10 @@ import * as os from 'os';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 const distBase = path.join(projectRoot, 'v3/@claude-flow/cli/dist/src');
+// Windows: absolute paths must be file:// URLs for dynamic import() — a bare
+// C:\... path fails with ERR_UNSUPPORTED_ESM_URL_SCHEME (hit while debugging
+// #2312 locally). No-op on POSIX.
+const distImport = (rel) => import(pathToFileURL(path.join(distBase, rel)).href);
 
 // sql.js is available in root node_modules (installed by the CI setup step via
 // `npm install --legacy-peer-deps --ignore-scripts` at the repo root).
@@ -72,10 +76,10 @@ console.log('\n[ADR-130 smoke] Phase 3 — SONA trajectory-to-graph hooks\n');
 async function testTrajectoryStep() {
   console.log('TEST 1: trajectory-step writes trajectory-caused edge');
   try {
-    const { initializeMemoryDatabase } = await import(path.join(distBase, 'memory/memory-initializer.js'));
+    const { initializeMemoryDatabase } = await distImport('memory/memory-initializer.js');
     await initializeMemoryDatabase({ dbPath, force: true });
 
-    const mod = await import(path.join(distBase, 'mcp-tools/hooks-tools.js'));
+    const mod = await distImport('mcp-tools/hooks-tools.js');
     const traj = mod.hooksTrajectoryStep ?? mod.allHooksTools?.find(t => t.name === 'hooks_intelligence_trajectory-step');
     if (!traj) { fail('1a', 'hooks_intelligence_trajectory-step not found'); return; }
 
@@ -107,7 +111,7 @@ async function testTrajectoryStep() {
 async function testPostTask() {
   console.log('\nTEST 2: post-task writes reinforced-by edge');
   try {
-    const mod = await import(path.join(distBase, 'mcp-tools/hooks-tools.js'));
+    const mod = await distImport('mcp-tools/hooks-tools.js');
     const postTask = mod.hooksPostTask ?? mod.allHooksTools?.find(t => t.name === 'hooks_post-task');
     if (!postTask) { fail('2a', 'hooks_post-task not found'); return; }
 
@@ -139,7 +143,7 @@ async function testPostTask() {
 async function testPostTaskFailure() {
   console.log('\nTEST 3: post-task with success=false does not write reinforced-by edge');
   try {
-    const mod = await import(path.join(distBase, 'mcp-tools/hooks-tools.js'));
+    const mod = await distImport('mcp-tools/hooks-tools.js');
     const postTask = mod.hooksPostTask ?? mod.allHooksTools?.find(t => t.name === 'hooks_post-task');
 
     const beforeCount = await countEdgesByRelation('reinforced-by');
@@ -165,7 +169,7 @@ async function testPostTaskFailure() {
 async function testNonBlocking() {
   console.log('\nTEST 4: async writes are non-blocking (<200ms tool response)');
   try {
-    const mod = await import(path.join(distBase, 'mcp-tools/hooks-tools.js'));
+    const mod = await distImport('mcp-tools/hooks-tools.js');
     const traj = mod.hooksTrajectoryStep ?? mod.allHooksTools?.find(t => t.name === 'hooks_intelligence_trajectory-step');
 
     const times = [];

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -568,25 +568,41 @@ async function rescueAgentdbEmbedder(agentdb: { embedder?: { pipeline?: unknown;
   // own embed() does the right thing and we should not interpose.
   if (emb.pipeline) return;
 
-  type EmbedFn = (text: string) => Promise<{ embedding: number[] | Float32Array; dimensions: number; model: string }>;
-  let generateEmbedding: EmbedFn | null = null;
+  // #2312: delegate to generateLOCALEmbedding, NOT generateEmbedding.
+  // generateEmbedding is bridge-first — routing the rescued embed through it
+  // closes a cycle (generateEmbedding → bridgeGenerateEmbedding →
+  // embedder.embed [patched] → generateEmbedding → …) that allocated
+  // unboundedly via microtasks until V8 hit the heap limit (~4 GB on the CI
+  // runner, SIGABRT 134). The local chain never consults the bridge, so the
+  // rescued embedder is a leaf. If the running memory-initializer build
+  // predates generateLocalEmbedding, decline the rescue entirely — a stale
+  // pairing must fail safe, not recurse.
+  type EmbedFn = (text: string) => Promise<{ embedding: number[] | Float32Array; dimensions: number; model: string; backend?: 'onnx' | 'mock' }>;
+  let localEmbed: EmbedFn | null = null;
   try {
-    const mod = (await import('./memory-initializer.js')) as unknown as { generateEmbedding?: EmbedFn };
-    generateEmbedding = mod.generateEmbedding ?? null;
+    const mod = (await import('./memory-initializer.js')) as unknown as { generateLocalEmbedding?: EmbedFn };
+    localEmbed = mod.generateLocalEmbedding ?? null;
   } catch {
     return; // can't import the rescuer — leave the mock fallback alone
   }
-  if (!generateEmbedding) return;
-  const embed: EmbedFn = generateEmbedding;
+  if (!localEmbed) return;
+  const embed: EmbedFn = localEmbed;
 
-  // Probe once to confirm the rescuer actually returns real (non-zero) vectors.
-  // If our own fallback chain also dead-ends in mock embeddings, leave
-  // agentdb as-is rather than swapping one mock for another.
+  // Probe once to confirm the rescuer actually returns REAL ONNX vectors
+  // (#2312: the old probe only checked non-zero, which the deterministic
+  // hash fallback also satisfies — so it "rescued" agentdb's mock with our
+  // own mock and reported it as real). Require backend === 'onnx'.
   try {
     const probe = await embed('rescue-probe');
     const arr = probe?.embedding ? Array.from(probe.embedding as ArrayLike<number>) : [];
     const hasSignal = arr.length > 0 && arr.some((v: number) => Math.abs(v) > 1e-9);
-    if (!hasSignal) return;
+    if (!hasSignal || probe.backend !== 'onnx') {
+      // Local chain is also degraded — leave agentdb's embedder alone, but
+      // tag it so bridgeGenerateEmbedding's AUDIT-#3 isMock check reports
+      // backend='mock' truthfully instead of labeling mock vectors 'onnx'.
+      try { (emb as { backend?: string }).backend = 'mock'; } catch { /* frozen */ }
+      return;
+    }
   } catch {
     return;
   }

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -1867,6 +1867,30 @@ export async function generateEmbedding(text: string): Promise<{
     }
   }
 
+  return generateLocalEmbedding(text);
+}
+
+/**
+ * Generate an embedding using ONLY the local model chain (transformers.js /
+ * ruvector ONNX / hash fallback) — never the AgentDB bridge.
+ *
+ * #2312: this MUST stay bridge-free. `memory-bridge.ts` rescues a degraded
+ * agentdb embedder by delegating to this module; if that delegation went
+ * through `generateEmbedding` (bridge-first), the call would re-enter the
+ * patched `agentdb.embedder.embed` and recurse unboundedly:
+ *
+ *   generateEmbedding → bridgeGenerateEmbedding → embedder.embed (patched)
+ *     → generateEmbedding → … (heap OOM at ~4 GB on CI, no stack overflow
+ *     because the cycle is async/microtask-driven)
+ *
+ * Keeping the local chain as its own export breaks that cycle structurally.
+ */
+export async function generateLocalEmbedding(text: string): Promise<{
+  embedding: number[];
+  dimensions: number;
+  model: string;
+  backend: 'onnx' | 'mock';
+}> {
   // Ensure model is loaded
   if (!embeddingModelState?.loaded) {
     await loadEmbeddingModel();


### PR DESCRIPTION
## Root cause

**Not** the suspected SONA `endTrajectory`/`distillLearning`/EWC chain — container bisection shows that entire path flat at 122MB. The allocator is a **mutual recursion** armed by `rescueAgentdbEmbedder` (#2256-followup) in `memory-bridge.ts`:

```
generateEmbedding            (bridge-first, memory-initializer.ts)
  → bridgeGenerateEmbedding  (memory-bridge.ts)
    → registry.getAgentDB().embedder.embed   ← monkey-patched by the rescue…
      → generateEmbedding    …to call generateEmbedding. Cycle closed.
```

Microtask-driven, so no stack overflow — monotonic heap growth to the V8 limit (4050MB on the runner, SIGABRT 134, ~35s). V8 `--prof` of the crash names the loop directly: `newEmbed → generateEmbedding → getBridge` at 100% of the hot parent ticks.

**Why it evaded diagnosis:**
- Only arms when `@xenova/transformers` fails to init (`pipeline === null` → rescue applies) — true on the Linux CI runner, false on dev machines. Windows local peaks at 22MB heap.
- Only fires after the bridge registry is initialized — `hooks_post-task`'s `bridgeRecordFeedback` (phase 1) does that, then phase 3's `recordTrajectory → generateEmbedding` detonates. TEST 1 never initializes the registry, so it passes.
- The `CLAUDE_FLOW_SKIP_RUVLLM_TRAJECTORY` bypass had no effect because ruvllm was never the allocator.
- The rescue's own probe was supposed to prevent useless patching but accepted **any non-zero vector** — the deterministic hash fallback qualifies, so the probe "confirmed" a working rescuer using the very mock it was meant to avoid.

## Fix

1. **`memory-initializer.ts`** — extract `generateLocalEmbedding()` (transformers/ruvector/hash chain, never the bridge). `generateEmbedding()` delegates to it after the bridge attempt — zero behavior change for normal callers.
2. **`memory-bridge.ts`** — the rescue now delegates to `generateLocalEmbedding` (a bridge-free leaf — the cycle is structurally impossible). If the running memory-initializer build doesn't export it, the rescue declines entirely: stale pairings fail safe.
3. **Probe hardening** — requires `backend === 'onnx'`; when declining because the local chain is also degraded, tags `embedder.backend = 'mock'` so `bridgeGenerateEmbedding`'s AUDIT-#3 check stops labeling mock vectors as `onnx`.
4. **`v3-ci.yml`** — `continue-on-error` removed from the graph-trajectory smoke; it gates again.
5. **Smoke script** — `pathToFileURL` for dist imports (was unrunnable on Windows: `ERR_UNSUPPORTED_ESM_URL_SCHEME`).

## Verification

In a `node:22-bookworm` container with a CI-equivalent fresh install (`npm install` root + `pnpm install`/`pnpm -r build` in v3):

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Smoke, default heap, cold model cache | OOM SIGABRT ~36s | **10/10 PASS**, TEST 2 in 17ms |
| Smoke, `--max-old-space-size=512` | OOM | **10/10 PASS** |
| Direct `bridgeGenerateEmbedding` after registry init | OOM in <8s at 768MB | bounded |

Also: `tsc` clean; `memory-ruvector-deep` (147) + `memory-search-unified-2246` (9) green. The one failing test in `sona-embeddings-validation` (`embeddingServiceName` regex) fails identically on unmodified main — pre-existing, unrelated.

Note: on Windows the smoke now *runs* (item 5) but assertion 2b can fail on first run because the cold ONNX model load (~3s) blocks the first embed — pre-existing latency, separate concern from this fix; CI (ubuntu) is unaffected.

Fixes #2312

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)