### PR TITLE
fix(init,doctor): #2448 — migrate stale npx @latest in statusLine/hooks + release 3.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -133,6 +133,85 @@ async function checkConfigFile(): Promise<HealthCheck> {
 }
 
 // Check daemon status
+/**
+ * #2448 — Detect the runaway `npx @claude-flow/cli@latest` statusLine / hook
+ * commands left over in `.claude/settings.json` from pre-#2337 installs.
+ *
+ * These fire on every Claude Code event (statusLine refires every few hundred
+ * ms, hooks fire per tool-use), each spawning a cold Node process + npm
+ * registry round-trip. On the reporter's 48 GB macOS box this produced
+ * load average 49, jetsam, and a kernel watchdog panic two minutes after
+ * boot. Severity is CRITICAL when present; users who installed before #2337
+ * and never re-ran `ruflo init` still have it.
+ *
+ * Detection only — does not modify settings. Fix path is `ruflo init` (the
+ * executor's migration logic, also patched in #2448, will now regenerate
+ * the broken commands).
+ */
+async function checkStaleSettingsNpx(): Promise<HealthCheck> {
+  // Same regex pattern the executor migration uses — kept in sync.
+  const BROKEN_RE = /npx\s+(?:--?\S+\s+)*@?claude-flow\/cli@latest\s+hooks\s+(?:statusline|\S+)/;
+
+  // Look in both project-local and home-dir settings.
+  const candidates = [
+    join(process.cwd(), '.claude', 'settings.json'),
+    join(process.env.HOME ?? '', '.claude', 'settings.json'),
+  ].filter((p, i, a) => p && a.indexOf(p) === i);
+
+  const offenders: Array<{ path: string; where: string }> = [];
+  for (const settingsPath of candidates) {
+    if (!existsSync(settingsPath)) continue;
+    let settings: Record<string, unknown>;
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    } catch {
+      continue; // checkConfigFile reports JSON errors separately
+    }
+
+    // statusLine.command
+    const sl = settings.statusLine as { command?: string } | undefined;
+    if (sl?.command && BROKEN_RE.test(sl.command)) {
+      offenders.push({ path: settingsPath, where: 'statusLine' });
+    }
+
+    // hooks.<event>[].hooks[].command
+    const hooks = settings.hooks as Record<string, Array<{ hooks?: Array<{ command?: string }> }>> | undefined;
+    if (hooks) {
+      for (const [eventName, groups] of Object.entries(hooks)) {
+        if (!Array.isArray(groups)) continue;
+        for (const group of groups) {
+          if (!Array.isArray(group.hooks)) continue;
+          for (const h of group.hooks) {
+            if (typeof h?.command === 'string' && BROKEN_RE.test(h.command)) {
+              offenders.push({ path: settingsPath, where: `hooks.${eventName}` });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (offenders.length === 0) {
+    return { name: 'Stale npx@latest in settings (#2448)', status: 'pass', message: 'no runaway commands detected' };
+  }
+
+  // Group by file for readable output
+  const byFile = offenders.reduce((acc, o) => {
+    (acc[o.path] ??= []).push(o.where);
+    return acc;
+  }, {} as Record<string, string[]>);
+  const summary = Object.entries(byFile)
+    .map(([p, wheres]) => `${p} [${[...new Set(wheres)].join(', ')}]`)
+    .join('; ');
+
+  return {
+    name: 'Stale npx@latest in settings (#2448)',
+    status: 'fail',
+    message: `CRITICAL — runaway \`npx @claude-flow/cli@latest\` commands detected: ${summary}`,
+    fix: 'Re-run `npx ruflo init` to migrate (the v3.13.3+ init migrator regenerates these to local-helper form). On macOS this prevents the process-storm / kernel-panic class reported in #2448.',
+  };
+}
+
 async function checkDaemonStatus(): Promise<HealthCheck> {
   try {
     const pidFile = '.claude-flow/daemon.pid';
@@ -1002,6 +1081,7 @@ export const doctorCommand: Command = {
       checkGit,
       checkGitRepo,
       checkConfigFile,
+      checkStaleSettingsNpx, // #2448 — runaway `npx @latest` in statusLine/hooks
       checkDaemonStatus,
       checkMemoryDatabase,
       checkApiKeys,
@@ -1023,6 +1103,7 @@ export const doctorCommand: Command = {
       'npm': checkNpmVersion,
       'claude': checkClaudeCode,
       'config': checkConfigFile,
+      'stale-settings': checkStaleSettingsNpx, // #2448
       'daemon': checkDaemonStatus,
       'memory': checkMemoryDatabase,
       'api': checkApiKeys,

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -360,13 +360,64 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
 
   // 3. Fix statusLine config (remove invalid fields, ensure correct format)
   // Claude Code only supports: type, command, padding
+  //
+  // #2448 — Detect and REGENERATE the runaway `npx @claude-flow/cli@latest`
+  // statusline form. Pre-#2337 init wrote this to settings.json; it spawns
+  // a cold Node process + npm registry round-trip on every fire (statusline
+  // refires every few hundred ms), which on macOS produced load average 49
+  // / jetsam / kernel panic. Preserving the user's existing command (the
+  // old behavior here) means anyone who installed pre-#2337 and upgraded
+  // never gets the fix. Now we detect the broken form and overwrite.
+  const NEW_STATUSLINE_CMD =
+    `node -e "var c=require('child_process'),p=require('path'),r;try{r=c.execSync('git rev-parse --show-toplevel',{encoding:'utf8'}).trim()}catch(e){r=process.cwd()}var s=p.join(r,'.claude/helpers/statusline.cjs');process.argv.splice(1,0,s);require(s)"`;
+  // Matches: `npx [--prefer-offline] [@]claude-flow/cli@latest hooks statusline …`
+  const BROKEN_STATUSLINE_RE = /npx\s+(?:--?\S+\s+)*@?claude-flow\/cli@latest\s+hooks\s+statusline/;
   const existingStatusLine = existing.statusLine as Record<string, unknown> | undefined;
   if (existingStatusLine) {
+    const existingCmd = typeof existingStatusLine.command === 'string' ? existingStatusLine.command : '';
+    const isBroken = BROKEN_STATUSLINE_RE.test(existingCmd);
     merged.statusLine = {
       type: 'command',
-      command: existingStatusLine.command || `node -e "var c=require('child_process'),p=require('path'),r;try{r=c.execSync('git rev-parse --show-toplevel',{encoding:'utf8'}).trim()}catch(e){r=process.cwd()}var s=p.join(r,'.claude/helpers/statusline.cjs');process.argv.splice(1,0,s);require(s)"`,
+      command: isBroken || !existingCmd ? NEW_STATUSLINE_CMD : existingCmd,
       // Remove invalid fields: refreshMs, enabled (not supported by Claude Code)
     };
+  }
+
+  // #2448 — Detect and REGENERATE per-action hook commands that still use
+  // the runaway `npx @claude-flow/cli@latest hooks <sub>` form. These fire
+  // on every PreToolUse/PostToolUse/UserPromptSubmit, each spawning ~130 MB
+  // of cold Node + npm registry resolution; the storm is what kernel-paniced
+  // the reporter's machine in #2448.
+  //
+  // We walk each hook event's `hooks[]` and swap any command matching the
+  // broken pattern for the local-helper form. Idempotent: re-running this
+  // migration on already-correct settings is a no-op.
+  const BROKEN_HOOK_RE = /npx\s+(?:--?\S+\s+)*@?claude-flow\/cli@latest\s+hooks\s+(\S+)/;
+  const localHookCmd = (sub: string): string => {
+    // POSIX form mirrors settings-generator.ts::hookCmd() exactly.
+    // Windows users hit a separate code path (cmd /c …) — Claude Code on
+    // Windows is rarer and the migration there is left to a follow-up.
+    if (process.platform === 'win32') {
+      return `cmd /c "IF EXIST \"%CLAUDE_PROJECT_DIR%\\.claude\\helpers\\hook-handler.cjs\" (node \"%CLAUDE_PROJECT_DIR%\\.claude\\helpers\\hook-handler.cjs\" ${sub}) ELSE (node \"%USERPROFILE%\\.claude\\helpers\\hook-handler.cjs\" ${sub})"`;
+    }
+    return `sh -c 'D="\${CLAUDE_PROJECT_DIR:-.}"; [ -f "$D/.claude/helpers/hook-handler.cjs" ] || D="\${HOME}"; exec node "$D/.claude/helpers/hook-handler.cjs" ${sub}'`;
+  };
+  const mergedHooks = merged.hooks as Record<string, unknown> | undefined;
+  if (mergedHooks) {
+    for (const eventName of Object.keys(mergedHooks)) {
+      const groups = mergedHooks[eventName] as Array<{ hooks?: Array<{ type?: string; command?: string; timeout?: number }> }> | undefined;
+      if (!Array.isArray(groups)) continue;
+      for (const group of groups) {
+        if (!Array.isArray(group.hooks)) continue;
+        for (const h of group.hooks) {
+          if (typeof h?.command !== 'string') continue;
+          const m = BROKEN_HOOK_RE.exec(h.command);
+          if (!m) continue;
+          // Subcommand captured (e.g. "pre-bash", "post-edit", "route") — keep it.
+          h.command = localHookCmd(m[1]);
+        }
+      }
+    }
   }
 
   // 4. Merge claudeFlow settings (preserve existing, add agentTeams + memory)


### PR DESCRIPTION
## Summary
- Closes **#2448** (CRITICAL — kernel watchdog panic on affected install)
- Pre-#2337 init wrote runaway \`npx @claude-flow/cli@latest hooks <sub>\` into \`~/.claude/settings.json\`. Current init emits the local-helper form, BUT \`executor.ts:362\` preserved the user's existing command verbatim on re-init — so anyone who installed pre-#2337 still has the broken settings after upgrading to 3.13.2.

## Two changes

| File | Change |
|------|--------|
| \`v3/@claude-flow/cli/src/init/executor.ts\` | Detect broken \`npx @claude-flow/cli@latest hooks <sub>\` in statusLine + every hooks event. Regenerate to local-helper form. Idempotent. Subcommand captured from broken string preserves intent. |
| \`v3/@claude-flow/cli/src/commands/doctor.ts\` | New \`checkStaleSettingsNpx\` health check. Scans project-local AND \`\$HOME/.claude/settings.json\`. Reports \`fail\` with file path + offending sections + fix instruction. Registered as \`stale-settings\` component. |

## Smoke verification
Built fixture with statusLine + PreToolUse + UserPromptSubmit (with \`--prefer-offline\` prefix) — doctor correctly flagged all three:
\`\`\`
✗ Stale npx@latest in settings (#2448): CRITICAL — runaway \`npx @claude-flow/cli@latest\` commands detected:
  /private/tmp/settings-2448-fixture/.claude/settings.json [statusLine, hooks.PreToolUse, hooks.UserPromptSubmit]
\`\`\`

## Published

| Package | latest | alpha | v3alpha |
|---|---|---|---|
| \`@claude-flow/cli\` | 3.13.3 | 3.13.3 | 3.13.3 |
| \`claude-flow\` | 3.13.3 | 3.13.3 | 3.13.3 |
| \`ruflo\` | 3.13.3 | 3.13.3 | 3.13.3 |

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)