### PR TITLE
Implement real multi-agent orchestration and metrics

### DIFF
--- a/docs/QUALITY-SWEEP.md
+++ b/docs/QUALITY-SWEEP.md
@@ -17,7 +17,7 @@
 Session 1 commits:
 - `6d864e578` chore(quality-sweep): T1/T3/T5 — dep dedup, dead script removal, stale comment
 - `d82c5c721` chore(quality-sweep): T7/T10 — remove trivial assertion, tighten protobufjs override
-- coordination_orchestrate stub — add issue #2140 reference to _note field
+- coordination_orchestrate stub replaced with real orchestrate service (parallel/sequential/pipeline/broadcast)
 - STATUS.md — update stale 3.6.x counts to 3.10.x reality (MCP 323, CLI 45)
 - `ff685013a` witness regen pass — 117 verified, 0 missing, 0 drifted
 
@@ -33,7 +33,7 @@ Draft PR: #2139
 - T2 (done): All plugin scripts wired or documented. 0 violations.
 - T3 (done): Deleted `scripts/regenerate-witness.mjs` (pointed at non-existent root verification.md.json). Wired `scripts/smoke-memory-no-stray-db.mjs` to CI as `memory-no-stray-db-smoke` job. 5 remaining unreferenced scripts are intentional utilities (documented).
 - T4 (clean): All 5 TODO/FIXME entries in cli/src are part of the `analyze` tool's scan logic, not implementation TODOs.
-- T5 (done): Removed stale "placeholder" comment from `analyze.ts`. `coordination_orchestrate` stub linked to issue #2140. All stubs either honestly labeled or removed.
+- T5 (done): Removed stale "placeholder" comment from `analyze.ts`. `coordination_orchestrate` stub replaced with real orchestration service (parallel/sequential/pipeline/broadcast). All stubs either honestly labeled, replaced, or removed.
 - T6 (deferred to 3.12.0): No obvious O(n2) in hot paths. Profile-guided work requires instrumentation.
 - T7 (done): All 46 skips documented. Removed the one `expect(true).toBe(true)` trivial assertion in coverage-router.test.ts.
 - T8 (done): All file paths cited in ADR-120 through ADR-130 verified to exist. No drift.
@@ -60,7 +60,7 @@ Draft PR: #2139
 | T2 | Dead-code sweep -- `plugins/**` | **done** | 0 violations found; all scripts wired | done |
 | T3 | Stale scripts | **done** | regenerate-witness.mjs deleted; smoke-memory-no-stray-db wired to CI; 5 remaining are documented utilities | done |
 | T4 | Slop hunt -- `any` types, magic numbers, TODOs | **clean** | 0 implementation TODOs; any in non-ambient code is acceptable optional-module pattern | done |
-| T5 | Mocked / placeholder claims | **done** | All placeholders either wired, honestly stubbed with issue ref (#2140), or legitimate fallbacks | done |
+| T5 | Mocked / placeholder claims | **done** | coordination_orchestrate stub replaced with real service; coordination_metrics wired; all stubs labeled or replaced | done |
 | T6 | Perf hotspots | **deferred to 3.12.0** | Requires profiling infra; no obvious O(n2) in hot paths confirmed | done (deferred scope) |
 | T7 | Test honesty | **done** | 0 trivial assertions; all 46 skips documented | done |
 | T8 | ADR implementation drift | **done** | All file paths in ADR-120 through ADR-130 verified at HEAD | done |

--- a/v3/@claude-flow/cli/__tests__/agent-repository.test.ts
+++ b/v3/@claude-flow/cli/__tests__/agent-repository.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const testDir = mkdtempSync(join(tmpdir(), 'agent-repo-test-'));
+const storeDir = join(testDir, '.claude-flow', 'agents');
+
+vi.mock('../src/mcp-tools/types.js', () => ({
+  getProjectCwd: () => testDir,
+}));
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('AgentRepository', () => {
+  it('loadStore returns empty store when no file exists', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    const store = repo.loadStore();
+    expect(store.agents).toEqual({});
+    expect(store.version).toBe('3.0.0');
+  });
+
+  it('saveStore and loadStore round-trips agents', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    const agent = {
+      agentId: 'agent-1',
+      agentType: 'coder',
+      status: 'idle' as const,
+      health: 1.0,
+      taskCount: 0,
+      config: {},
+      createdAt: new Date().toISOString(),
+    };
+    const store = { agents: { 'agent-1': agent }, version: '3.0.0' };
+    repo.saveStore(store);
+    const loaded = repo.loadStore();
+    expect(loaded.agents['agent-1'].agentId).toBe('agent-1');
+  });
+
+  it('atomic write produces valid JSON on concurrent save', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    const promises = [];
+    for (let i = 0; i < 10; i++) {
+      promises.push(new Promise<void>(resolve => {
+        setTimeout(() => {
+          const agent = {
+            agentId: `agent-${i}`,
+            agentType: 'test',
+            status: 'idle' as const,
+            health: 1.0,
+            taskCount: i,
+            config: {},
+            createdAt: new Date().toISOString(),
+          };
+          repo.saveStore({ agents: { [`agent-${i}`]: agent }, version: '3.0.0' });
+          resolve();
+        }, Math.random() * 20);
+      }));
+    }
+    await Promise.all(promises);
+    const store = repo.loadStore();
+    expect(Object.keys(store.agents).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('getAllActiveAgents excludes terminated', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    const store = {
+      agents: {
+        'a1': { agentId: 'a1', agentType: 't', status: 'idle' as const, health: 1, taskCount: 0, config: {}, createdAt: '' },
+        'a2': { agentId: 'a2', agentType: 't', status: 'terminated' as const, health: 1, taskCount: 0, config: {}, createdAt: '' },
+      },
+      version: '3.0.0',
+    };
+    repo.saveStore(store);
+    const active = repo.getAllActiveAgents();
+    expect(active.length).toBe(1);
+    expect(active[0].agentId).toBe('a1');
+  });
+
+  it('incrementActiveTask sets busy and increments count', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    repo.saveStore({
+      agents: {
+        'a1': { agentId: 'a1', agentType: 't', status: 'idle' as const, health: 1, taskCount: 3, config: {}, createdAt: '' },
+      },
+      version: '3.0.0',
+    });
+    repo.incrementActiveTask('a1');
+    const agent = repo.getAgent('a1')!;
+    expect(agent.status).toBe('busy');
+    expect(agent.activeTaskCount).toBe(1);
+  });
+
+  it('decrementActiveTask restores idle after last task', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    repo.saveStore({
+      agents: {
+        'a1': { agentId: 'a1', agentType: 't', status: 'busy' as const, health: 1, taskCount: 3, activeTaskCount: 1, config: {}, createdAt: '' },
+      },
+      version: '3.0.0',
+    });
+    repo.decrementActiveTask('a1', { success: true });
+    const agent = repo.getAgent('a1')!;
+    expect(agent.status).toBe('idle');
+    expect(agent.activeTaskCount).toBe(0);
+    expect(agent.lastResult).toEqual({ success: true });
+  });
+
+  it('decrementActiveTask preserves terminated status', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    repo.saveStore({
+      agents: {
+        'a1': { agentId: 'a1', agentType: 't', status: 'terminated' as const, health: 1, taskCount: 3, activeTaskCount: 1, config: {}, createdAt: '' },
+      },
+      version: '3.0.0',
+    });
+    repo.decrementActiveTask('a1', { success: true });
+    const agent = repo.getAgent('a1')!;
+    expect(agent.status).toBe('terminated');
+    expect(agent.lastResult).toEqual({ success: true });
+  });
+
+  it('decrementActiveTask persists failed result', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    repo.saveStore({
+      agents: {
+        'a1': { agentId: 'a1', agentType: 't', status: 'busy' as const, health: 1, taskCount: 3, activeTaskCount: 1, config: {}, createdAt: '' },
+      },
+      version: '3.0.0',
+    });
+    repo.decrementActiveTask('a1', { error: 'API timeout', success: false });
+    const agent = repo.getAgent('a1')!;
+    expect(agent.lastResult).toEqual({ error: 'API timeout', success: false });
+  });
+
+  it('terminateAgent sets status to terminated', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    repo.saveStore({
+      agents: {
+        'a1': { agentId: 'a1', agentType: 't', status: 'idle' as const, health: 1, taskCount: 0, config: {}, createdAt: '' },
+      },
+      version: '3.0.0',
+    });
+    repo.terminateAgent('a1');
+    expect(repo.getAgent('a1')!.status).toBe('terminated');
+  });
+
+  it('updateAgent returns false for unknown agent', async () => {
+    const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+    const repo = new AgentRepository();
+    const result = repo.updateAgent('nonexistent', { status: 'terminated' });
+    expect(result).toBe(false);
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/coordination-metrics.test.ts
+++ b/v3/@claude-flow/cli/__tests__/coordination-metrics.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getProjectCwd } from '../src/mcp-tools/types.js';
+import { mkdirSync } from 'node:fs';
+
+const testDir = mkdtempSync(join(tmpdir(), 'coord-metrics-test-'));
+
+vi.mock('../src/mcp-tools/types.js', () => ({
+  getProjectCwd: () => testDir,
+}));
+
+vi.mock('../src/mcp-tools/validate-input.js', () => ({
+  validateIdentifier: () => ({ valid: true }),
+  validateText: (v: string) => ({ valid: v.length > 0, error: '' }),
+}));
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function seedRecords(records: Array<Record<string, unknown>>) {
+  const dir = join(testDir, '.claude-flow', 'coordination');
+  mkdirSync(dir, { recursive: true });
+  const existing = { orchestrations: records };
+  writeFileSync(join(dir, 'store.json'), JSON.stringify(existing, null, 2), 'utf-8');
+}
+
+describe('coordination_metrics', () => {
+  it('returns zeros when no records exist', async () => {
+    const { coordinationTools } = await import('../src/mcp-tools/coordination-tools.js');
+    const tool = coordinationTools.find(t => t.name === 'coordination_metrics')!;
+    const result = await tool.handler({ metric: 'all' }) as Record<string, unknown>;
+    expect(result.success).toBe(true);
+    const metrics = result.metrics as Record<string, unknown>;
+    const latency = metrics.latency as Record<string, unknown>;
+    expect(latency.p50).toBeNull();
+  });
+
+  it('computes latency percentiles from completed records', async () => {
+    seedRecords([
+      { id: 'r1', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 100, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+      { id: 'r2', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 200, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+      { id: 'r3', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 300, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+      { id: 'r4', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 400, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+      { id: 'r5', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 500, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+    ]);
+    const { coordinationTools } = await import('../src/mcp-tools/coordination-tools.js');
+    const tool = coordinationTools.find(t => t.name === 'coordination_metrics')!;
+    const result = await tool.handler({ metric: 'all' }) as Record<string, unknown>;
+    const metrics = result.metrics as Record<string, unknown>;
+    const latency = metrics.latency as Record<string, unknown>;
+    expect(latency.p50).toBe(300);
+    expect(latency.p95).toBe(500);
+    expect(latency.p99).toBe(500);
+  });
+
+  it('reports throughput within time range', async () => {
+    const now = Date.now();
+    const hourAgo = new Date(now - 60 * 60 * 1000).toISOString();
+    const mins90 = new Date(now - 90 * 60 * 1000).toISOString();
+    seedRecords([
+      { id: 'r1', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: hourAgo, startedAt: hourAgo, completedAt: hourAgo, durationMs: 100, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+      { id: 'r2', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: mins90, startedAt: mins90, completedAt: mins90, durationMs: 200, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+    ]);
+    const { coordinationTools } = await import('../src/mcp-tools/coordination-tools.js');
+    const tool = coordinationTools.find(t => t.name === 'coordination_metrics')!;
+    const result = await tool.handler({ metric: 'throughput', timeRange: '2h' }) as Record<string, unknown>;
+    expect(result.data).toBeDefined();
+    const data = result.data as Record<string, unknown>;
+    expect(data.count).toBe(2);
+    expect(data.unit).toBe('ops/h');
+  });
+
+  it('rejects invalid time range format', async () => {
+    const { coordinationTools } = await import('../src/mcp-tools/coordination-tools.js');
+    const tool = coordinationTools.find(t => t.name === 'coordination_metrics')!;
+    const result = await tool.handler({ metric: 'throughput', timeRange: 'invalid' }) as Record<string, unknown>;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timeRange');
+  });
+
+  it('reports success rate from completed records', async () => {
+    seedRecords([
+      { id: 'r1', status: 'completed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 100, aggregate: { completed: 1, failed: 0, skipped: 0, totalAgents: 1, totalTokens: 50 } },
+      { id: 'r2', status: 'partial', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 200, aggregate: { completed: 1, failed: 1, skipped: 0, totalAgents: 2, totalTokens: 50 } },
+      { id: 'r3', status: 'failed', strategy: 'parallel', agents: ['a1'], task: 't', scheduledAt: new Date().toISOString(), startedAt: new Date().toISOString(), durationMs: 300, aggregate: { completed: 0, failed: 1, skipped: 0, totalAgents: 1, totalTokens: 0 } },
+    ]);
+    const { coordinationTools } = await import('../src/mcp-tools/coordination-tools.js');
+    const tool = coordinationTools.find(t => t.name === 'coordination_metrics')!;
+    const result = await tool.handler({ metric: 'all' }) as Record<string, unknown>;
+    const metrics = result.metrics as Record<string, unknown>;
+    const availability = metrics.availability as Record<string, unknown>;
+    expect(availability.totalOrchestrations).toBe(3);
+    expect(availability.successRate).toBeCloseTo(33.33, 1);
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts
@@ -28,6 +28,12 @@ vi.mock('node:fs', () => {
     readdirSync: vi.fn(() => []),
     unlinkSync: vi.fn(),
     statSync: vi.fn(() => ({ size: 100, isFile: () => true, isDirectory: () => false })),
+    openSync: vi.fn(() => 123),
+    renameSync: vi.fn((src: string, dest: string) => {
+      const data = memStore.get(src);
+      if (data !== undefined) memStore.set(dest, data);
+      memStore.delete(src);
+    }),
   };
 });
 
@@ -41,6 +47,12 @@ vi.mock('fs', () => {
     readdirSync: vi.fn(() => []),
     unlinkSync: vi.fn(),
     statSync: vi.fn(() => ({ size: 100, isFile: () => true, isDirectory: () => false })),
+    openSync: vi.fn(() => 123),
+    renameSync: vi.fn((src: string, dest: string) => {
+      const data = memStore.get(src);
+      if (data !== undefined) memStore.set(dest, data);
+      memStore.delete(src);
+    }),
   };
 });
 
@@ -777,8 +789,9 @@ describe('MCP Tools Deep Test Suite', () => {
     it('coordination_orchestrate accepts task', async () => {
       const tool = coordinationTools.find(t => t.name === 'coordination_orchestrate')!;
       const result: any = await tool.handler({ task: 'test task' });
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false); // no agents available
       expect(result.orchestrationId).toBeDefined();
+      expect(result.status).toBe('failed');
     });
   });
 

--- a/v3/@claude-flow/cli/__tests__/orchestration-service.test.ts
+++ b/v3/@claude-flow/cli/__tests__/orchestration-service.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const testDir = mkdtempSync(join(tmpdir(), 'orch-svc-test-'));
+
+vi.mock('../src/mcp-tools/types.js', () => ({
+  getProjectCwd: () => testDir,
+}));
+
+// Mock agent-execute-core at the module level (hoisted)
+const mockExecute = vi.fn();
+vi.mock('../src/mcp-tools/agent-execute-core.js', () => ({
+  executeAgentTask: mockExecute,
+}));
+
+// Mock swarm-tools to avoid @claude-flow/cli-core dependency
+vi.mock('../src/mcp-tools/swarm-tools.js', () => {
+  let store: { swarms: Record<string, unknown> } = { swarms: {} };
+  return {
+    loadSwarmStore: () => store,
+    saveSwarmStore: (s: typeof store) => { store = s; },
+  };
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+async function seedAgent(id: string, status = 'idle' as const) {
+  const { AgentRepository } = await import('../src/agent-store/agent-repository.js');
+  const repo = new AgentRepository();
+  const store = repo.loadStore();
+  store.agents[id] = {
+    agentId: id,
+    agentType: 'test',
+    status,
+    health: 1.0,
+    taskCount: 0,
+    config: {},
+    createdAt: new Date().toISOString(),
+  };
+  repo.saveStore(store);
+}
+
+async function seedSwarm(agents: string[]) {
+  const { loadSwarmStore, saveSwarmStore } = await import('../src/mcp-tools/swarm-tools.js');
+  const store = loadSwarmStore();
+  store.swarms['swarm-1'] = {
+    swarmId: 'swarm-1',
+    topology: 'hierarchical',
+    maxAgents: 10,
+    status: 'running',
+    agents,
+    tasks: [],
+    config: {},
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  saveSwarmStore(store);
+}
+
+describe('OrchestrationService', () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
+  it('parallel executes all agents concurrently', async () => {
+    await seedAgent('p1');
+    await seedAgent('p2');
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'do work', agents: ['p1', 'p2'], strategy: 'parallel' });
+    expect(result.executor).toBe('agent_execute');
+    expect(result.agents).toEqual(['p1', 'p2']);
+    expect(result.status).toBe('completed');
+    expect(result.success).toBe(true);
+    expect(result.results.length).toBe(2);
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it('sequential executes agents in order', async () => {
+    await seedAgent('s1');
+    await seedAgent('s2');
+    await seedAgent('s3');
+    const callOrder: string[] = [];
+    mockExecute.mockImplementation((input: { agentId: string }) => {
+      callOrder.push(input.agentId);
+      return Promise.resolve({ success: true, output: `done-${input.agentId}`, durationMs: 5 });
+    });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'seq', agents: ['s1', 's2', 's3'], strategy: 'sequential' });
+    expect(callOrder).toEqual(['s1', 's2', 's3']);
+    expect(result.success).toBe(true);
+  });
+
+  it('pipeline chains prompts with previous output', async () => {
+    await seedAgent('pl1');
+    await seedAgent('pl2');
+    const prompts: string[] = [];
+    mockExecute.mockImplementation((input: { prompt: string }) => {
+      prompts.push(input.prompt);
+      return Promise.resolve({ success: true, output: 'stage-output', durationMs: 5 });
+    });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'pipeline-task', agents: ['pl1', 'pl2'], strategy: 'pipeline' });
+    expect(prompts.length).toBe(2);
+    expect(prompts[0]).not.toContain('Previous stage');
+    expect(prompts[1]).toContain('Previous stage output');
+    expect(prompts[1]).toContain('stage-output');
+    expect(result.success).toBe(true);
+  });
+
+  it('pipeline stops after first failure', async () => {
+    await seedAgent('pf1');
+    await seedAgent('pf2');
+    const callOrder: string[] = [];
+    mockExecute.mockImplementation((input: { agentId: string }) => {
+      callOrder.push(input.agentId);
+      if (input.agentId === 'pf1') {
+        return Promise.resolve({ success: false, error: 'fail', durationMs: 5 });
+      }
+      return Promise.resolve({ success: true, output: 'ok', durationMs: 5 });
+    });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'pipe-fail', agents: ['pf1', 'pf2'], strategy: 'pipeline' });
+    expect(callOrder).toEqual(['pf1']);
+    expect(result.status).toBe('failed');
+    expect(result.success).toBe(false);
+  });
+
+  it('broadcast behaves as alias for parallel', async () => {
+    await seedAgent('b1');
+    await seedAgent('b2');
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'broadcast test', agents: ['b1', 'b2'], strategy: 'broadcast' });
+    expect(result.strategy).toBe('parallel');
+    expect(result.results.length).toBe(2);
+  });
+
+  it('deduplicates agent IDs', async () => {
+    await seedAgent('d1');
+    await seedAgent('d2');
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'dedup', agents: ['d1', 'd1', 'd2', 'd2'], strategy: 'parallel' });
+    expect(result.agents).toEqual(['d1', 'd2']);
+    expect(result.results.length).toBe(2);
+  });
+
+  it('rejects unknown agent IDs', async () => {
+    await seedAgent('k1');
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'unknown agent', agents: ['k1', 'unknown-agent'], strategy: 'parallel' });
+    expect(result.agents).toEqual(['k1']);
+  });
+
+  it('rejects terminated agents', async () => {
+    await seedAgent('ta1');
+    await seedAgent('dead-agent', 'terminated');
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'terminated check', agents: ['ta1', 'dead-agent'], strategy: 'parallel' });
+    expect(result.agents).toEqual(['ta1']);
+  });
+
+  it('resolves from swarm when no explicit agents given', async () => {
+    await seedAgent('sw1');
+    await seedAgent('sw2');
+    await seedSwarm(['sw1', 'sw2']);
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'swarm resolve' });
+    expect(result.agents.length).toBeGreaterThan(0);
+    expect(result.agents).toContain('sw1');
+  });
+
+  it('returns partial when some agents fail', async () => {
+    await seedAgent('pa1');
+    await seedAgent('pa2');
+    mockExecute
+      .mockResolvedValueOnce({ success: true, output: 'ok', durationMs: 10 })
+      .mockResolvedValueOnce({ success: false, error: 'fail', durationMs: 5 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'partial test', agents: ['pa1', 'pa2'], strategy: 'parallel' });
+    expect(result.status).toBe('partial');
+    expect(result.success).toBe(false);
+    expect(result.aggregate.completed).toBe(1);
+    expect(result.aggregate.failed).toBe(1);
+  });
+
+  it('returns failed when no agents resolved', async () => {
+    mockExecute.mockResolvedValue({ success: true, output: 'ok', durationMs: 10 });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'no agents', agents: [] });
+    expect(result.status).toBe('failed');
+    expect(result.success).toBe(false);
+    expect(result.results).toEqual([]);
+  });
+
+  it('aggregates token usage', async () => {
+    await seedAgent('tu1');
+    await seedAgent('tu2');
+    mockExecute.mockResolvedValue({
+      success: true,
+      output: 'ok',
+      durationMs: 10,
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+    });
+    const { orchestrate } = await import('../src/orchestration/orchestration-service.js');
+    const result = await orchestrate({ task: 'token count', agents: ['tu1', 'tu2'], strategy: 'parallel' });
+    expect(result.aggregate.totalTokens).toBe(300);
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/orchestration-store.test.ts
+++ b/v3/@claude-flow/cli/__tests__/orchestration-store.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const testDir = mkdtempSync(join(tmpdir(), 'orch-store-test-'));
+
+vi.mock('../src/mcp-tools/types.js', () => ({
+  getProjectCwd: () => testDir,
+}));
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function makeRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: overrides.id as string || 'orch-1',
+    task: (overrides.task as string) || 'test task',
+    strategy: 'parallel' as const,
+    agents: ['a1', 'a2'],
+    status: (overrides.status as string) || 'running',
+    scheduledAt: new Date().toISOString(),
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('OrchestrationStore', () => {
+  it('loadRecords returns empty array when no file exists', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    expect(store.loadRecords()).toEqual([]);
+  });
+
+  it('addRecord and loadRecords round-trips', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    const rec = makeRecord({ id: 'test-1' }) as Parameters<typeof store.addRecord>[0];
+    store.addRecord(rec);
+    const records = store.loadRecords();
+    expect(records.length).toBe(1);
+    expect(records[0].id).toBe('test-1');
+  });
+
+  it('updateRecord modifies existing record', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    store.addRecord(makeRecord({ id: 'upd-1' }) as Parameters<typeof store.addRecord>[0]);
+    const updated = store.updateRecord('upd-1', { status: 'completed', completedAt: new Date().toISOString() });
+    expect(updated).toBe(true);
+    const records = store.loadRecords();
+    expect(records[0].status).toBe('completed');
+  });
+
+  it('updateRecord returns false for unknown id', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    const result = store.updateRecord('nonexistent', { status: 'completed' });
+    expect(result).toBe(false);
+  });
+
+  it('enforces 100 record retention', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    for (let i = 0; i < 110; i++) {
+      store.addRecord(makeRecord({ id: `ret-${i}` }) as Parameters<typeof store.addRecord>[0]);
+    }
+    const records = store.loadRecords();
+    expect(records.length).toBeLessThanOrEqual(100);
+  });
+
+  it('reconciles expired running records as failed', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    const oldStarted = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    store.addRecord(makeRecord({
+      id: 'stale-1',
+      status: 'running',
+      startedAt: oldStarted,
+    }) as Parameters<typeof store.addRecord>[0]);
+    const store2 = new OrchestrationStore();
+    const records = store2.loadRecords();
+    const stale = records.find(r => r.id === 'stale-1');
+    expect(stale).toBeDefined();
+    expect(stale!.status).toBe('failed');
+  });
+
+  it('getCompletedRecords returns only completed/partial/failed with startedAt', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    store.addRecord(makeRecord({ id: 'r1', status: 'completed' }) as Parameters<typeof store.addRecord>[0]);
+    store.addRecord(makeRecord({ id: 'r2', status: 'partial' }) as Parameters<typeof store.addRecord>[0]);
+    store.addRecord(makeRecord({ id: 'r3', status: 'failed' }) as Parameters<typeof store.addRecord>[0]);
+    const completed = store.getCompletedRecords();
+    expect(completed.length).toBe(3);
+  });
+
+  it('getMetricsRecords excludes legacy scheduled-only records', async () => {
+    const { OrchestrationStore } = await import('../src/orchestration/orchestration-store.js');
+    const store = new OrchestrationStore();
+    store.addRecord(makeRecord({ id: 'm1', status: 'completed', startedAt: new Date().toISOString() }) as Parameters<typeof store.addRecord>[0]);
+    store.addRecord({
+      id: 'legacy-1',
+      task: 'old',
+      strategy: 'parallel',
+      agents: [],
+      status: 'scheduled',
+      scheduledAt: new Date().toISOString(),
+    } as Parameters<typeof store.addRecord>[0]);
+    const metrics = store.getMetricsRecords();
+    expect(metrics.length).toBe(1);
+    expect(metrics[0].id).toBe('m1');
+  });
+});

--- a/v3/@claude-flow/cli/src/agent-store/agent-repository.ts
+++ b/v3/@claude-flow/cli/src/agent-store/agent-repository.ts
@@ -1,0 +1,187 @@
+import { existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getProjectCwd } from '../mcp-tools/types.js';
+
+export type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'inherit';
+
+export interface AgentRecord {
+  agentId: string;
+  agentType: string;
+  status: 'idle' | 'busy' | 'terminated';
+  health: number;
+  taskCount: number;
+  config: Record<string, unknown>;
+  createdAt: string;
+  domain?: string;
+  model?: ClaudeModel;
+  modelRoutedBy?: 'explicit' | 'router' | 'codemod' | 'default' | 'hybrid';
+  modelId?: string;
+  provider?: 'anthropic' | 'openrouter';
+  openrouterModel?: string;
+  lastResult?: Record<string, unknown>;
+  activeTaskCount?: number;
+}
+
+export interface AgentStore {
+  agents: Record<string, AgentRecord>;
+  version: string;
+}
+
+const STORAGE_DIR = '.claude-flow';
+const AGENT_DIR = 'agents';
+const AGENT_FILE = 'store.json';
+const LOCK_FILE = '.lock';
+const LOCK_TIMEOUT_MS = 5000;
+const STALE_LOCK_MS = 30000;
+const LOCK_RETRY_INTERVAL = 50;
+
+function getProjectRoot(): string {
+  return getProjectCwd();
+}
+
+function getAgentDir(): string {
+  return join(getProjectRoot(), STORAGE_DIR, AGENT_DIR);
+}
+
+function getAgentPath(): string {
+  return join(getAgentDir(), AGENT_FILE);
+}
+
+function getLockPath(): string {
+  return join(getAgentDir(), LOCK_FILE);
+}
+
+function ensureDir(): void {
+  const dir = getAgentDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function acquireLock(): void {
+  ensureDir();
+  const lockPath = getLockPath();
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const fd = openSync(lockPath, 'wx', 0o600);
+      writeFileSync(lockPath, String(process.pid), { mode: 0o600 });
+      fd as unknown as number;
+      return;
+    } catch {
+      const elapsed = Date.now() - deadline + LOCK_TIMEOUT_MS;
+      if (elapsed > STALE_LOCK_MS) {
+        try {
+          const stats = existsSync(lockPath);
+          if (stats) {
+            unlinkSync(lockPath);
+            continue;
+          }
+        } catch {
+        }
+      }
+    }
+  }
+  throw new Error('Failed to acquire agent store lock after 5s');
+}
+
+function releaseLock(): void {
+  try {
+    const lockPath = getLockPath();
+    if (existsSync(lockPath)) {
+      unlinkSync(lockPath);
+    }
+  } catch {
+  }
+}
+
+export class AgentRepository {
+  loadStore(): AgentStore {
+    try {
+      const path = getAgentPath();
+      if (existsSync(path)) {
+        const data = readFileSync(path, 'utf-8');
+        return JSON.parse(data);
+      }
+    } catch {
+    }
+    return { agents: {}, version: '3.0.0' };
+  }
+
+  saveStore(store: AgentStore): void {
+    ensureDir();
+    const targetPath = getAgentPath();
+    const tmpPath = join(getAgentDir(), `${AGENT_FILE}.${process.pid}.${Math.random().toString(36).slice(2, 8)}`);
+    try {
+      writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600, encoding: 'utf-8' });
+      renameSync(tmpPath, targetPath);
+    } catch (err) {
+      try { unlinkSync(tmpPath); } catch {}
+      throw err;
+    }
+  }
+
+  withLock<T>(fn: () => T): T {
+    acquireLock();
+    try {
+      return fn();
+    } finally {
+      releaseLock();
+    }
+  }
+
+  getAgent(agentId: string): AgentRecord | undefined {
+    return this.loadStore().agents[agentId];
+  }
+
+  getAllActiveAgents(): AgentRecord[] {
+    const store = this.loadStore();
+    return Object.values(store.agents).filter(a => a.status !== 'terminated');
+  }
+
+  updateAgent(agentId: string, partial: Partial<AgentRecord>): boolean {
+    return this.withLock(() => {
+      const store = this.loadStore();
+      if (!store.agents[agentId]) return false;
+      store.agents[agentId] = { ...store.agents[agentId], ...partial };
+      this.saveStore(store);
+      return true;
+    });
+  }
+
+  incrementActiveTask(agentId: string): void {
+    this.withLock(() => {
+      const store = this.loadStore();
+      const agent = store.agents[agentId];
+      if (!agent) return;
+      agent.activeTaskCount = (agent.activeTaskCount || 0) + 1;
+      agent.status = 'busy';
+      this.saveStore(store);
+    });
+  }
+
+  decrementActiveTask(agentId: string, result?: Record<string, unknown>): void {
+    this.withLock(() => {
+      const store = this.loadStore();
+      const agent = store.agents[agentId];
+      if (!agent) return;
+      const wasTerminated = agent.status === 'terminated';
+      agent.activeTaskCount = Math.max(0, (agent.activeTaskCount || 1) - 1);
+      if (agent.activeTaskCount === 0 && !wasTerminated) {
+        agent.status = 'idle';
+      }
+      if (result !== undefined) {
+        agent.lastResult = result;
+      }
+      agent.taskCount = (agent.taskCount || 0) + 1;
+      this.saveStore(store);
+    });
+  }
+
+  terminateAgent(agentId: string): boolean {
+    return this.updateAgent(agentId, { status: 'terminated' });
+  }
+}
+
+export const agentRepository = new AgentRepository();

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-execute-core.ts
@@ -8,63 +8,8 @@
  * place rather than duplicated.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { getProjectCwd } from './types.js';
-
-const STORAGE_DIR = '.claude-flow';
-const AGENT_DIR = 'agents';
-const AGENT_FILE = 'store.json';
-
-type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'inherit';
-
-export interface AgentRecord {
-  agentId: string;
-  agentType: string;
-  status: 'idle' | 'busy' | 'terminated';
-  health: number;
-  taskCount: number;
-  config: Record<string, unknown>;
-  createdAt: string;
-  domain?: string;
-  model?: ClaudeModel;
-  modelRoutedBy?: 'explicit' | 'router' | 'codemod' | 'default' | 'hybrid';
-  /**
-   * ADR-149 — concrete picked model id (e.g. `openai/gpt-4.1`,
-   * `inclusionai/ling-2.6-flash`). Present when the cost-optimal neural
-   * router contributed to the decision; downstream `executeAgentInline`
-   * uses this to dispatch via the correct provider's API instead of
-   * falling back to MODEL_MAP[tier].
-   */
-  modelId?: string;
-  /** ADR-148 phase 2 — execution provider hint. */
-  provider?: 'anthropic' | 'openrouter';
-  /** ADR-148 phase 2 — concrete OpenRouter slug when provider='openrouter'. */
-  openrouterModel?: string;
-  lastResult?: Record<string, unknown>;
-}
-
-interface AgentStore {
-  agents: Record<string, AgentRecord>;
-  version: string;
-}
-
-function getAgentDir(): string { return join(getProjectCwd(), STORAGE_DIR, AGENT_DIR); }
-function getAgentPath(): string { return join(getAgentDir(), AGENT_FILE); }
-function ensureAgentDir(): void {
-  const dir = getAgentDir();
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-}
-function loadAgentStore(): AgentStore {
-  try {
-    if (existsSync(getAgentPath())) return JSON.parse(readFileSync(getAgentPath(), 'utf-8'));
-  } catch { /* fall through */ }
-  return { agents: {}, version: '3.0.0' };
-}
-function saveAgentStore(store: AgentStore): void {
-  ensureAgentDir();
-  writeFileSync(getAgentPath(), JSON.stringify(store, null, 2), 'utf-8');
-}
+import { agentRepository } from '../agent-store/agent-repository.js';
+export type { AgentRecord } from '../agent-store/agent-repository.js';
 
 // #1906/#2232 — Current model ids (Claude 4.x family):
 //   Opus 4.8    → claude-opus-4-8   (current, the `opus` alias)
@@ -473,7 +418,7 @@ export interface AgentExecuteResult {
 }
 
 export async function executeAgentTask(input: AgentExecuteInput): Promise<AgentExecuteResult> {
-  const store = loadAgentStore();
+  const store = agentRepository.loadStore();
   const agent = store.agents[input.agentId];
   if (!agent) return { success: false, agentId: input.agentId, error: 'Agent not found' };
   if (agent.status === 'terminated') return { success: false, agentId: input.agentId, error: 'Agent has been terminated' };
@@ -513,7 +458,7 @@ export async function executeAgentTask(input: AgentExecuteInput): Promise<AgentE
 
   agent.status = 'busy';
   agent.taskCount = (agent.taskCount || 0) + 1;
-  saveAgentStore(store);
+  agentRepository.saveStore(store);
 
   const startedAt = Date.now();
 
@@ -645,11 +590,11 @@ export async function executeAgentTask(input: AgentExecuteInput): Promise<AgentE
       ...(fallbackHistory.length > 0 ? { fallbackHistory } : {}),
     };
     agent.lastResult = out as unknown as Record<string, unknown>;
-    saveAgentStore(store);
+    agentRepository.saveStore(store);
     return out;
   }
 
-  saveAgentStore(store);
+  agentRepository.saveStore(store);
   // No-provider-configured error → surface the same actionable message
   // the router built, with a #2042-aware remediation pointer.
   const noProvider = (result.error || '').includes('No LLM provider configured');

--- a/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts
@@ -5,86 +5,24 @@
  * Includes model routing integration for intelligent model selection.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { type MCPTool, getProjectCwd } from './types.js';
+import { type MCPTool } from './types.js';
 import { validateIdentifier, validateText, validateAgentSpawn } from './validate-input.js';
 import { executeAgentTask } from './agent-execute-core.js';
+import { agentRepository } from '../agent-store/agent-repository.js';
+import type { AgentRecord, ClaudeModel } from '../agent-store/agent-repository.js';
 
-// Storage paths
-const STORAGE_DIR = '.claude-flow';
-const AGENT_DIR = 'agents';
-const AGENT_FILE = 'store.json';
 // #1916: hive-mind_spawn writes its workers to `.claude-flow/agents.json`
 // (a *different* file from the canonical `.claude-flow/agents/store.json`
 // used here). agent_status / agent_list / agent_logs merge that store so a
 // hive-spawned worker is resolvable instead of returning `not_found`.
 const HIVE_AGENT_FILE = 'agents.json';
 
-// Model types matching Claude Agent SDK
-type ClaudeModel = 'haiku' | 'sonnet' | 'opus' | 'opus-4.7' | 'inherit';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getProjectCwd } from './types.js';
 
-interface AgentRecord {
-  agentId: string;
-  agentType: string;
-  status: 'idle' | 'busy' | 'terminated';
-  health: number;
-  taskCount: number;
-  config: Record<string, unknown>;
-  createdAt: string;
-  domain?: string;
-  model?: ClaudeModel;  // Tier label assigned to this agent
-  modelRoutedBy?: 'explicit' | 'router' | 'codemod' | 'default' | 'hybrid';  // ADR-026/143/149
-  /** ADR-149 — concrete picked model id (e.g. inclusionai/ling-2.6-flash). */
-  modelId?: string;
-  /** ADR-148 — execution provider hint. */
-  provider?: 'anthropic' | 'openrouter';
-  /** ADR-148 — concrete OpenRouter slug when provider='openrouter'. */
-  openrouterModel?: string;
-  lastResult?: Record<string, unknown>;
-}
-
-interface AgentStore {
-  agents: Record<string, AgentRecord>;
-  version: string;
-}
-
-function getAgentDir(): string {
-  return join(getProjectCwd(), STORAGE_DIR, AGENT_DIR);
-}
-
-function getAgentPath(): string {
-  return join(getAgentDir(), AGENT_FILE);
-}
-
-function ensureAgentDir(): void {
-  const dir = getAgentDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-}
-
-function loadAgentStore(): AgentStore {
-  try {
-    const path = getAgentPath();
-    if (existsSync(path)) {
-      const data = readFileSync(path, 'utf-8');
-      return JSON.parse(data);
-    }
-  } catch {
-    // Return empty store on error
-  }
-  return { agents: {}, version: '3.0.0' };
-}
-
-function saveAgentStore(store: AgentStore): void {
-  ensureAgentDir();
-  writeFileSync(getAgentPath(), JSON.stringify(store, null, 2), 'utf-8');
-}
-
-// #1916: read hive-mind-spawned workers from `.claude-flow/agents.json`.
 function getHiveAgentPath(): string {
-  return join(getProjectCwd(), STORAGE_DIR, HIVE_AGENT_FILE);
+  return join(getProjectCwd(), '.claude-flow', HIVE_AGENT_FILE);
 }
 
 function loadHiveAgents(): Record<string, AgentRecord> {
@@ -96,19 +34,12 @@ function loadHiveAgents(): Record<string, AgentRecord> {
         return data.agents as Record<string, AgentRecord>;
       }
     }
-  } catch {
-    // Ignore — hive store is optional/best-effort.
-  }
+  } catch {}
   return {};
 }
 
-/**
- * #1916: merged view of every tracked agent — the canonical agent store
- * plus hive-mind-spawned workers. On an id collision the canonical record
- * wins (it carries model-routing + lastResult that the hive store omits).
- */
 function loadAllAgents(): Record<string, AgentRecord> {
-  return { ...loadHiveAgents(), ...loadAgentStore().agents };
+  return { ...loadHiveAgents(), ...agentRepository.loadStore().agents };
 }
 
 // Default model mappings for agent types (can be overridden)
@@ -296,7 +227,7 @@ export const agentTools: MCPTool[] = [
         return { success: false, error: `Input validation failed: ${validation.errors.join('; ')}` };
       }
 
-      const store = loadAgentStore();
+      const store = agentRepository.loadStore();
       const agentId = (input.agentId as string) || `agent-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const agentType = input.agentType as string;
       const config = (input.config as Record<string, unknown>) || {};
@@ -333,7 +264,7 @@ export const agentTools: MCPTool[] = [
       };
 
       store.agents[agentId] = agent;
-      saveAgentStore(store);
+      agentRepository.saveStore(store);
 
       // #2085 — also push to the swarm store's agents array so that
       // swarm_status reports the new agent. Without this, agent_spawn
@@ -457,12 +388,12 @@ export const agentTools: MCPTool[] = [
       const v = validateIdentifier(input.agentId, 'agentId');
       if (!v.valid) return { success: false, error: `Input validation failed: ${v.error}` };
 
-      const store = loadAgentStore();
+      const store = agentRepository.loadStore();
       const agentId = input.agentId as string;
 
       if (store.agents[agentId]) {
         store.agents[agentId].status = 'terminated';
-        saveAgentStore(store);
+        agentRepository.saveStore(store);
         return {
           success: true,
           agentId,
@@ -590,7 +521,7 @@ export const agentTools: MCPTool[] = [
         if (!v.valid) return { action: input.action, error: `Input validation failed: ${v.error}` };
       }
 
-      const store = loadAgentStore();
+      const store = agentRepository.loadStore();
       const agents = Object.values(store.agents).filter(a => a.status !== 'terminated');
       const action = (input.action as string) || 'status';  // Default to status
 
@@ -658,7 +589,7 @@ export const agentTools: MCPTool[] = [
           }
         }
 
-        saveAgentStore(store);
+        agentRepository.saveStore(store);
         return {
           action,
           agentType,
@@ -681,7 +612,7 @@ export const agentTools: MCPTool[] = [
             }
           }
         }
-        saveAgentStore(store);
+        agentRepository.saveStore(store);
         return {
           action,
           agentType: agentType || 'all',
@@ -710,7 +641,7 @@ export const agentTools: MCPTool[] = [
         if (!v.valid) return { agentId: input.agentId, error: `Input validation failed: ${v.error}` };
       }
 
-      const store = loadAgentStore();
+      const store = agentRepository.loadStore();
       const agents = Object.values(store.agents).filter(a => a.status !== 'terminated');
       const threshold = (input.threshold as number) || 0.5;
 
@@ -794,7 +725,7 @@ export const agentTools: MCPTool[] = [
         if (!vs.valid) return { success: false, agentId: input.agentId, error: `Input validation failed: ${vs.error}` };
       }
 
-      const store = loadAgentStore();
+      const store = agentRepository.loadStore();
       const agentId = input.agentId as string;
       const agent = store.agents[agentId];
 
@@ -805,7 +736,7 @@ export const agentTools: MCPTool[] = [
         if (input.config) {
           agent.config = { ...agent.config, ...(input.config as Record<string, unknown>) };
         }
-        saveAgentStore(store);
+        agentRepository.saveStore(store);
 
         return {
           success: true,

--- a/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/coordination-tools.ts
@@ -11,8 +11,11 @@
 
 import { type MCPTool, getProjectCwd } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { orchestrate } from '../orchestration/orchestration-service.js';
+import { orchestrationStore } from '../orchestration/orchestration-store.js';
+import type { OrchestrationRecord } from '../orchestration/types.js';
 
 // Storage paths
 const STORAGE_DIR = '.claude-flow';
@@ -717,98 +720,102 @@ export const coordinationTools: MCPTool[] = [
       if (input.agents && Array.isArray(input.agents)) {
         for (const a of input.agents as string[]) { const vA = validateIdentifier(a, 'agents[]'); if (!vA.valid) return { success: false, error: vA.error }; }
       }
-      const store = loadCoordStore();
-      const task = input.task as string;
-      const agents = (input.agents as string[]) || Object.keys(store.nodes);
-      const strategy = (input.strategy as string) || 'parallel';
 
-      const orchestrationId = `orch-${Date.now()}`;
-
-      // ADR-093 F7: this tool only schedules an orchestration record — it
-      // does not actually execute. Previously it returned a hardcoded
-      // `estimatedCompletion: "50ms"` which was misleading. Now we return
-      // an honest stub-status with a note pointing callers at agent_spawn
-      // / Task tool / hive-mind tools for real orchestration. Persist the
-      // record so callers can list/inspect what was scheduled.
-      const orchestration = {
-        id: orchestrationId,
-        task,
-        strategy,
-        agents,
-        status: 'scheduled' as const,
-        scheduledAt: new Date().toISOString(),
-        topology: store.topology.type,
-      };
-      // Best-effort persist — keep last 100 scheduled orchestrations.
-      type CoordStoreShape = ReturnType<typeof loadCoordStore> & {
-        orchestrations?: Array<typeof orchestration>;
-      };
-      const orchStore = store as CoordStoreShape;
-      if (!Array.isArray(orchStore.orchestrations)) orchStore.orchestrations = [];
-      orchStore.orchestrations.push(orchestration);
-      if (orchStore.orchestrations.length > 100) {
-        orchStore.orchestrations = orchStore.orchestrations.slice(-100);
-      }
-      saveCoordStore(orchStore);
-
-      return {
-        success: true,
-        orchestrationId,
-        task,
-        strategy,
-        agents,
-        status: 'scheduled',
-        topology: store.topology.type,
-        // Honest stub: no executor wired up yet. Don't lie about completion time.
-        executor: 'none',
-        _note: 'coordination_orchestrate currently records the orchestration request but does not execute it. For real multi-agent execution use agent_spawn + the Task tool, or hive-mind_spawn for queen-led coordination. Real executor tracked in issue #2140.',
-      };
+      return orchestrate({
+        task: input.task as string,
+        agents: input.agents as string[] | undefined,
+        strategy: input.strategy as 'parallel' | 'sequential' | 'pipeline' | 'broadcast' | undefined,
+        timeout: input.timeout as number | undefined,
+      });
     },
   },
   {
     name: 'coordination_metrics',
-    description: 'Get coordination metrics Use when native Task is wrong because the work crosses multiple agents that need to vote/sync/load-balance — TodoWrite + a single Task cannot orchestrate consensus. For one-off subtask dispatch, native Task is fine.',
+    description: 'Get coordination metrics derived from orchestration execution records. Use when native Task is wrong because the work crosses multiple agents that need to vote/sync/load-balance — TodoWrite + a single Task cannot orchestrate consensus. For one-off subtask dispatch, native Task is fine.',
     category: 'coordination',
     inputSchema: {
       type: 'object',
       properties: {
         metric: { type: 'string', enum: ['all', 'latency', 'throughput', 'availability'], description: 'Metric type' },
-        timeRange: { type: 'string', description: 'Time range' },
+        timeRange: { type: 'string', description: 'Time range: <N>m (minutes), <N>h (hours), <N>d (days)' },
       },
     },
     handler: async (input) => {
-      const store = loadCoordStore();
       const metric = (input.metric as string) || 'all';
+      const timeRange = input.timeRange as string | undefined;
 
-      const nodes = Object.values(store.nodes);
-      const activeNodes = nodes.filter(n => n.status === 'active');
+      const records = orchestrationStore.getMetricsRecords();
+
+      let filteredRecords = records;
+      if (timeRange) {
+        if (typeof timeRange !== 'string') {
+          return { success: false, error: 'timeRange must be a string' };
+        }
+        const match = timeRange.match(/^(\d+)(m|h|d)$/);
+        if (!match) {
+          return { success: false, error: `Invalid timeRange format: "${timeRange}". Use <N>m, <N>h, or <N>d.` };
+        }
+        const value = parseInt(match[1], 10);
+        const unit = match[2];
+        const cutoff = Date.now() - (
+          unit === 'm' ? value * 60 * 1000 :
+          unit === 'h' ? value * 60 * 60 * 1000 :
+          value * 24 * 60 * 60 * 1000
+        );
+        filteredRecords = records.filter(r => {
+          const t = r.completedAt || r.startedAt;
+          return t && new Date(t).getTime() >= cutoff;
+        });
+      }
+
+      const completedRecords = filteredRecords.filter(r => r.status === 'completed' || r.status === 'partial' || r.status === 'failed');
+      const durations = completedRecords.map(r => r.durationMs).filter((d): d is number => d != null).sort((a, b) => a - b);
+      const n = durations.length;
+
+      const p50 = n > 0 ? durations[Math.floor(n * 0.5)] : null;
+      const p95 = n > 0 ? durations[Math.floor(n * 0.95)] : null;
+      const p99 = n > 0 ? durations[Math.floor(n * 0.99)] : null;
+      const avg = n > 0 ? durations.reduce((s, d) => s + d, 0) / n : null;
+
+      const byStatus: Record<string, number> = {};
+      for (const r of filteredRecords) {
+        byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+      }
+
+      const totalOrchestrations = filteredRecords.length;
+      const successCount = byStatus['completed'] || 0;
+      const partialCount = byStatus['partial'] || 0;
+      const failedCount = byStatus['failed'] || 0;
+      const successRate = totalOrchestrations > 0
+        ? Math.round((successCount / totalOrchestrations) * 10000) / 100
+        : 0;
+
+      const timeRangeWindow = timeRange || 'all';
+      const throughputUnit = timeRange
+        ? (timeRange.endsWith('m') ? 'ops/min' : timeRange.endsWith('h') ? 'ops/h' : 'ops/d')
+        : 'total';
 
       const metrics = {
         latency: {
-          avg: null,
-          p50: null,
-          p95: null,
-          p99: null,
+          avg,
+          p50,
+          p95,
+          p99,
           unit: 'ms',
-          _note: 'Real-time latency metrics not available — coordination is state-tracking only',
         },
         throughput: {
-          current: null,
-          peak: null,
-          avg: null,
-          unit: 'ops/s',
-          _note: 'Real-time throughput metrics not available — coordination is state-tracking only',
+          count: filteredRecords.length,
+          unit: throughputUnit,
+          byStatus,
         },
         availability: {
-          uptime: null,
-          _note: 'Uptime not tracked — coordination store has no persistent start time',
-          activeNodes: activeNodes.length,
-          totalNodes: nodes.length,
-          syncCount: store.sync.syncCount,
-          lastSync: store.sync.lastSync,
-          conflicts: store.sync.conflicts,
-          pendingChanges: store.sync.pendingChanges,
-          syncStatus: store.sync.conflicts === 0 ? 'healthy' : 'conflicts',
+          totalOrchestrations,
+          completed: successCount,
+          partial: partialCount,
+          failed: failedCount,
+          successRate,
+          running: byStatus['running'] || 0,
+          timeRange: timeRangeWindow,
         },
       };
 

--- a/v3/@claude-flow/cli/src/orchestration/orchestration-service.ts
+++ b/v3/@claude-flow/cli/src/orchestration/orchestration-service.ts
@@ -1,0 +1,240 @@
+import { agentRepository } from '../agent-store/agent-repository.js';
+import { executeAgentTask } from '../mcp-tools/agent-execute-core.js';
+import { orchestrationStore } from './orchestration-store.js';
+import type { OrchestrateInput, OrchestrateResult, OrchestrationRecord, AgentResult, OrchestrationStrategy } from './types.js';
+
+async function resolveAgents(agentsInput?: string[]): Promise<{ agentIds: string[]; errors: string[] }> {
+  if (agentsInput && agentsInput.length > 0) {
+    const ids = [...new Set(agentsInput)];
+    const errors: string[] = [];
+    const valid: string[] = [];
+    const store = agentRepository.loadStore();
+    for (const id of ids) {
+      const agent = store.agents[id];
+      if (!agent) {
+        errors.push(`Agent not found: ${id}`);
+      } else if (agent.status === 'terminated') {
+        errors.push(`Agent terminated: ${id}`);
+      } else {
+        valid.push(id);
+      }
+    }
+    return { agentIds: valid, errors };
+  }
+
+  try {
+    const { loadSwarmStore } = await import('../mcp-tools/swarm-tools.js');
+    const swarmStore = loadSwarmStore();
+    const running = Object.values(swarmStore.swarms)
+      .filter(s => s.status === 'running')
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    if (running.length > 0) {
+      const swarmAgents = running[0].agents || [];
+      const valid = swarmAgents.filter(id => {
+        const agent = agentRepository.getAgent(id);
+        return agent && agent.status !== 'terminated';
+      });
+      return { agentIds: [...new Set(valid)], errors: [] };
+    }
+  } catch {}
+
+  const active = agentRepository.getAllActiveAgents();
+  return { agentIds: [...new Set(active.map(a => a.agentId))], errors: [] };
+}
+
+async function executeAgent(
+  agentId: string,
+  prompt: string,
+  timeoutMs: number | undefined,
+): Promise<AgentResult> {
+  agentRepository.incrementActiveTask(agentId);
+  try {
+    const result = await executeAgentTask({ agentId, prompt, timeoutMs });
+    const agentResult: AgentResult = {
+      agentId,
+      status: result.success ? 'completed' : 'failed',
+      output: result.output,
+      error: result.error,
+      usage: result.usage ? {
+        inputTokens: result.usage.inputTokens,
+        outputTokens: result.usage.outputTokens,
+        totalTokens: result.usage.totalTokens,
+      } : undefined,
+      durationMs: result.durationMs,
+    };
+    agentRepository.decrementActiveTask(agentId, result.success ? (result as unknown as Record<string, unknown>) : { error: result.error, success: false });
+    return agentResult;
+  } catch (err) {
+    const agentResult: AgentResult = {
+      agentId,
+      status: 'failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+    agentRepository.decrementActiveTask(agentId, { error: err instanceof Error ? err.message : String(err), success: false });
+    return agentResult;
+  }
+}
+
+async function executeParallel(agentIds: string[], task: string, timeoutMs?: number): Promise<AgentResult[]> {
+  const promises = agentIds.map(id => executeAgent(id, task, timeoutMs));
+  return Promise.all(promises);
+}
+
+async function executeSequential(agentIds: string[], task: string, timeoutMs?: number): Promise<AgentResult[]> {
+  const results: AgentResult[] = [];
+  for (const id of agentIds) {
+    const result = await executeAgent(id, task, timeoutMs);
+    results.push(result);
+  }
+  return results;
+}
+
+async function executePipeline(agentIds: string[], task: string, timeoutMs?: number): Promise<AgentResult[]> {
+  const results: AgentResult[] = [];
+  for (let i = 0; i < agentIds.length; i++) {
+    const prevOutput = results.length > 0 ? results[results.length - 1].output : undefined;
+    const pipelinePrompt = prevOutput
+      ? `${task}\n\nPrevious stage output:\n${prevOutput}`
+      : task;
+    const result = await executeAgent(agentIds[i], pipelinePrompt, timeoutMs);
+    results.push(result);
+    if (result.status === 'failed') break;
+  }
+  return results;
+}
+
+function deduplicate(agentIds: string[]): string[] {
+  return [...new Set(agentIds)];
+}
+
+function computeAggregate(results: AgentResult[]): { completed: number; failed: number; skipped: number; totalTokens: number } {
+  let completed = 0, failed = 0, skipped = 0, totalTokens = 0;
+  for (const r of results) {
+    if (r.status === 'completed') completed++;
+    else if (r.status === 'failed') failed++;
+    else skipped++;
+    if (r.usage?.totalTokens) totalTokens += r.usage.totalTokens;
+  }
+  return { completed, failed, skipped, totalTokens };
+}
+
+export async function orchestrate(input: OrchestrateInput): Promise<OrchestrateResult> {
+  const strategy: OrchestrationStrategy = input.strategy || 'parallel';
+  const resolved = await resolveAgents(input.agents);
+  const agentIds = deduplicate(resolved.agentIds);
+  const isBroadcastAlias = strategy === 'broadcast';
+
+  const effectiveStrategy: OrchestrationStrategy = isBroadcastAlias ? 'parallel' : strategy;
+
+  const scheduledAt = new Date().toISOString();
+  const orchestrationId = `orch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const record: OrchestrationRecord = {
+    id: orchestrationId,
+    task: input.task,
+    strategy: effectiveStrategy,
+    agents: agentIds,
+    status: 'scheduled',
+    scheduledAt,
+  };
+
+  orchestrationStore.addRecord(record);
+
+  if (agentIds.length === 0) {
+    const completedAt = new Date().toISOString();
+    const result: OrchestrateResult = {
+      success: false,
+      executor: 'agent_execute',
+      orchestrationId,
+      task: input.task,
+      strategy: effectiveStrategy,
+      agents: [],
+      status: 'failed',
+      scheduledAt,
+      startedAt: completedAt,
+      completedAt,
+      durationMs: 0,
+      results: [],
+      aggregate: { completed: 0, failed: 0, skipped: 0, totalAgents: 0, totalTokens: 0 },
+    };
+    if (resolved.errors.length > 0) {
+      (result as unknown as { preflightErrors: string[] }).preflightErrors = resolved.errors;
+    }
+    orchestrationStore.updateRecord(orchestrationId, {
+      status: 'failed',
+      startedAt: completedAt,
+      completedAt,
+      durationMs: 0,
+      results: [],
+      aggregate: { completed: 0, failed: 0, skipped: 0, totalAgents: 0, totalTokens: 0 },
+    });
+    return result;
+  }
+
+  if (resolved.errors.length > 0) {
+    orchestrationStore.updateRecord(orchestrationId, {
+      status: 'running',
+      startedAt: new Date().toISOString(),
+    });
+  }
+
+  const startedAt = new Date().toISOString();
+  orchestrationStore.updateRecord(orchestrationId, { status: 'running', startedAt });
+
+  const timeoutMs = input.timeout;
+
+  let results: AgentResult[];
+  const effectiveIds = isBroadcastAlias ? agentIds : agentIds;
+
+  switch (effectiveStrategy) {
+    case 'sequential':
+      results = await executeSequential(effectiveIds, input.task, timeoutMs);
+      break;
+    case 'pipeline':
+      results = await executePipeline(effectiveIds, input.task, timeoutMs);
+      break;
+    case 'parallel':
+    default:
+      results = await executeParallel(effectiveIds, input.task, timeoutMs);
+      break;
+  }
+
+  const { completed, failed, skipped, totalTokens } = computeAggregate(results);
+  const completedAt = new Date().toISOString();
+  const durationMs = Date.now() - new Date(startedAt).getTime();
+
+  let status: 'completed' | 'partial' | 'failed';
+  if (completed > 0 && failed === 0 && skipped === 0) {
+    status = 'completed';
+  } else if (failed > 0 && completed === 0) {
+    status = 'failed';
+  } else {
+    status = 'partial';
+  }
+
+  const isSuccess = failed === 0 && skipped === 0;
+
+  orchestrationStore.updateRecord(orchestrationId, {
+    status,
+    completedAt,
+    durationMs,
+    results,
+    aggregate: { completed, failed, skipped, totalAgents: agentIds.length, totalTokens },
+  });
+
+  return {
+    success: isSuccess,
+    executor: 'agent_execute',
+    orchestrationId,
+    task: input.task,
+    strategy: effectiveStrategy,
+    agents: agentIds,
+    status,
+    scheduledAt,
+    startedAt,
+    completedAt,
+    durationMs,
+    results,
+    aggregate: { completed, failed, skipped, totalAgents: agentIds.length, totalTokens },
+  };
+}

--- a/v3/@claude-flow/cli/src/orchestration/orchestration-store.ts
+++ b/v3/@claude-flow/cli/src/orchestration/orchestration-store.ts
@@ -1,0 +1,190 @@
+import { existsSync, mkdirSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getProjectCwd } from '../mcp-tools/types.js';
+import type { OrchestrationRecord, OrchestrationStatus } from './types.js';
+
+const STORAGE_DIR = '.claude-flow';
+const COORD_DIR = 'coordination';
+const COORD_FILE = 'store.json';
+const LOCK_FILE = '.coord.lock';
+const MAX_RECORDS = 100;
+const STALE_RUNNING_TTL_MS = 30 * 60 * 1000;
+const LOCK_TIMEOUT_MS = 5000;
+const STALE_LOCK_MS = 30000;
+
+function getCoordDir(): string {
+  return join(getProjectCwd(), STORAGE_DIR, COORD_DIR);
+}
+
+function getCoordPath(): string {
+  return join(getCoordDir(), COORD_FILE);
+}
+
+function getLockPath(): string {
+  return join(getCoordDir(), LOCK_FILE);
+}
+
+function ensureDir(): void {
+  const dir = getCoordDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function acquireLock(): void {
+  ensureDir();
+  const lockPath = getLockPath();
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const fd = openSync(lockPath, 'wx', 0o600);
+      writeFileSync(lockPath, String(process.pid), { mode: 0o600 });
+      fd as unknown as number;
+      return;
+    } catch {
+      if (existsSync(lockPath)) {
+        const mtime = (function () {
+          try { return statSync(lockPath).mtimeMs; } catch { return 0; }
+        })();
+        if (mtime > 0 && (Date.now() - mtime) > STALE_LOCK_MS) {
+          try { unlinkSync(lockPath); } catch {}
+          continue;
+        }
+      }
+    }
+  }
+  throw new Error('Failed to acquire coordination store lock after 5s');
+}
+
+function releaseLock(): void {
+  try {
+    const lockPath = getLockPath();
+    if (existsSync(lockPath)) unlinkSync(lockPath);
+  } catch {}
+}
+
+interface CoordinationStoreShape {
+  orchestrations?: OrchestrationRecord[];
+}
+
+function loadRawStore(): Record<string, unknown> {
+  try {
+    const path = getCoordPath();
+    if (existsSync(path)) return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {}
+  return {};
+}
+
+function saveRawStore(store: Record<string, unknown>): void {
+  ensureDir();
+  const targetPath = getCoordPath();
+  const tmpPath = join(getCoordDir(), `${COORD_FILE}.${process.pid}.${Math.random().toString(36).slice(2, 8)}`);
+  try {
+    writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600, encoding: 'utf-8' });
+    renameSync(tmpPath, targetPath);
+  } catch (err) {
+    try { unlinkSync(tmpPath); } catch {}
+    throw err;
+  }
+}
+
+function reconcileExpiredRunning(records: OrchestrationRecord[]): number {
+  let reconciled = 0;
+  const now = Date.now();
+  for (const rec of records) {
+    if (rec.status !== 'running') continue;
+    if (!rec.startedAt) continue;
+    const age = now - new Date(rec.startedAt).getTime();
+    if (age > STALE_RUNNING_TTL_MS) {
+      rec.status = 'failed';
+      rec.completedAt = new Date().toISOString();
+      rec.durationMs = now - new Date(rec.startedAt).getTime();
+      reconciled++;
+    }
+  }
+  return reconciled;
+}
+
+function enforceRetention(records: OrchestrationRecord[]): OrchestrationRecord[] {
+  if (records.length > MAX_RECORDS) {
+    return records.slice(-MAX_RECORDS);
+  }
+  return records;
+}
+
+export class OrchestrationStore {
+  loadRecords(): OrchestrationRecord[] {
+    const raw = loadRawStore();
+    const shape = raw as CoordinationStoreShape;
+    const records = Array.isArray(shape.orchestrations) ? shape.orchestrations : [];
+    const reconciled = reconcileExpiredRunning(records);
+    if (reconciled > 0) {
+      try {
+        const store = loadRawStore();
+        (store as CoordinationStoreShape).orchestrations = records;
+        saveRawStore(store);
+      } catch {}
+    }
+    return records;
+  }
+
+  saveRecords(records: OrchestrationRecord[]): void {
+    acquireLock();
+    try {
+      const store = loadRawStore();
+      const trimmed = enforceRetention(records);
+      (store as CoordinationStoreShape).orchestrations = trimmed;
+      saveRawStore(store);
+    } finally {
+      releaseLock();
+    }
+  }
+
+  addRecord(record: OrchestrationRecord): void {
+    acquireLock();
+    try {
+      const records = this.loadRecords();
+      records.push(record);
+      const trimmed = enforceRetention(records);
+      const store = loadRawStore();
+      (store as CoordinationStoreShape).orchestrations = trimmed;
+      saveRawStore(store);
+    } finally {
+      releaseLock();
+    }
+  }
+
+  updateRecord(id: string, partial: Partial<OrchestrationRecord>): boolean {
+    acquireLock();
+    try {
+      const store = loadRawStore();
+      const shape = store as CoordinationStoreShape;
+      const records = Array.isArray(shape.orchestrations) ? shape.orchestrations : [];
+      const idx = records.findIndex(r => r.id === id);
+      if (idx === -1) return false;
+      records[idx] = { ...records[idx], ...partial };
+      shape.orchestrations = enforceRetention(records);
+      saveRawStore(store);
+      return true;
+    } finally {
+      releaseLock();
+    }
+  }
+
+  getActiveRecords(): OrchestrationRecord[] {
+    return this.loadRecords().filter(r => r.status === 'running');
+  }
+
+  getCompletedRecords(): OrchestrationRecord[] {
+    return this.loadRecords().filter(
+      r => r.status === 'completed' || r.status === 'partial' || r.status === 'failed'
+    ).filter(r => r.startedAt != null);
+  }
+
+  /** Legacy scheduled-only records (no startedAt) are excluded from metrics views. */
+  getMetricsRecords(): OrchestrationRecord[] {
+    return this.loadRecords().filter(r => r.startedAt != null);
+  }
+}
+
+export const orchestrationStore = new OrchestrationStore();

--- a/v3/@claude-flow/cli/src/orchestration/types.ts
+++ b/v3/@claude-flow/cli/src/orchestration/types.ts
@@ -1,0 +1,57 @@
+export type OrchestrationStrategy = 'parallel' | 'sequential' | 'pipeline' | 'broadcast';
+export type OrchestrationStatus = 'scheduled' | 'running' | 'completed' | 'partial' | 'failed';
+export type AgentResultStatus = 'completed' | 'failed' | 'skipped';
+
+export interface AgentResult {
+  agentId: string;
+  status: AgentResultStatus;
+  output?: string;
+  error?: string;
+  usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
+  durationMs?: number;
+}
+
+export interface CompletionAggregate {
+  completed: number;
+  failed: number;
+  skipped: number;
+  totalAgents: number;
+  totalTokens: number;
+}
+
+export interface OrchestrationRecord {
+  id: string;
+  task: string;
+  strategy: OrchestrationStrategy;
+  agents: string[];
+  status: OrchestrationStatus;
+  scheduledAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  durationMs?: number;
+  results?: AgentResult[];
+  aggregate?: CompletionAggregate;
+}
+
+export interface OrchestrateInput {
+  task: string;
+  agents?: string[];
+  strategy?: OrchestrationStrategy;
+  timeout?: number;
+}
+
+export interface OrchestrateResult {
+  success: boolean;
+  executor: 'agent_execute';
+  orchestrationId: string;
+  task: string;
+  strategy: OrchestrationStrategy;
+  agents: string[];
+  status: OrchestrationStatus;
+  scheduledAt: string;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  results: AgentResult[];
+  aggregate: CompletionAggregate;
+}


### PR DESCRIPTION
## Summary

Replaces `coordination_orchestrate` and `coordination_metrics` stubs with a real multi-agent executor.

### Changes
- **New:** `src/agent-store/agent-repository.ts` — shared agent persistence with file locking, atomic rename
- **New:** `src/orchestration/` — types, store (CRUD + TTL reconcile + 100-record retention), service (parallel/sequential/pipeline/broadcast)
- **Refactored:** `agent-execute-core.ts`, `agent-tools.ts` — duplicated inline store → shared `agentRepository`
- **Wired:** `coordination_orchestrate` (4 strategies) and `coordination_metrics` (percentiles, throughput, success rate)
- **Untouched:** `coordination_topology`, `load_balance`, `sync`, `node`, `consensus`, hive-mind — zero diff

### Validation
- tsc -b: 0 errors
- 35 new tests: all pass
- Full suite: 78/82 files pass, 2344/2395 tests pass
- 0 regressions vs. HEAD

### Pre-existing Baseline Failures (5 — do not block merge)
These 5 failures exist at HEAD before this change and are unrelated to this PR:

1. **bug-cluster-2219-2226** — pattern store/search ONNX model download timeout
2. **commands.test.ts** — memory search assertion (mock context setup)
3. **commands.test.ts** — memory list assertion (mock context setup)
4. **mcp-client-guardrail.test.ts** — guardrail doesn't reject injection payload
5. **sona-embeddings-validation.test.ts** — unexpected provider label when ruvector is installed locally

**Do not merge until CI confirms these 5 failures match the base revision.