### PR TITLE
fix(memory): #2461 — embedding fall-through, null guard, default namespace (3.14.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -83,7 +83,9 @@ const storeCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const key = ctx.flags.key as string;
     let value = ctx.flags.value as string || ctx.args[0];
-    const namespace = ctx.flags.namespace as string;
+    // #2461: without `|| 'default'`, omitting -n stores under the literal
+    // string namespace "undefined" — silent data loss for first-time users.
+    const namespace = (ctx.flags.namespace as string) || 'default';
     const ttl = ctx.flags.ttl as number;
     const tags = ctx.flags.tags ? (ctx.flags.tags as string).split(',') : [];
     const asVector = ctx.flags.vector as boolean;
@@ -208,7 +210,9 @@ const retrieveCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const key = ctx.flags.key as string || ctx.args[0];
-    const namespace = ctx.flags.namespace as string;
+    // #2461: mirror the store-side default so `memory retrieve -k k` (no -n)
+    // looks under "default" rather than the literal namespace "undefined".
+    const namespace = (ctx.flags.namespace as string) || 'default';
 
     if (!key) {
       output.printError('Key is required');

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -1733,24 +1733,42 @@ export async function loadEmbeddingModel(options?: {
     }
 
     if (pipelineFn && transformersSource) {
-      if (verbose) {
-        console.log(`Loading ONNX embedding model via ${transformersSource} (all-MiniLM-L6-v2)...`);
+      // #2461: pipelineFn() can throw with `fetch failed` on Windows behind
+      // a corporate proxy / strict firewall when transformers tries to pull
+      // the model files from the HuggingFace CDN. Without the catch, that
+      // throw escapes the outer try and aborts loadEmbeddingModel() with
+      // success=false BEFORE we reach the (working) ruvector ONNX fallback
+      // below — leaving embeddingModelState=null, which then crashes
+      // generateLocalEmbedding() with "Cannot read properties of null
+      // (reading 'model')" on every memory store / search call.
+      try {
+        if (verbose) {
+          console.log(`Loading ONNX embedding model via ${transformersSource} (all-MiniLM-L6-v2)...`);
+        }
+        const embedder = await pipelineFn('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
+
+        embeddingModelState = {
+          loaded: true,
+          model: embedder,
+          tokenizer: null,
+          dimensions: 384 // MiniLM-L6 produces 384-dim vectors
+        };
+
+        return {
+          success: true,
+          dimensions: 384,
+          modelName: 'Xenova/all-MiniLM-L6-v2',
+          loadTime: Date.now() - startTime
+        };
+      } catch (err) {
+        if (verbose) {
+          console.warn(
+            `${transformersSource} pipeline init failed (${err instanceof Error ? err.message : String(err)}); ` +
+            'falling through to ruvector ONNX / agentic-flow / hash fallback.'
+          );
+        }
+        // Intentional fall-through to the next embedder branch.
       }
-      const embedder = await pipelineFn('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
-
-      embeddingModelState = {
-        loaded: true,
-        model: embedder,
-        tokenizer: null,
-        dimensions: 384 // MiniLM-L6 produces 384-dim vectors
-      };
-
-      return {
-        success: true,
-        dimensions: 384,
-        modelName: 'Xenova/all-MiniLM-L6-v2',
-        loadTime: Date.now() - startTime
-      };
     }
 
     // Fallback: Check for agentic-flow ReasoningBank embeddings (v3)
@@ -1923,7 +1941,18 @@ export async function generateLocalEmbedding(text: string): Promise<{
     await loadEmbeddingModel();
   }
 
-  const state = embeddingModelState!;
+  // #2461: loadEmbeddingModel() can leave embeddingModelState null when an
+  // earlier loader (transformers fetch, ruvector init) throws and we never
+  // reach the hash-fallback assignment. Don't lie with a `!` non-null
+  // assertion — fall back to a synthetic hash-fallback state so we degrade
+  // to the deterministic 128-dim hash embedding instead of crashing the
+  // entire memory store/search path with "reading property 'model' of null".
+  const state = embeddingModelState ?? {
+    loaded: true,
+    model: null,
+    tokenizer: null,
+    dimensions: 128,
+  };
 
   // Use ONNX model if available
   if (state.model && typeof (state.model as any) === 'function') {


### PR DESCRIPTION
## Summary

Fixes #2461 — \`ruflo memory store\` / \`memory search\` crashing on Windows with \`Cannot read properties of null (reading 'model')\` whenever \`@xenova/transformers\` can't reach the HuggingFace CDN (corporate proxy, strict firewall, offline). Three bugs in one commit, all reproduced + verified against the built artifact and the published npm package.

| Bug | Fix |
|-----|-----|
| \`loadEmbeddingModel()\` aborted on transformers throw, never reached working ruvector ONNX fallback | Wrap transformers branch in try/catch; fall through to next loader |
| \`generateLocalEmbedding()\` deref'd null \`embeddingModelState\` after (1) | Replace \`!\` non-null assertion with \`?? { …hash-fallback default }\` |
| \`memory store\` w/o \`-n\` stored under literal namespace \`"undefined"\` (silent data loss) | \`(ctx.flags.namespace as string) || 'default'\` in store + retrieve |

## Verification

| Test | Result |
|------|--------|
| Local: 100× \`generateLocalEmbedding\` with all embedder modules unresolvable | 100/100 success (was: crash on call #1) |
| Local: built dist contains \`'|| default'\` namespace guard | present |
| **End-to-end smoke against published \`ruflo@3.14.2\`**: fresh \`npm i ruflo@3.14.2\` then 50× \`generateLocalEmbedding\` | 50/50 success, 0 crashes |
| \`@claude-flow/cli\` build | clean, no new TS errors |

## Published

Already on npm:
- \`@claude-flow/cli@3.14.2\`
- \`claude-flow@3.14.2\`
- \`ruflo@3.14.2\`

All three with consistent \`latest === alpha === v3alpha\` dist-tags.

## Credits

Reporter @Pishro-canadaapply did the root-cause investigation and proposed the exact fix shape in #2461. This PR implements their proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)