### PR TITLE
fix(witness): use node symlink in precondition smoke

### DIFF
--- a/scripts/smoke-witness-verify-precondition.mjs
+++ b/scripts/smoke-witness-verify-precondition.mjs
@@ -28,7 +28,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -112,8 +112,7 @@ console.log('\nCase 2: dist manifest files missing (source-only, deps installed)
     const src = join(realNodeModules, '@noble', 'ed25519');
     const dst = join(tmp, 'node_modules', '@noble', 'ed25519');
     try {
-      // fs.symlinkSync via spawnSync to avoid extra import for the rare-path branch.
-      spawnSync('ln', ['-s', src, dst]);
+      symlinkSync(src, dst, process.platform === 'win32' ? 'junction' : 'dir');
     } catch { /* best-effort */ }
   }
 


### PR DESCRIPTION
## Summary
- replace the POSIX `ln -s` subprocess in the witness precondition smoke with Node's `symlinkSync`
- use `junction` on Windows and `dir` elsewhere so the helper remains portable
- keep the existing best-effort behavior for environments where linking is unavailable

## Test Plan
- `node --check scripts/smoke-witness-verify-precondition.mjs`
- `node scripts/smoke-witness-verify-precondition.mjs`