### PR TITLE
feat: add Skill Hub (4083+ AI Agent Skills Navigator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ User --> Ruflo (CLI/MCP) --> Router --> Swarm --> Agents --> Memory --> LLM Prov
 
 ![Ruflo Plugins](./ruflo-plugins.gif)
 
+
+## Skill Hub
+
+[Skill Hub](https://skill.442595.xyz/) — **4083+** AI Agent Skills across 22 functional categories.
+
+- 🛠️ **Dev Tools** · 🤖 **Agent Framework** · 🎨 **Design UI** · 📊 **Data AI** · 🔒 **Security** and more
+- 🔍 Platform: Claude Code, Codex, Cursor, OpenCode, Hermes
+- 🌐 Bilingual CN+EN  |  🐙 [GitHub](https://github.com/rdone4425/skill)
+
 ## Quick Start
 
 There are **two different install paths** with very different surface areas. Pick based on what you need (#1744):


### PR DESCRIPTION
## Skill Hub — AI Agent Skills Navigator

**4083+ AI Agent Skills** organized into 22 functional categories.

### What is Skill Hub?
A curated navigation site for AI Agent Skills and MCP Tools, featuring:
- Browse by function: Dev Tools, Agent Framework, Design UI, Data AI, Security, etc.
- Platform filter: Claude Code, Codex, Cursor, OpenCode, Hermes, and more
- Bilingual Chinese + English
- Pure static frontend with real-time updates
- Open source and community-driven

### Links
- 🌐 **Live site**: https://skill.442595.xyz/
- 🐙 **GitHub**: https://github.com/rdone4425/skill

*Submitted by rdone4425*
