### PR TITLE
chore(marketplace): register ruflo-metaharness and ruflo-arena in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -170,6 +170,16 @@
       "name": "ruflo-sparc",
       "source": "./plugins/ruflo-sparc",
       "description": "SPARC methodology — Specification, Pseudocode, Architecture, Refinement, Completion phases with quality gates"
+    },
+    {
+      "name": "ruflo-metaharness",
+      "source": "./plugins/ruflo-metaharness",
+      "description": "MetaHarness integration — surfaces score/genome/mint/mcp-scan/threat-model via skills; pairs with @metaharness/router (ADR-148/149) for cost-optimal model routing; honors ADR-150 optional-augmentation constraint"
+    },
+    {
+      "name": "ruflo-arena",
+      "source": "./plugins/ruflo-arena",
+      "description": "Competitive ruliology for ruflo swarms — arenas, tournaments, and adaptive co-evolution of program strategies (ADR-147/148); strategies-as-programs compete under payoff games"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- \`ruflo-metaharness\` and \`ruflo-arena\` exist in \`plugins/\` on disk but were missing from \`.claude-plugin/marketplace.json\`, so \`/plugin marketplace add ruvnet/ruflo\` in Claude Code did not surface them
- Adds the two missing entries; manifest now lists **35** plugins, matching the **35** \`ruflo-*\` directories under \`plugins/\`

## Test plan
- [x] \`python3 -m json.tool .claude-plugin/marketplace.json\` — manifest is valid JSON
- [x] \`ls plugins/ | grep -c ruflo-\` returns 35, matching \`jq '.plugins | length' .claude-plugin/marketplace.json\` → 35
- [x] Both new entries have correct \`name\` matching their \`plugin.json\` and \`source\` paths matching disk
- [ ] After merge: \`/plugin marketplace add ruvnet/ruflo\` in Claude Code lists both new plugins

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)