### PR TITLE
chore(release): bump 3.12.4 → 3.13.0 — @metaharness/darwin integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.12.4",
+  "version": "3.13.0",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.12.4",
+  "version": "3.13.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.12.4",
+  "version": "3.13.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- MINOR bump per semver — backward-compatible additions only
- Picks up #2440 (Darwin Mode integration) and ships it to npm
- All three packages × all three dist-tags = **3.13.0**

## What's new in 3.13.0

| Surface | Detail |
|---|---|
| MCP tools | \`metaharness_evolve\`, \`metaharness_security_bench\`, \`metaharness_bench\` |
| Plugin skills | \`harness-evolve\`, \`harness-security-bench\`, \`harness-bench\` |
| Optional dep | \`@metaharness/darwin@~0.3.1\` (new) |
| Optional dep | \`metaharness@~0.2.6\` (was \`~0.1.11\`) |

Strategic note: \`harness-security-bench\` wraps the upstream \"Darwin Shield\" — the closest reference implementation for [our ADR-155 nightly self-learning security harness (#2417)](https://github.com/ruvnet/ruflo/pull/2417). Gives Loop A its empirical reward-signal floor.

## Published artifacts

| Package | latest | alpha | v3alpha |
|---|---|---|---|
| \`@claude-flow/cli\` | 3.13.0 | 3.13.0 | 3.13.0 |
| \`claude-flow\` | 3.13.0 | 3.13.0 | 3.13.0 |
| \`ruflo\` | 3.13.0 | 3.13.0 | 3.13.0 |

## Test plan
- [x] \`npm view <pkg>@3.13.0 version\` returns 3.13.0 for all three
- [x] \`npm view <pkg> dist-tags --json\` shows latest=alpha=v3alpha=3.13.0 for all three
- [x] \`npx tsc --noEmit\` clean on \`@claude-flow/cli\` (verified pre-publish)
- [x] All 16 graceful-degradation drill assertions pass (verified in #2440)
- [x] Build artifact contains the 3 new MCP tools (\`grep -c\` on compiled metaharness-tools.js = 8)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)