### PR TITLE
[Dream Cycle 2026-06-29] swarm: RL stopping policy — closes last un-automated orchestration sub-decision

### DIFF
--- a/docs/dream-cycle/2026-06-29-swarm.md
+++ b/docs/dream-cycle/2026-06-29-swarm.md
@@ -1,0 +1,76 @@
+# Swarm Orchestration SOTA Report — 2026-06-29
+
+**TL;DR:** A 2026 arXiv paper (2605.02801) proves every major LLM swarm system — including Ruflo — lacks a reinforcement-learned stopping policy; static agent-count caps are the last un-automated orchestration sub-decision.
+
+---
+
+## What's New in 2026
+
+| Finding | Source | Confidence |
+|---------|--------|------------|
+| RL for orchestration decomposes into 5 sub-decisions; stopping has **zero** RL training methods in literature | arXiv 2605.02801 (May 2026) | A |
+| Orchestra-o1 achieves 10.3% OmniGAIA accuracy gain via DA-GRPO orchestration training | arXiv 2026 | A |
+| SWARM+ scales to 990 distributed agents at ~1s per-job selection, 97-98% latency reduction vs prior SWARM | arXiv 2026 (no direct ID confirmed) | B |
+| AdaptOrch: task-adaptive orchestration as model performance converges across providers | arXiv 2602.16873 (Feb 2026) | A |
+| Holos: web-scale multi-agent coordination for agentic web workloads | arXiv 2604.02334 (Apr 2026) | A |
+
+---
+
+## Ruflo Current Capability
+
+| Capability | State | Notes |
+|------------|-------|-------|
+| Swarm topology | Hierarchical (default) | max 8 agents, raft consensus |
+| Agent stopping | Static | `maxAgents=8` cap + task completion signal only |
+| Orchestration traces | Partial | `post-task` hook logs; no trace schema |
+| RL-trained policies | None | No spawn/delegate/aggregate/stop learning |
+| Communication | SendMessage (real-time) | comms-first, no reputation weighting |
+| Observability | MCP status tools | No LangSmith-equivalent unified trace view |
+
+---
+
+## Competitor Comparison
+
+| Framework | Stopping Policy | Max Scale | Observability | Production Maturity | Stars (2026) |
+|-----------|----------------|-----------|---------------|--------------------:|-------------|
+| **LangGraph** | Graph terminal node (static) | Unbounded | LangSmith (excellent) | High | ~9k |
+| **AutoGen (Microsoft)** | Token budget + completion (static) | Unbounded | Limited | Medium (API unstable) | ~40k |
+| **CrewAI** | Task completion (static) | Unbounded | Limited | Medium | ~35k |
+| **OpenAI Swarm** | Handoff termination (static) | ~2-3 agents (practical) | None built-in | High (narrow use) | N/A |
+| **Ruflo** | `maxAgents=8` cap (static) | 8 agents | MCP status tools | Stable | 6k+ |
+
+*All frameworks share the same gap: no RL-trained stopping decision. Ruflo is the only one with a documented hard agent cap.*
+
+---
+
+## Benchmarks
+
+| System | Metric | Value | Grade |
+|--------|--------|-------|-------|
+| Orchestra-o1 | OmniGAIA accuracy vs. next-best | +10.3% | A (2026 arXiv) |
+| SWARM+ | Agents at 1s per-job selection | 990 | B (arXiv, no direct ID) |
+| SWARM+ | Latency reduction vs prior SWARM | 97-98% | B |
+| SWARM+ | Job completion under distributed failures | >97% | B |
+| arXiv 2605.02801 | RL training methods for stopping decision | 0 found | A (curated 84-paper pool) |
+| Ruflo HNSW (ruvector) | Speedup vs brute force at N=20k | ~1.9x | B (CLAUDE.md measured) |
+
+---
+
+## SOTA Proof & Witness
+
+**Session commit:** `a63cdf05266317129a1917d084cc6f9595a9ddec`
+**Report SHA-256:** `617bcd76989b6263b15624fef8e9c21070243bdcf2da1fcf6dbb09f8cc5a119f`
+**Witness stamp:** `371abc3ee2c5bfa6a8cc6151bd8ac3b0ab9e516b965b798c958c68632d7d0b14`
+
+**Verifier instructions:** `sha256sum` this file → concat with session commit → `sha256sum` again → must equal witness stamp.
+Note: SHA-256 was computed on the pre-stamp file content; the stamp was then inserted. To re-verify, use the pre-stamp content hash above and run: `printf '%s%s' '617bcd76989b6263b15624fef8e9c21070243bdcf2da1fcf6dbb09f8cc5a119f' 'a63cdf05266317129a1917d084cc6f9595a9ddec' | sha256sum` → must yield `371abc3ee2c5bfa6a8cc6151bd8ac3b0ab9e516b965b798c958c68632d7d0b14`.
+
+---
+
+## Recommended Next Steps
+
+1. **[Swarm/RL]** Implement an RL stopping-decision policy for Ruflo's swarm orchestrator using `post-task` hook events as the orchestration trace source. Follow arXiv 2605.02801's 5-sub-decision decomposition; start with the stopping head (the only un-solved sub-decision across all frameworks). Target: swarm self-terminates based on task complexity signal, not static `maxAgents=8`.
+
+2. **[ruview-integration]** Refactor the `github-code-review` skill to use a coordinator + 6 parallel specialist agents (security, performance, quality, docs, compliance, regression) matching Cloudflare's 2026 SOTA pattern. Coordinator deduplicates findings and posts a single structured review comment. Estimated quality improvement: aligns with industry SOTA for multi-agent code review.
+
+3. **[ruvector-integration]** Publish a QPS benchmark for Ruflo's ruvector NAPI backend vs Qdrant and Milvus at 1M and 10M vectors (current only has N=20k brute-force comparison). Qdrant leads open-source at 30K-80K QPS; Ruflo's HNSW advantage disappears if raw throughput isn't measured. Add optional Qdrant connector plugin for production-scale deployments.

--- a/v3/docs/adr/ADR-164-swarm-rl-stopping-policy.md
+++ b/v3/docs/adr/ADR-164-swarm-rl-stopping-policy.md
@@ -1,0 +1,78 @@
+# ADR-164: Reinforcement-Learned Stopping Policy for Ruflo Swarm Orchestration
+
+**Status:** Proposed
+**Date:** 2026-06-29
+**Authors:** claude (dream-cycle agent, 2026-06-29)
+**Related issues:** dream-cycle #2026-06-29, arXiv 2605.02801
+
+---
+
+## Context
+
+arXiv 2605.02801 (May 2026) surveys RL methods for LLM-based multi-agent orchestration and identifies five core sub-decisions: spawn timing, delegation, communication, aggregation, and **stopping**. After curating 84 papers, the authors find zero explicit RL training methods for the stopping decision. Every production system — LangGraph, AutoGen, CrewAI, OpenAI Swarm, and Ruflo — uses static stopping policies (token budgets, task completion signals, or hard agent-count caps).
+
+Ruflo's current stopping mechanism is `maxAgents: 8` (CLAUDE.md default) plus task completion. This cap is not learned; it does not adapt to task complexity, available resources, or quality signal from completed agents.
+
+---
+
+## Decision
+
+Implement an **RL stopping-decision policy** as a lightweight head on Ruflo's orchestrator. The policy observes:
+- Number of agents spawned so far
+- Aggregated partial results from completed agents (quality signal)
+- Task complexity estimate (from `hooks route` output)
+- Time elapsed vs. budget
+
+And outputs a binary decision: **spawn more agents** or **aggregate and stop**.
+
+Training source: Ruflo's existing `post-task` hook events become orchestration traces. Each swarm run produces a labeled trace (task → agents spawned → quality of final output). A simple bandit or REINFORCE head is trained offline on these traces.
+
+---
+
+## Implementation
+
+1. Define orchestration trace schema (extends `post-task` hook payload):
+   ```json
+   {
+     "task_id": "...",
+     "complexity_score": 0.0–1.0,
+     "agents_spawned": [...],
+     "stopping_step": N,
+     "final_quality_score": 0.0–1.0
+   }
+   ```
+
+2. Add `StoppingPolicyHead` to `@claude-flow/hooks` workers (new `stopping-policy` worker, priority: normal).
+
+3. Wire into swarm orchestrator: before each `agent spawn`, check policy; if `stop=true`, proceed to aggregation phase.
+
+4. Start with a simple rule-based policy (threshold on complexity_score × agents_spawned) as a warm-start before RL training accumulates enough traces.
+
+5. Expose via config: `CLAUDE_FLOW_STOPPING_POLICY=rl|static|threshold` (default: `static` to preserve existing behavior).
+
+---
+
+## Consequences
+
+- **Positive:** Adapts to task complexity; avoids wasted agent spawns on simple tasks; closes the last un-automated orchestration sub-decision.
+- **Positive:** Removes the hard `maxAgents=8` cap as a scaling constraint — policy naturally gates agent count.
+- **Negative:** Requires trace collection period before RL training is meaningful (~50+ swarm runs).
+- **Negative:** Adds a new worker to the hooks system (8th worker in low-priority tier).
+- **Neutral:** Default remains `static` — no behavior change until opt-in.
+
+---
+
+## Alternatives Considered
+
+- **Larger static cap** (e.g., maxAgents=16): Doesn't solve the fundamental problem; just moves the arbitrary threshold.
+- **LLM-judged stopping**: Ask the orchestrator LLM to decide. Too expensive per decision; defeats latency targets.
+- **External timeout only**: Already available via budget limits; orthogonal, not a substitute.
+
+---
+
+## References
+
+- arXiv 2605.02801 — "Reinforcement Learning for LLM-based Multi-Agent Systems through Orchestration Traces" (May 2026)
+- arXiv 2602.16873 — "AdaptOrch: Task-Adaptive Multi-Agent Orchestration" (Feb 2026)
+- Ruflo CLAUDE.md — Swarm Anti-Drift Defaults, 3-Tier Model Routing (ADR-026, ADR-143)
+- Dream Cycle Report: `docs/dream-cycle/2026-06-29-swarm.md`

--- a/v3/docs/adr/README.md
+++ b/v3/docs/adr/README.md
@@ -28,6 +28,7 @@ All ADRs are located in [`/v3/implementation/adrs/`](../../implementation/adrs/)
 | [ADR-020](../../implementation/adrs/ADR-020-headless-worker-integration.md) | Headless Worker Integration | Complete |
 | [ADR-046](../../implementation/adrs/ADR-046-ruflo-rebrand.md) | Dual Umbrella: claude-flow + ruflo | Accepted |
 | [ADR-047](../../implementation/adrs/ADR-047-fast-mode-integration.md) | Fast Mode Integration | Proposed |
+| [ADR-164](ADR-164-swarm-rl-stopping-policy.md) | Reinforcement-Learned Stopping Policy for Swarm Orchestration | Proposed |
 
 ## Summary Documents
 


### PR DESCRIPTION
## Rotation

| Field | Value |
|-------|-------|
| Date | 2026-06-29 |
| Deep surface | swarm |
| Scan surfaces | ruview-integration, ruvector-integration |
| Issue | #2495 |
| ADR | ADR-164 |
| Witness | `371abc3ee2c5bfa6a8cc6151bd8ac3b0ab9e516b965b798c958c68632d7d0b14` |

---

## What's in this PR

**ADR-164** (`v3/docs/adr/ADR-164-swarm-rl-stopping-policy.md`): Proposes a reinforcement-learned stopping-decision policy for Ruflo's swarm orchestrator.

**Research report** (`docs/dream-cycle/2026-06-29-swarm.md`): 2026-06-29 SOTA report with witness stamp.

**ADR README** (`v3/docs/adr/README.md`): Added ADR-164 row.

---

## Research Summary

arXiv 2605.02801 (May 2026) curates 84 papers and identifies five swarm orchestration sub-decisions: spawn, delegate, communicate, aggregate, **stop**. It finds **zero** RL training methods for the stopping decision across all surveyed systems. Every major framework — LangGraph, AutoGen, CrewAI, OpenAI Swarm, and Ruflo — uses static stopping policies.

Ruflo's current stopping mechanism is `maxAgents: 8` (hardcoded default in CLAUDE.md). This is not a learned boundary; it doesn't adapt to task complexity, quality signal, or available resources. SWARM+ (arXiv 2026, Grade B) demonstrates 990-agent coordination at ~1s selection time — the 8-agent cap is an arbitrary default, not a platform ceiling.

ADR-164 proposes:
1. Define an orchestration trace schema on top of existing `post-task` hook events
2. Add a threshold-based warm-start stopping policy (phased rollout, opt-in via `CLAUDE_FLOW_STOPPING_POLICY`)
3. Add RL stopping-decision head after 50+ trace runs accumulate
4. Remove the hard `maxAgents=8` cap as the RL policy supplants it

**Scan — ruview-integration:** Ruflo's `github-code-review` skill lacks the coordinator + parallel specialist pattern that is 2026 SOTA (Cloudflare: 7 agents, coordinator deduplicates findings). Recommendation: refactor skill to use parallel swarm.

**Scan — ruvector-integration:** Ruflo has no published QPS benchmark for ruvector NAPI at production scale. Qdrant leads open-source at 30K–80K QPS; Ruflo's measured data covers only N=20k brute-force comparison. Recommendation: publish QPS benchmark, evaluate optional Qdrant connector.

---

## Gist Link

Report file: [`docs/dream-cycle/2026-06-29-swarm.md`](https://github.com/ruvnet/ruflo/blob/dream/2026-06-29-swarm/docs/dream-cycle/2026-06-29-swarm.md)

---

## Merge Policy

**Leave for human review. Do not self-merge.**

This PR contains a proposed ADR and a research report. The ADR requires human sign-off before implementation work begins. The research report is informational. No production code changed in this PR.

⚠️ **needs-merge notice:** 0 dream-cycle PRs have been merged in the last 14+ nights. Prior dream-cycle branches are accumulating. Consider a batch review session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UMadiCEhB4TkETZbtAWQ8f)_