### PR TITLE
fix(ci): regenerate pnpm-lock.yaml for @metaharness/redblue

### DIFF
--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@metaharness/kernel':
         specifier: ~0.1.0
         version: 0.1.0
+      '@metaharness/redblue':
+        specifier: ~0.1.1
+        version: 0.1.4
       '@metaharness/router':
         specifier: ~0.3.2
         version: 0.3.2(@ruvector/tiny-dancer@0.1.22)
@@ -1755,6 +1758,14 @@ packages:
         optional: true
     dependencies:
       '@ruvector/emergent-time': 0.1.0
+    dev: false
+    optional: true
+
+  /@metaharness/redblue@0.1.4:
+    resolution: {integrity: sha512-JaAk6bs3xA7Ks5RnAcZoxI3WfzpYL+Bk262SCI07w82BDOA7C6VxwGM63F7b86lRTKUVjTEnSqf7QZ3uyElT/g==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    requiresBuild: true
     dev: false
     optional: true
 


### PR DESCRIPTION
## Summary
- Adds `@metaharness/redblue@~0.1.1` (resolves to 0.1.4) to `v3/pnpm-lock.yaml`
- 11-line, single-file lockfile delta — no source changes
- Unblocks main: `pnpm install --frozen-lockfile` was failing with `ERR_PNPM_OUTDATED_LOCKFILE`, cascading through 14+ CI jobs

## Root cause
Commit `a63cdf05` (`feat(metaharness): integrate @metaharness/redblue@~0.1.1`) added the dep to `v3/@claude-flow/cli/package.json` but didn't regenerate `v3/pnpm-lock.yaml`. Since CI's `pnpm install --frozen-lockfile` refuses any spec drift, the install step fails on every job that runs it (Type Check V3, Test V3 Packages, all init-hooks/guardrail/statusline smokes, both no-better-sqlite3 smoke matrices, npx-install smoke on Node 22+24, plugin install-safety, graph schema smoke). Downstream "Build CLI" / "Build memory" / etc. then fail as a cascade.

## Verification (local)
- `pnpm install --frozen-lockfile` in `v3/` → ✅ passes
- `npm run build` in `v3/@claude-flow/cli` → ✅ TypeScript build clean

## Diff
```diff
+      '@metaharness/redblue':
+        specifier: ~0.1.1
+        version: 0.1.4
...
+  /@metaharness/redblue@0.1.4:
+    resolution: {integrity: sha512-...}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
```

## Test plan
- [x] Local `pnpm install --frozen-lockfile` passes
- [x] Local CLI build clean
- [ ] CI: V3 CI/CD pipeline goes green on this branch

Closes #2483
Closes #2487

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)