### PR TITLE
chore(release): 3.14.4 → 3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.14.4",
+  "version": "3.15.0",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.14.4",
+  "version": "3.15.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.14.4",
+  "version": "3.15.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

MINOR bump from 3.14.4 → 3.15.0 for the agenticow integration that landed in #2500.

## What changed

| Package | Old | New |
|---------|-----|-----|
| `@claude-flow/cli` | 3.14.4 | 3.15.0 |
| `claude-flow` | 3.14.4 | 3.15.0 |
| `ruflo` | 3.14.4 | 3.15.0 |

All three published to npm with `latest` + legacy `alpha` + legacy `v3alpha` dist-tags pointing at 3.15.0.

## Published artifacts (verified via `npm view dist-tags`)

```
@claude-flow/cli  latest=3.15.0  alpha=3.15.0  v3alpha=3.15.0
claude-flow       latest=3.15.0  alpha=3.15.0  v3alpha=3.15.0
ruflo             latest=3.15.0  alpha=3.15.0  v3alpha=3.15.0
```

## Test plan

- [x] All 3 `npm publish` succeeded
- [x] All 3 `npm dist-tag add` for latest+alpha+v3alpha succeeded
- [x] `npm view <pkg> dist-tags` confirms lockstep state

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01WbBa4nccx5aGhXphoHxcni