### PR TITLE
fix(hooks): harden memory/hook helpers (timeout race, signal cleanup, truncation, cross-platform slug)

### DIFF
--- a/.claude/helpers/auto-memory-hook.mjs
+++ b/.claude/helpers/auto-memory-hook.mjs
@@ -31,6 +31,27 @@ const log = (msg) => console.log(`${CYAN}[AutoMemory] ${msg}${RESET}`);
 const success = (msg) => console.log(`${GREEN}[AutoMemory] ✓ ${msg}${RESET}`);
 const dim = (msg) => console.log(`  ${DIM}${msg}${RESET}`);
 
+const DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+
+// ── Graceful shutdown (FIX 3) ───────────────────────────────────────────────
+// Track the backend currently in use so a SIGTERM/SIGINT mid-run can still
+// flush it (the JSON backend persists, a SQLite-backed one closes/flushes WAL)
+// instead of leaving a half-written store or a stale lock behind.
+let activeBackend = null;
+let shuttingDown = false;
+function trackBackend(b) { activeBackend = b; return b; }
+async function gracefulExit(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (DEBUG) process.stderr.write(`[AutoMemory] received ${signal}, flushing backend before exit\n`);
+  try {
+    if (activeBackend && typeof activeBackend.shutdown === 'function') await activeBackend.shutdown();
+  } catch { /* best effort — never block exit on cleanup */ }
+  process.exit(0);
+}
+process.on('SIGTERM', () => { gracefulExit('SIGTERM'); });
+process.on('SIGINT', () => { gracefulExit('SIGINT'); });
+
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -219,7 +240,7 @@ async function doImport() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const bridgeConfig = {
@@ -302,7 +323,7 @@ async function doSync() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const entryCount = await backend.count();
@@ -542,9 +563,17 @@ async function doImportAll() {
 
 const command = process.argv[2] || 'status';
 
-// Suppress unhandled rejection warnings from dynamic import() failures
-// which can cause non-zero exit codes even when caught
-process.on('unhandledRejection', () => {});
+// Dynamic import() failures can surface as unhandled rejections on a later
+// microtask even when the awaiting call site already caught them, which would
+// otherwise force a non-zero exit. Swallow to keep hooks exit-0, but surface the
+// reason under RUFLO_DEBUG/DEBUG so genuine async bugs aren't silently hidden
+// (FIX 2 — the previous `() => {}` discarded every rejection process-wide).
+process.on('unhandledRejection', (reason) => {
+  if (DEBUG) {
+    const detail = reason && reason.message ? reason.message : String(reason);
+    process.stderr.write(`[AutoMemory] unhandledRejection (suppressed): ${detail}\n`);
+  }
+});
 
 try {
   switch (command) {

--- a/.claude/helpers/context-persistence-hook.mjs
+++ b/.claude/helpers/context-persistence-hook.mjs
@@ -59,6 +59,28 @@ const AUTOPILOT_STATE_PATH = join(DATA_DIR, 'autopilot-state.json');
 // Approximate tokens per character (Claude averages ~3.5 chars per token)
 const CHARS_PER_TOKEN = 3.5;
 
+const DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+
+// ── Graceful shutdown (FIX 3) ───────────────────────────────────────────────
+// The active backend is created mid-handler and closed at the end. SQLite holds
+// a native handle and a WAL; if a SIGTERM/SIGINT arrives between creation and
+// `backend.shutdown()`, that close is skipped — risking an unflushed WAL or a
+// stale lock file. Track the active backend and flush it on signal before exit.
+let activeBackend = null;
+let shuttingDown = false;
+function trackBackend(b) { activeBackend = b; return b; }
+async function gracefulExit(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (DEBUG) process.stderr.write(`[ContextPersistence] received ${signal}, flushing backend before exit\n`);
+  try {
+    if (activeBackend && typeof activeBackend.shutdown === 'function') await activeBackend.shutdown();
+  } catch { /* best effort — never block exit on cleanup */ }
+  process.exit(0);
+}
+process.on('SIGTERM', () => { gracefulExit('SIGTERM'); });
+process.on('SIGINT', () => { gracefulExit('SIGINT'); });
+
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -714,7 +736,7 @@ async function resolveBackend() {
   try {
     const backend = new SQLiteBackend(ARCHIVE_DB_PATH);
     await backend.initialize();
-    return { backend, type: 'sqlite' };
+    return { backend: trackBackend(backend), type: 'sqlite' };
   } catch { /* fall through */ }
 
   // Tier 2: RuVector PostgreSQL (TB-scale, vector search, GNN)
@@ -723,7 +745,7 @@ async function resolveBackend() {
     if (rvConfig) {
       const backend = new RuVectorBackend(rvConfig);
       await backend.initialize();
-      return { backend, type: 'ruvector' };
+      return { backend: trackBackend(backend), type: 'ruvector' };
     }
   } catch { /* fall through */ }
 
@@ -739,14 +761,14 @@ async function resolveBackend() {
     if (memPkg?.AgentDBBackend) {
       const backend = new memPkg.AgentDBBackend();
       await backend.initialize();
-      return { backend, type: 'agentdb' };
+      return { backend: trackBackend(backend), type: 'agentdb' };
     }
   } catch { /* fall through */ }
 
   // Tier 4: JSON file (always works)
   const backend = new JsonFileBackend(ARCHIVE_JSON_PATH);
   await backend.initialize();
-  return { backend, type: 'json' };
+  return { backend: trackBackend(backend), type: 'json' };
 }
 
 // ============================================================================

--- a/.claude/helpers/hook-handler.cjs
+++ b/.claude/helpers/hook-handler.cjs
@@ -37,20 +37,35 @@ const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 
 // ── Intelligence timeout protection (fixes #1530, #1531) ───────────────────
 var INTELLIGENCE_TIMEOUT_MS = 3000;
+// Race the (possibly-async) work against a real timeout.
+//
+// The previous implementation called `fn()` and then `clearTimeout(timer)`
+// immediately — but if `fn()` returns a *pending* promise (async work), the
+// timer was cancelled before the work settled and the promise resolved with the
+// still-pending promise, so the timeout protected nothing. This version only
+// settles when the work resolves OR the timeout fires, whichever comes first,
+// and clears the timer afterwards.
+//
+// LIMITATION (be honest): a *synchronous* CPU-bound `fn` (e.g. the current
+// intelligence.init(), which does blocking fs reads) cannot be interrupted by
+// any in-process timer — the event loop is blocked, so the timeout callback
+// can't run until `fn` already returned. The real guard for that case lives in
+// intelligence.cjs (MAX_DATA_FILE_SIZE / MAX_GRAPH_NODES caps). This util only
+// bounds work that yields to the event loop (async I/O, dynamic import, etc.).
 function runWithTimeout(fn, label) {
-  return new Promise(function(resolve) {
-    var timer = setTimeout(function() {
+  var timer;
+  var timeout = new Promise(function(resolve) {
+    timer = setTimeout(function() {
       process.stderr.write("[WARN] " + label + " timed out after " + INTELLIGENCE_TIMEOUT_MS + "ms, skipping\n");
       resolve(null);
     }, INTELLIGENCE_TIMEOUT_MS);
-    try {
-      var result = fn();
-      clearTimeout(timer);
-      resolve(result);
-    } catch (e) {
-      clearTimeout(timer);
-      resolve(null);
-    }
+  });
+  // Promise.resolve().then(fn) turns a synchronous throw into a rejection so it
+  // is handled here rather than escaping the Promise constructor.
+  var work = Promise.resolve().then(fn).catch(function() { return null; });
+  return Promise.race([work, timeout]).then(function(result) {
+    clearTimeout(timer);
+    return result;
   });
 }
 
@@ -261,9 +276,16 @@ if (command && handlers[command]) {
   }
 }
 
-main().catch(function(e) {
-  console.log('[WARN] Hook handler error: ' + e.message);
-}).finally(function() {
-  // Ensure clean exit for Claude Code hooks
-  process.exit(0);
-});
+// Only dispatch hooks when run directly (node hook-handler.cjs ...). When
+// require()'d by a test, just expose the internals so they can be unit-tested
+// without triggering stdin reads / process.exit.
+if (require.main === module) {
+  main().catch(function(e) {
+    console.log('[WARN] Hook handler error: ' + e.message);
+  }).finally(function() {
+    // Ensure clean exit for Claude Code hooks
+    process.exit(0);
+  });
+}
+
+module.exports = { runWithTimeout: runWithTimeout, INTELLIGENCE_TIMEOUT_MS: INTELLIGENCE_TIMEOUT_MS };

--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -56,6 +56,21 @@ function tokenize(text) {
   return text.toLowerCase().replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(function(w) { return w.length > 2; });
 }
 
+// ── Truncation transparency (FIX 4) ─────────────────────────────────────────
+// Silently severing stored values means later reasoning can be built on
+// incomplete text. Warn (debug-gated) and mark the cut point with an ellipsis
+// so it is visible that the value was clipped.
+var DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+function clip(text, max, label) {
+  text = text == null ? "" : String(text);
+  if (text.length <= max) return text;
+  if (DEBUG) {
+    process.stderr.write("[INTELLIGENCE] WARN: truncated " + (label || "value") +
+      " from " + text.length + " to " + max + " chars\n");
+  }
+  return text.slice(0, max - 1) + "…";
+}
+
 // ── Deduplication helper (fixes #1518) ──────────────────────────────────────
 function deduplicateById(entries) {
   if (!entries || !Array.isArray(entries)) return entries;
@@ -73,8 +88,14 @@ function deduplicateById(entries) {
 
 function bootstrapFromMemoryFiles() {
   var entries = [];
-  // Scope to current project only (not all 51+ project dirs)
-  var projectSlug = process.cwd().replace(/^\//, '').replace(/\//g, '-');
+  // Scope to current project only (not all 51+ project dirs).
+  // Match Claude Code's project-dir slug convention: every non-alphanumeric char
+  // becomes '-' (e.g. "G:\\My Drive\\TJ_Vault" -> "G--My-Drive-TJ-Vault"). The old
+  // version only stripped a leading '/' and replaced '/', so on Windows the slug
+  // kept ':' and '\\' and never matched the real ~/.claude/projects/<slug> dir —
+  // memory bootstrap then silently found nothing (FIX 5). Runs are NOT collapsed:
+  // Claude emits "G--My" because ':' and '\\' each map to their own '-'.
+  var projectSlug = process.cwd().replace(/[^a-zA-Z0-9]/g, '-');
   var candidates = [
     path.join(os.homedir(), ".claude", "projects", projectSlug, "memory"),
     path.join(process.cwd(), ".claude-flow", "memory"),
@@ -101,14 +122,15 @@ function bootstrapFromMemoryFiles() {
           for (var s = 0; s < sections.length; s++) {
             var lines = sections[s].split("\n");
             var title = lines[0] ? lines[0].trim() : "section-" + s;
+            var clippedContent = clip(sections[s], 500, "memory content");
             entries.push({
               id: "mem-" + entries.length,
-              content: sections[s].substring(0, 500),
-              summary: title.substring(0, 100),
+              content: clippedContent,
+              summary: clip(title, 100, "memory summary"),
               category: "memory",
               confidence: 0.5,
               sourceFile: files[k],
-              words: tokenize(sections[s].substring(0, 500)),
+              words: tokenize(clippedContent),
             });
           }
         } catch (e) { /* skip */ }

--- a/tests/hook-handler-runwithtimeout.test.cjs
+++ b/tests/hook-handler-runwithtimeout.test.cjs
@@ -1,0 +1,56 @@
+'use strict';
+/**
+ * Unit tests for hook-handler.cjs runWithTimeout (FIX 1).
+ *
+ * The previous implementation called fn() and clearTimeout(timer) immediately,
+ * so an async fn returned a *pending* promise that resolved through the race —
+ * the timeout never fired. The "times out a slow async fn" case below fails
+ * against the old code (it would return 'late') and passes against the fix.
+ *
+ * Uses node:test (built-in) so it runs without installing dependencies.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { runWithTimeout, INTELLIGENCE_TIMEOUT_MS } = require(
+  path.join(__dirname, '..', '.claude', 'helpers', 'hook-handler.cjs')
+);
+
+test('returns the value for a fast async fn', async () => {
+  const r = await runWithTimeout(() => Promise.resolve(42), 'fast-async');
+  assert.equal(r, 42);
+});
+
+test('returns the value for a fast sync fn', async () => {
+  const r = await runWithTimeout(() => 7, 'fast-sync');
+  assert.equal(r, 7);
+});
+
+test('resolves null (never rejects) when fn throws synchronously', async () => {
+  const r = await runWithTimeout(() => { throw new Error('boom'); }, 'sync-throw');
+  assert.equal(r, null);
+});
+
+test('resolves null (never rejects) when an async fn rejects', async () => {
+  const r = await runWithTimeout(() => Promise.reject(new Error('boom')), 'async-reject');
+  assert.equal(r, null);
+});
+
+test('times out a slow async fn and resolves null near the timeout', { timeout: 8000 }, async () => {
+  const start = Date.now();
+  const r = await runWithTimeout(
+    () => new Promise((res) => {
+      // .unref() so the dangling timer never keeps the test process alive
+      const t = setTimeout(() => res('late'), INTELLIGENCE_TIMEOUT_MS + 2000);
+      if (t.unref) t.unref();
+    }),
+    'slow-async'
+  );
+  const elapsed = Date.now() - start;
+  assert.equal(r, null, "should time out to null, not return the late value");
+  assert.ok(
+    elapsed >= INTELLIGENCE_TIMEOUT_MS - 200 && elapsed < INTELLIGENCE_TIMEOUT_MS + 1500,
+    `should resolve near the ${INTELLIGENCE_TIMEOUT_MS}ms timeout, took ${elapsed}ms`
+  );
+});

--- a/v3/@claude-flow/cli/.claude/helpers/auto-memory-hook.mjs
+++ b/v3/@claude-flow/cli/.claude/helpers/auto-memory-hook.mjs
@@ -31,6 +31,27 @@ const log = (msg) => console.log(`${CYAN}[AutoMemory] ${msg}${RESET}`);
 const success = (msg) => console.log(`${GREEN}[AutoMemory] ✓ ${msg}${RESET}`);
 const dim = (msg) => console.log(`  ${DIM}${msg}${RESET}`);
 
+const DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+
+// ── Graceful shutdown (FIX 3) ───────────────────────────────────────────────
+// Track the backend in use so a SIGTERM/SIGINT mid-run can still flush it
+// (the JSON backend persists; a SQLite-backed one closes/flushes WAL) instead
+// of leaving a half-written store or a stale lock behind.
+let activeBackend = null;
+let shuttingDown = false;
+function trackBackend(b) { activeBackend = b; return b; }
+async function gracefulExit(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (DEBUG) process.stderr.write(`[AutoMemory] received ${signal}, flushing backend before exit\n`);
+  try {
+    if (activeBackend && typeof activeBackend.shutdown === 'function') await activeBackend.shutdown();
+  } catch { /* best effort — never block exit on cleanup */ }
+  process.exit(0);
+}
+process.on('SIGTERM', () => { gracefulExit('SIGTERM'); });
+process.on('SIGINT', () => { gracefulExit('SIGINT'); });
+
 // Ensure data dir
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -219,7 +240,7 @@ async function doImport() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const bridgeConfig = {
@@ -272,7 +293,7 @@ async function doSync() {
   }
 
   const config = readConfig();
-  const backend = new JsonFileBackend(STORE_PATH);
+  const backend = trackBackend(new JsonFileBackend(STORE_PATH));
   await backend.initialize();
 
   const entryCount = await backend.count();
@@ -348,8 +369,17 @@ async function doStatus() {
 
 const command = process.argv[2] || 'status';
 
-// Suppress unhandled rejection warnings from dynamic import() failures
-process.on('unhandledRejection', () => {});
+// Dynamic import() failures can surface as unhandled rejections on a later
+// microtask even when the awaiting call site already caught them, which would
+// otherwise force a non-zero exit. Swallow to keep hooks exit-0, but surface the
+// reason under RUFLO_DEBUG/DEBUG so genuine async bugs aren't silently hidden
+// (FIX 2 — the previous `() => {}` discarded every rejection process-wide).
+process.on('unhandledRejection', (reason) => {
+  if (DEBUG) {
+    const detail = reason && reason.message ? reason.message : String(reason);
+    process.stderr.write(`[AutoMemory] unhandledRejection (suppressed): ${detail}\n`);
+  }
+});
 
 try {
   switch (command) {

--- a/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
@@ -49,23 +49,27 @@ const intelligence = safeRequire(path.join(helpersDir, 'intelligence.cjs'));
 
 // ── Intelligence timeout protection (fixes #1530, #1531) ───────────────────
 const INTELLIGENCE_TIMEOUT_MS = 3000;
+// Race the (possibly-async) work against a real timeout. The previous version
+// called fn() and clearTimeout(timer) immediately, so an async fn returned a
+// pending promise that resolved THROUGH the race — the timeout protected
+// nothing. This settles on whichever finishes first, then clears the timer.
+//
+// LIMITATION: a synchronous blocking fn (the current intelligence.init() does
+// blocking fs reads) cannot be interrupted by any in-process timer — the event
+// loop is blocked. The real guard for that case is the readJSON file-size
+// limit in intelligence.cjs. This util only bounds work that yields (async I/O).
 function runWithTimeout(fn, label) {
-  // For synchronous blocking calls, we use a global safety timer.
-  // The readJSON file-size guard prevents loading huge files, but this
-  // is an additional safety net.
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => {
       process.stderr.write("[WARN] " + label + " timed out after " + INTELLIGENCE_TIMEOUT_MS + "ms, skipping\n");
       resolve(null);
     }, INTELLIGENCE_TIMEOUT_MS);
-    try {
-      const result = fn();
-      clearTimeout(timer);
-      resolve(result);
-    } catch (e) {
-      clearTimeout(timer);
-      resolve(null);
-    }
+  });
+  const work = Promise.resolve().then(fn).catch(() => null);
+  return Promise.race([work, timeout]).then((result) => {
+    clearTimeout(timer);
+    return result;
   });
 }
 

--- a/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
@@ -318,7 +318,11 @@ function bootstrapFromMemoryFiles() {
     // For the projects dir, scope to CURRENT project only (not all 51+ dirs)
     if (base.endsWith('projects')) {
       try {
-        const projectSlug = cwd.replace(/^\//, '').replace(/\//g, '-');
+        // Match Claude Code's project-dir slug: every non-alphanumeric char -> '-'
+        // (e.g. "G:\\My Drive\\TJ_Vault" -> "G--My-Drive-TJ-Vault"). The old version
+        // only handled POSIX '/', so on Windows the slug kept ':' and '\\' and never
+        // matched the real <projects>/<slug>/memory dir — bootstrap found nothing (FIX 5).
+        const projectSlug = cwd.replace(/[^a-zA-Z0-9]/g, '-');
         const memDir = path.join(base, projectSlug, 'memory');
         if (fs.existsSync(memDir)) {
           parseMemoryDir(memDir, entries);
@@ -330,6 +334,16 @@ function bootstrapFromMemoryFiles() {
   }
 
   return entries;
+}
+
+// Truncation transparency (FIX 4): mark the cut with an ellipsis and warn under
+// debug, so later reasoning isn't silently built on severed text.
+const CLIP_DEBUG = !!(process.env.RUFLO_DEBUG || process.env.DEBUG);
+function clip(text, max, label) {
+  text = text == null ? '' : String(text);
+  if (text.length <= max) return text;
+  if (CLIP_DEBUG) process.stderr.write(`[INTELLIGENCE] WARN: truncated ${label || 'value'} from ${text.length} to ${max} chars\n`);
+  return text.slice(0, max - 1) + '…';
 }
 
 function parseMemoryDir(dir, entries) {
@@ -353,7 +367,7 @@ function parseMemoryDir(dir, entries) {
         entries.push({
           id,
           key: title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 50),
-          content: body.slice(0, 500),
+          content: clip(body, 500, 'memory content'),
           summary: title,
           namespace: file === 'MEMORY.md' ? 'core' : file.replace('.md', ''),
           type: 'semantic',


### PR DESCRIPTION
## What

Hardens the `.claude/helpers/*` memory & hook helpers against five grounded bugs, and reconciles the diverged `v3/@claude-flow/cli` copies so the fixes don't drift.

### Fixes

1. **`hook-handler.cjs` — `runWithTimeout()` never guarded async callees.** The timer was cleared the instant `fn()` returned, so an async callee's hang was never caught — the "timeout" protected nothing. Replaced with a real `Promise.race` between the work and the timeout; the timer clears only after one settles. (A *synchronous* blocking callee still can't be preempted in-process — documented honestly; the real guard there is the file-size cap in `intelligence.cjs`.)
2. **`auto-memory-hook.mjs` — `process.on('unhandledRejection', () => {})` swallowed all async failures process-wide.** Scoped to keep hooks exit-0 but log the reason under `RUFLO_DEBUG`/`DEBUG`, restoring visibility of real bugs.
3. **`auto-memory-hook.mjs` / `context-persistence-hook.mjs` — no SIGTERM/SIGINT cleanup.** A signal mid-write could skip `backend.shutdown()`, leaving an unflushed SQLite WAL / stale `agentdb.rvf.lock`. Added signal handlers that flush the active backend before exit.
4. **`intelligence.cjs` — silent 500/100-char truncation.** Downstream reasoning could be built on severed text with no signal. Added a `clip()` helper that appends `…` and warns under debug when it actually cuts.
5. **`intelligence.cjs` — `projectSlug` only handled POSIX `/`.** On Windows the slug kept `:` and `\`, so it never matched Claude Code's real `~/.claude/projects/<slug>` dir and memory bootstrap silently found nothing. Now slugifies every non-alphanumeric to `-`, matching Claude Code's convention.

Plus: reconciles the diverged `v3/@claude-flow/cli/.claude/helpers/{hook-handler,auto-memory-hook,intelligence}` copies so they carry the same fixes as the root dogfood copies.

## Verification

- `node --check` passes on all changed helpers (root + CLI copies).
- `node --test tests/hook-handler-runwithtimeout.test.cjs` — **5/5**, including the decisive case: a slow async fn resolves to `null` at ~3007ms (old code returned the late value at ~5000ms). This test is added by the PR.
- `node --test tests/context-persistence-hook.test.mjs` — 65/66. The one failure is a pre-existing stale assertion expecting a 768-dim hash embedding, while the implementation is 384-dim ONNX-aligned — unrelated to this change.

## Not included

A sixth `statusline.cjs` `execSync`→`execFileSync` hardening exists in my fork but depends on the #2195 statusline *delegation* rewrite that isn't on `main` here, so it's intentionally left out of this PR.

## Notes

Deliberately **not** done: a `session_id` key-sanitization "fix" — it's a controlled Claude UUID stored in a parameterized column, so it was a non-problem.
