### PR TITLE
fix(neural): #2549 — status misreports native ruvllm training path as Unavailable

### DIFF
--- a/v3/@claude-flow/cli/__tests__/neural-status-training-backend-2549.test.ts
+++ b/v3/@claude-flow/cli/__tests__/neural-status-training-backend-2549.test.ts
@@ -1,0 +1,57 @@
+/**
+ * #2549 regression — `neural status` misreported the native @ruvector/ruvllm
+ * training path as Unavailable.
+ *
+ * Two defects: `_trainingBackend` was a dead variable (declared 'unavailable',
+ * returned, never assigned), and contrastive availability was read only from
+ * an in-process global that a fresh read-only status process never populates.
+ * Both made a bundled, working module invisible — with a remediation hint
+ * ("Install @ruvector/ruvllm") that was actively wrong.
+ *
+ * These tests pin the capability contract: when @ruvector/ruvllm RESOLVES,
+ * the stats layer must never report the training path as unavailable.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { resolveTrainingBackend } from '../src/ruvector/lora-adapter.js';
+import { getIntelligenceStats } from '../src/memory/intelligence.js';
+
+function ruvllmResolves(): boolean {
+  try {
+    createRequire(import.meta.url).resolve('@ruvector/ruvllm');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('#2549 — training backend capability reporting', () => {
+  it('resolveTrainingBackend reflects module resolution, not in-process load state', () => {
+    // The probe must not depend on a prior in-process train having run.
+    const backend = resolveTrainingBackend();
+    if (ruvllmResolves()) {
+      expect(backend).toBe('ruvllm');
+    } else {
+      expect(backend).toBe('js-fallback');
+    }
+  });
+
+  it('getIntelligenceStats populates _trainingBackend (the dead-variable regression)', () => {
+    const stats = getIntelligenceStats() as { _trainingBackend?: string };
+    // Whatever the environment, the field must carry a real verdict —
+    // 'unavailable' is only legitimate when the probe itself threw.
+    if (ruvllmResolves()) {
+      expect(stats._trainingBackend).toBe('ruvllm');
+    } else {
+      expect(stats._trainingBackend).toBe('js-fallback');
+    }
+  });
+
+  it('contrastive trainer reads available (not unavailable) in a fresh process when the module resolves', () => {
+    const stats = getIntelligenceStats() as { _contrastiveTrainer?: unknown };
+    if (!ruvllmResolves()) return; // nothing to assert without the module
+    // Fresh process ⇒ no __claudeFlowSonaStats global ⇒ must fall back to
+    // the capability probe, never to 'unavailable'.
+    expect(stats._contrastiveTrainer).not.toBe('unavailable');
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/neural.ts
+++ b/v3/@claude-flow/cli/src/commands/neural.ts
@@ -525,17 +525,27 @@ const statusCommand: Command = {
           },
           {
             component: 'Contrastive Trainer',
-            status: stats._contrastiveTrainer && stats._contrastiveTrainer !== 'unavailable' ? output.success('Active') : output.dim('Unavailable'),
-            details: stats._contrastiveTrainer && stats._contrastiveTrainer !== 'unavailable'
+            // #2549 — three states: live session (object with counts),
+            // 'available' (module resolves, no in-process session — the
+            // normal case for a read-only status process), 'unavailable'
+            // (module genuinely does not resolve).
+            status: typeof stats._contrastiveTrainer === 'object'
+              ? output.success('Active')
+              : stats._contrastiveTrainer === 'available'
+                ? output.success('Available')
+                : output.dim('Unavailable'),
+            details: typeof stats._contrastiveTrainer === 'object'
               ? `${(stats._contrastiveTrainer as any).triplets ?? 0} triplets, ${(stats._contrastiveTrainer as any).agents ?? 0} agents`
-              : 'Install @ruvector/ruvllm',
+              : stats._contrastiveTrainer === 'available'
+                ? 'ready — trains in-process on demand'
+                : 'Install @ruvector/ruvllm',
           },
           {
             component: 'Training Pipeline',
-            status: stats._trainingBackend === 'ruvllm' ? output.success('Active') : output.dim(stats._trainingBackend || 'Unavailable'),
+            status: stats._trainingBackend === 'ruvllm' ? output.success('Available') : output.dim(stats._trainingBackend || 'Unavailable'),
             details: stats._trainingBackend === 'ruvllm'
-              ? 'ruvllm checkpoints enabled'
-              : 'JS fallback (no checkpoints)',
+              ? 'native @ruvector/ruvllm pipeline'
+              : 'JS fallback',
           },
           await (async () => {
             try {

--- a/v3/@claude-flow/cli/src/memory/intelligence.ts
+++ b/v3/@claude-flow/cli/src/memory/intelligence.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+import { resolveTrainingBackend } from '../ruvector/lora-adapter.js';
 
 // ============================================================================
 // Persistence Configuration
@@ -1261,15 +1262,27 @@ export function getIntelligenceStats(): IntelligenceStats & {
   }
   const ruvllmStats = ruvllmCoordinator?.stats?.() || null;
 
-  // Fetch cross-module stats for unified reporting
+  // Fetch cross-module stats for unified reporting.
+  //
+  // #2549 — two prior defects here: `trainingBackend` was declared and
+  // returned but never assigned (always 'unavailable'), and contrastive
+  // availability was read ONLY from an in-process global that a fresh
+  // read-only `neural status` process never populates. Both made the
+  // native @ruvector/ruvllm path invisible even when installed. Backend
+  // now comes from the lora-adapter's capability probe; the global still
+  // wins when present because it carries live in-process session counts.
   let contrastiveTrainer: { triplets: number; agents: number } | string = 'unavailable';
   let trainingBackend = 'unavailable';
   try {
-    // Synchronous check — contrastiveTrainer is module-level in sona-optimizer
-    // We read it via the SONAOptimizer singleton if available
+    trainingBackend = resolveTrainingBackend();
+  } catch { /* module absent — stay 'unavailable' */ }
+  try {
     const sonaModule = (globalThis as any).__claudeFlowSonaStats;
-    if (sonaModule) {
-      contrastiveTrainer = sonaModule._contrastiveTrainer || 'unavailable';
+    if (sonaModule?._contrastiveTrainer) {
+      contrastiveTrainer = sonaModule._contrastiveTrainer;
+    } else if (trainingBackend === 'ruvllm') {
+      // Module resolves but no in-process session — available, idle.
+      contrastiveTrainer = 'available';
     }
   } catch { /* not available */ }
 

--- a/v3/@claude-flow/cli/src/ruvector/lora-adapter.ts
+++ b/v3/@claude-flow/cli/src/ruvector/lora-adapter.ts
@@ -20,6 +20,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
+import { createRequire } from 'module';
 
 // ============================================================================
 // Types & Constants
@@ -135,6 +136,24 @@ const DEFAULT_CONFIG: LoRAConfig = {
 
 let ruvllmPipeline: any = null;
 let pipelineLoaded = false;
+
+/**
+ * Which training backend a train call would use — WITHOUT loading the
+ * pipeline (#2549). Before this existed, status surfaces read module state
+ * that only a prior in-process train populates, so a fresh read-only
+ * process always reported 'js-fallback'/'unavailable' even with
+ * @ruvector/ruvllm installed. The pipeline stays lazy: this only probes
+ * module resolution.
+ */
+export function resolveTrainingBackend(): 'ruvllm' | 'js-fallback' {
+  if (pipelineLoaded) return ruvllmPipeline ? 'ruvllm' : 'js-fallback';
+  try {
+    createRequire(import.meta.url).resolve('@ruvector/ruvllm');
+    return 'ruvllm';
+  } catch {
+    return 'js-fallback';
+  }
+}
 
 async function loadTrainingPipeline(adapter: LoRAAdapter): Promise<any> {
   if (pipelineLoaded) return ruvllmPipeline;
@@ -407,9 +426,7 @@ export class LoRAAdapter {
         ? this.adaptationNormSum / this.totalAdaptations
         : 0,
       lastUpdate: this.lastUpdate,
-      _trainingBackend: pipelineLoaded
-        ? (ruvllmPipeline ? 'ruvllm' : 'js-fallback')
-        : 'js-fallback',
+      _trainingBackend: resolveTrainingBackend(),
     };
   }
 


### PR DESCRIPTION
Fixes #2549 — all three reporter claims verified against source and runtime before fixing (triage: https://github.com/ruvnet/ruflo/issues/2549#issuecomment-4879592811).

## Fixes
1. **Dead `_trainingBackend` variable** → populated via new `resolveTrainingBackend()` capability probe in lora-adapter (module resolution only — pipeline stays lazy)
2. **Cross-process-blind contrastive availability** → three honest states: live in-process session → `Active` with counts; module resolves → `Available` ('ready — trains in-process on demand'); genuine resolution failure → the Install hint (now the ONLY case that shows it)
3. **Honesty fix**: 'ruvllm checkpoints enabled' claim dropped — upstream `saveCheckpoint()` writes no file (@ruvector/ruvllm 2.5.6, tracked separately)

## Before/after (`neural status`, module bundled)
```
before: | Contrastive Trainer | Unavailable | Install @ruvector/ruvllm |
        | Training Pipeline   | unavailable | JS fallback (no checkpoints) |
after:  | Contrastive Trainer | Available   | ready — trains in-process on demand |
        | Training Pipeline   | Available   | native @ruvector/ruvllm pipeline |
```

## Validation
- tsc clean; regression test `neural-status-training-backend-2549.test.ts` 3/3 (pins the capability contract in both resolve/no-resolve environments)
- Runtime proof above on the built CLI

Not in scope (follow-ups per triage): routing `neural train` through the native pipeline; upstream checkpoint fix.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01S7GYqnVUVxBfZ5W8znqry3