### PR TITLE
chore(release): 3.15.0 → 3.16.0 (ADR-164)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
MINOR bump for ADR-164 Phases 1-4 (PR #2503).

All 3 packages published to npm with latest+alpha+v3alpha dist-tags.

```
@claude-flow/cli  latest=3.16.0  alpha=3.16.0  v3alpha=3.16.0
claude-flow       latest=3.16.0  alpha=3.16.0  v3alpha=3.16.0
ruflo             latest=3.16.0  alpha=3.16.0  v3alpha=3.16.0
```

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)