### PR TITLE
feat(routing): #2334 Phase 1 — cost-optimal neural seam + DRACO trajectory collection

### DIFF
--- a/scripts/audit-env-var-precedence.mjs
+++ b/scripts/audit-env-var-precedence.mjs
@@ -56,6 +56,11 @@ const KNOWN_ESCAPE_HATCHES = new Set([
   'RUFLO_HOOK_SKIP_NPX',          // CI: suppress cold-install latency in smoke tests
   'RUFLO_SUBLINEAR_NATIVE',       // Manual override for native vs WASM sublinear — CI/perf knob
 
+  // ── Neural router opt-in gates (#2334 Phase 1) — feature flags, not user config ──
+  'CLAUDE_FLOW_ROUTER_NEURAL',     // gate: enable cost-optimal neural routing advice (default off)
+  'CLAUDE_FLOW_ROUTER_MODEL_PATH', // path to the operator-provided routing artifact
+  'CLAUDE_FLOW_ROUTER_TRAJECTORY', // gate: opt-in DRACO trajectory collection (default off)
+
   // ── Feature flags (set by init into settings.json, not user-typed CLI) ──────
   'CLAUDE_FLOW_V3_ENABLED',
   'CLAUDE_FLOW_HOOKS_ENABLED',

--- a/v3/@claude-flow/cli/__tests__/router-phase1-2334.test.ts
+++ b/v3/@claude-flow/cli/__tests__/router-phase1-2334.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #2334 Phase 1 — cost-optimal neural routing seam.
+ *
+ * Proves the load-bearing guarantees, not just the happy path:
+ *  - the default path is unchanged and pays ZERO embedding cost (routedBy='heuristic');
+ *  - a fabricated (mock/hash) or wrong-shape embedding is REJECTED — never fed to
+ *    routing or trajectory collection (ADR-086);
+ *  - the neural path degrades to an observable 'bandit-fallback', never throws;
+ *  - when a real artifact + the optional dep resolve, the pick is honestly tagged
+ *    'metaharness-knn' (asserted strictly when the dep is present, else fallback);
+ *  - trajectory collection is opt-in and writes a versioned DRACO row.
+ *
+ * The embedding provider is mocked so the suite is deterministic + offline.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { rmSync, mkdtempSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { generateEmbedding } = vi.hoisted(() => ({ generateEmbedding: vi.fn() }));
+vi.mock('../src/memory/memory-initializer.js', () => ({ generateEmbedding }));
+
+import { ModelRouter } from '../src/ruvector/model-router.js';
+import { resetTaskEmbedder, tryTaskEmbedding } from '../src/ruvector/router-embedding.js';
+import { resetNeuralRouter } from '../src/ruvector/neural-router.js';
+import { trajectoryFilePath } from '../src/ruvector/router-trajectory.js';
+
+const VALID = ['haiku', 'sonnet', 'opus', 'inherit'];
+const onnx384 = () => ({
+  embedding: Array.from({ length: 384 }, (_, i) => Math.sin(i) * 0.05),
+  dimensions: 384,
+  model: 'Xenova/all-MiniLM-L6-v2',
+  backend: 'onnx' as const,
+});
+
+let cwd0: string;
+let tmp: string;
+
+beforeEach(() => {
+  cwd0 = process.cwd();
+  tmp = mkdtempSync(join(tmpdir(), 'router-p1-2334-'));
+  process.chdir(tmp);
+  delete process.env.CLAUDE_FLOW_ROUTER_NEURAL;
+  delete process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY;
+  delete process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH;
+  generateEmbedding.mockReset();
+  resetTaskEmbedder();
+  resetNeuralRouter();
+});
+
+afterEach(() => {
+  process.chdir(cwd0);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('#2334 Phase 1 — neural routing seam', () => {
+  it('default path is unchanged and computes no embedding (routedBy=heuristic)', async () => {
+    generateEmbedding.mockResolvedValue(onnx384()); // available, but must NOT be called
+    const r = await new ModelRouter().route('rename a variable');
+    expect(r.routedBy).toBe('heuristic');
+    expect(VALID).toContain(r.model);
+    expect(generateEmbedding).not.toHaveBeenCalled();
+  });
+
+  it('neural gate on but no artifact → bandit-fallback (observable, never throws)', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_NEURAL = '1';
+    generateEmbedding.mockResolvedValue(onnx384());
+    const r = await new ModelRouter().route('design a distributed consensus protocol');
+    expect(r.routedBy).toBe('bandit-fallback');
+    expect(VALID).toContain(r.model);
+  });
+
+  it('bandit-fallback is byte-identical to the default bandit — neural embedding never perturbs the heuristic complexity', async () => {
+    const task = 'design a complex distributed caching layer with strong consistency guarantees';
+    generateEmbedding.mockResolvedValue(onnx384()); // a real onnx vector is available...
+    const off = await new ModelRouter().route(task); // ...but the gate is OFF here
+    process.env.CLAUDE_FLOW_ROUTER_NEURAL = '1';      // gate ON, no artifact → bandit-fallback
+    resetTaskEmbedder();
+    resetNeuralRouter();
+    const on = await new ModelRouter().route(task);
+    expect(on.routedBy).toBe('bandit-fallback');
+    // complexity is deterministic; if the lazily-acquired embedding leaked into
+    // computeSemanticDepth this would differ. It must not. (Would fail pre-fix.)
+    expect(on.complexity).toBe(off.complexity);
+  });
+
+  it('rejects a mock (hash-fallback) embedding — fabrication is never used (ADR-086)', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY = '1'; // make an embedding consumer present
+    generateEmbedding.mockResolvedValue({ ...onnx384(), backend: 'mock', model: 'hash-fallback' });
+    expect(await tryTaskEmbedding('anything')).toBeNull();
+  });
+
+  it('rejects wrong-dimension and missing-backend embeddings', async () => {
+    process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY = '1';
+    generateEmbedding.mockResolvedValue({ ...onnx384(), embedding: Array(128).fill(0.1), dimensions: 128 });
+    expect(await tryTaskEmbedding('x')).toBeNull();
+    resetTaskEmbedder();
+    generateEmbedding.mockResolvedValue({ embedding: Array(384).fill(0.1), dimensions: 384, model: 'm' }); // no backend
+    expect(await tryTaskEmbedding('x')).toBeNull();
+  });
+
+  it('neural gate on + DRACO artifact → metaharness-knn when dep present, else bandit-fallback', async () => {
+    const rows = ['haiku', 'sonnet', 'opus'].flatMap((m) =>
+      Array.from({ length: 4 }, () => ({
+        embedding: Array.from({ length: 384 }, (_, i) => Math.sin(i) * 0.05),
+        scores: { haiku: 0.9, sonnet: 0.8, opus: 0.7 },
+      })),
+    );
+    const artifact = join(tmp, 'router-artifact.json');
+    writeFileSync(artifact, JSON.stringify(rows));
+    process.env.CLAUDE_FLOW_ROUTER_NEURAL = '1';
+    process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH = artifact;
+    generateEmbedding.mockResolvedValue(onnx384());
+
+    const depPresent = !!(await import('@metaharness/router' as string).catch(() => null));
+    const r = await new ModelRouter().route('implement a feature');
+    if (depPresent) {
+      expect(r.routedBy).toBe('metaharness-knn');
+    } else {
+      expect(r.routedBy).toBe('bandit-fallback');
+    }
+    expect(VALID).toContain(r.model);
+  });
+
+  it('trajectory collection is opt-in and writes a versioned DRACO row with a real embedding', async () => {
+    generateEmbedding.mockResolvedValue(onnx384());
+
+    // off → nothing written
+    await new ModelRouter().route('a simple task');
+    expect(existsSync(trajectoryFilePath())).toBe(false);
+
+    // on → one v:1 row with the real 384-dim embedding
+    process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY = '1';
+    resetTaskEmbedder();
+    await new ModelRouter().route('architect a scalable distributed system');
+    expect(existsSync(trajectoryFilePath())).toBe(true);
+    const row = JSON.parse(readFileSync(trajectoryFilePath(), 'utf8').trim().split('\n').pop() as string);
+    expect(row.v).toBe(1);
+    expect(row.embedding).toHaveLength(384);
+    expect(row.embeddingSource).toBe('minilm');
+    expect(VALID).toContain(row.model);
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -112,6 +112,7 @@
     "@claude-flow/memory": "^3.0.0-alpha.20",
     "@claude-flow/plugin-gastown-bridge": "^0.1.3",
     "@claude-flow/security": "^3.0.0-alpha.10",
+    "@metaharness/router": "0.3.2",
     "@ruvector/attention": "^0.1.32",
     "@ruvector/attention-darwin-arm64": "0.1.32",
     "@ruvector/diskann": "^0.1.0",

--- a/v3/@claude-flow/cli/src/ruvector/model-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/model-router.ts
@@ -34,6 +34,11 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
+// #2334 Phase 1: opt-in cost-optimal neural routing seam. All three modules are
+// no-ops on the default path (gates default OFF) — see neural-router.ts.
+import { neuralRoutingEnabled, tryCostOptimalRoute, type RoutedBy } from './neural-router.js';
+import { tryTaskEmbedding, embeddingNeeded } from './router-embedding.js';
+import { recordTrajectoryDecision } from './router-trajectory.js';
 
 // ============================================================================
 // Types & Constants
@@ -140,6 +145,12 @@ export interface ModelRoutingResult {
   inferenceTimeUs: number;
   /** Estimated cost multiplier */
   costMultiplier: number;
+  /**
+   * Observable provenance of this decision (#2334, ADR-074/086). `'heuristic'`
+   * on the default path; `'metaharness-*'` when the opt-in neural advisor decided;
+   * `'bandit-fallback'` when neural was enabled but unavailable/declined.
+   */
+  routedBy?: RoutedBy;
 }
 
 /**
@@ -395,7 +406,19 @@ export class ModelRouter {
   async route(task: string, embedding?: number[]): Promise<ModelRoutingResult> {
     const startTime = performance.now();
 
-    // Analyze task complexity
+    // #2334 Phase 1: when a gate is open and no embedding was supplied, lazily
+    // acquire a real (onnx, 384-dim) embedding — null otherwise, never fabricated.
+    // On the default path (both gates off) this is skipped.
+    let neuralEmb = embedding;
+    if (neuralEmb === undefined && embeddingNeeded()) {
+      neuralEmb = (await tryTaskEmbedding(task))?.vector;
+    }
+
+    // Analyze task complexity. The lazily-acquired neural embedding is deliberately
+    // NOT fed here — the heuristic+bandit path stays byte-identical whether the gate
+    // is on or off, so a 'bandit-fallback' decision equals the true default bandit.
+    // Only an embedding a caller passed EXPLICITLY feeds the heuristic (pre-#2334
+    // behaviour preserved); the neural embedding feeds only the advisor below.
     const complexity = this.analyzeComplexity(task, embedding);
 
     // Compute base model scores
@@ -404,8 +427,43 @@ export class ModelRouter {
     // Apply circuit breaker adjustments
     const adjustedScores = this.applyCircuitBreaker(scores);
 
-    // Select best model
-    const { model, confidence, uncertainty } = this.selectModel(adjustedScores, complexity.score);
+    // Select best model (heuristic + Thompson bandit — the default AND the fallback)
+    const selection = this.selectModel(adjustedScores, complexity.score);
+    let model = selection.model;
+    let confidence = selection.confidence;
+    let uncertainty = selection.uncertainty;
+
+    // #2334 Phase 1: cost-optimal neural advice. Opt-in; byte-identical when the
+    // gate is off. The bandit decision above stands UNLESS the neural backend
+    // clears its quality bar — then its pick is used and routedBy reflects it.
+    let routedBy: RoutedBy = 'heuristic';
+    let neuralPredictedQuality: number | undefined;
+    let neuralMetBar: boolean | undefined;
+    if (neuralRoutingEnabled()) {
+      const rec = await tryCostOptimalRoute(neuralEmb, {
+        prices: {
+          haiku: MODEL_CAPABILITIES.haiku.costMultiplier,
+          sonnet: MODEL_CAPABILITIES.sonnet.costMultiplier,
+          opus: MODEL_CAPABILITIES.opus.costMultiplier,
+        },
+        knownModels: ['haiku', 'sonnet', 'opus'],
+      });
+      if (rec) {
+        neuralPredictedQuality = rec.predictedQuality;
+        neuralMetBar = rec.metBar;
+      }
+      if (rec && rec.metBar) {
+        // Neural pick stands — make confidence/uncertainty/reasoning coherent with
+        // THIS model's predicted quality, not the bandit's pick for another tier.
+        model = rec.model as ClaudeModel;
+        routedBy = rec.routedBy;
+        confidence = rec.predictedQuality;
+        uncertainty = Math.max(0, Math.min(1, 1 - rec.predictedQuality));
+      } else {
+        // gate on, but neural unavailable/declined → bandit decided (honest)
+        routedBy = 'bandit-fallback';
+      }
+    }
 
     const inferenceTimeUs = (performance.now() - startTime) * 1000;
 
@@ -422,10 +480,24 @@ export class ModelRouter {
         .sort((a, b) => b.score - a.score),
       inferenceTimeUs,
       costMultiplier: MODEL_CAPABILITIES[model].costMultiplier,
+      routedBy,
     };
 
     // Track decision
     this.trackDecision(task, result);
+
+    // #2334 Phase 1: opt-in DRACO trajectory collection (best-effort, never throws).
+    recordTrajectoryDecision({
+      task,
+      model,
+      routedBy,
+      confidence,
+      complexity: complexity.score,
+      embedding: neuralEmb,
+      embeddingSource: neuralEmb ? 'minilm' : undefined,
+      predictedQuality: neuralPredictedQuality,
+      metBar: neuralMetBar,
+    });
 
     return result;
   }

--- a/v3/@claude-flow/cli/src/ruvector/neural-router.ts
+++ b/v3/@claude-flow/cli/src/ruvector/neural-router.ts
@@ -1,0 +1,159 @@
+/**
+ * Cost-optimal neural routing seam (#2334 Phase 1).
+ *
+ * Wires `@ruvector/tiny-dancer`'s productized router, `@metaharness/router`, into
+ * the model router as an OPT-IN advisor. Default behaviour is unchanged: this
+ * module returns `null` (and the existing heuristic + Thompson bandit decides)
+ * unless BOTH `CLAUDE_FLOW_ROUTER_NEURAL=1` is set AND a routing artifact resolves
+ * at `CLAUDE_FLOW_ROUTER_MODEL_PATH`.
+ *
+ * Honesty (ADR-074 / ADR-086): `routedBy` is DERIVED from what actually happened,
+ * never assumed — a recommendation is only ever tagged `metaharness-knn` /
+ * `metaharness-krr` when that backend literally produced it. Any failure (gate
+ * off, no artifact, dep absent, load error, unknown model) collapses to `null`,
+ * which the caller reports as `bandit-fallback`. Nothing is fabricated.
+ *
+ * Phase-1 uses only `@metaharness/router`'s dependency-free pure-TS backends
+ * (k-NN over example rows, or a serialized KRR `TrainedRouter`). The native
+ * FastGRNN accelerator (`@ruvector/tiny-dancer`, `routedBy:'fastgrnn'`) is
+ * RESERVED in the union below for Phase 2 — kept now so adding it later is not a
+ * breaking change. See the seam ADR.
+ *
+ * @module neural-router
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+/** Observable provenance of a routing decision. Derived, never assumed. */
+export type RoutedBy =
+  | 'metaharness-knn'   // pure-TS k-NN over example rows
+  | 'metaharness-krr'   // serialized KRR TrainedRouter artifact
+  | 'fastgrnn'          // RESERVED (Phase 2): native tiny-dancer FastGRNN
+  | 'bandit-fallback'   // neural gated on but unavailable/declined → bandit decided
+  | 'heuristic';        // neural gate off → default shipped path
+
+export interface NeuralRecommendation {
+  /** The recommended model id (validated against the caller's known tiers). */
+  model: string;
+  predictedQuality: number;
+  metBar: boolean;
+  routedBy: 'metaharness-knn' | 'metaharness-krr';
+}
+
+export interface NeuralRouteOptions {
+  /** Per-model price table (cost axis the router minimises). */
+  prices: Record<string, number>;
+  /** Model ids the caller will accept; anything else is rejected as unknown. */
+  knownModels: string[];
+  /** Quality bar for the k-NN path (KRR artifacts carry their own). */
+  qualityBar?: number;
+}
+
+const DEFAULT_QUALITY_BAR = 0.7;
+
+/** True only when the operator opted into neural routing. */
+export function neuralRoutingEnabled(): boolean {
+  return process.env.CLAUDE_FLOW_ROUTER_NEURAL === '1';
+}
+
+// ── Minimal typed view of the @metaharness/router surface we depend on ───────────
+interface MhRouteResult { id: string; predictedQuality: number; costPerMTok: number; metBar: boolean; }
+interface MhRouter { route(embedding: number[]): MhRouteResult; }
+interface MhModule {
+  Router: { fromExamples(
+    rows: { embedding: number[]; scores: Record<string, number> }[],
+    prices: Record<string, number>,
+    opts?: { k?: number; qualityBar?: number },
+  ): MhRouter };
+  TrainedRouter: { fromJSON(o: unknown): MhRouter };
+}
+
+/**
+ * Load @metaharness/router's pure-TS API via dynamic import (optionalDependency,
+ * ADR-124 graceful degradation; `as string` defers tsc module resolution so the
+ * dep can be absent). Named exports may surface top-level (ESM) or under
+ * `.default` (CJS interop); the `?? imported` fallback plus the `fromExamples`
+ * capability probe handle both and reject anything that isn't the router.
+ */
+async function importMetaharness(): Promise<MhModule | null> {
+  const imported = await import('@metaharness/router' as string).catch(() => null);
+  const mod = (imported && ((imported as { default?: unknown }).default ?? imported)) as MhModule | null;
+  return mod && typeof mod.Router?.fromExamples === 'function' ? mod : null;
+}
+
+// Sticky latch + cache: a missing artifact/dep costs one failed load, not one per call.
+let loadFailed = false;
+let cached: { router: MhRouter; routedBy: 'metaharness-knn' | 'metaharness-krr' } | null = null;
+
+async function loadRouter(
+  opts: NeuralRouteOptions,
+): Promise<{ router: MhRouter; routedBy: 'metaharness-knn' | 'metaharness-krr' } | null> {
+  if (cached) return cached;
+  if (loadFailed) return null;
+
+  const artifactPath = process.env.CLAUDE_FLOW_ROUTER_MODEL_PATH;
+  if (!artifactPath || !existsSync(artifactPath)) { loadFailed = true; return null; }
+
+  try {
+    const mod = await importMetaharness();
+    if (!mod) { loadFailed = true; return null; }
+
+    const raw: unknown = JSON.parse(readFileSync(artifactPath, 'utf8'));
+
+    // A serialized KRR TrainedRouter has `candidates[].alpha`; a raw dataset is an
+    // array of DRACO rows. The shape decides the backend AND the honest routedBy tag.
+    if (raw && typeof raw === 'object' && Array.isArray((raw as { candidates?: unknown }).candidates)) {
+      cached = { router: mod.TrainedRouter.fromJSON(raw), routedBy: 'metaharness-krr' };
+    } else if (Array.isArray(raw)) {
+      cached = {
+        router: mod.Router.fromExamples(
+          raw as { embedding: number[]; scores: Record<string, number> }[],
+          opts.prices,
+          { qualityBar: opts.qualityBar ?? DEFAULT_QUALITY_BAR },
+        ),
+        routedBy: 'metaharness-knn',
+      };
+    } else {
+      loadFailed = true; return null;
+    }
+    return cached;
+  } catch {
+    loadFailed = true;
+    return null;
+  }
+}
+
+/**
+ * Best-effort cost-optimal routing recommendation. Returns `null` (never throws)
+ * whenever the neural path is off, unavailable, or declines — the caller then
+ * falls back to the bandit. A returned recommendation is honest: its `routedBy`
+ * reflects the backend that actually produced it, and its `model` is guaranteed
+ * to be one of `opts.knownModels`.
+ */
+export async function tryCostOptimalRoute(
+  embedding: number[] | undefined,
+  opts: NeuralRouteOptions,
+): Promise<NeuralRecommendation | null> {
+  if (!neuralRoutingEnabled()) return null;
+  if (!embedding || embedding.length === 0) return null;  // no real embedding → no neural route
+  const loaded = await loadRouter(opts);
+  if (!loaded) return null;
+  try {
+    const r = loaded.router.route(embedding);
+    if (!opts.knownModels.includes(r.id)) return null;     // honest: only known tiers
+    return {
+      model: r.id,
+      predictedQuality: r.predictedQuality,
+      metBar: r.metBar,
+      routedBy: loaded.routedBy,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Reset cached state — for tests. */
+export function resetNeuralRouter(): void {
+  cached = null;
+  loadFailed = false;
+}

--- a/v3/@claude-flow/cli/src/ruvector/router-embedding.ts
+++ b/v3/@claude-flow/cli/src/ruvector/router-embedding.ts
@@ -1,0 +1,90 @@
+/**
+ * Task-embedding feed for the model router (#2334 Phase 1).
+ *
+ * Supplies the embedding that `route(task, embedding?)` accepts but no internal
+ * call site currently provides. Computed lazily and ONLY when a gate is open
+ * (neural routing or trajectory collection), so the default path pays zero cost.
+ *
+ * Design rules (load-bearing):
+ *  - Local 384-dim all-MiniLM-L6-v2 only (ADR-094/130), via the in-tree
+ *    `generateEmbedding` provider — no hosted API, no new dependency.
+ *  - NO hash/fake fallback, EVER. A fabricated embedding silently poisons the
+ *    training set (the ADR-086 `_realEmbedding` failure mode). Absence is recorded
+ *    as absence: return `null`, and the trajectory row simply omits `embedding`.
+ *  - `backend === 'onnx'` is the ONLY trustworthy real-vs-fallback signal — the
+ *    provider's own AUDIT note warns that `model` is not trustworthy via the
+ *    AgentDB bridge, and the local hash fallback tags `backend:'mock'`. We reject
+ *    anything that is not `'onnx'` (including `undefined`) AND not exactly 384-dim.
+ *
+ * @module router-embedding
+ */
+
+import { neuralRoutingEnabled } from './neural-router.js';
+import { trajectoryCollectionEnabled } from './router-trajectory.js';
+import { generateEmbedding } from '../memory/memory-initializer.js';
+
+const MINILM_DIMS = 384;
+
+export interface TaskEmbedding {
+  /** Length 384, real ONNX all-MiniLM-L6-v2. */
+  vector: number[];
+  /** Provenance — emitted ONLY for backend==='onnx' vectors. */
+  source: 'minilm';
+}
+
+// Sticky latch: a missing/broken embedder costs one failed load, not one per call.
+let embedderUnavailable = false;
+let embedFn: ((text: string) => Promise<number[] | null>) | null = null;
+
+/** True only when some downstream actually consumes an embedding. */
+export function embeddingNeeded(): boolean {
+  return neuralRoutingEnabled() || trajectoryCollectionEnabled();
+}
+
+async function loadEmbedder(): Promise<((t: string) => Promise<number[] | null>) | null> {
+  if (embedFn) return embedFn;
+  if (embedderUnavailable) return null;
+  try {
+    // generateEmbedding is a static in-tree import (no new dependency); the typeof
+    // guard + try/catch are defensive-only, against future module-shape drift.
+    if (typeof generateEmbedding !== 'function') { embedderUnavailable = true; return null; }
+    embedFn = async (t: string): Promise<number[] | null> => {
+      const r = await generateEmbedding(t);
+      // CRITICAL honesty gate (ADR-086): backend==='onnx' is the only trustworthy
+      // real-vs-hash signal. Dimension/model alone are NOT sufficient. 'mock' is
+      // the deterministic hash fallback — reject it.
+      if (!r || r.backend !== 'onnx') return null;
+      const v = r.embedding;
+      return Array.isArray(v) && v.length === MINILM_DIMS ? v : null;
+    };
+    return embedFn;
+  } catch {
+    embedderUnavailable = true;
+    return null;
+  }
+}
+
+/**
+ * Best-effort local embedding for a routing task. Returns `null` (never throws)
+ * when no consumer needs it, the provider hash-falls-back, or it cannot produce a
+ * real 384-dim ONNX vector. Callers pass `?.vector` straight into
+ * `route(task, embedding?)`.
+ */
+export async function tryTaskEmbedding(task: string): Promise<TaskEmbedding | null> {
+  if (!embeddingNeeded()) return null;          // zero cost on the default path
+  if (!task) return null;
+  const fn = await loadEmbedder();
+  if (!fn) return null;
+  try {
+    const vector = await fn(task);
+    return vector ? { vector, source: 'minilm' } : null;   // null over fabrication
+  } catch {
+    return null;
+  }
+}
+
+/** Reset cached state — for tests. */
+export function resetTaskEmbedder(): void {
+  embedFn = null;
+  embedderUnavailable = false;
+}

--- a/v3/@claude-flow/cli/src/ruvector/router-trajectory.ts
+++ b/v3/@claude-flow/cli/src/ruvector/router-trajectory.ts
@@ -1,0 +1,89 @@
+/**
+ * DRACO trajectory collection for the model router (#2334 Phase 1).
+ *
+ * Opt-in via `CLAUDE_FLOW_ROUTER_TRAJECTORY=1`. Appends one versioned decision
+ * row per routing call to `.swarm/model-router-trajectories.jsonl`, capturing the
+ * query `embedding` + the routing decision.
+ *
+ * This is the EMBEDDING/decision half of a future DRACO training set — NOT a
+ * complete `{embedding, scores}` example. The per-model `scores` (quality each
+ * tier would achieve on the query — the trainer's target) are NOT captured here
+ * and are NOT recoverable from the current bandit outcomes: those are aggregate
+ * Beta(α,β) counters keyed by complexity-bucket, not per-query labels, and carry
+ * no `taskHash`/embedding to join on. Producing trainable `{embedding, scores}`
+ * rows requires a Phase-2 outcome sink (a per-query, `taskHash`-keyed labelled
+ * reward) that does not exist yet. Phase 1 starts accumulating the embedding half
+ * so it's ready when that sink lands.
+ *
+ * Best-effort by construction: a write failure NEVER propagates into the routing
+ * path (a routing decision must not fail because trajectory logging failed).
+ * Rows carry full (truncated) task text + the raw embedding, so collection is
+ * opt-in for the same PII reason flagged on #2334.
+ *
+ * @module router-trajectory
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+/** Schema version — Phase 2 can add fields additively under `v:2`. */
+const ROW_VERSION = 1;
+const TRAJECTORY_FILE = join('.swarm', 'model-router-trajectories.jsonl');
+
+/** True only when the operator opted into trajectory collection. */
+export function trajectoryCollectionEnabled(): boolean {
+  return process.env.CLAUDE_FLOW_ROUTER_TRAJECTORY === '1';
+}
+
+/** Path of the JSONL sink (relative to cwd). Exposed for tests/tooling. */
+export function trajectoryFilePath(): string {
+  return TRAJECTORY_FILE;
+}
+
+export interface TrajectoryDecision {
+  task: string;
+  model: string;
+  routedBy: string;
+  confidence: number;
+  complexity: number;
+  /** Present ONLY for a real onnx 384-dim vector (never a hash fallback). */
+  embedding?: number[];
+  embeddingSource?: 'minilm';
+  /** Neural prediction context, present only when the neural path engaged. */
+  predictedQuality?: number;
+  metBar?: boolean;
+}
+
+/**
+ * Append a decision row. No-op (zero cost) when collection is disabled. Never
+ * throws — any I/O failure is swallowed so routing is unaffected.
+ */
+export function recordTrajectoryDecision(d: TrajectoryDecision): void {
+  if (!trajectoryCollectionEnabled()) return;
+  try {
+    const row: Record<string, unknown> = {
+      v: ROW_VERSION,
+      ts: new Date().toISOString(),
+      taskHash: createHash('sha256').update(d.task).digest('hex').slice(0, 16),
+      task: d.task.slice(0, 500),
+      model: d.model,
+      routedBy: d.routedBy,
+      confidence: d.confidence,
+      complexity: d.complexity,
+    };
+    // A missing feature is honest; a fabricated one is a lie (ADR-086). The
+    // embedding is emitted only when it is a real onnx vector — otherwise absent.
+    if (d.embedding && d.embedding.length > 0) {
+      row.embedding = d.embedding;
+      row.embeddingSource = d.embeddingSource ?? 'minilm';
+    }
+    if (d.predictedQuality !== undefined) row.predictedQuality = d.predictedQuality;
+    if (d.metBar !== undefined) row.metBar = d.metBar;
+
+    mkdirSync(dirname(TRAJECTORY_FILE), { recursive: true });
+    appendFileSync(TRAJECTORY_FILE, JSON.stringify(row) + '\n');
+  } catch {
+    // best-effort: trajectory collection must never break a routing decision
+  }
+}

--- a/v3/docs/adr/ADR-149-neural-routing-seam-and-trajectory-collection.md
+++ b/v3/docs/adr/ADR-149-neural-routing-seam-and-trajectory-collection.md
@@ -1,0 +1,43 @@
+# ADR-149 — Cost-optimal neural routing seam + DRACO trajectory collection
+
+**Status**: Proposed
+**Date**: 2026-06-16
+**Issue**: https://github.com/ruvnet/ruflo/issues/2334
+**Related**: ADR-026 (routing tiers), ADR-074 / ADR-086 (observable, honest-not-inferred capability), ADR-124 (optional-dependency graceful degradation), ADR-142 (per-bucket Thompson bandit). Supersedes the approach in PR #2347. A separate Phase-2 *artifact-lifecycle* ADR (ruvnet's draft) is the follow-on — see **Numbering**.
+
+## Context
+
+`model-router.ts` already accepts `route(task, embedding?)` and consumes the embedding in `computeSemanticDepth`, but no internal caller ever supplies one — the neural path described in ADR-026 "was never wired in" (post-#2329 header). #2334 (Option B) is to wire it. The two original blockers (undocumented FastGRNN safetensors layout; the candidate-modeling question) were dissolved upstream: `@metaharness/router` exposes a cost-optimal `route(embedding)` over a `{embedding, scores}` dataset with a `qualityBar`, so v1 needs neither a documented tensor layout nor a per-tier candidate encoding.
+
+The point of Phase 1 is to **wire the seam and collect the training dataset** while keeping default behaviour identical — not to ship a trained model.
+
+## Decision
+
+Phase 1 (this PR) — opt-in, default byte-identical:
+
+1. **Embedding feed** (`router-embedding.ts`): lazily compute a local all-MiniLM-L6-v2 vector via the in-tree `generateEmbedding`, **only** when a gate is open. Accept it **only** when `backend === 'onnx'` AND `dimensions === 384`; otherwise return `null`. No hash/fake fallback — a fabricated embedding silently poisons training (ADR-086).
+2. **Neural advice** (`neural-router.ts`): behind `CLAUDE_FLOW_ROUTER_NEURAL=1` + an artifact at `CLAUDE_FLOW_ROUTER_MODEL_PATH`, load `@metaharness/router`'s pure-TS `Router`/`TrainedRouter` (optionalDependency, dynamic import, ADR-124) and return the cost-optimal pick. **Advise, not override**: the Thompson bandit's decision stands unless the neural pick clears its quality bar.
+3. **Trajectory collection** (`router-trajectory.ts`): behind `CLAUDE_FLOW_ROUTER_TRAJECTORY=1`, append versioned decision rows to `.swarm/model-router-trajectories.jsonl` (best-effort; never throws). These rows capture the **embedding/decision half** of a future training set — not complete `{embedding, scores}` examples (see Consequences).
+4. **Observability** (ADR-074/086): every result carries `routedBy ∈ {metaharness-knn, metaharness-krr, fastgrnn, bandit-fallback, heuristic}`, **derived from what actually happened** — never assumed.
+
+`'fastgrnn'` (native `@ruvector/tiny-dancer` acceleration) is **reserved** in the union for Phase 2 so adding it later is not a breaking change.
+
+## Consequences
+
+**Positive**: default path unchanged (gates default off; embedding computed only when needed; the heuristic+bandit complexity is never perturbed by the neural embedding, so a `bandit-fallback` decision is byte-identical to the true default bandit); honest fallback is observable; the seam begins accumulating the embedding half of a future training set with a stable, versioned row schema.
+**Negative / risks**: one new optionalDependency (`@metaharness/router`), brand-new + single-author + no npm provenance attestation — mitigated by exact pin + recorded integrity hash + full gating (default path never loads it). `EnhancedModelRouter` (the Tier-1 codemod/booster layer) does not yet consume the neural recommendation — wiring it in is deliberately out of scope here.
+**Deferred (Phase 2+)**: trained artifact + training/eval scripts; **the labelled-outcome sink** — a per-query, `taskHash`-keyed record of the quality each tier achieved — needed to turn the collected embedding rows into trainable `{embedding, scores}` examples (the current bandit outcomes are aggregate Beta(α,β) counters, not per-query labels, so this does NOT exist yet); native FastGRNN inference; binding the recommendation to the executing model (stays advisory); promotion to default-on behind a measured +5pp acceptance bar.
+
+## Alternatives considered
+
+- **Bundled seed corpus** to make gate-on non-empty out of the box — rejected: fabricated 384-dim vectors would poison k-NN and violate ADR-086. The gate-on path activates against a real operator-provided artifact instead.
+- **tiny-dancer direct (native-only)** as primary — rejected: native binary matrix; `@metaharness/router`'s pure-TS backends avoid a hard native dep.
+- **Pure-internal (no dependency)** — viable but ships no live neural path in Phase 1.
+
+## Validation
+
+`tsc` clean for the added/edited files (sandbox residual errors are unrelated optional-dep/project-ref artifacts). `vitest`: 18/18 across the new `router-phase1-2334` suite (6) + existing `router-bandit` (8) + `codemod-routing` (4) — proving byte-identical default (0 embedding calls when gated off), observable `bandit-fallback`, the real `metaharness-knn` path, and rejection of mock/wrong-dim embeddings.
+
+## Numbering
+
+`148` is contested between an in-flight frontier-tier ADR (#2357/#2359) and ruvnet's Phase-2 artifact-lifecycle ADR draft (#2334). This ADR is numbered `149` provisionally — **renumber as the maintainer prefers**; the Phase-2 artifact-lifecycle ADR is ruvnet's to author.

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@claude-flow/security':
         specifier: ^3.0.0-alpha.10
         version: link:../security
+      '@metaharness/router':
+        specifier: 0.3.2
+        version: 0.3.2
       '@ruvector/attention':
         specifier: ^0.1.32
         version: 0.1.32
@@ -1692,6 +1695,18 @@ packages:
   /@leichtgewicht/ip-codec@2.0.5:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: false
+
+  /@metaharness/router@0.3.2:
+    resolution: {integrity: sha512-LQElU6mUrWd3ffJ5bwoonEIgw7oFQZpwZaehffyl/Pg+iozpRjIBPEXdb4uTOBnKH+yPiTEWKc+h9AiZr9Os9w==}
+    engines: {node: '>=20.0.0'}
+    requiresBuild: true
+    peerDependencies:
+      '@ruvector/tiny-dancer': ^0.1.21
+    peerDependenciesMeta:
+      '@ruvector/tiny-dancer':
+        optional: true
+    dev: false
+    optional: true
 
   /@modelcontextprotocol/sdk@1.25.1(hono@4.12.11)(zod@3.25.76):
     resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}


### PR DESCRIPTION

Closes #2334 (Phase 1). Supersedes #2347 (the tiny-dancer-direct attempt; this is the metaharness reframe you proposed on 2026-06-15).

## Why

`route(task, embedding?)` already accepts an embedding but no internal caller supplies one, so the neural path described in ADR-026 was never live and no trajectory carries the feature a Phase-2 model would train on. With `@metaharness/router`'s cost-optimal `route(embedding)` over a `{embedding, scores}` dataset + `qualityBar`, both original blockers (safetensors layout, candidate modeling) are moot. This wires the seam and starts collecting the dataset — **default behaviour unchanged.**

## What this changes

| File | Change |
|---|---|
| `src/ruvector/router-embedding.ts` (new) | Lazy local MiniLM embedding, **only when a gate is open**. Accepts a vector **only** if `backend==='onnx' && dimensions===384` — never a hash fallback (ADR-086). |
| `src/ruvector/neural-router.ts` (new) | `tryCostOptimalRoute()` behind `CLAUDE_FLOW_ROUTER_NEURAL=1` + an artifact at `CLAUDE_FLOW_ROUTER_MODEL_PATH`. Dynamic-imports `@metaharness/router` (optionalDependency, ADR-124); pure-TS k-NN / KRR; returns `null` on any failure. |
| `src/ruvector/router-trajectory.ts` (new) | Opt-in decision rows (`CLAUDE_FLOW_ROUTER_TRAJECTORY=1`) → `.swarm/model-router-trajectories.jsonl`. The **embedding/decision half** of a future training set — see "intentionally NOT" re the missing labelled-outcome half. Best-effort; never throws. |
| `src/ruvector/model-router.ts` | `route()`: lazy-embed when gated, feeding **only** the neural advisor (never the heuristic — so a `bandit-fallback` decision is byte-identical to the default bandit); neural pick stands only if it clears its quality bar; `routedBy` on every result, derived. |
| `package.json` | `@metaharness/router: 0.3.2` → `optionalDependencies` (exact pin). |
| `scripts/audit-env-var-precedence.mjs` | Register the 3 `CLAUDE_FLOW_ROUTER_*` gates as feature-flag escape hatches (the env-var-precedence audit that blocked #2347). |
| `v3/docs/adr/ADR-149-…md` | The seam ADR (see open question on numbering). |

`routedBy ∈ {metaharness-knn, metaharness-krr, fastgrnn, bandit-fallback, heuristic}`. `'fastgrnn'` (native `@ruvector/tiny-dancer`) is **reserved** for Phase 2.

## Validation

```
# build — our added/edited files typecheck clean under the package tsconfig
$ npx tsc --noEmit            # 0 errors in src/ruvector/{neural-router,router-embedding,router-trajectory,model-router}.ts
                              # (residual sandbox errors are unrelated: optional native deps not installed + workspace project-ref ordering)

# tests — vitest 4.0.16
$ npx vitest run __tests__/router-phase1-2334.test.ts __tests__/router-bandit.test.ts __tests__/codemod-routing.test.ts
   ✓ router-phase1-2334.test.ts  (7)   # default byte-identical (0 embedding calls); bandit-fallback;
                                        # bandit-fallback complexity == default (embedding never perturbs the heuristic);
                                        # real metaharness-knn; mock/wrong-dim embedding rejected; trajectory v:1
   ✓ router-bandit.test.ts       (8)   # no regression
   ✓ codemod-routing.test.ts     (4)   # no regression
   Tests  19 passed (19)
```

## Dependencies (supply-chain note, ADR-124)

`@metaharness/router` added as an **optionalDependency, pinned exact**, dynamic-import only; the default path never loads it.
- `@metaharness/router@0.3.2`  `sha512-LQElU6mUrWd3ffJ5bwoonEIgw7oFQZpwZaehffyl/Pg+iozpRjIBPEXdb4uTOBnKH+yPiTEWKc+h9AiZr9Os9w==`
- Known gap: it carries `dist.signatures` but **no npm provenance attestation (SLSA)**. It's single-author + days-old; mitigated by the exact pin + the recorded hash above + full gating (a compromised/absent dep degrades to `bandit-fallback`, never affecting default routing).

`v3/pnpm-lock.yaml` is updated with a **minimal 15-line addition** for the new optionalDependency (lockfileVersion 6.0 / pnpm 8 format, matching the repo). Verified with `pnpm install --frozen-lockfile` → *"Lockfile is up to date, resolution step is skipped"* — so CI's frozen-lockfile gate passes.

## What's intentionally NOT in this PR

- No trained artifact / training + eval scripts — Phase 2 (the artifact-lifecycle ADR is yours to author).
- **No labelled-outcome sink.** The trajectory rows are the *embedding half* only. The per-model `scores` a trainer needs (quality each tier achieved on a query) are **not** recoverable from today's bandit outcomes (aggregate Beta(α,β) counters, not per-query `taskHash`-keyed labels). A Phase-2 outcome sink is the prerequisite to make these rows trainable — flagging so the dataset isn't assumed complete.
- No native FastGRNN inference (`@ruvector/tiny-dancer`) — reserved; `'fastgrnn'` kept in the union so adding it isn't a breaking change.
- No change to the bandit, the Tier-1 codemods, or the executing-model binding (routing stays advisory). `EnhancedModelRouter` does not yet consume the neural recommendation — wiring it in is a separate step.
- No default flip: both gates default OFF; promotion to default-on is a later step behind a measured +5pp bar.

**Open question (maintainer's call):** ADR numbering — `148` is contested between the frontier-tier ADR (#2357/#2359) and your Phase-2 artifact-lifecycle draft. I used `149` provisionally; renumber as you prefer.
