### PR TITLE
fix(agent-execute): refresh retired OpenRouter Claude slugs (#2357 Finding C)

### DIFF
--- a/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
@@ -132,7 +132,11 @@ export async function callAnthropicMessages(input: AnthropicCallInput): Promise<
       apiKey: openrouterKey,
       baseUrl: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api',
       providerLabel: 'openrouter',
-      defaultModel: process.env.OPENROUTER_DEFAULT_MODEL || 'anthropic/claude-3.5-sonnet',
+      // #2357 Finding C: anthropic/claude-3.5-sonnet was retired Oct 2025.
+      // Default to the same canonical family the rest of the resolver uses
+      // (MODEL_MAP). `OPENROUTER_DEFAULT_MODEL` still wins for callers who
+      // want to pin a specific OpenRouter slug.
+      defaultModel: process.env.OPENROUTER_DEFAULT_MODEL || 'anthropic/claude-sonnet-4-6',
     });
   }
   if (useOllama && ollamaKey) {
@@ -392,10 +396,12 @@ async function callOpenAICompat(
 
 function resolveOpenAICompatModel(input: string | undefined, fallback: string): string {
   if (!input) return fallback;
-  // Logical Claude names → OpenRouter Anthropic-vendored names
-  if (input === 'haiku') return 'anthropic/claude-3.5-haiku';
-  if (input === 'sonnet' || input === 'inherit') return 'anthropic/claude-3.5-sonnet';
-  if (input === 'opus') return 'anthropic/claude-3-opus';
+  // Logical Claude names → OpenRouter Anthropic-vendored names.
+  // #2357 Finding C: the 3.5 / 3-opus slugs were retired Oct 2025; align with
+  // MODEL_MAP (claude-haiku-4-5 / claude-sonnet-4-6 / claude-opus-4-8).
+  if (input === 'haiku') return 'anthropic/claude-haiku-4-5';
+  if (input === 'sonnet' || input === 'inherit') return 'anthropic/claude-sonnet-4-6';
+  if (input === 'opus') return 'anthropic/claude-opus-4-8';
   return input;
 }
 


### PR DESCRIPTION
## Summary

Finding C from #2357 — the OpenAI-compat path used by \`OPENROUTER_API_KEY\` callers references model IDs that Anthropic retired in October 2025.

## Changes

\`v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts\`:

| | before | after |
|---|---|---|
| OpenRouter default model | \`anthropic/claude-3.5-sonnet\` | \`anthropic/claude-sonnet-4-6\` |
| \`haiku\` alias | \`anthropic/claude-3.5-haiku\` | \`anthropic/claude-haiku-4-5\` |
| \`sonnet\`/\`inherit\` alias | \`anthropic/claude-3.5-sonnet\` | \`anthropic/claude-sonnet-4-6\` |
| \`opus\` alias | \`anthropic/claude-3-opus\` | \`anthropic/claude-opus-4-8\` |

Same canonical family as \`MODEL_MAP\` (the native Anthropic resolver). \`OPENROUTER_DEFAULT_MODEL\` env var still wins for callers who want to pin a different slug.

## Why

Companion to PR #2358 (Finding A, already merged in \`b12788777\`). Together they cover the entire current frontier family across both the native Anthropic and the OpenRouter vendored path.

## Test plan

- [x] \`npm run build\` clean
- [x] Existing \`sampling-params-2357.test.ts\` — 13 tests still pass
- [x] No behavioural regression on the Anthropic native path (untouched)
- [ ] Manual: a real \`OPENROUTER_API_KEY\` invocation should now hit \`claude-sonnet-4-6\` instead of a 404'd 3.5-sonnet slug

Refs #2357.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)