### PR TITLE
feat(router): Claude Fable 5 explicit-opt-in frontier tier — ADR-148 P1+P2 (RFC, #2357)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/fable-tier-2357.test.ts
+++ b/v3/@claude-flow/cli/__tests__/fable-tier-2357.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for #2357 / ADR-148 P1+P2: Claude Fable 5 as an explicit-opt-in
+ * frontier tier.
+ *
+ * Pins three contracts:
+ *  1. Alias — `fable` resolves to `claude-fable-5`; literal ids pass through.
+ *  2. Behavior-neutrality — fable's complexity score is 0, so the router's
+ *     automatic selection NEVER returns fable (it is reachable only via
+ *     explicit `model: "fable"`). Routing for existing tiers is unchanged.
+ *  3. Forward-migration safety — persisted router state written BEFORE the
+ *     `fable` key existed (both v1-flat and v2-bucketed layouts) must load
+ *     without crashing and backfill Beta(1,1) for the new key, instead of
+ *     propagating `undefined` into sampleBeta() (NaN poisons the argmax).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+
+import { resolveAnthropicModel } from '../src/mcp-tools/agent-execute-core.js';
+import {
+  MODEL_CAPABILITIES,
+  clonePriors,
+  createModelRouter,
+} from '../src/ruvector/model-router.js';
+
+describe('fable alias + capabilities (#2357)', () => {
+  it('resolves the fable alias to the canonical model id', () => {
+    expect(resolveAnthropicModel('fable')).toBe('claude-fable-5');
+  });
+
+  it('still passes the literal id through verbatim (post-#2232 contract)', () => {
+    expect(resolveAnthropicModel('claude-fable-5')).toBe('claude-fable-5');
+  });
+
+  it('registers fable in MODEL_CAPABILITIES at 2x opus cost', () => {
+    expect(MODEL_CAPABILITIES.fable).toBeDefined();
+    expect(MODEL_CAPABILITIES.fable.costMultiplier).toBe(2.0);
+    // ties opus on the capped complexity axis — cost is the differentiator
+    expect(MODEL_CAPABILITIES.fable.maxComplexity).toBe(1.0);
+  });
+});
+
+describe('clonePriors backfills missing model keys (#2357 trap)', () => {
+  it('backfills Beta(1,1) for a pre-fable prior object', () => {
+    const legacy = {
+      haiku: { alpha: 5, beta: 2 },
+      sonnet: { alpha: 1, beta: 1 },
+      opus: { alpha: 3, beta: 4 },
+      inherit: { alpha: 1, beta: 1 },
+      // no `fable` key — written by an older version
+    };
+    const cloned = clonePriors(legacy);
+    expect(cloned.fable).toEqual({ alpha: 1, beta: 1 });
+    // learned values survive untouched
+    expect(cloned.haiku).toEqual({ alpha: 5, beta: 2 });
+    expect(cloned.opus).toEqual({ alpha: 3, beta: 4 });
+  });
+
+  it('ignores malformed entries instead of propagating them', () => {
+    const cloned = clonePriors({ haiku: { alpha: 2, beta: 1 }, fable: null as never });
+    expect(cloned.fable).toEqual({ alpha: 1, beta: 1 });
+    expect(cloned.haiku).toEqual({ alpha: 2, beta: 1 });
+  });
+});
+
+describe('router with legacy persisted state (#2357 forward-migration)', () => {
+  const dirs: string[] = [];
+  // ModelRouter resolves statePath via join(process.cwd(), statePath), which
+  // mangles absolute paths — hand it a cwd-relative path so loadState()
+  // genuinely reads our crafted legacy file.
+  const tmpStatePath = (state: unknown): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'ruflo-2357-'));
+    dirs.push(dir);
+    const p = join(dir, 'model-router-state.json');
+    writeFileSync(p, JSON.stringify(state), 'utf-8');
+    return relative(process.cwd(), p);
+  };
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  const legacyFlatPriors = {
+    haiku: { alpha: 4, beta: 2 },
+    sonnet: { alpha: 2, beta: 2 },
+    opus: { alpha: 1, beta: 3 },
+    inherit: { alpha: 1, beta: 1 },
+  };
+
+  it('loads v1-flat pre-fable state without crashing and routes normally', async () => {
+    const router = createModelRouter({
+      statePath: tmpStatePath({ priors: legacyFlatPriors }),
+      autoSaveInterval: 1000, // don't persist during the test
+    });
+    const result = await router.route('fix a typo in the README');
+    expect(['haiku', 'sonnet', 'opus']).toContain(result.model);
+    expect(Number.isNaN(result.confidence)).toBe(false);
+  });
+
+  it('loads v2-bucketed pre-fable state and backfills fable priors', async () => {
+    const router = createModelRouter({
+      statePath: tmpStatePath({
+        priors: {
+          low: legacyFlatPriors,
+          med: legacyFlatPriors,
+          high: legacyFlatPriors,
+        },
+      }),
+      autoSaveInterval: 1000,
+    });
+    // selection must not crash on the missing key…
+    const result = await router.route(
+      'redesign the distributed consensus architecture for byzantine fault tolerance'
+    );
+    expect(['haiku', 'sonnet', 'opus']).toContain(result.model);
+    // …and the migrated priors expose a valid Beta(1,1) for fable
+    const priors = router.getBanditPriors('med');
+    expect(priors.fable).toEqual({ alpha: 1, beta: 1 });
+    // learned legacy values survive the migration
+    expect(priors.haiku).toEqual({ alpha: 4, beta: 2 });
+  });
+
+  it('never auto-selects fable from complexity alone (explicit-only contract)', async () => {
+    const router = createModelRouter({
+      statePath: tmpStatePath({}),
+      autoSaveInterval: 1000,
+    });
+    // maximum-complexity prompts across repeated runs — fable must never win
+    for (let i = 0; i < 25; i++) {
+      const result = await router.route(
+        'architect a security-critical distributed system migration with formal verification and byzantine consensus'
+      );
+      expect(result.model).not.toBe('fable');
+    }
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/sampling-params-2357.test.ts
+++ b/v3/@claude-flow/cli/__tests__/sampling-params-2357.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #2357 (Finding A): callAnthropicMessages always sent
+ * `temperature` (default 0.7), but the adaptive-thinking family — Fable 5,
+ * Opus 4.8, Opus 4.7 — removed temperature/top_p/top_k. The API rejects the
+ * request with 400 "temperature: Extra inputs are not permitted", so
+ * agent_execute / workflow_run / the WASM-agent Anthropic path could not
+ * call any current frontier model when an ANTHROPIC_API_KEY was set.
+ *
+ * Pin the contract: sampling params are omitted for models that reject them,
+ * and unchanged (including the 0.7 default) for models that still accept
+ * them. The Ollama / OpenRouter OpenAI-compat paths are out of scope — they
+ * accept temperature.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  callAnthropicMessages,
+  modelRejectsSamplingParams,
+} from '../src/mcp-tools/agent-execute-core.js';
+
+describe('modelRejectsSamplingParams (#2357)', () => {
+  it.each([
+    'claude-fable-5',
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+  ])('rejects sampling params for %s', (m) => {
+    expect(modelRejectsSamplingParams(m)).toBe(true);
+  });
+
+  it('covers dated snapshots of the same family', () => {
+    expect(modelRejectsSamplingParams('claude-opus-4-8-20260301')).toBe(true);
+  });
+
+  it.each([
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5-20251001',
+    'claude-opus-4-6', // pre-4.7 Opus still accepts sampling params
+  ])('keeps sampling params for %s', (m) => {
+    expect(modelRejectsSamplingParams(m)).toBe(false);
+  });
+});
+
+describe('callAnthropicMessages request body (#2357)', () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    captured.length = 0;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-not-real';
+    delete process.env.RUFLO_PROVIDER;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_KEY;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, opts: { body: string }) => {
+        const body = JSON.parse(opts.body) as Record<string, unknown>;
+        captured.push(body);
+        return {
+          ok: true,
+          json: async () => ({
+            id: 'msg_test',
+            model: body.model,
+            content: [{ type: 'text', text: 'ok' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+        };
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...savedEnv };
+  });
+
+  it.each([
+    'claude-fable-5',
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+  ])('omits temperature for %s (the API 400s otherwise)', async (model) => {
+    const r = await callAnthropicMessages({ prompt: 'ping', model, maxTokens: 8 });
+    expect(r.success).toBe(true);
+    expect(captured[0]).not.toHaveProperty('temperature');
+  });
+
+  it('still sends the 0.7 default for models that accept sampling params', async () => {
+    await callAnthropicMessages({ prompt: 'ping', model: 'claude-sonnet-4-6', maxTokens: 8 });
+    expect(captured[0]).toHaveProperty('temperature', 0.7);
+  });
+
+  it('honors an explicit temperature for accepting models', async () => {
+    await callAnthropicMessages({
+      prompt: 'ping',
+      model: 'claude-haiku-4-5-20251001',
+      temperature: 0.2,
+      maxTokens: 8,
+    });
+    expect(captured[0]).toHaveProperty('temperature', 0.2);
+  });
+
+  it('drops even an explicit temperature for frontier models (would 400)', async () => {
+    await callAnthropicMessages({
+      prompt: 'ping',
+      model: 'claude-fable-5',
+      temperature: 0.9,
+      maxTokens: 8,
+    });
+    expect(captured[0]).not.toHaveProperty('temperature');
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
@@ -16,7 +16,7 @@ const STORAGE_DIR = '.claude-flow';
 const AGENT_DIR = 'agents';
 const AGENT_FILE = 'store.json';
 
-type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'inherit';
+type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'fable' | 'inherit';
 
 export interface AgentRecord {
   agentId: string;
@@ -66,6 +66,9 @@ const MODEL_MAP: Record<string, string> = {
   sonnet: 'claude-sonnet-4-6',
   opus: 'claude-opus-4-8',
   'opus-4.7': 'claude-opus-4-7',
+  // #2357 / ADR-148 P1 — frontier tier ($10/$50 per MTok, 2× Opus 4.8);
+  // explicit opt-in only, never auto-selected by the router.
+  fable: 'claude-fable-5',
   inherit: DEFAULT_ANTHROPIC_MODEL,
 };
 

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
@@ -69,6 +69,16 @@ const MODEL_MAP: Record<string, string> = {
   inherit: DEFAULT_ANTHROPIC_MODEL,
 };
 
+// #2357 — the adaptive-thinking family (Fable 5, Opus 4.8, Opus 4.7) removed
+// the sampling parameters (temperature/top_p/top_k); the Anthropic API
+// returns 400 "Extra inputs are not permitted" when any is present.
+// Prefix-match so dated snapshots (e.g. claude-opus-4-8-YYYYMMDD) are
+// covered. Applies only to the direct Anthropic path — the Ollama/OpenRouter
+// OpenAI-compat paths accept temperature and are unchanged.
+export function modelRejectsSamplingParams(model: string): boolean {
+  return /^claude-(fable-5|opus-4-8|opus-4-7)/.test(model);
+}
+
 export interface AnthropicCallInput {
   prompt: string;
   systemPrompt?: string;
@@ -150,7 +160,13 @@ export async function callAnthropicMessages(input: AnthropicCallInput): Promise<
       body: JSON.stringify({
         model,
         max_tokens: input.maxTokens || 1024,
-        temperature: typeof input.temperature === 'number' ? input.temperature : 0.7,
+        // #2357 — omit temperature for models that reject sampling params
+        // (Fable 5 / Opus 4.8 / Opus 4.7 → 400 "Extra inputs are not
+        // permitted"); keep the 0.7 default unchanged for models that still
+        // accept it (sonnet / haiku / opus ≤4.6).
+        ...(modelRejectsSamplingParams(model)
+          ? {}
+          : { temperature: typeof input.temperature === 'number' ? input.temperature : 0.7 }),
         // #8 prompt caching (hermes-agent pattern): mark the (often large,
         // stable) system prompt as an ephemeral cache breakpoint so repeated
         // agent_execute calls with the same system prompt hit Anthropic's

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -22,7 +22,7 @@ const AGENT_FILE = 'store.json';
 const HIVE_AGENT_FILE = 'agents.json';
 
 // Model types matching Claude Agent SDK
-type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'inherit';
+type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'fable' | 'inherit';
 
 interface AgentRecord {
   agentId: string;
@@ -159,7 +159,7 @@ async function determineAgentModel(
   tier?: 1 | 2 | 3;
 }> {
   // 1. Explicit model in config
-  if (config.model && ['haiku', 'sonnet', 'opus', 'opus-4.7', 'inherit'].includes(config.model as string)) {
+  if (config.model && ['haiku', 'sonnet', 'opus', 'opus-4.7', 'fable', 'inherit'].includes(config.model as string)) {
     return { model: config.model as ClaudeModel, routedBy: 'explicit' };
   }
 
@@ -230,7 +230,7 @@ export const agentTools: MCPTool[] = [
         model: {
           type: 'string',
           enum: ['haiku', 'sonnet', 'opus', 'opus-4.7', 'inherit'],
-          description: 'Claude model alias (haiku=fast/cheap, sonnet=balanced, opus=current Opus 4.8, opus-4.7=prior Opus pin)'
+          description: 'Claude model alias (haiku=fast/cheap, sonnet=balanced, opus=current Opus 4.8, opus-4.7=prior Opus pin, fable=frontier Fable 5 — 2× Opus cost, explicit opt-in only)'
         },
         task: { type: 'string', description: 'Task description for intelligent model routing' },
       },

--- a/v3/@claude-flow/cli/src/ruvector/model-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/model-router.ts
@@ -42,7 +42,7 @@ import { dirname, join } from 'path';
 /**
  * Available Claude models for routing
  */
-export type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'inherit';
+export type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'fable' | 'inherit';
 
 /**
  * Model capabilities and characteristics
@@ -70,6 +70,15 @@ export const MODEL_CAPABILITIES: Record<ClaudeModel, {
     costMultiplier: 1.0,    // Baseline
     speedMultiplier: 1.0,   // Baseline
     description: 'Most capable for complex reasoning',
+  },
+  // #2357 / ADR-148 — Fable 5 ties opus on the (0–1-capped) complexity axis;
+  // cost is the real differentiator ($10/$50 vs $5/$25 per MTok). Opt-in
+  // only — never auto-selected from complexity (see computeModelScores).
+  fable: {
+    maxComplexity: 1.0,
+    costMultiplier: 2.0,    // 2× Opus
+    speedMultiplier: 0.8,   // estimate — tune from telemetry
+    description: 'Frontier tier — maximum intelligence for critical / long-horizon work (explicit opt-in)',
   },
   inherit: {
     maxComplexity: 1.0,
@@ -184,6 +193,9 @@ const BANDIT_REWARDS: Record<ClaudeModel, Record<'success' | 'failure' | 'escala
   haiku:   { success: 1.0, failure: 0.0, escalated: 0.0 },
   sonnet:  { success: 0.7, failure: 0.0, escalated: 0.1 },
   opus:    { success: 0.4, failure: 0.0, escalated: 0.0 },
+  // #2357 — success reward continues the cost gradient (1.0/0.7/0.4/0.2):
+  // the dearer the model, the less credit a bare success earns.
+  fable:   { success: 0.2, failure: 0.0, escalated: 0.0 },
   inherit: { success: 0.5, failure: 0.0, escalated: 0.0 },
 };
 
@@ -296,6 +308,7 @@ function defaultBanditPriors(): Record<ClaudeModel, BetaPrior> {
     haiku:   { alpha: 1, beta: 1 },
     sonnet:  { alpha: 1, beta: 1 },
     opus:    { alpha: 1, beta: 1 },
+    fable:   { alpha: 1, beta: 1 },
     inherit: { alpha: 1, beta: 1 },
   };
 }
@@ -305,8 +318,18 @@ function defaultBucketedPriors(): BucketedPriors {
   return { low: defaultBanditPriors(), med: defaultBanditPriors(), high: defaultBanditPriors() };
 }
 
-function clonePriors(p: Record<ClaudeModel, BetaPrior>): Record<ClaudeModel, BetaPrior> {
-  return { haiku: { ...p.haiku }, sonnet: { ...p.sonnet }, opus: { ...p.opus }, inherit: { ...p.inherit } };
+// #2357 — defensive clone: persisted snapshots written before a model key
+// existed (e.g. pre-`fable` state) must backfill Beta(1,1) instead of
+// propagating `undefined` into sampleBeta() (NaN scores poison the argmax).
+// Iterates the canonical key set so future model additions can't silently
+// miss this site again. Exported for tests.
+export function clonePriors(p: Partial<Record<ClaudeModel, BetaPrior>>): Record<ClaudeModel, BetaPrior> {
+  const out = defaultBanditPriors();
+  for (const k of Object.keys(out) as ClaudeModel[]) {
+    const prior = p[k];
+    if (prior && typeof prior.alpha === 'number') out[k] = { ...prior };
+  }
+  return out;
 }
 
 /**
@@ -322,9 +345,11 @@ function migratePriors(p: unknown): BucketedPriors {
   const obj = p as Record<string, any>;
   if (obj.low && typeof obj.low === 'object' && obj.low.haiku) {
     return {
-      low: obj.low,
-      med: obj.med ?? clonePriors(obj.low),
-      high: obj.high ?? clonePriors(obj.low),
+      // clonePriors (not raw keep) so legacy buckets missing a newer model
+      // key — e.g. pre-`fable` state — are backfilled with Beta(1,1) (#2357).
+      low: clonePriors(obj.low),
+      med: clonePriors(obj.med ?? obj.low),
+      high: clonePriors(obj.high ?? obj.low),
     };
   }
   if (obj.haiku && typeof obj.haiku.alpha === 'number') {
@@ -381,6 +406,7 @@ export class ModelRouter {
     haiku: 0,
     sonnet: 0,
     opus: 0,
+    fable: 0,
     inherit: 0,
   };
 
@@ -561,6 +587,11 @@ export class ModelRouter {
       haiku: Math.max(0, 1 - score * 2), // Drops off quickly as complexity rises
       sonnet: 1 - Math.abs(score - 0.5) * 2, // Peaks at medium complexity
       opus: Math.min(1, score * 1.5), // Rises with complexity
+      // #2357 / ADR-148 P2 — explicit-only: the 0–1 complexity axis caps at
+      // opus, so fable never wins the argmax here. Reachable today via
+      // routedBy:'explicit' (model:"fable"); ADR-148 P3 adds the
+      // allowFrontier-gated escalation rung.
+      fable: 0,
       inherit: 0.1, // Low baseline unless explicitly needed
     };
   }
@@ -603,10 +634,14 @@ export class ModelRouter {
     // keyed by complexity bucket (ADR-142) so learning is task-type-local.
     const bucketed = this.state.priors ?? defaultBucketedPriors();
     const priors = bucketed[complexityBucket(complexityScore)] ?? defaultBanditPriors();
+    // #2357 — belt-and-braces: state objects can predate the `fable` key
+    // (migratePriors/clonePriors backfill on load, but guard the read too).
+    const fablePrior = priors.fable ?? { alpha: 1, beta: 1 };
     const sampledScores: Record<ClaudeModel, number> = {
       haiku:   scores.haiku   * sampleBeta(priors.haiku.alpha,   priors.haiku.beta),
       sonnet:  scores.sonnet  * sampleBeta(priors.sonnet.alpha,  priors.sonnet.beta),
       opus:    scores.opus    * sampleBeta(priors.opus.alpha,    priors.opus.beta),
+      fable:   scores.fable   * sampleBeta(fablePrior.alpha,     fablePrior.beta),
       inherit: scores.inherit, // not bandit-controlled
     };
 
@@ -788,7 +823,7 @@ export class ModelRouter {
   private loadState(): RouterState {
     const defaultState: RouterState = {
       totalDecisions: 0,
-      modelDistribution: { haiku: 0, sonnet: 0, opus: 0, inherit: 0 },
+      modelDistribution: { haiku: 0, sonnet: 0, opus: 0, fable: 0, inherit: 0 },
       avgComplexity: 0.5,
       avgConfidence: 0.8,
       circuitBreakerTrips: 0,
@@ -839,7 +874,7 @@ export class ModelRouter {
   reset(): void {
     this.state = {
       totalDecisions: 0,
-      modelDistribution: { haiku: 0, sonnet: 0, opus: 0, inherit: 0 },
+      modelDistribution: { haiku: 0, sonnet: 0, opus: 0, fable: 0, inherit: 0 },
       avgComplexity: 0.5,
       avgConfidence: 0.8,
       circuitBreakerTrips: 0,
@@ -848,7 +883,7 @@ export class ModelRouter {
       version: 2,
       priors: defaultBucketedPriors(),
     };
-    this.consecutiveFailures = { haiku: 0, sonnet: 0, opus: 0, inherit: 0 };
+    this.consecutiveFailures = { haiku: 0, sonnet: 0, opus: 0, fable: 0, inherit: 0 };
     this.decisionCount = 0;
     this.saveState();
   }
@@ -861,12 +896,9 @@ export class ModelRouter {
   getBanditPriors(bucket: ComplexityBucket = 'med'): Record<ClaudeModel, BetaPrior> {
     const bucketed = this.state.priors ?? defaultBucketedPriors();
     const p = bucketed[bucket] ?? defaultBanditPriors();
-    return {
-      haiku:   { ...p.haiku },
-      sonnet:  { ...p.sonnet },
-      opus:    { ...p.opus },
-      inherit: { ...p.inherit },
-    };
+    // #2357 — clonePriors (not a literal-keyed copy) so the accessor can't
+    // silently drop newer model keys; was the fifth literal-key site.
+    return clonePriors(p);
   }
 
   /** All bucketed priors (copy) — for dashboards/tests. */


### PR DESCRIPTION
## What

Implements **ADR-148 P1+P2** from #2357: `claude-fable-5` as an **explicit-opt-in frontier tier**. Draft/RFC — the design calls flagged below are yours to make; happy to iterate.

> **Stacked on #2358** (the `temperature` 400 fix) — that commit appears first in this diff. Merge #2358 and this PR reduces to the second commit only.

## Behavior-neutral by construction

Fable's complexity base score is **0** — the 0–1 axis caps at Opus (`Math.min(1, score * 1.5)`), so automatic selection **can never return fable**. It is reachable only via explicit `model: "fable"` or the literal id. The 25-iteration regression test pins this contract. **P3 (gated `opus → fable` escalation) and P4 (criticality / credit pool) are deliberately NOT included** pending design sign-off — see the draft ADR-148 in #2357.

## Changes

| Area | Change |
|---|---|
| Alias | `MODEL_MAP.fable → 'claude-fable-5'`; `ClaudeModel` union updated in all 3 definition sites |
| Capabilities | `MODEL_CAPABILITIES.fable` (`costMultiplier: 2.0`, ties opus on the capped axis) |
| Bandit | `BANDIT_REWARDS.fable: 0.2` (continues the 1.0/0.7/0.4/**0.2** cost gradient); priors + Thompson `sampledScores` include fable |
| **Hardening** | `clonePriors` rewritten as a defensive merge — backfills `Beta(1,1)` for model keys missing from persisted snapshots; `migratePriors` routes **all** legacy layouts (v1-flat, v2-bucketed) through it |
| `agent_spawn` | `"fable"` accepted as explicit (`routedBy: 'explicit'`); schema doc notes the 2× cost opt-in |

## The part worth reading: the literal-key trap, measured

#2357 §5 predicted **3** "silent trap" sites (model-keyed object literals that compile fine but drop a new model key). Implementation surfaced **8**:

`defaultBanditPriors` · `clonePriors` · `selectModel.sampledScores` · `consecutiveFailures` (init + reset) · `modelDistribution` (loadState default + reset) · `BANDIT_REWARDS` · **`getBanditPriors`**

That last one was caught **by the new regression test during development** — the literal-keyed copy in `getBanditPriors` silently dropped `fable` from its return value. Exactly the failure mode the issue warned about, demonstrated live. The fix replaces literal-key copies with the defensive `clonePriors` where state crosses a persistence or API boundary, so the *next* model addition can't hit this class of bug at those sites.

## Forward-migration safety (the crash that didn't ship)

Without the defensive merge, a pre-fable `model-router-state.json` (every existing install) would feed `priors.fable === undefined` into `sampleBeta()` → NaN scores → poisoned argmax. The test crafts both legacy layouts on disk, loads them through the real `loadState()` path, and asserts: no crash, valid routing, `fable` backfilled `Beta(1,1)`, learned legacy values (`haiku: {α:4, β:2}`) preserved.

## Tests

`__tests__/fable-tier-2357.test.ts` + the #2358 file — **21/21 passing locally** (vitest 4):

```text
 Test Files  2 passed (2)
      Tests  21 passed (21)
```

- alias resolution + literal pass-through (post-#2232 contract)
- capabilities registration at 2× cost
- `clonePriors` backfill incl. malformed-entry tolerance
- legacy-state forward-migration, both layouts, through the real load path
- 25× max-complexity routing loop: fable never auto-selected
- tsc: no fable-related type errors (`Record<ClaudeModel, …>` literals all complete; remaining diagnostics in my sandbox are module-resolution artifacts from running without the pnpm workspace, affecting untouched files equally)

## Design knobs for you

- `BANDIT_REWARDS.fable = 0.2` — chosen to continue the cost gradient; tune freely.
- `speedMultiplier: 0.8` — an estimate; worth replacing with telemetry.
- Whether `fable` should appear in any agent-type default mappings (I left them untouched).

Part of #2357 / draft ADR-148 — does not close the issue.

🤖 Generated with [ruflo](https://github.com/ruvnet/ruflo)
