### PR TITLE
chore: sync package-lock.json version to 3.14.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.14.2",
+  "version": "3.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.14.2",
+      "version": "3.14.4",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",


### PR DESCRIPTION
## Summary

- Lockfile `version` field was stale at `3.14.2` after the 3.14.4 release cycle completed
- Running `npm install` during the scheduled 12-hour verification run synced it to match the current `package.json` version (`3.14.4`)
- No dependency changes — only the root `version` field in the lockfile was updated

## Test plan

- [ ] Verify `package-lock.json` root version matches `package.json` version (`3.14.4`)
- [ ] Confirm `npm ci` passes without lockfile conflicts

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01RcN8eLYxgsjK2gomSKnaVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcN8eLYxgsjK2gomSKnaVw)_