### PR TITLE
fix(plugins): make npm install/uninstall/upgrade work on Windows

### DIFF
--- a/v3/@claude-flow/cli/src/plugins/manager.ts
+++ b/v3/@claude-flow/cli/src/plugins/manager.ts
@@ -11,6 +11,21 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
+// On Windows, `npm` is a shell script (no `.exe`) and `npm.cmd` is a batch
+// wrapper. Since Node 18.20.2 / 20.12.2 (CVE-2024-27980) the runtime refuses
+// to spawn `.cmd`/`.bat` files directly and throws `spawn EINVAL` — the only
+// supported invocation is via a real `.exe` shell. We wrap every npm call
+// through `cmd.exe /d /s /c npm <args>`, which keeps Node's safe array-form
+// argument escaping intact and avoids both ENOENT and EINVAL.
+const isWindows = process.platform === 'win32';
+
+function runNpm(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+  if (isWindows) {
+    return execFileAsync('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], { timeout: timeoutMs });
+  }
+  return execFileAsync('npm', args, { timeout: timeoutMs });
+}
+
 /**
  * Validate npm package name to prevent shell injection (S-3)
  */
@@ -160,10 +175,7 @@ export class PluginManager {
       // Use npm to install (array form prevents shell injection)
       console.log(`[PluginManager] Installing ${versionSpec}...`);
 
-      await execFileAsync(
-        'npm', ['install', '--prefix', this.config.pluginsDir, versionSpec],
-        { timeout: 120000 }
-      );
+      await runNpm(['install', '--prefix', this.config.pluginsDir, versionSpec], 120000);
 
       // Get installed version
       const packageJsonPath = path.join(installDir, packageName, 'package.json');
@@ -291,10 +303,7 @@ export class PluginManager {
       // For npm-installed plugins, remove from node_modules
       if (plugin.source === 'npm') {
         validatePackageName(packageName);
-        await execFileAsync(
-          'npm', ['uninstall', '--prefix', this.config.pluginsDir, packageName],
-          { timeout: 60000 }
-        );
+        await runNpm(['uninstall', '--prefix', this.config.pluginsDir, packageName], 60000);
       }
 
       // Remove from manifest
@@ -451,10 +460,7 @@ export class PluginManager {
       validatePackageName(versionSpec);
 
       // Reinstall with new version (array form prevents shell injection)
-      await execFileAsync(
-        'npm', ['install', '--prefix', this.config.pluginsDir, versionSpec],
-        { timeout: 120000 }
-      );
+      await runNpm(['install', '--prefix', this.config.pluginsDir, versionSpec], 120000);
 
       // Update manifest
       const installDir = path.join(this.config.pluginsDir, 'node_modules');


### PR DESCRIPTION
## Summary
On Windows, `PluginManager` failed every plugin lifecycle command with two distinct Node failure modes:

1. **`spawn npm ENOENT`** — `npm` on Windows is a bash shim with no `.exe`, so `execFile('npm', ...)` cannot resolve it.
2. **`spawn EINVAL`** — falling back to `npm.cmd` runs into CVE-2024-27980 (fixed in Node 18.20.2 / 20.12.2 / 21.7.3): the runtime refuses to spawn `.cmd`/`.bat` files directly.

This PR routes all three call sites (`install`, `uninstall`, `upgrade`) through a single `runNpm` helper that invokes `cmd.exe /d /s /c npm <args>` on Windows. `cmd.exe` is a real `.exe`, so neither failure mode applies, and Node's safe array-form argument escaping is preserved. POSIX path is unchanged.

## Test plan
- [x] `tsc` build clean — no new TS errors in `manager.ts` (8 unrelated pre-existing errors in other files)
- [x] Verified end-to-end on Windows 11 / Node 20:
  ```
  ruflo plugins install -n @claude-flow/security
  -> Installed @claude-flow/security@3.0.0-alpha.10
  ```
- [ ] (Maintainer) verify Linux/macOS regression-free — POSIX branch is unchanged, but appreciated as a sanity check
- [ ] (Maintainer) verify same install on a fresh Windows host where it previously threw `spawn npm ENOENT` / `spawn EINVAL`

## Files
- `v3/@claude-flow/cli/src/plugins/manager.ts` (+18 / −12)
