### PR TITLE
fix: community bug batch — Windows path validation (#2352), trajectory-end feedback (#2351), init hooks settings (#2350)

### DIFF
--- a/v3/@claude-flow/cli-core/src/mcp-tools/validate-input.ts
+++ b/v3/@claude-flow/cli-core/src/mcp-tools/validate-input.ts
@@ -82,6 +82,15 @@ export function validatePackageName(value: unknown, label: string): ValidationRe
   return { valid: true, sanitized: value };
 }
 
+// Path-specific shell-meta check: backslash is a legitimate Windows path
+// separator (e.g. `E:\Repos\app\file.ts`) and Claude Code's hook events
+// deliver absolute paths in `tool_input.file_path` with backslashes on
+// Windows. The general SHELL_META set includes `\` for identifier safety,
+// but paths are not shell-expanded — normalizing to forward slashes for
+// the check keeps every other shell metacharacter rejected while letting
+// absolute Windows paths through (#2352).
+const PATH_SHELL_META = /[;&|`$(){}[\]<>!#]/;
+
 /**
  * Validate a file path (prevents traversal and shell injection).
  */
@@ -95,10 +104,13 @@ export function validatePath(value: unknown, label: string): ValidationResult {
   if (PATH_TRAVERSAL.test(value)) {
     return { valid: false, sanitized: '', error: `${label} contains path traversal (..)` };
   }
-  if (SHELL_META.test(value)) {
+  if (PATH_SHELL_META.test(value)) {
     return { valid: false, sanitized: '', error: `${label} contains shell metacharacters` };
   }
-  return { valid: true, sanitized: value };
+  // Normalize Windows backslashes to forward slashes in the sanitized value
+  // so downstream consumers see a single path shape regardless of OS.
+  const sanitized = value.replace(/\\/g, '/');
+  return { valid: true, sanitized };
 }
 
 /**

--- a/v3/@claude-flow/cli/__tests__/validate-input-path-2352.test.ts
+++ b/v3/@claude-flow/cli/__tests__/validate-input-path-2352.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #2352 (Bug A): validatePath used to reject every
+ * absolute Windows path because backslash was in the general SHELL_META set.
+ * Claude Code hook events deliver absolute paths in `tool_input.file_path`,
+ * so every forwarded `hooks post-edit` call failed on Windows — and Bug B
+ * hid the failure behind a "[OK]" log.
+ *
+ * Pin the contract: Windows-shaped paths are accepted, dangerous shell
+ * metacharacters and path traversal are still rejected.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validatePath } from '../src/mcp-tools/validate-input.js';
+
+describe('validatePath (#2352)', () => {
+  describe('Windows paths (the regression)', () => {
+    it('accepts an absolute Windows path with a drive letter', () => {
+      const r = validatePath('E:\\Repos\\my-app\\middleware.ts', 'filePath');
+      expect(r.valid).toBe(true);
+      // Sanitized form normalizes backslashes to forward slashes
+      expect(r.sanitized).toBe('E:/Repos/my-app/middleware.ts');
+    });
+
+    it('accepts a UNC-style Windows path', () => {
+      const r = validatePath('\\\\server\\share\\file.txt', 'filePath');
+      expect(r.valid).toBe(true);
+    });
+
+    it('accepts mixed separators', () => {
+      const r = validatePath('C:\\Users\\ruv/Projects\\ruflo/file.ts', 'filePath');
+      expect(r.valid).toBe(true);
+    });
+  });
+
+  describe('POSIX paths (must keep working)', () => {
+    it('accepts a relative forward-slash path', () => {
+      const r = validatePath('app/page.tsx', 'filePath');
+      expect(r.valid).toBe(true);
+      expect(r.sanitized).toBe('app/page.tsx');
+    });
+
+    it('accepts an absolute POSIX path', () => {
+      const r = validatePath('/home/ruv/repo/src/file.ts', 'filePath');
+      expect(r.valid).toBe(true);
+    });
+  });
+
+  describe('still rejects dangerous input', () => {
+    it('rejects path traversal with forward slashes', () => {
+      const r = validatePath('../etc/passwd', 'filePath');
+      expect(r.valid).toBe(false);
+      expect(r.error).toMatch(/path traversal/);
+    });
+
+    it('rejects path traversal with backslashes (Windows form)', () => {
+      const r = validatePath('..\\windows\\system32\\config', 'filePath');
+      expect(r.valid).toBe(false);
+      expect(r.error).toMatch(/path traversal/);
+    });
+
+    it.each([
+      ['semicolon', 'foo;rm -rf /'],
+      ['pipe',      'foo|cat /etc/passwd'],
+      ['ampersand', 'foo&calc.exe'],
+      ['backtick',  'foo`whoami`'],
+      ['dollar',    'foo$BAR'],
+      ['parens',    'foo$(echo bar)'],
+      ['braces',    'foo{a,b}.txt'],
+      ['brackets',  'foo[1].txt'],
+      ['redirect',  'foo>out.txt'],
+      ['append',    'foo<in.txt'],
+      ['bang',      'foo!bar'],
+      ['hash',      'foo#bar'],
+    ])('rejects %s in path', (_label, value) => {
+      const r = validatePath(value, 'filePath');
+      expect(r.valid).toBe(false);
+      expect(r.error).toMatch(/shell metacharacters/);
+    });
+
+    it('rejects an empty string', () => {
+      expect(validatePath('', 'filePath').valid).toBe(false);
+    });
+
+    it('rejects non-string input', () => {
+      expect(validatePath(null, 'filePath').valid).toBe(false);
+      expect(validatePath(undefined, 'filePath').valid).toBe(false);
+      expect(validatePath(42, 'filePath').valid).toBe(false);
+    });
+
+    it('rejects an over-long path', () => {
+      const long = 'a/'.repeat(2500) + 'file.ts';
+      expect(validatePath(long, 'filePath').valid).toBe(false);
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -466,9 +466,22 @@ const postEditCommand: Command = {
         timestamp: Date.now(),
       });
 
+      // #2352: the MCP handler returns `{success: false, error: "..."}` on
+      // validation failure (e.g. unsupported path shape) without throwing.
+      // Surface that explicitly instead of always printing the success line —
+      // Windows users were seeing `[OK]` while nothing reached the learning
+      // pipeline because absolute paths were rejected upstream.
+      const mcpFailed = result && (result as { success?: boolean }).success === false;
+      const mcpError = (result as { error?: string } | undefined)?.error;
+
       if (ctx.flags.format === 'json') {
         output.printJson(result);
-        return { success: true, data: result };
+        return { success: !mcpFailed, exitCode: mcpFailed ? 1 : 0, data: result };
+      }
+
+      if (mcpFailed) {
+        output.printError(`Post-edit hook failed: ${mcpError || 'unknown error'}`);
+        return { success: false, exitCode: 1 };
       }
 
       output.writeln();

--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -884,7 +884,13 @@ const hooksCommand: Command = {
         skills: false,
         commands: false,
         agents: false,
-        helpers: false,
+        // #2350: helpers MUST ship with the hooks subcommand. The hook entries
+        // in settings.json point at `.claude/helpers/hook-handler.cjs`; if
+        // that file doesn't exist, settings-generator (#1744 fix) drops the
+        // hooks block entirely — so the one subcommand whose stated purpose
+        // is "Initialize only hooks configuration" produced settings.json
+        // with no `hooks` key while reporting "N hooks enabled".
+        helpers: true,
         statusline: false,
         mcp: false,
         runtime: false,

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -2795,7 +2795,82 @@ export const hooksTrajectoryEnd: MCPTool = {
       } catch { /* intelligence module not loadable — keep sona-only behaviour */ }
     }
 
+    // #2351: when an agent calls trajectory-end with no recorded steps but a
+    // non-empty `feedback` string, the feedback was previously dropped on the
+    // floor — `patternsExtracted` reported 0 and `pattern-search` never
+    // surfaced it. Step-less trajectories are the common case for LLM agents
+    // (nothing forces step logging mid-task), and feedback is often the most
+    // distilled lesson available. Route it through the same store + embed
+    // path that pattern-store uses so it becomes searchable. Best-effort:
+    // failures here must not turn the trajectory-end call itself into a
+    // failure — the trajectory record was already persisted above.
+    let feedbackDistilled: { stored: boolean; patternId?: string; controller?: string } = { stored: false };
+    const hasSteps = !!trajectory && trajectory.steps.length > 0;
+    const trimmedFeedback = typeof feedback === 'string' ? feedback.trim() : '';
+    if (trajectory && !hasSteps && trimmedFeedback.length > 0) {
+      const distilledPatternId = `pattern-feedback-${trajectoryId}-${Date.now()}`;
+      const patternMetadata: Record<string, unknown> = {
+        sourceTrajectoryId: trajectoryId,
+        task: trajectory.task,
+        agent: trajectory.agent,
+        outcome: success ? 'success' : 'failure',
+        distilledFrom: 'trajectory-end-feedback',
+      };
+      // Modest default confidence — step-less feedback hasn't been validated
+      // by execution evidence the way a multi-step trajectory has.
+      const feedbackConfidence = success ? 0.6 : 0.4;
+
+      try {
+        const bridge = await import('../memory/memory-bridge.js');
+        const rb = await bridge.bridgeStorePattern({
+          pattern: trimmedFeedback,
+          type: 'trajectory-feedback',
+          confidence: feedbackConfidence,
+          metadata: patternMetadata,
+        });
+        if (rb?.success) {
+          feedbackDistilled = { stored: true, patternId: rb.patternId, controller: rb.controller };
+        }
+      } catch {
+        // Bridge unavailable — fall through to direct store
+      }
+
+      if (!feedbackDistilled.stored) {
+        try {
+          const storeFn = await getRealStoreFunction();
+          if (storeFn) {
+            const r = await storeFn({
+              key: distilledPatternId,
+              value: JSON.stringify({
+                pattern: trimmedFeedback,
+                type: 'trajectory-feedback',
+                confidence: feedbackConfidence,
+                metadata: patternMetadata,
+                timestamp: endedAt,
+              }),
+              namespace: 'pattern',
+              generateEmbeddingFlag: true,
+              tags: [
+                'trajectory-feedback',
+                success ? 'success' : 'failure',
+                `confidence-${Math.round(feedbackConfidence * 100)}`,
+              ],
+            });
+            if (r?.success) {
+              feedbackDistilled = { stored: true, patternId: r.id || distilledPatternId, controller: 'store-fallback' };
+            }
+          }
+        } catch {
+          // Both paths failed — leave feedbackDistilled.stored = false.
+        }
+      }
+    }
+
     const learningTimeMs = Date.now() - startTime;
+    // patternsExtracted now reflects either recorded steps (the original
+    // semantics) OR a distilled feedback pattern (#2351), so step-less
+    // trajectories with useful feedback no longer report 0.
+    const patternsExtracted = (trajectory?.steps.length || 0) + (feedbackDistilled.stored ? 1 : 0);
 
     return {
       trajectoryId,
@@ -2809,7 +2884,11 @@ export const hooksTrajectoryEnd: MCPTool = {
         sonaConfidence: sonaResult.confidence || undefined,
         ewcConsolidation: ewcResult.consolidated,
         ewcPenalty: ewcResult.penalty || undefined,
-        patternsExtracted: trajectory?.steps.length || 0,
+        patternsExtracted,
+        feedbackDistilled: feedbackDistilled.stored ? {
+          patternId: feedbackDistilled.patternId,
+          controller: feedbackDistilled.controller,
+        } : undefined,
         learningTimeMs,
         globalStatsTrajectoriesDelta: globalStatsDelta,  // Round B: was 0, now reflects
       },


### PR DESCRIPTION
## Summary

Three reproducible community bugs reported by @grym3s, batched in the style of #2346.

- **Closes #2352** — `hooks post-edit`: `validatePath` rejected absolute Windows paths because `\` was in the general shell-metacharacter set. Claude Code hook events deliver absolute paths in `tool_input.file_path`, so every forwarded `post-edit` call failed on Windows — and the CLI printed `[OK]` over the failure, so the loss was silent.
- **Closes #2351** — `trajectory-end`: when called with `feedback` but no recorded steps (the common LLM-agent case), the feedback was persisted with the trajectory but never embedded as a searchable pattern. `patternsExtracted` always reported 0 and `pattern-search` never surfaced it.
- **Closes #2350** — `init hooks` subcommand wrote a `settings.json` with no top-level `hooks` key while reporting `"N hooks enabled"`. The settings generator gates the hooks block on `components.helpers`, which the subcommand had hard-coded to `false`.

## Changes

| File | Fix |
|------|-----|
| `v3/@claude-flow/cli-core/src/mcp-tools/validate-input.ts` | New `PATH_SHELL_META` excludes `\`; sanitized output normalizes `\` → `/`. Path traversal regex already covered `..\`. |
| `v3/@claude-flow/cli/src/commands/hooks.ts` | `post-edit` action checks `result.success`, surfaces the error, exits non-zero. Applies to both `--format json` and default output. |
| `v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts` | `trajectory-end`: when `steps.length === 0` and `feedback` is non-empty, route the trimmed feedback through `bridge.bridgeStorePattern` (or store-fallback) with modest default confidence (0.6 success / 0.4 failure), tagged `trajectory-feedback`. Best-effort: distillation failures don't fail the call. New `feedbackDistilled` field on the response. |
| `v3/@claude-flow/cli/src/commands/init.ts` | `init hooks` subcommand now sets `helpers: true` so the settings generator emits the hooks block and the handler script is installed. |
| `v3/@claude-flow/cli/__tests__/validate-input-path-2352.test.ts` | New 22-test regression suite — Windows path acceptance, POSIX still works, all shell metacharacters and traversal still rejected. |

## Test plan

- [x] New: `validate-input-path-2352.test.ts` — 22 tests pass
- [x] Existing `validate-input-env.test.ts`, `validate-input-agent-spawn.test.ts` — 23 tests pass
- [x] Existing `init-wizard-bugs.test.ts`, `hooks-intelligence-learning.test.ts`, `hooks-post-task-parent-agent-id.test.ts` — 21 tests pass
- [x] `npm run build` clean on both `@claude-flow/cli-core` and `@claude-flow/cli`
- [ ] Repro check from issue bodies:
  - `ruflo hooks post-edit -f "E:\Repos\my-app\middleware.ts" --success true --format json` — now `{success: true, ...}` instead of `{success: false, error: "shell metacharacters"}`
  - Same call without `--format json` — now prints success line; an actual failure surfaces as `[ERROR]` with exit 1
  - `hooks_intelligence_trajectory-start {task:"x"}` → `hooks_intelligence_trajectory-end {trajectoryId, success:true, feedback:"useful lesson"}` — `patternsExtracted: 1`, response now includes `feedbackDistilled.{patternId, controller}`, `pattern-search` for "useful lesson" returns the new pattern
  - `mkdir t1 && cd t1 && ruflo init hooks` — `.claude/settings.json` now contains the full `hooks` block (PreToolUse/PostToolUse/SessionStart/SessionEnd/Stop/PreCompact/Subagent*/Notification) wired to `.claude/helpers/hook-handler.cjs`, and the helper exists

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)