### PR TITLE
security(deps): bump agentic-flow ^2.0.13 → ^2.0.14 (CWE-78), release 3.12.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.11.0",
+  "version": "3.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.11.0",
+      "version": "3.12.3",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",
@@ -15,6 +15,7 @@
         "@claude-flow/shared": "3.0.0-alpha.8",
         "@noble/ed25519": "2.3.0",
         "@ruvector/rabitq-wasm": "0.1.0",
+        "agentic-flow": "^2.0.14",
         "semver": "7.7.3",
         "zod": "3.25.76"
       },
@@ -46,7 +47,7 @@
         "@ruvector/router-linux-x64-gnu": "^0.1.30",
         "@ruvector/sona": "^0.1.5",
         "agentdb": "^3.0.0-alpha.16",
-        "agentic-flow": "^2.0.13"
+        "agentic-flow": "^2.0.14"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -3961,9 +3962,9 @@
       "license": "MIT"
     },
     "node_modules/agentic-flow": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/agentic-flow/-/agentic-flow-2.0.13.tgz",
-      "integrity": "sha512-VN3OVYUweVtCE4ARzxwf0Qf22Z3+6dgYWukKvnE5qlBIa5FEPjD5rRN4Fz5mecQ+88+0fnFgJ/00lb6MVhWsNQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/agentic-flow/-/agentic-flow-2.0.14.tgz",
+      "integrity": "sha512-8+AQhXI0P0mK26mZ8zsTQkhUhRsPWYP52Diwzr3Nk0dUNXd+pBjzdyQDfFxttGIymBfMqvRr8VRBd+bZLSYWcg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3977,6 +3978,7 @@
         "@ruvector/ruvllm": "^0.2.3",
         "@ruvector/tiny-dancer": "^0.1.17",
         "@supabase/supabase-js": "^2.78.0",
+        "@xenova/transformers": "^2.17.2",
         "axios": "^1.12.2",
         "dotenv": "^16.4.5",
         "express": "^5.1.0",
@@ -3988,7 +3990,7 @@
         "ruvector-onnx-embeddings-wasm": "^0.1.2",
         "tiktoken": "^1.0.22",
         "ulid": "^3.0.1",
-        "ws": "^8.18.3",
+        "ws": "^8.20.0",
         "yaml": "^2.8.1",
         "zod": "^3.25.76"
       },
@@ -4003,7 +4005,6 @@
         "@rollup/rollup-darwin-arm64": "^4.59.0",
         "@ruvector/attention": "^0.1.4",
         "@ruvector/sona": "^0.1.4",
-        "@xenova/transformers": "^2.17.2",
         "agentdb": "^3.0.0-alpha.14",
         "better-sqlite3": "^11.10.0",
         "onnxruntime-node": "^1.23.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@ruvector/router-linux-x64-gnu": "^0.1.30",
     "@ruvector/sona": "^0.1.5",
     "agentdb": "^3.0.0-alpha.16",
-    "agentic-flow": "^2.0.13"
+    "agentic-flow": "^2.0.14"
   },
   "overrides": {
     "ruvector": "^0.2.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -76,7 +76,8 @@
     "@opentelemetry/otlp-exporter-base": "0.52.1",
     "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
     "@opentelemetry/otlp-transformer": "0.52.1",
-    "agentdb": ">=3.0.0-alpha.16"
+    "agentdb": ">=3.0.0-alpha.16",
+    "agentic-flow": ">=2.0.14"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- Closes #2414
- Picks up [agentic-flow@2.0.14](https://www.npmjs.com/package/agentic-flow/v/2.0.14) which fixes CWE-78 OS command injection in its MCP server tools (full advisory: ruvnet/agentic-flow#169)
- Cuts release 3.12.4 across all three packages, all three dist-tags

## What changed
- Root \`package.json\`: \`agentic-flow\` \`^2.0.13\` → \`^2.0.14\`, version \`3.12.3\` → \`3.12.4\`
- \`v3/@claude-flow/cli/package.json\`: version \`3.12.3\` → \`3.12.4\`
- \`ruflo/package.json\` (wrapper): version \`3.12.3\` → \`3.12.4\`, adds \`"agentic-flow": ">=2.0.14"\` to \`overrides\` (per the #2112 lesson — wrapper does not inherit root \`overrides\`)
- \`package-lock.json\` refreshed
- Companion upstream PR: ruvnet/agentic-flow#170 (merged at commit \`0c2ec96\`)

## Published artifacts

| Package | latest | alpha | v3alpha |
|---|---|---|---|
| \`@claude-flow/cli\` | 3.12.4 | 3.12.4 | 3.12.4 |
| \`claude-flow\` | 3.12.4 | 3.12.4 | 3.12.4 |
| \`ruflo\` | 3.12.4 | 3.12.4 | 3.12.4 |

## Test plan
- [x] Upstream \`agentic-flow@2.0.14\` published, verified \`npm view agentic-flow version\` returns \`2.0.14\`
- [x] Installed \`node_modules/agentic-flow/dist/mcp/standalone-stdio.js\` has 0 \`execSync()\` calls, 14 \`execFileSync()\` calls
- [x] Same 0/N pattern across all six advisory-listed files in the installed dist
- [x] All three packages published to npm
- [x] All three dist-tags updated on all three packages
- [x] Verified via \`npm view <pkg> dist-tags --json\`

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)