### PR TITLE
docs: fix broken verification.md links after reorg to verification/

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Four docs for four audiences:
 | **[User Guide](docs/USERGUIDE.md)** | Daily reference — every command, every config flag, every plugin. The *how-do-I* doc. |
 | **[MetaHarness Guide](docs/metaharness-user-guide.md)** | How to grade your agent setup, scan tool configs for security, detect changes between runs, and eject a project into a standalone agent toolkit. The *audit-my-setup* doc. |
 | **[Benchmarks](https://gist.github.com/ruvnet/298f8c668c8859b369f91734a0e9cbbe)** | v3.8.0 SOTA matrix vs LangGraph / AutoGen / CrewAI on darwin-arm64 + linux-x64. ruflo wins cold start, single turn, RSS by 1.3×–1953×. The *is-it-fast* doc. |
-| **[Verification](verification.md)** | Cryptographically prove your installed bytes match the signed witness — `ruflo verify`. The *trust-but-verify* doc. |
+| **[Verification](verification/README.md)** | Cryptographically prove your installed bytes match the signed witness — `ruflo verify`. The *trust-but-verify* doc. |
 | **[Team Gateway Checklist](docs/TEAM-GATEWAY-CHECKLIST.md)** | Before-merge gates, dual-mode handoff, memory namespace sharing, and witness manifest entry per merge. The *safer-team-workflows* doc. |
 
 Benchmark internals (for reproduction): [`sota-workload-spec.md`](https://github.com/ruvnet/ruflo/blob/perf/sota-comparator-benchmarks/docs/benchmarks/sota-workload-spec.md) · [`SOTA-PROGRESS.md`](https://github.com/ruvnet/ruflo/blob/perf/sota-comparator-benchmarks/docs/benchmarks/SOTA-PROGRESS.md) · [raw matrix JSON: darwin](https://github.com/ruvnet/ruflo/blob/perf/sota-comparator-benchmarks/docs/benchmarks/sota-matrix.json) · [linux](https://github.com/ruvnet/ruflo/blob/perf/sota-comparator-benchmarks/docs/benchmarks/sota-matrix-linux.json)

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ RuFlo plugins use Claude Code's native capabilities when available:
 - Plugins declare required permissions in their manifest
 - Pin versions for production use: `/plugin install ruflo-core@0.1.0@ruflo`
 - Security scanning available via ruflo-security-audit
-- Cryptographically-signed [witness manifest](../verification.md) attests every documented fix; see [Validation System](validation/) for the three-layer regression-protection stack
+- Cryptographically-signed [witness manifest](../verification/README.md) attests every documented fix; see [Validation System](validation/) for the three-layer regression-protection stack
 
 ## Links
 


### PR DESCRIPTION
## Summary
- `verification.md` was split into the `verification/` directory (see commit 9817695, "per-OS verification cognitive containers + tutorial README"), but `README.md` and `docs/index.md` still link to the old, now-nonexistent `verification.md` path.
- Updates both references to point to `verification/README.md`.

## Test plan
- [x] Confirmed `verification.md` no longer exists at the repo root; `verification/README.md` exists and covers the same content
- [x] Verified no other docs reference the stale path