### PR TITLE
fix: 4 user-reported bugs — CI lockfile, statusline migration, MCP 64KB pipe, USERGUIDE consensus

### DIFF
--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -260,12 +260,12 @@ Agents organize into swarms led by queens that coordinate work, prevent drift, a
 | Coordination | Queen, Swarm, Consensus | Manages agent teams (Raft, Byzantine, Gossip) |
 | Drift Control | Hierarchical topology, Checkpoints | Prevents agents from going off-task |
 | Hive Mind | Queen-led hierarchy, Collective memory | Strategic/tactical/adaptive queens coordinate workers |
-| Consensus | Byzantine, Weighted, Majority | Fault-tolerant decisions (2/3 majority for BFT) |
+| Consensus | Byzantine, Raft, Gossip, CRDT, Quorum | Fault-tolerant decisions (2/3 majority for BFT) |
 
 **Hive Mind Capabilities:**
 - 🐝 **Queen Types**: Strategic (planning), Tactical (execution), Adaptive (optimization)
 - 👷 **8 Worker Types**: Researcher, Coder, Analyst, Tester, Architect, Reviewer, Optimizer, Documenter
-- 🗳️ **3 Consensus Algorithms**: Majority, Weighted (Queen 3x), Byzantine (f < n/3)
+- 🗳️ **5 Consensus Algorithms**: Byzantine (f < n/3), Raft (leader-elected), Gossip (eventually consistent), CRDT (conflict-free), Quorum (configurable threshold)
 - 🧠 **Collective Memory**: Shared knowledge, LRU cache, SQLite persistence with WAL
 - ⚡ **Performance**: Fast batch spawning with parallel agent coordination
 
@@ -1689,9 +1689,11 @@ The Hive Mind system implements queen-led hierarchical coordination where strate
 
 | Algorithm | Voting | Fault Tolerance | Best For |
 |-----------|--------|-----------------|----------|
-| **Majority** | Simple democratic | None | Quick decisions |
-| **Weighted** | Queen 3x weight | None | Strategic guidance |
 | **Byzantine** | 2/3 supermajority | f < n/3 faulty | Critical decisions |
+| **Raft** | Leader-elected | f < n/2 faulty | Strongly-consistent state |
+| **Quorum** | Configurable (majority / supermajority / unanimous) | Threshold-dependent | Tunable agreement |
+| **Gossip** | Epidemic | Eventually consistent | Large peer networks |
+| **CRDT** | Conflict-free merge | Partition-tolerant | Distributed shared state |
 
 **Collective Memory Types:**
 - `knowledge` (permanent), `context` (1h TTL), `task` (30min TTL), `result` (permanent)
@@ -2434,7 +2436,8 @@ ruflo ruvector backup --output ./backup.sql
 | **Queen Types** | Strategic, Tactical, Adaptive | Research/planning, execution, optimization |
 | **Worker Types** | 8 specialized agents | researcher, coder, analyst, tester, architect, reviewer, optimizer, documenter |
 | **Byzantine Consensus** | Fault-tolerant agreement | f < n/3 tolerance (2/3 supermajority) |
-| **Weighted Consensus** | Queen 3x voting power | Strategic guidance with democratic input |
+| **Raft Consensus** | Leader-elected agreement | f < n/2 tolerance, strongly-consistent state |
+| **Quorum Consensus** | Configurable voting threshold | Majority / supermajority / unanimous |
 | **Collective Memory** | Shared pattern storage | 8 memory types with TTL, LRU cache, SQLite WAL |
 | **Specialist Spawning** | Domain-specific agents | Security, performance, etc. |
 | **Adaptive Topology** | Dynamic structure changes | Load-based optimization, auto-scaling |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -370,8 +370,13 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
   // never gets the fix. Now we detect the broken form and overwrite.
   const NEW_STATUSLINE_CMD =
     `node -e "var c=require('child_process'),p=require('path'),r;try{r=c.execSync('git rev-parse --show-toplevel',{encoding:'utf8'}).trim()}catch(e){r=process.cwd()}var s=p.join(r,'.claude/helpers/statusline.cjs');process.argv.splice(1,0,s);require(s)"`;
-  // Matches: `npx [--prefer-offline] [@]claude-flow/cli@latest hooks statusline …`
-  const BROKEN_STATUSLINE_RE = /npx\s+(?:--?\S+\s+)*@?claude-flow\/cli@latest\s+hooks\s+statusline/;
+  // Matches any invocation of `claude-flow hooks statusline` — either via npx
+  // (`npx [--prefer-offline] [@]claude-flow[/cli][@<tag>] hooks statusline …`)
+  // or as a bare command (`claude-flow hooks statusline …`). Both forms cold-
+  // load the ONNX model on every fire (~1s); Claude Code times out and hides
+  // the status bar (#2450). The migration replaces the whole command with
+  // NEW_STATUSLINE_CMD which invokes the local helper directly via `node -e`.
+  const BROKEN_STATUSLINE_RE = /(?:npx\s+(?:--?\S+\s+)*)?@?claude-flow(?:\/cli)?(?:@\S+)?\s+hooks\s+statusline/;
   const existingStatusLine = existing.statusLine as Record<string, unknown> | undefined;
   if (existingStatusLine) {
     const existingCmd = typeof existingStatusLine.command === 'string' ? existingStatusLine.command : '';

--- a/v3/@claude-flow/cli/src/mcp-server.ts
+++ b/v3/@claude-flow/cli/src/mcp-server.ts
@@ -327,6 +327,30 @@ export class MCPServerManager extends EventEmitter {
     console.info = (...args: unknown[]) => process.stderr.write('[stdout→stderr] ' + args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ') + '\n');
     console.debug = (...args: unknown[]) => process.stderr.write('[stdout→stderr] ' + args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ') + '\n');
 
+    // #2426 — Force blocking writes on stdout so JSON-RPC frames larger than
+    // the OS pipe buffer (64KB on macOS) are delivered atomically. Without
+    // this, `process.stdout.write()` returns after a partial write when the
+    // pipe buffer is full; the truncated frame is unparseable JSON and the
+    // MCP client (Claude Code) silently drops all 314 tools. The MCP SDK's
+    // StdioServerTransport does the same thing for this reason. `setBlocking`
+    // is an internal Node API but stable since v10 and used in many MCP
+    // implementations; we feature-gate it so we degrade gracefully on
+    // exotic stdout handles (e.g., when not bound to a pipe in tests).
+    const stdoutHandle = (process.stdout as unknown as {
+      _handle?: { setBlocking?: (b: boolean) => void };
+    })._handle;
+    if (stdoutHandle && typeof stdoutHandle.setBlocking === 'function') {
+      stdoutHandle.setBlocking(true);
+    }
+    // Same for stderr — long structured error messages can also exceed the
+    // pipe buffer and tearing those mid-message corrupts the client's log view.
+    const stderrHandle = (process.stderr as unknown as {
+      _handle?: { setBlocking?: (b: boolean) => void };
+    })._handle;
+    if (stderrHandle && typeof stderrHandle.setBlocking === 'function') {
+      stderrHandle.setBlocking(true);
+    }
+
     /** Send a single JSON-RPC frame to the real stdout. Use this instead
      * of `console.log` so the hijack above can't redirect protocol frames. */
     const writeFrame = (msg: unknown): void => {

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
     optionalDependencies:
       '@claude-flow/aidefence':
         specifier: ^3.0.2
-        version: 3.0.3(agentdb@3.0.0-alpha.16)
+        version: 3.0.3(agentdb@3.0.0-alpha.17)
       '@claude-flow/codex':
         specifier: ^3.0.0-alpha.8
         version: 3.0.0-alpha.12(@types/node@20.19.27)
@@ -138,7 +138,7 @@ importers:
         specifier: ^3.0.0-alpha.1
         version: link:../guidance
       '@claude-flow/memory':
-        specifier: ^3.0.0-alpha.20
+        specifier: ^3.0.0-alpha.21
         version: link:../memory
       '@claude-flow/plugin-gastown-bridge':
         specifier: ^0.1.3
@@ -146,6 +146,9 @@ importers:
       '@claude-flow/security':
         specifier: ^3.0.0-alpha.10
         version: link:../security
+      '@metaharness/darwin':
+        specifier: ~0.3.1
+        version: 0.3.1
       '@metaharness/kernel':
         specifier: ~0.1.0
         version: 0.1.0
@@ -180,14 +183,14 @@ importers:
         specifier: ^0.1.22
         version: 0.1.22
       agentdb:
-        specifier: ^3.0.0-alpha.16
-        version: 3.0.0-alpha.16(@types/node@20.19.27)(zod@3.25.76)
+        specifier: ^3.0.0-alpha.17
+        version: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
       agentic-flow:
         specifier: ^3.0.0-alpha.1
         version: 3.0.0-alpha.2
       metaharness:
-        specifier: ~0.1.11
-        version: 0.1.15(@metaharness/kernel@0.1.0)
+        specifier: ~0.2.6
+        version: 0.2.6(@metaharness/kernel@0.1.0)
       ruvector:
         specifier: ^0.2.27
         version: 0.2.27(@ruvector/diskann@0.1.0)(@ruvector/router@0.1.30)(zod@3.25.76)
@@ -418,7 +421,7 @@ importers:
     optionalDependencies:
       agentdb:
         specifier: ^2.0.0 || ^3.0.0-alpha.1
-        version: 3.0.0-alpha.16(@types/node@20.19.27)(zod@3.25.76)
+        version: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
 
   '@claude-flow/performance':
     dependencies:
@@ -758,7 +761,7 @@ packages:
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
     requiresBuild: true
 
-  /@claude-flow/aidefence@3.0.3(agentdb@3.0.0-alpha.16):
+  /@claude-flow/aidefence@3.0.3(agentdb@3.0.0-alpha.17):
     resolution: {integrity: sha512-KP2kgopV9EeicXtIhxhjZJaALg5arqf8h9fPpFDACBfyM8gI7s+zk6TDoL9VWC9eHWtRB/a/cBnq80rjA79ihA==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
@@ -768,7 +771,7 @@ packages:
       agentdb:
         optional: true
     dependencies:
-      agentdb: 3.0.0-alpha.16(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
     dev: false
     optional: true
 
@@ -1724,6 +1727,22 @@ packages:
   /@leichtgewicht/ip-codec@2.0.5:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: false
+
+  /@metaharness/darwin@0.2.8:
+    resolution: {integrity: sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@metaharness/darwin@0.3.1:
+    resolution: {integrity: sha512-gNQQQiSsbcsSXG9g1C7IJoX50Ozw1nIg6Nez40OVKo5PSvlGjDKElBjFng7M7O7bIrlBo0fS9lcP5hjEQXi+iQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@metaharness/kernel@0.1.0:
     resolution: {integrity: sha512-KDrrdbtw39S3o8YS/r52k3GGQyX5LvQ78raaZ1NiHxAyApwWnLfVLX/66ZdzjUZwwU2xjUs/3GkrHgQXtOUtFg==}
@@ -5578,7 +5597,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@ruvector/ruvllm-darwin-x64@0.2.0:
@@ -5595,7 +5613,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@ruvector/ruvllm-linux-arm64-gnu@0.2.0:
@@ -5612,7 +5629,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@ruvector/ruvllm-linux-x64-gnu@0.2.0:
@@ -5629,7 +5645,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@ruvector/ruvllm-wasm@2.0.2:
@@ -5652,7 +5667,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@ruvector/ruvllm@0.2.4:
@@ -5670,17 +5684,6 @@ packages:
       '@ruvector/ruvllm-linux-x64-gnu': 0.2.0
       '@ruvector/ruvllm-win32-x64-msvc': 0.2.0
 
-  /@ruvector/ruvllm@2.5.4:
-    resolution: {integrity: sha512-EUdKvRDBxS/WDqA2Wl0gC1zhlklkWnbob72iJpyu3TcBTRHY8JTM3bqA5c9GyDmD74iRGTGfbfw4lVnS7CT8eg==}
-    engines: {node: '>= 18'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      chalk: 4.1.2
-      commander: 12.1.0
-      ora: 5.4.1
-    optional: true
-
   /@ruvector/ruvllm@2.5.6:
     resolution: {integrity: sha512-B29ej1aJCNN7UCiIj0wtDMLCe01UWA7KMPTSAriGeey13aNYnstsTD+lz3tkglLSMSdwf9ozQ+N4lVQXvc96+A==}
     engines: {node: '>= 18'}
@@ -5696,7 +5699,6 @@ packages:
       '@ruvector/ruvllm-linux-arm64-gnu': 2.0.1
       '@ruvector/ruvllm-linux-x64-gnu': 2.0.1
       '@ruvector/ruvllm-win32-x64-msvc': 2.0.1
-    dev: false
     optional: true
 
   /@ruvector/rvagent-wasm@0.1.0:
@@ -7073,7 +7075,7 @@ packages:
       '@ruvector/gnn': 0.1.25
       '@ruvector/graph-node': 2.0.3
       '@ruvector/router': 0.1.30
-      '@ruvector/ruvllm': 2.5.4
+      '@ruvector/ruvllm': 2.5.6
       '@ruvector/rvf': 0.1.9
       '@ruvector/rvf-node': 0.1.8
       '@ruvector/rvf-solver': 0.1.8
@@ -7097,6 +7099,53 @@ packages:
       - react-native-b4a
       - supports-color
       - zod
+    dev: false
+
+  /agentdb@3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76):
+    resolution: {integrity: sha512-LK8drZFQteNkff+ji52vCmIXyE3A3ipzabx+ubBcX0CRgF96GU8m36sWyOfqL7pWRfnYDgkEEEgZmagiNCaz/A==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
+      '@ruvector/graph-transformer': 2.0.4
+      ajv: 8.18.0
+      jsonwebtoken: 9.0.3
+      sql.js: 1.14.1
+    optionalDependencies:
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@ruvector/attention': 0.1.32
+      '@ruvector/gnn': 0.1.25
+      '@ruvector/graph-node': 2.0.3
+      '@ruvector/router': 0.1.30
+      '@ruvector/ruvllm': 2.5.6
+      '@ruvector/rvf': 0.1.9
+      '@ruvector/rvf-node': 0.1.8
+      '@ruvector/rvf-solver': 0.1.8
+      '@ruvector/rvf-wasm': 0.1.6
+      '@ruvector/sona': 0.1.7
+      '@xenova/transformers': 2.17.2
+      argon2: 0.44.0
+      better-sqlite3: 11.10.0
+      chalk: 5.6.2
+      commander: 12.1.0
+      hnswlib-node: 3.0.0
+      inquirer: 9.3.8(@types/node@20.19.27)
+      ruvector: 0.1.100(zod@3.25.76)
+      ruvector-attention-wasm: 0.1.32
+      ruvector-graph-transformer-wasm: 2.0.4
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@types/node'
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+      - zod
+    optional: true
 
   /agentic-flow@1.10.2(@modelcontextprotocol/sdk@1.27.1):
     resolution: {integrity: sha512-h3d1KNUFkmdFdtjwn792/MPqYrEf7OId2LIIXlJDGM4epx0Vcm5FQ+ROrjxWDE04xgG3AHQ5dNynxPTDdkC7RA==}
@@ -7251,7 +7300,7 @@ packages:
       '@rollup/rollup-darwin-arm64': 4.60.3
       '@ruvector/attention': 0.1.32
       '@ruvector/sona': 0.1.7
-      agentdb: 3.0.0-alpha.16(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
       better-sqlite3: 11.10.0
       onnxruntime-node: 1.24.3
       sharp: 0.32.6
@@ -7307,7 +7356,7 @@ packages:
       '@ruvector/attention': 0.1.32
       '@ruvector/sona': 0.1.7
       '@xenova/transformers': 2.17.2
-      agentdb: 3.0.0-alpha.16(@types/node@20.19.27)(zod@3.25.76)
+      agentdb: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
       better-sqlite3: 11.10.0
       onnxruntime-node: 1.24.3
       sharp: 0.32.6
@@ -10476,17 +10525,18 @@ packages:
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  /metaharness@0.1.15(@metaharness/kernel@0.1.0):
-    resolution: {integrity: sha512-lka99eyRoeEBgfsiFr/XsaC5Uh2XhS3ArO+PhoSPcR9/RtjJJaIukKuGiCCWBcZo+tjIwx1ms19hEnKqGmtD3g==}
+  /metaharness@0.2.6(@metaharness/kernel@0.1.0):
+    resolution: {integrity: sha512-9xQFQuKWqflSpNPzsudhl6GwZnbw5OSOhpNRvYND8Fgw0Xz/mQfMQG+p7apX5CJV0qqf/ydODJ7+jvHoWaoJkg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     requiresBuild: true
     peerDependencies:
-      '@metaharness/kernel': 0.1.0
+      '@metaharness/kernel': ^0.1.0
     peerDependenciesMeta:
       '@metaharness/kernel':
         optional: true
     dependencies:
+      '@metaharness/darwin': 0.2.8
       '@metaharness/kernel': 0.1.0
       kolorist: 1.8.0
       prompts: 2.4.2


### PR DESCRIPTION
## Summary

Four distinct user-reported bugs, each fixed as an atomic commit so they can be reviewed (or reverted) independently.

| # | Issue | Severity | Fix |
|---|-------|----------|-----|
| #2412 | `v3-ci.yml` red on `main` for 5+ days (10+ recurrences) | HIGH | Regenerate `v3/pnpm-lock.yaml` to match `cli/package.json` after recent version bumps |
| #2450 | `hooks statusline` cold-loads ONNX (~1s) → Claude Code times out, status bar hidden | normal | Broaden migration regex in `executor.ts` to catch the bare `claude-flow hooks statusline` form (#2448 only caught `npx @latest`) |
| #2426 | MCP `tools/list` response (65,747 B) truncated at macOS 64KB pipe buffer → all 314 tools fail to register | HIGH | Set stdout/stderr to blocking in stdio-mode MCP server (what the MCP SDK transport does) |
| #2422 | USERGUIDE documents `Weighted` (Queen 3×) / `Majority` consensus that the CLI hard-rejects + `--queen-type` is cosmetic | docs | Rewrite 4 USERGUIDE locations to the shipped 5 modes: byzantine/raft/gossip/crdt/quorum |

## Verification per fix

- **#2412** — `pnpm install --frozen-lockfile` (CI's exact gate) now exits 0 locally; was hard-failing with `ERR_PNPM_OUTDATED_LOCKFILE` on every CI job
- **#2450** — regex test in commit body covers 5 broken forms + 2 should-not-match forms; 7/7
- **#2426** — direct stdio probe writing 70KB+ payload through a pipe: baseline truncates to exactly 65,536 B (matches #2426 reporter's number); with `setBlocking(true)`, full 83,146 B delivered intact across 3 runs
- **#2422** — `grep -n "Weighted\|Queen 3" docs/USERGUIDE.md` returns 0 matches; CLI behavior unchanged

## Build

`npm run build` in `v3/@claude-flow/cli` exits 0.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes in `v3/`
- [x] `@claude-flow/cli` builds clean
- [x] Statusline migration regex unit test (inline in commit body)
- [x] MCP pipe-buffer reproduction + fix verified with a direct probe
- [ ] v3-ci.yml goes green on this branch (the actual test for #2412)
- [ ] After release: `npx ruflo@<new-version> hooks statusline` runs <200ms

Co-Authored-By: RuFlo <ruv@ruv.net>