### PR TITLE
docs(readme): add missing ruflo-arena to plugin list + fix count 34 → 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There are **two different install paths** with very different surface areas. Pic
 This adds slash commands and agent definitions only. The Ruflo MCP server is NOT registered, so `memory_store`, `swarm_init`, `agent_spawn`, etc. won't be callable from Claude. For the full loop, use Path B below.
 
 <details>
-<summary><strong>🔌 All 34 plugins</strong></summary>
+<summary><strong>🔌 All 35 plugins</strong></summary>
 
 #### Core & Orchestration
 
@@ -133,6 +133,7 @@ This adds slash commands and agent definitions only. The Ruflo MCP server is NOT
 | [**ruflo-ddd**](plugins/ruflo-ddd/README.md) | Scaffold domain-driven design — contexts, aggregates, events |
 | [**ruflo-sparc**](plugins/ruflo-sparc/README.md) | Guided 5-phase development methodology with quality gates |
 | [**ruflo-metaharness**](plugins/ruflo-metaharness/README.md) | Grade your agent setup, scan tool configs for security risks, and track changes over time ([guide](docs/metaharness-user-guide.md)) |
+| [**ruflo-arena**](plugins/ruflo-arena/README.md) | Competitive ruliology — pit agent strategies against each other in tournaments, hill-climb and co-evolve the winners (ADR-147/148) |
 
 #### DevOps & Observability
 


### PR DESCRIPTION
## Summary
- The \"🔌 All 34 plugins\" collapsed section was missing **\`ruflo-arena\`** (35 dirs on disk, only 34 listed)
- Added arena to **Architecture & Methodology** next to \`ruflo-metaharness\` (evolutionary-strategy siblings: Arena = tournaments, MetaHarness = audit)
- Bumped header count \`All 34 plugins\` → \`All 35 plugins\`

## Verification
\`\`\`
$ ls plugins/ | grep -c ruflo-                                           # 35
$ grep -oE '\[\*\*ruflo-[a-z-]+\*\*\]' README.md | sort -u | wc -l       # 35
$ comm -3 <(both lists)                                                  # (empty)
\`\`\`

Followup to #2446.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)