### PR TITLE
fix(hooks): harden memory/hook helpers — real timeout, signal cleanup, truncation transparency, cross-platform slug

### DIFF
--- a/.claude/helpers/auto-memory-hook.mjs
+++ b/.claude/helpers/auto-memory-hook.mjs
@@ -31,6 +31,27 @@ const log = (msg) => console.log(`${CYAN}[AutoMemory] ${msg}${RESET}`);
 const success = (msg) => console.log(`${GREEN}[AutoMemory] ✓ ${msg}${RESET}`);
 const dim = (msg) => console.log(`  ${DIM}${msg}${RESET}`);
 
+const DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+
+// ── Graceful shutdown (FIX 3) ───────────────────────────────────────────────
+// Track the backend currently in use so a SIGTERM/SIGINT mid-run can still
+// flush it (the JSON backend persists, a SQLite-backed one closes/flushes WAL)
+// instead of leaving a half-written store or a stale lock behind.
+let activeBackend = null;
+let shuttingDown = false;
+function trackBackend(b) { activeBackend = b; return b; }
+async function gracefulExit(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (DEBUG) process.stderr.write(`[AutoMemory] received ${signal}, flushing backend before exit\n`);
+  try {
+    if (activeBackend && typeof activeBackend.shutdown === 'function') await activeBackend.shutdown();
+  } catch { /* best effort — never block exit on cleanup */ }
+  process.exit(0);
+}
+process.on('SIGTERM', () => { gracefulExit('SIGTERM'); });
+process.on('SIGINT', () => { gracefulExit('SIGINT'); });
+
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -267,7 +288,7 @@ async function doImport() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const bridgeConfig = {
@@ -353,7 +374,7 @@ async function doSync() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const entryCount = await backend.count();
@@ -594,9 +615,17 @@ async function doImportAll() {
 
 const command = process.argv[2] || 'status';
 
-// Suppress unhandled rejection warnings from dynamic import() failures
-// which can cause non-zero exit codes even when caught
-process.on('unhandledRejection', () => {});
+// Dynamic import() failures can surface as unhandled rejections on a later
+// microtask even when the awaiting call site already caught them, which would
+// otherwise force a non-zero exit. Swallow to keep hooks exit-0, but surface the
+// reason under RUFLO_DEBUG/DEBUG so genuine async bugs aren't silently hidden
+// (FIX 2 — the previous `() => {}` discarded every rejection process-wide).
+process.on('unhandledRejection', (reason) => {
+  if (DEBUG) {
+    const detail = reason && reason.message ? reason.message : String(reason);
+    process.stderr.write(`[AutoMemory] unhandledRejection (suppressed): ${detail}\n`);
+  }
+});
 
 try {
   switch (command) {

--- a/.claude/helpers/context-persistence-hook.mjs
+++ b/.claude/helpers/context-persistence-hook.mjs
@@ -59,6 +59,28 @@ const AUTOPILOT_STATE_PATH = join(DATA_DIR, 'autopilot-state.json');
 // Approximate tokens per character (Claude averages ~3.5 chars per token)
 const CHARS_PER_TOKEN = 3.5;
 
+const DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+
+// ── Graceful shutdown (FIX 3) ───────────────────────────────────────────────
+// The active backend is created mid-handler and closed at the end. SQLite holds
+// a native handle and a WAL; if a SIGTERM/SIGINT arrives between creation and
+// `backend.shutdown()`, that close is skipped — risking an unflushed WAL or a
+// stale lock file. Track the active backend and flush it on signal before exit.
+let activeBackend = null;
+let shuttingDown = false;
+function trackBackend(b) { activeBackend = b; return b; }
+async function gracefulExit(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (DEBUG) process.stderr.write(`[ContextPersistence] received ${signal}, flushing backend before exit\n`);
+  try {
+    if (activeBackend && typeof activeBackend.shutdown === 'function') await activeBackend.shutdown();
+  } catch { /* best effort — never block exit on cleanup */ }
+  process.exit(0);
+}
+process.on('SIGTERM', () => { gracefulExit('SIGTERM'); });
+process.on('SIGINT', () => { gracefulExit('SIGINT'); });
+
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -714,7 +736,7 @@ async function resolveBackend() {
   try {
     const backend = new SQLiteBackend(ARCHIVE_DB_PATH);
     await backend.initialize();
-    return { backend, type: 'sqlite' };
+    return { backend: trackBackend(backend), type: 'sqlite' };
   } catch { /* fall through */ }
 
   // Tier 2: RuVector PostgreSQL (TB-scale, vector search, GNN)
@@ -723,7 +745,7 @@ async function resolveBackend() {
     if (rvConfig) {
       const backend = new RuVectorBackend(rvConfig);
       await backend.initialize();
-      return { backend, type: 'ruvector' };
+      return { backend: trackBackend(backend), type: 'ruvector' };
     }
   } catch { /* fall through */ }
 
@@ -739,14 +761,14 @@ async function resolveBackend() {
     if (memPkg?.AgentDBBackend) {
       const backend = new memPkg.AgentDBBackend();
       await backend.initialize();
-      return { backend, type: 'agentdb' };
+      return { backend: trackBackend(backend), type: 'agentdb' };
     }
   } catch { /* fall through */ }
 
   // Tier 4: JSON file (always works)
   const backend = new JsonFileBackend(ARCHIVE_JSON_PATH);
   await backend.initialize();
-  return { backend, type: 'json' };
+  return { backend: trackBackend(backend), type: 'json' };
 }
 
 // ============================================================================

--- a/.claude/helpers/hook-handler.cjs
+++ b/.claude/helpers/hook-handler.cjs
@@ -37,20 +37,35 @@ const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 
 // ── Intelligence timeout protection (fixes #1530, #1531) ───────────────────
 var INTELLIGENCE_TIMEOUT_MS = 3000;
+// Race the (possibly-async) work against a real timeout.
+//
+// The previous implementation called `fn()` and then `clearTimeout(timer)`
+// immediately — but if `fn()` returns a *pending* promise (async work), the
+// timer was cancelled before the work settled and the promise resolved with the
+// still-pending promise, so the timeout protected nothing. This version only
+// settles when the work resolves OR the timeout fires, whichever comes first,
+// and clears the timer afterwards.
+//
+// LIMITATION (be honest): a *synchronous* CPU-bound `fn` (e.g. the current
+// intelligence.init(), which does blocking fs reads) cannot be interrupted by
+// any in-process timer — the event loop is blocked, so the timeout callback
+// can't run until `fn` already returned. The real guard for that case lives in
+// intelligence.cjs (MAX_DATA_FILE_SIZE / MAX_GRAPH_NODES caps). This util only
+// bounds work that yields to the event loop (async I/O, dynamic import, etc.).
 function runWithTimeout(fn, label) {
-  return new Promise(function(resolve) {
-    var timer = setTimeout(function() {
+  var timer;
+  var timeout = new Promise(function(resolve) {
+    timer = setTimeout(function() {
       process.stderr.write("[WARN] " + label + " timed out after " + INTELLIGENCE_TIMEOUT_MS + "ms, skipping\n");
       resolve(null);
     }, INTELLIGENCE_TIMEOUT_MS);
-    try {
-      var result = fn();
-      clearTimeout(timer);
-      resolve(result);
-    } catch (e) {
-      clearTimeout(timer);
-      resolve(null);
-    }
+  });
+  // Promise.resolve().then(fn) turns a synchronous throw into a rejection so it
+  // is handled here rather than escaping the Promise constructor.
+  var work = Promise.resolve().then(fn).catch(function() { return null; });
+  return Promise.race([work, timeout]).then(function(result) {
+    clearTimeout(timer);
+    return result;
   });
 }
 
@@ -261,9 +276,16 @@ if (command && handlers[command]) {
   }
 }
 
-main().catch(function(e) {
-  console.log('[WARN] Hook handler error: ' + e.message);
-}).finally(function() {
-  // Ensure clean exit for Claude Code hooks
-  process.exit(0);
-});
+// Only dispatch hooks when run directly (node hook-handler.cjs ...). When
+// require()'d by a test, just expose the internals so they can be unit-tested
+// without triggering stdin reads / process.exit.
+if (require.main === module) {
+  main().catch(function(e) {
+    console.log('[WARN] Hook handler error: ' + e.message);
+  }).finally(function() {
+    // Ensure clean exit for Claude Code hooks
+    process.exit(0);
+  });
+}
+
+module.exports = { runWithTimeout: runWithTimeout, INTELLIGENCE_TIMEOUT_MS: INTELLIGENCE_TIMEOUT_MS };

--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -56,6 +56,21 @@ function tokenize(text) {
   return text.toLowerCase().replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(function(w) { return w.length > 2; });
 }
 
+// ── Truncation transparency (FIX 4) ─────────────────────────────────────────
+// Silently severing stored values means later reasoning can be built on
+// incomplete text. Warn (debug-gated) and mark the cut point with an ellipsis
+// so it is visible that the value was clipped.
+var DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+function clip(text, max, label) {
+  text = text == null ? "" : String(text);
+  if (text.length <= max) return text;
+  if (DEBUG) {
+    process.stderr.write("[INTELLIGENCE] WARN: truncated " + (label || "value") +
+      " from " + text.length + " to " + max + " chars\n");
+  }
+  return text.slice(0, max - 1) + "…";
+}
+
 // ── Deduplication helper (fixes #1518) ──────────────────────────────────────
 function deduplicateById(entries) {
   if (!entries || !Array.isArray(entries)) return entries;
@@ -73,8 +88,14 @@ function deduplicateById(entries) {
 
 function bootstrapFromMemoryFiles() {
   var entries = [];
-  // Scope to current project only (not all 51+ project dirs)
-  var projectSlug = process.cwd().replace(/^\//, '').replace(/\//g, '-');
+  // Scope to current project only (not all 51+ project dirs).
+  // Match Claude Code's project-dir slug convention: every non-alphanumeric char
+  // becomes '-' (e.g. "G:\\My Drive\\TJ_Vault" -> "G--My-Drive-TJ-Vault"). The old
+  // version only stripped a leading '/' and replaced '/', so on Windows the slug
+  // kept ':' and '\\' and never matched the real ~/.claude/projects/<slug> dir —
+  // memory bootstrap then silently found nothing (FIX 5). Runs are NOT collapsed:
+  // Claude emits "G--My" because ':' and '\\' each map to their own '-'.
+  var projectSlug = process.cwd().replace(/[^a-zA-Z0-9]/g, '-');
   var candidates = [
     path.join(os.homedir(), ".claude", "projects", projectSlug, "memory"),
     path.join(process.cwd(), ".claude-flow", "memory"),
@@ -101,14 +122,15 @@ function bootstrapFromMemoryFiles() {
           for (var s = 0; s < sections.length; s++) {
             var lines = sections[s].split("\n");
             var title = lines[0] ? lines[0].trim() : "section-" + s;
+            var clippedContent = clip(sections[s], 500, "memory content");
             entries.push({
               id: "mem-" + entries.length,
-              content: sections[s].substring(0, 500),
-              summary: title.substring(0, 100),
+              content: clippedContent,
+              summary: clip(title, 100, "memory summary"),
               category: "memory",
               confidence: 0.5,
               sourceFile: files[k],
-              words: tokenize(sections[s].substring(0, 500)),
+              words: tokenize(clippedContent),
             });
           }
         } catch (e) { /* skip */ }

--- a/DEVICE-SETUP.md
+++ b/DEVICE-SETUP.md
@@ -1,0 +1,58 @@
+# ruflo — Use it from any device, any time
+
+This setup lets you run your hardened ruflo on any machine with **no servers**. The split:
+
+- **Code travels via Git** — this fork (`github.com/tjaiyen/ruflo`, branch `harden-helpers`).
+- **Memory travels via Google Drive** — ruflo's *durable* memory is the Markdown in your
+  Obsidian vault and `~/.claude/projects/<slug>/memory/MEMORY.md`, which Google Drive already syncs
+  across your devices.
+- **The local cache is rebuilt per device** — the SQLite/AgentDB under `.claude-flow/data/` is just a
+  fast local cache that ruflo regenerates from that Markdown on each machine (via the SessionStart
+  memory import + `intelligence.cjs` bootstrap). Nothing about the cache needs to sync.
+
+> Why this works on Windows now: the bootstrap that rebuilds the cache from `MEMORY.md` previously
+> only matched POSIX paths, so on Windows it silently found nothing. **FIX 5** in this branch makes
+> the project-dir slug match Claude Code's real convention, so memory is picked up on every OS.
+
+## One-time setup on each new device
+
+1. **Clone the fork to LOCAL disk — not inside Google Drive.**
+   Google Drive can't create the symlinks this repo uses and can corrupt an open SQLite file, so keep
+   the working copy off the synced drive.
+   ```
+   git clone https://github.com/tjaiyen/ruflo.git
+   cd ruflo
+   git checkout harden-helpers
+   ```
+
+2. **Wire ruflo into Claude Code on this device.**
+   ```
+   npx ruflo@latest init          # fresh machine
+   # or, if ruflo was set up here before:
+   npx ruflo@latest init upgrade  # preserves existing data
+   ```
+
+3. **Make sure your memory is present (Google Drive synced).**
+   Confirm the Drive client has synced your Obsidian vault and that
+   `~/.claude/projects/<this-project-slug>/memory/MEMORY.md` exists. ruflo's SessionStart hook imports
+   from it automatically — open Claude Code and you should see a `[INTELLIGENCE] Loaded N patterns`
+   line confirming the memory was picked up.
+
+## Day-to-day across devices
+
+- **Pull the latest code** before working: `git pull origin harden-helpers` (origin = your fork).
+- **Memory updates** flow automatically: MEMORY.md changes saved on one device sync via Drive and are
+  re-imported by the next device's SessionStart. Edit memory through your normal Obsidian/Claude flow.
+- **Don't run two devices against the same clone at once on Drive** — keep each device's clone local.
+
+## What is intentionally NOT used here
+
+- No hosted database, no always-on server, no `flow-nexus` (that integration isn't functional).
+- ruflo *can* do shared live memory via a PostgreSQL (`RUVECTOR_*`) backend or expose a remote MCP
+  server over HTTP — those are heavier, infra-bound options. If you ever want a true single shared
+  brain (vs. per-device caches rebuilt from synced Markdown), that's the upgrade path.
+
+## Debugging
+
+Set `RUFLO_DEBUG=1` to surface the new diagnostics added in this branch: truncation warnings when a
+stored memory value is clipped, and suppressed-rejection / signal-flush messages from the hooks.

--- a/tests/hook-handler-runwithtimeout.test.cjs
+++ b/tests/hook-handler-runwithtimeout.test.cjs
@@ -1,0 +1,56 @@
+'use strict';
+/**
+ * Unit tests for hook-handler.cjs runWithTimeout (FIX 1).
+ *
+ * The previous implementation called fn() and clearTimeout(timer) immediately,
+ * so an async fn returned a *pending* promise that resolved through the race —
+ * the timeout never fired. The "times out a slow async fn" case below fails
+ * against the old code (it would return 'late') and passes against the fix.
+ *
+ * Uses node:test (built-in) so it runs without installing dependencies.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { runWithTimeout, INTELLIGENCE_TIMEOUT_MS } = require(
+  path.join(__dirname, '..', '.claude', 'helpers', 'hook-handler.cjs')
+);
+
+test('returns the value for a fast async fn', async () => {
+  const r = await runWithTimeout(() => Promise.resolve(42), 'fast-async');
+  assert.equal(r, 42);
+});
+
+test('returns the value for a fast sync fn', async () => {
+  const r = await runWithTimeout(() => 7, 'fast-sync');
+  assert.equal(r, 7);
+});
+
+test('resolves null (never rejects) when fn throws synchronously', async () => {
+  const r = await runWithTimeout(() => { throw new Error('boom'); }, 'sync-throw');
+  assert.equal(r, null);
+});
+
+test('resolves null (never rejects) when an async fn rejects', async () => {
+  const r = await runWithTimeout(() => Promise.reject(new Error('boom')), 'async-reject');
+  assert.equal(r, null);
+});
+
+test('times out a slow async fn and resolves null near the timeout', { timeout: 8000 }, async () => {
+  const start = Date.now();
+  const r = await runWithTimeout(
+    () => new Promise((res) => {
+      // .unref() so the dangling timer never keeps the test process alive
+      const t = setTimeout(() => res('late'), INTELLIGENCE_TIMEOUT_MS + 2000);
+      if (t.unref) t.unref();
+    }),
+    'slow-async'
+  );
+  const elapsed = Date.now() - start;
+  assert.equal(r, null, "should time out to null, not return the late value");
+  assert.ok(
+    elapsed >= INTELLIGENCE_TIMEOUT_MS - 200 && elapsed < INTELLIGENCE_TIMEOUT_MS + 1500,
+    `should resolve near the ${INTELLIGENCE_TIMEOUT_MS}ms timeout, took ${elapsed}ms`
+  );
+});

--- a/v3/@claude-flow/cli/.claude/helpers/auto-memory-hook.mjs
+++ b/v3/@claude-flow/cli/.claude/helpers/auto-memory-hook.mjs
@@ -31,6 +31,27 @@ const log = (msg) => console.log(`${CYAN}[AutoMemory] ${msg}${RESET}`);
 const success = (msg) => console.log(`${GREEN}[AutoMemory] ✓ ${msg}${RESET}`);
 const dim = (msg) => console.log(`  ${DIM}${msg}${RESET}`);
 
+const DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+
+// ── Graceful shutdown (FIX 3) ───────────────────────────────────────────────
+// Track the backend in use so a SIGTERM/SIGINT mid-run can still flush it
+// (the JSON backend persists; a SQLite-backed one closes/flushes WAL) instead
+// of leaving a half-written store or a stale lock behind.
+let activeBackend = null;
+let shuttingDown = false;
+function trackBackend(b) { activeBackend = b; return b; }
+async function gracefulExit(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (DEBUG) process.stderr.write(`[AutoMemory] received ${signal}, flushing backend before exit\n`);
+  try {
+    if (activeBackend && typeof activeBackend.shutdown === 'function') await activeBackend.shutdown();
+  } catch { /* best effort — never block exit on cleanup */ }
+  process.exit(0);
+}
+process.on('SIGTERM', () => { gracefulExit('SIGTERM'); });
+process.on('SIGINT', () => { gracefulExit('SIGINT'); });
+
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -219,7 +240,7 @@ async function doImport() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const bridgeConfig = {
@@ -272,7 +293,7 @@ async function doSync() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const entryCount = await backend.count();
@@ -348,8 +369,17 @@ async function doStatus() {
 
 const command = process.argv[2] || 'status';
 
-// Suppress unhandled rejection warnings from dynamic import() failures
-process.on('unhandledRejection', () => {});
+// Dynamic import() failures can surface as unhandled rejections on a later
+// microtask even when the awaiting call site already caught them, which would
+// otherwise force a non-zero exit. Swallow to keep hooks exit-0, but surface the
+// reason under RUFLO_DEBUG/DEBUG so genuine async bugs aren't silently hidden
+// (FIX 2 — the previous `() => {}` discarded every rejection process-wide).
+process.on('unhandledRejection', (reason) => {
+  if (DEBUG) {
+    const detail = reason && reason.message ? reason.message : String(reason);
+    process.stderr.write(`[AutoMemory] unhandledRejection (suppressed): ${detail}\n`);
+  }
+});
 
 try {
   switch (command) {

--- a/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
@@ -49,23 +49,27 @@ const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 
 // ── Intelligence timeout protection (fixes #1530, #1531) ───────────────────
 const INTELLIGENCE_TIMEOUT_MS = 3000;
+// Race the (possibly-async) work against a real timeout. The previous version
+// called fn() and clearTimeout(timer) immediately, so an async fn returned a
+// pending promise that resolved THROUGH the race — the timeout protected
+// nothing. This settles on whichever finishes first, then clears the timer.
+//
+// LIMITATION: a synchronous blocking fn (the current intelligence.init() does
+// blocking fs reads) cannot be interrupted by any in-process timer — the event
+// loop is blocked. The real guard for that case is the readJSON file-size
+// limit in intelligence.cjs. This util only bounds work that yields (async I/O).
 function runWithTimeout(fn, label) {
-  // For synchronous blocking calls, we use a global safety timer.
-  // The readJSON file-size guard prevents loading huge files, but this
-  // is an additional safety net.
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => {
       process.stderr.write("[WARN] " + label + " timed out after " + INTELLIGENCE_TIMEOUT_MS + "ms, skipping\n");
       resolve(null);
     }, INTELLIGENCE_TIMEOUT_MS);
-    try {
-      const result = fn();
-      clearTimeout(timer);
-      resolve(result);
-    } catch (e) {
-      clearTimeout(timer);
-      resolve(null);
-    }
+  });
+  const work = Promise.resolve().then(fn).catch(() => null);
+  return Promise.race([work, timeout]).then((result) => {
+    clearTimeout(timer);
+    return result;
   });
 }
 

--- a/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
@@ -318,7 +318,11 @@ function bootstrapFromMemoryFiles() {
     // For the projects dir, scope to CURRENT project only (not all 51+ dirs)
     if (base.endsWith('projects')) {
       try {
-        const projectSlug = cwd.replace(/^\//, '').replace(/\//g, '-');
+        // Match Claude Code's project-dir slug: every non-alphanumeric char -> '-'
+        // (e.g. "G:\\My Drive\\TJ_Vault" -> "G--My-Drive-TJ-Vault"). The old version
+        // only handled POSIX '/', so on Windows the slug kept ':' and '\\' and never
+        // matched the real <projects>/<slug>/memory dir — bootstrap found nothing (FIX 5).
+        const projectSlug = cwd.replace(/[^a-zA-Z0-9]/g, '-');
         const memDir = path.join(base, projectSlug, 'memory');
         if (fs.existsSync(memDir)) {
           parseMemoryDir(memDir, entries);
@@ -330,6 +334,16 @@ function bootstrapFromMemoryFiles() {
   }
 
   return entries;
+}
+
+// Truncation transparency (FIX 4): mark the cut with an ellipsis and warn under
+// debug, so later reasoning isn't silently built on severed text.
+const CLIP_DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+function clip(text, max, label) {
+  text = text == null ? '' : String(text);
+  if (text.length <= max) return text;
+  if (CLIP_DEBUG) process.stderr.write(`[INTELLIGENCE] WARN: truncated ${label || 'value'} from ${text.length} to ${max} chars\n`);
+  return text.slice(0, max - 1) + '…';
 }
 
 function parseMemoryDir(dir, entries) {
@@ -353,7 +367,7 @@ function parseMemoryDir(dir, entries) {
         entries.push({
           id,
           key: title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 50),
-          content: body.slice(0, 500),
+          content: clip(body, 500, 'memory content'),
           summary: title,
           namespace: file === 'MEMORY.md' ? 'core' : file.replace('.md', ''),
           type: 'semantic',


### PR DESCRIPTION
﻿## Summary

Five hardening fixes to the `.claude/helpers` hook/memory scripts, all reproduced against current `main`. Each is small, isolated, and verified with Node's built-in test runner (no new deps).

### Fixes

1. **`runWithTimeout()` never enforced its timeout** (`hook-handler.cjs`). It called `fn()` then `clearTimeout(timer)` immediately, so an async `fn` returned a pending promise that resolved *through* the race — the timeout protected nothing (the intelligence-init guard for #1530/#1531 was inert). Reimplemented as a real `Promise.race` between the work and the timeout. Documented that a *synchronous* blocking callee can't be preempted in-process (the real guard there is the file-size cap in `intelligence.cjs`). Applied to both `hook-handler.cjs` copies (root + `v3/@claude-flow/cli`).

2. **Global silent swallow of unhandled rejections** (`auto-memory-hook.mjs`). `process.on('unhandledRejection', () => {})` hid *all* async failures process-wide. Kept exit-0 behaviour but log the reason under `RUFLO_DEBUG`/`DEBUG` so genuine bugs are visible.

3. **No SIGTERM/SIGINT cleanup** in db-touching helpers (`auto-memory-hook.mjs`, `context-persistence-hook.mjs`). A signal mid-write skipped `backend.shutdown()`, risking an unflushed SQLite WAL / stale `agentdb.rvf.lock`. Track the active backend and flush it on signal.

4. **Silent value truncation** (`intelligence.cjs`). Memory content was cut at 500 chars with no signal. Added a `clip()` helper that appends an ellipsis and warns under debug when it actually truncates.

5. **Cross-platform `projectSlug` bug** (`intelligence.cjs`). The slug used `cwd().replace(/^\//,'').replace(/\//g,'-')` — POSIX-only. On Windows it kept `:` and `\`, so it never matched Claude Code's real `~/.claude/projects/<slug>` dir and memory bootstrap silently found nothing. Now slugifies every non-alphanumeric to `-`, matching Claude Code's actual convention (verified: `G:\My Drive\...\ruflo-fix` -> `G--My-Drive-...-ruflo-fix`).

## Testing

- `node --test tests/hook-handler-runwithtimeout.test.cjs` — 5/5, including the decisive case: a slow async fn now resolves `null` at ~3s (old code returned the late value at ~5s).
- `node scripts/smoke-pre-bash-hook.mjs` — passes for both dispatcher copies (no regression).
- `node --check` on all 8 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
