### PR TITLE
fix(agent-execute): omit removed sampling params for Fable 5 / Opus 4.8 / Opus 4.7 (#2357 Finding A)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/sampling-params-2357.test.ts
+++ b/v3/@claude-flow/cli/__tests__/sampling-params-2357.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #2357 (Finding A): callAnthropicMessages always sent
+ * `temperature` (default 0.7), but the adaptive-thinking family — Fable 5,
+ * Opus 4.8, Opus 4.7 — removed temperature/top_p/top_k. The API rejects the
+ * request with 400 "temperature: Extra inputs are not permitted", so
+ * agent_execute / workflow_run / the WASM-agent Anthropic path could not
+ * call any current frontier model when an ANTHROPIC_API_KEY was set.
+ *
+ * Pin the contract: sampling params are omitted for models that reject them,
+ * and unchanged (including the 0.7 default) for models that still accept
+ * them. The Ollama / OpenRouter OpenAI-compat paths are out of scope — they
+ * accept temperature.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  callAnthropicMessages,
+  modelRejectsSamplingParams,
+} from '../src/mcp-tools/agent-execute-core.js';
+
+describe('modelRejectsSamplingParams (#2357)', () => {
+  it.each([
+    'claude-fable-5',
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+  ])('rejects sampling params for %s', (m) => {
+    expect(modelRejectsSamplingParams(m)).toBe(true);
+  });
+
+  it('covers dated snapshots of the same family', () => {
+    expect(modelRejectsSamplingParams('claude-opus-4-8-20260301')).toBe(true);
+  });
+
+  it.each([
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5-20251001',
+    'claude-opus-4-6', // pre-4.7 Opus still accepts sampling params
+  ])('keeps sampling params for %s', (m) => {
+    expect(modelRejectsSamplingParams(m)).toBe(false);
+  });
+});
+
+describe('callAnthropicMessages request body (#2357)', () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    captured.length = 0;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-not-real';
+    delete process.env.RUFLO_PROVIDER;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_KEY;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, opts: { body: string }) => {
+        const body = JSON.parse(opts.body) as Record<string, unknown>;
+        captured.push(body);
+        return {
+          ok: true,
+          json: async () => ({
+            id: 'msg_test',
+            model: body.model,
+            content: [{ type: 'text', text: 'ok' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+        };
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...savedEnv };
+  });
+
+  it.each([
+    'claude-fable-5',
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+  ])('omits temperature for %s (the API 400s otherwise)', async (model) => {
+    const r = await callAnthropicMessages({ prompt: 'ping', model, maxTokens: 8 });
+    expect(r.success).toBe(true);
+    expect(captured[0]).not.toHaveProperty('temperature');
+  });
+
+  it('still sends the 0.7 default for models that accept sampling params', async () => {
+    await callAnthropicMessages({ prompt: 'ping', model: 'claude-sonnet-4-6', maxTokens: 8 });
+    expect(captured[0]).toHaveProperty('temperature', 0.7);
+  });
+
+  it('honors an explicit temperature for accepting models', async () => {
+    await callAnthropicMessages({
+      prompt: 'ping',
+      model: 'claude-haiku-4-5-20251001',
+      temperature: 0.2,
+      maxTokens: 8,
+    });
+    expect(captured[0]).toHaveProperty('temperature', 0.2);
+  });
+
+  it('drops even an explicit temperature for frontier models (would 400)', async () => {
+    await callAnthropicMessages({
+      prompt: 'ping',
+      model: 'claude-fable-5',
+      temperature: 0.9,
+      maxTokens: 8,
+    });
+    expect(captured[0]).not.toHaveProperty('temperature');
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
@@ -69,6 +69,16 @@ const MODEL_MAP: Record<string, string> = {
   inherit: DEFAULT_ANTHROPIC_MODEL,
 };
 
+// #2357 — the adaptive-thinking family (Fable 5, Opus 4.8, Opus 4.7) removed
+// the sampling parameters (temperature/top_p/top_k); the Anthropic API
+// returns 400 "Extra inputs are not permitted" when any is present.
+// Prefix-match so dated snapshots (e.g. claude-opus-4-8-YYYYMMDD) are
+// covered. Applies only to the direct Anthropic path — the Ollama/OpenRouter
+// OpenAI-compat paths accept temperature and are unchanged.
+export function modelRejectsSamplingParams(model: string): boolean {
+  return /^claude-(fable-5|opus-4-8|opus-4-7)/.test(model);
+}
+
 export interface AnthropicCallInput {
   prompt: string;
   systemPrompt?: string;
@@ -150,7 +160,13 @@ export async function callAnthropicMessages(input: AnthropicCallInput): Promise<
       body: JSON.stringify({
         model,
         max_tokens: input.maxTokens || 1024,
-        temperature: typeof input.temperature === 'number' ? input.temperature : 0.7,
+        // #2357 — omit temperature for models that reject sampling params
+        // (Fable 5 / Opus 4.8 / Opus 4.7 → 400 "Extra inputs are not
+        // permitted"); keep the 0.7 default unchanged for models that still
+        // accept it (sonnet / haiku / opus ≤4.6).
+        ...(modelRejectsSamplingParams(model)
+          ? {}
+          : { temperature: typeof input.temperature === 'number' ? input.temperature : 0.7 }),
         // #8 prompt caching (hermes-agent pattern): mark the (often large,
         // stable) system prompt as an ephemeral cache breakpoint so repeated
         // agent_execute calls with the same system prompt hit Anthropic's


### PR DESCRIPTION
## What

`callAnthropicMessages()` always sent `temperature` (default `0.7`), but the adaptive-thinking family — **Fable 5, Opus 4.8, Opus 4.7** — removed `temperature`/`top_p`/`top_k`. The API rejects the request:

```text
400 invalid_request_error: temperature: Extra inputs are not permitted
```

So `agent_execute` / `workflow_run` / the WASM-agent Anthropic path **cannot call any current frontier model** when an `ANTHROPIC_API_KEY` is set. (Invisible on Claude-Max — no key → the provider check short-circuits before the fetch — fatal on a real key.)

**Part of #2357 (Finding A) — does not close the issue** (the Fable routing tier in #2357 §4–§6 is separate work).

## How

- New exported predicate `modelRejectsSamplingParams(model)` — prefix-matched (`/^claude-(fable-5|opus-4-8|opus-4-7)/`) so dated snapshots are covered.
- The Anthropic request body includes `temperature` **only** when the model accepts it. The `0.7` default for sonnet / haiku / opus ≤ 4.6 is byte-for-byte unchanged.
- The Ollama / OpenRouter OpenAI-compat paths accept `temperature` and are untouched.

Net source diff: **+17 / −1** in `agent-execute-core.ts`, plus a vitest regression.

## Proof (mocked `fetch`, request body captured per model — no network, no real key)

**BEFORE — installed `3.10.42` dist (the shipping artifact):**
```text
claude-fable-5               temperature in body: YES (0.7)   ← would 400
claude-opus-4-8              temperature in body: YES (0.7)   ← would 400
claude-opus-4-7              temperature in body: YES (0.7)   ← would 400
claude-sonnet-4-6            temperature in body: YES (0.7)
```

**AFTER — identical harness, fix applied:**
```text
claude-fable-5               temperature in body: no          ✅
claude-opus-4-8              temperature in body: no          ✅
claude-opus-4-7              temperature in body: no          ✅
claude-sonnet-4-6            temperature in body: YES (0.7)   ✅ unchanged
```

## Tests

`v3/@claude-flow/cli/__tests__/sampling-params-2357.test.ts` (follows the `validate-input-path-2352.test.ts` convention):
- predicate: rejects the frontier three + dated snapshots; keeps sonnet/haiku/opus-4.6
- request body via stubbed `fetch`: omits `temperature` for the frontier three (even when explicitly provided — it would 400); preserves the `0.7` default and explicit values for accepting models

**Run locally ✅:** the before/after dist-level harness above (full transcript), **plus the vitest regressions — 21/21 passing** across this file and #2359's (npm can't resolve the workspace's pnpm `workspace:*` protocol, so vitest was side-installed; the workspace sibling `@claude-flow/cli-core` resolved from the published 3.10.42 dist). Happy to iterate if CI flags anything.

## Risk

- Behavior-preserving for every model that accepts sampling params (the default path today).
- For the frontier three, the only behavior change is *removing* a parameter the API hard-rejects — there is no scenario where sending it succeeds.
- One judgment call: an **explicitly provided** `temperature` is also dropped for the frontier three (sending it can only 400). If you'd rather surface a warning instead of silently dropping, glad to add a `console.warn` — say the word.

🤖 Generated with [ruflo](https://github.com/ruvnet/ruflo)
