### PR TITLE
feat(statusline): show real Claude subscription usage (5h + 7d)

### DIFF
--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -501,6 +501,38 @@ function getCostFromStdin() {
   return null;
 }
 
+// Claude.ai subscription rate limits from Claude Code stdin. These are the same
+// numbers shown in Settings -> Plan usage: five_hour = current session window,
+// seven_day = weekly window. Only present for subscribers after the first API
+// response; returns null otherwise (so the caller simply omits the line).
+function getPlanLimitsFromStdin() {
+  const data = getStdinData();
+  if (!data || !data.rate_limits) return null;
+  const rl = data.rate_limits;
+
+  function fmtReset(resetsAt) {
+    if (!resetsAt) return '-';
+    const secsLeft = Math.max(0, Math.floor(resetsAt - Date.now() / 1000));
+    const totalMin = Math.ceil(secsLeft / 60);
+    const days = Math.floor(totalMin / 1440);
+    const hrs = Math.floor((totalMin % 1440) / 60);
+    const mins = totalMin % 60;
+    if (days > 0) return days + 'd ' + hrs + 'h';
+    if (hrs > 0) return hrs + 'h ' + mins + 'm';
+    return mins + 'm';
+  }
+
+  const five = rl.five_hour || null;
+  const seven = rl.seven_day || null;
+  return {
+    fiveHourPct: five ? Math.round(five.used_percentage) : null,
+    fiveHourReset: five ? fmtReset(five.resets_at) : null,
+    fiveHourSoon: five ? (five.resets_at - Date.now() / 1000) < 1800 : false,
+    sevenDayPct: seven ? Math.round(seven.used_percentage) : null,
+    sevenDayReset: seven ? fmtReset(seven.resets_at) : null,
+  };
+}
+
 // Read package version from the first package.json we find.
 function getPkgVersion() {
   let ver = '3.6';
@@ -621,6 +653,36 @@ function generateStatusline() {
     header += '  ' + c.dim + '│' + c.reset + '  ' + c.brightYellow + CONFIG.costSymbol + costInfo.costUsd.toFixed(2) + c.reset;
   }
   lines.push(header);
+
+  // Plan-usage line: real Claude subscription limits from stdin rate_limits.
+  // Only rendered for subscribers after the first API response (the field is
+  // absent otherwise). Shows the 5-hour session window and, when present, the
+  // 7-day weekly window side by side, each coloured by its own severity, with a
+  // warning keyed to whichever window is closest to its cap so a heavy run sees
+  // the wall coming before work gets cut off.
+  const planLimits = getPlanLimitsFromStdin();
+  if (planLimits && planLimits.fiveHourPct !== null) {
+    const planBarW = 7;
+    const planMkBar = function (p) {
+      const f = Math.max(0, Math.min(planBarW, Math.round((p / 100) * planBarW)));
+      return '▓'.repeat(f) + '░'.repeat(planBarW - f);
+    };
+    const planCol = function (p) { return p >= 80 ? c.brightRed : p >= 50 ? c.brightYellow : c.brightGreen; };
+    const p5 = planLimits.fiveHourPct;
+    let planLine = '⚡ ' + c.dim + '5h ' + c.reset + planCol(p5) + '[' + planMkBar(p5) + '] ' +
+      String(p5).padStart(2) + '%' + c.reset + ' ' +
+      (planLimits.fiveHourSoon ? c.brightRed : c.dim) + '↺' + planLimits.fiveHourReset + c.reset;
+    let planPeak = p5;
+    if (planLimits.sevenDayPct !== null) {
+      const p7 = planLimits.sevenDayPct;
+      planPeak = Math.max(p5, p7);
+      planLine += '  ' + c.dim + '│' + c.reset + '  ' + c.dim + '7d ' + c.reset + planCol(p7) + '[' + planMkBar(p7) + '] ' +
+        String(p7).padStart(2) + '%' + c.reset + ' ' + c.dim + '↺' + planLimits.sevenDayReset + c.reset;
+    }
+    if (planPeak >= 90) planLine += '  ' + c.bold + c.brightRed + '⚠ LIMIT' + c.reset;
+    else if (planPeak >= 80) planLine += '  ' + c.brightRed + '⚠' + c.reset;
+    lines.push(planLine);
+  }
 
   // Separator
   lines.push(c.dim + '─'.repeat(53) + c.reset);


### PR DESCRIPTION
## What

Adds a plan-usage line to the init-generated statusline that shows the user's real
Claude subscription usage, read from the `rate_limits` block Claude Code pipes to
status scripts (v2.1.150+).

For subscribers, it renders the two windows Claude surfaces in **Settings → Plan
usage**, side by side, each coloured by its own severity, with a warning keyed to
whichever window is closest to its cap:

```
▊ RuFlo Vx ● user  │  Opus 4.x
⚡ 5h [░░░░░░░]  3% ↺3h 22m  │  7d [▓▓▓▓░░░] 53% ↺2d 10h
─────────────────────────────────────────────────────
🏗️  DDD Domains   ...   (existing dashboard, unchanged)
```

- `five_hour` = current 5-hour session window
- `seven_day` = 7-day weekly window
- `⚠` at ≥ 80 %, bold `⚠ LIMIT` at ≥ 90 % (keyed to the higher window)
- reset times render as `45m` / `3h 22m` / `2d 10h`

## Why

The generated statusline already reads model / context / cost from the stdin
payload, but not `rate_limits`. Surfacing both windows lets a long or heavy session
see an approaching limit *before* work gets cut off — the weekly window in
particular tends to be the binding one during sustained use and isn't otherwise
visible at a glance.

## Scope / safety

- **Additive and data-gated:** the line is omitted entirely when `rate_limits` is
  absent (non-subscribers, or before the first API response in a session), so
  existing output is unchanged for everyone else.
- **No new dependencies, no network, no config, no state.** It reads only the stdin
  payload Claude Code already provides to the running user — purely that user's own
  local data. Nothing is hardcoded and nothing is transmitted.
- One small helper (`getPlanLimitsFromStdin`) plus one render block; a single file
  changed (`statusline-generator.ts`).

## Testing

Rendered the generator output and verified with `node --check` plus synthetic stdin
payloads: `5h + 7d` present, `5h`-only, ≥ 90 % (LIMIT), and no-`rate_limits` (line
correctly omitted).
