### PR TITLE
docs(ADR-167): forward contract SHIPPED (#2550) — AUD-1/3/4 now enforceable

### DIFF
--- a/v3/docs/adr/ADR-167-gaia-submission-integrity-exploit-audit.md
+++ b/v3/docs/adr/ADR-167-gaia-submission-integrity-exploit-audit.md
@@ -1,7 +1,7 @@
 # ADR-167: GAIA Submission Integrity — Pre-Submission Exploit Audit + Signed Attestation
 
 **ID**: ADR-167
-**Status**: Proposed — prototype + tests shipped on `feat/gaia-submission-integrity-audit` (this branch). Enforceable checks green now; four checks blocked on trajectory instrumentation (see §7).
+**Status**: Accepted — audit + tests shipped (`feat/gaia-submission-integrity-audit`); the trajectory-serialization forward contract that unblocks the CRITICAL leakage/isolation checks **shipped in PR #2550** (see §4). AUD-1/3/4 are now enforceable (measured before/after); residual follow-ups are the `/gaia submit --metadata` wiring and voting-wrapper trajectory propagation.
 **Date**: 2026-07-03
 **Authors**: rUv (drafted with Claude Code)
 **Related ADRs**:
@@ -69,14 +69,15 @@ change a ruflo GAIA submission attests two independent facts:
   catches the *known, mechanically-detectable* vectors from the RDI/METR
   catalogue. A sufficiently clever exploit that leaves no trace in the recorded
   trajectory is not caught. This is a floor, not a ceiling.
-- **Some checks are only as strong as the trajectory schema.** The current
-  harness (`gaia-bench.ts`) persists `QuestionResult[]` only — it does **not**
-  emit a `trajectories.jsonl`, and `gaia-agent.ts` discards the `messages[]`
-  array (fetched tool outputs, agent-visible prompts) after each question. Four
-  of the seven checks therefore **cannot enforce today** and return
-  `status: "skip"` with a `harness_gap` note rather than a false pass (§7). They
-  become enforceable once the harness records the data — this ADR specifies the
-  forward contract.
+- **Some checks are only as strong as the trajectory schema.** As originally
+  drafted, `gaia-bench.ts` persisted `QuestionResult[]` only and `gaia-agent.ts`
+  discarded the `messages[]` array — so the leakage/isolation checks returned
+  `status: "skip"` + `harness_gap` (never a false pass). **PR #2550 shipped the
+  §4 forward contract**: the harness now serializes a redacted `trajectories.jsonl`
+  (+ `run-metadata.json`), so AUD-1/3/4 (and AUD-6/7 with `--metadata`) are
+  enforceable. A run produced by a *pre-#2550* harness still `skip`s and the
+  attestation records the gap — the audit degrades honestly rather than
+  false-passing on old artifacts.
 - **No live network, no LLM, no env access.** The audit is $0 and deterministic
   by construction so its report can be signed reproducibly.
 
@@ -109,7 +110,7 @@ Verified by reading source on `origin/main` (not invented):
 - **Loader** — `gaia-loader.ts` hard-codes `split=validation`; gold answers are
   the public HF dataset.
 - **Submission package** — `gaia-submit.md`: `results.jsonl`,
-  `trajectories.jsonl` (documented but **not produced** by the harness today),
+  `trajectories.jsonl` (**now produced** by the harness as of #2550 — redacted),
   `metadata.json`, `manifest.md.json` (Ed25519 witness).
 - **Witness** — `plugins/ruflo-core/scripts/witness/{lib,verify,regen}.mjs`
   (ADR-103): `manifest.fixes[] = {id, desc, file, sha256, marker,
@@ -124,13 +125,13 @@ Verified by reading source on `origin/main` (not invented):
 
 | ID | Check | Severity | RDI/METR vector | Enforceable today? |
 |----|-------|----------|-----------------|--------------------|
-| AUD-1 | answer-leakage | CRITICAL | GAIA #1: ~98% answer leakage via public DB + fetched pages | **Blocked** — needs tool_result outputs in trajectory |
+| AUD-1 | answer-leakage | CRITICAL | GAIA #1: ~98% answer leakage via public DB + fetched pages | **Yes (#2550)** — trajectory now carries redacted tool_result outputs |
 | AUD-2 | no-work / no-LLM pass | CRITICAL | "100% without solving; zero LLM calls" | **Yes** — `turns`/`outputTokens` are real fields (stronger with trajectory) |
-| AUD-3 | oracle-leakage | CRITICAL | gold answer visible in agent prompt/context | **Blocked** — needs recorded prompt |
-| AUD-4 | grader-isolation | CRITICAL | METR: 30%+ grader monkey-patching / eval-code introspection | **Blocked** — needs tool_call names+args |
+| AUD-3 | oracle-leakage | CRITICAL | gold answer visible in agent prompt/context | **Yes (#2550)** — trajectory now records the agent-visible prompt |
+| AUD-4 | grader-isolation | CRITICAL | METR: 30%+ grader monkey-patching / eval-code introspection | **Yes (#2550)** — trajectory now records tool_call names+args |
 | AUD-5 | normalization-collision | WARN | GAIA normalization collisions + bidirectional-substring hazard | **Yes** — reads answers in the results file |
-| AUD-6 | voting-disclosure | WARN | hidden best-of-N score inflation | **Yes if metadata carries N** (harness gap: not persisted) |
-| AUD-7 | split-integrity | WARN/INFO | validation-split (public gold) presented as held-out | **Yes if metadata carries split** (harness gap: not persisted) |
+| AUD-6 | voting-disclosure | WARN | hidden best-of-N score inflation | **Yes** — #2550 persists `voting_attempts` to run-metadata.json (pass `--metadata`) |
+| AUD-7 | split-integrity | WARN/INFO | validation-split (public gold) presented as held-out | **Yes** — #2550 persists `gaia_split` to run-metadata.json (pass `--metadata`) |
 | AUD-8 | answer-key-reads | CRITICAL | RDI: answer keys read from unsanitized config/infra | **Yes** — static scan of runner sources + produced artifacts |
 | AUD-9 | dynamic-eval | CRITICAL | RDI: trojanized test infrastructure (eval/exec of task content) | **Yes** — static scan of the gaia-bench runner sources |
 | AUD-10 | judge-injection | WARN | prompt-injection in the produced answer aimed at the LLM judge | **Yes** — scans produced answers/outputs |
@@ -164,7 +165,23 @@ the audit sees answers exactly as the scorer does.
 
 ---
 
-## 4. Forward trajectory contract (unblocks AUD-1/3/4)
+## 4. Forward trajectory contract (unblocks AUD-1/3/4) — ✅ SHIPPED (PR #2550)
+
+> **Status update (2026-07-03):** this forward contract **landed** in PR #2550
+> (`feat: serialize GAIA trajectories.jsonl (redacted)`). `gaia-agent.ts` now
+> captures `prompt`/`llm_call`/`tool_call`/`tool_result` steps from the existing
+> `messages[]` flow and `gaia-bench.ts` writes `trajectories.jsonl` +
+> `run-metadata.json` (`voting_attempts`, `gaia_split`) to `~/.cache/ruflo/gaia`.
+> Tool outputs, prompts, and tool-call args are secret-**redacted** (10/10
+> redaction tests, incl. a live mocked run that plants an `hf_…` token and
+> confirms it is stripped while the answer text survives) and size-bounded
+> (8 KiB/step, 256 KiB/record). **Measured before/after against `gaia-audit.mjs`:**
+> AUD-1 (answer-leakage), AUD-3 (oracle-leakage), AUD-4 (grader-isolation) went
+> from `skip` → enforceable — a clean run passes all three; a dirty run fires all
+> four criticals (answer-DB signature match, oracle prompt leak,
+> `file_write→/judgments/`, `turns=0`) and exits 1. Remaining follow-ups: wire
+> `/gaia submit` to pass `--metadata` (unblocks voting/split end-to-end) and
+> propagate `.trajectory` through the voting/critic wrappers.
 
 To make the blocked checks enforceable, `gaia-agent.ts` must emit — and
 `gaia-bench.ts` must persist to `trajectories.jsonl` — one record per task:
@@ -187,8 +204,9 @@ To make the blocked checks enforceable, `gaia-agent.ts` must emit — and
 
 This is a faithful serialization of the `messages[]` array `runGaiaAgent`
 already builds — the fix is to *return and write it*, not to compute anything
-new. `is_error` tool results and image markers can be recorded as-is. Until
-this lands, AUD-1/3/4 skip and the attestation records the gap.
+new. `is_error` tool results and image markers can be recorded as-is. **This
+landed in #2550** — AUD-1/3/4 are now enforceable; the attestation records the
+gap only for runs produced by a pre-#2550 harness.
 
 ---
 


### PR DESCRIPTION
Updates ADR-167 to reflect that its §4 trajectory-serialization forward contract **landed in #2550**. Changes: Status Proposed→Accepted; §4 gets a shipped-banner with the measured before/after; the check table flips AUD-1/3/4 (answer-leakage, oracle-leakage, grader-isolation) + AUD-6/7 from Blocked/harness-gap to **enforceable**; §1.3 + §2 stale 'not produced'/'four checks skip' language corrected. Old-harness runs still `skip` honestly (no false-pass). Docs-only. Base = the audit branch so it merges as one unit with #2543; merge order into main remains #2543 → #2550.