### PR TITLE
docs: fix remaining #1744 inconsistencies in STATUS.md and USERGUIDE.md

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,7 +23,7 @@ The intended day-to-day flow:
 
 1. **Install once**:
    ```bash
-   npx ruflo init --wizard
+   npx ruflo init wizard
    ```
    This writes a `CLAUDE.md` with hooks and routing rules, registers the MCP server with Claude Code, and seeds `.claude-flow/` with config + memory.
 

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -559,14 +559,14 @@ npm install -g ruflo@latest --omit=optional
 
 #### Claude Code Plugin Marketplace
 
-Install Ruflo as a native Claude Code plugin -- adds skills, commands, agents, and MCP tools directly into Claude Code:
+Install Ruflo as a native Claude Code plugin -- adds skills, commands, and agent definitions directly into Claude Code. Note: this path does **not** register the Ruflo MCP server (`memory_store`, `swarm_init`, etc. won't be callable from Claude). For the full loop, use `npx ruflo init` instead.
 
 ```bash
 # Add the marketplace (one-time)
 /plugin marketplace add ruvnet/ruflo
 
 # Install individual plugins
-/plugin install ruflo-core@ruflo         # MCP server + base agents
+/plugin install ruflo-core@ruflo         # Base agents + slash commands (no MCP server)
 /plugin install ruflo-swarm@ruflo         # Swarm coordination + Monitor
 /plugin install ruflo-autopilot@ruflo     # Autonomous /loop completion
 /plugin install ruflo-loop-workers@ruflo  # Background workers + CronCreate


### PR DESCRIPTION
## Summary
- Fix `init --wizard` → `init wizard` in docs/STATUS.md (last remaining instance of the old flag syntax)
- Align docs/USERGUIDE.md plugin-install wording with the corrected README: plugin install does not register the MCP server

## Issue / motivation
Refs #1744. The README fixes from that issue didn't reach STATUS.md and USERGUIDE.md, so readers of those docs still hit both original problems.

## Approach
Documentation-only change. Matched the wording already used in the corrected README ("MCP server registered: No"). No code touched.

## Test plan
- [x] `grep -rn "init --wizard" docs/ README.md` returns no matches after the change
- [x] USERGUIDE.md wording now matches README's plugin vs CLI install table

## Risks / open questions
None — docs only.
