### PR TITLE
chore: sync package-lock.json version to 3.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.16.1",
+      "version": "3.16.2",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",


### PR DESCRIPTION
## Summary

- Syncs `package-lock.json` root version field from `3.16.1` to `3.16.2` to match `package.json`
- One-line lockfile consistency fix; no dependency changes, no API changes

## Context

The lockfile version field was stale. It was updated automatically when `npm install` ran during the scheduled 12-hour verification run (2026-07-01T07:03:24Z, commit `1a887969548b58e77f7853fedca922fc1cb5c6aa`). The `npm install` was required to resolve `@noble/ed25519` so the witness verification script could load its Ed25519 dependency.

## Verification run summary (2026-07-01)

Overall severity: **HIGH** — 3 pre-existing open issues reproduced:

| Issue | Finding |
|-------|---------|
| #2047 | Witness manifests: `missing=99 drift=4` (trending up from 95/2) |
| #2286 | `@claude-flow/cli@alpha --version` hangs >60s on cold ONNX download |
| #2458 | ADR-104 transport smoke blocked — `sharp` native binary fails through proxy |

Passing: federation breaker smoke, doctor (12 passed), npm tags all `3.16.2`, CI not in failure state.

Comments with reproduction evidence posted on #2047, #2286, #2458.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3F3WQkE5wKY7ySwnP3ePq)_