### PR TITLE
fix(wasm): wire JS model provider via set_model_provider(fn) — new JsModelProvider(fn) throws after agent-execute-core import

### DIFF
--- a/v3/@claude-flow/cli/src/ruvector/agent-wasm.ts
+++ b/v3/@claude-flow/cli/src/ruvector/agent-wasm.ts
@@ -159,12 +159,15 @@ export async function createWasmAgent(config: WasmAgentConfig = {}): Promise<Was
 async function attachJsModelProvider(agent: any, config: WasmAgentConfig): Promise<boolean> {
   const hasAny = !!(process.env.ANTHROPIC_API_KEY || process.env.OPENROUTER_API_KEY || process.env.OLLAMA_API_KEY);
   if (!hasAny) return false;
-  const mod = await import('@ruvector/rvagent-wasm');
   const { callAnthropicMessages, resolveAnthropicModel } = await import('../mcp-tools/agent-execute-core.js');
   const model = resolveAnthropicModel(config.model);
   const systemPrompt = config.instructions || 'You are a helpful coding assistant running in a Ruflo WASM agent sandbox.';
 
-  const provider = new mod.JsModelProvider(async (messagesJson: string) => {
+  // #fix — pass the raw fn straight to set_model_provider. `new JsModelProvider(fn)`
+  // throws "requires a function argument" once the agent-execute-core graph is
+  // loaded (wasm-bindgen interaction); set_model_provider accepts a Function
+  // directly (per d.ts) and works. Verified glm-5.2:cloud end-to-end.
+  agent.set_model_provider(async (messagesJson: string) => {
     const messages: Array<{ role: string; content: string }> = JSON.parse(messagesJson);
     const lastUser = [...messages].reverse().find(m => m.role === 'user');
     const prompt = lastUser?.content ?? messagesJson;
@@ -172,7 +175,6 @@ async function attachJsModelProvider(agent: any, config: WasmAgentConfig): Promi
     if (!result.success) throw new Error(result.error ?? 'provider call failed');
     return JSON.stringify({ role: 'assistant', content: result.output ?? '' });
   });
-  agent.set_model_provider(provider);
   return true;
 }
 


### PR DESCRIPTION
## Problem
`wasm_agent_create` / `createWasmAgent` fail for **any** model with:
```
JsModelProvider requires a function argument
```
Root cause: in `attachJsModelProvider`, `await import('../mcp-tools/agent-execute-core.js')` is evaluated, then `new mod.JsModelProvider(fn)` is constructed — after that module graph loads, the wasm-bindgen ctor rejects its (valid) JS callback. Reproduced in a fresh Node process via `createWasmAgent` directly (not a stale runtime). `@ruvector/rvagent-wasm@0.1.0` constructs fine in isolation, so it's the construct-after-graph-load interaction. Net effect: ADR-129 P1 real-LLM wiring is dead on the current build — every provider-keyed create throws; only the keyless echo stub survives.

## Fix
`WasmAgent.set_model_provider` accepts a raw `Function` (per `rvagent_wasm.d.ts`). Skip the broken wrapper and pass the callback directly. One-line-ish change in `attachJsModelProvider`.

## Verification
Fresh Node process, `RUFLO_PROVIDER=ollama` + `OLLAMA_API_KEY`, `model: "ollama:glm-5.2:cloud"`: `createWasmAgent` → `promptWasmAgent` succeeds; the provider call lands on `glm-5.2:cloud` at `https://ollama.com/v1/chat/completions` and returns content (pre-fix: throws).

## Secondary note (optional, not in this diff)
`callOllamaCompat` appends `/v1/chat/completions` to `OLLAMA_BASE_URL`, so a base of `https://ollama.com/v1` becomes `.../v1/v1/...`. Docs should specify the bare host (`https://ollama.com`) for the ruflo provider path. (The env-var table also lists `OLLAMA_URL=localhost:11434`, but the code reads `OLLAMA_BASE_URL` defaulting to `https://ollama.com`.)
