### PR TITLE
chore(deps): bump agentdb ^3.0.0-alpha.16 → ^3.0.0-alpha.17 + release 3.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",
@@ -71,7 +71,7 @@
     "@ruvector/router": "^0.1.30",
     "@ruvector/router-linux-x64-gnu": "^0.1.30",
     "@ruvector/sona": "^0.1.5",
-    "agentdb": "^3.0.0-alpha.16",
+    "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^2.0.14"
   },
   "overrides": {

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -77,7 +77,7 @@
     "@opentelemetry/otlp-exporter-base": "0.52.1",
     "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
     "@opentelemetry/otlp-transformer": "0.52.1",
-    "agentdb": ">=3.0.0-alpha.16",
+    "agentdb": ">=3.0.0-alpha.17",
     "agentic-flow": ">=2.0.14"
   },
   "engines": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
@@ -126,7 +126,7 @@
     "@ruvector/rvagent-wasm": "^0.1.0",
     "@ruvector/sona": "^0.1.6",
     "@ruvector/tiny-dancer": "^0.1.22",
-    "agentdb": "^3.0.0-alpha.16",
+    "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "ruvector": "^0.2.27"
   },


### PR DESCRIPTION
## Summary
- Picks up upstream [ruvnet/agentdb#10](https://github.com/ruvnet/agentdb/pull/10) (\`agentdb@3.0.0-alpha.17\`) — adds FinalizationRegistry safety net for the SqlJsRvfBackend MEMFS leak class (the upstream half of #2432)
- Bumps ruflo from 3.13.1 → 3.13.2 to consume

## Combined effect on #2432

| Layer | Fix | Version |
|---|---|---|
| Downstream (ruflo) | Close prior controller before \`Map.set()\` replacement | v3.13.1 (PR #2444) |
| Upstream (agentdb) | \`FinalizationRegistry\` reclaims MEMFS when wrapper GC'd without explicit close() | 3.0.0-alpha.17 (PR ruvnet/agentdb#10) |

The leak class is now closed at BOTH layers: belt + suspenders.

## Published artifacts

| Package | latest | alpha | v3alpha |
|---|---|---|---|
| \`agentdb\` | 3.0.0-alpha.17 | — | — |
| \`@claude-flow/cli\` | 3.13.2 | 3.13.2 | 3.13.2 |
| \`claude-flow\` | 3.13.2 | 3.13.2 | 3.13.2 |
| \`ruflo\` | 3.13.2 | 3.13.2 | 3.13.2 |

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)