### PR TITLE
feat(neural): use @ruvector/ruvllm 2.5.7 native checkpoints end-to-end (#2549 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3038,9 +3038,9 @@
       }
     },
     "node_modules/@ruvector/ruvllm": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm/-/ruvllm-2.5.5.tgz",
-      "integrity": "sha512-3WDQkN1EiRlmln6Y3qHIOwIRaRUWwagT1OG+AxohyFgr2UuvWCD5tsiPFtlgwUze4X01lgvBCiHdOsV3u81UWA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm/-/ruvllm-2.5.7.tgz",
+      "integrity": "sha512-XxvUsPZaiIfK5/n1/Vgv3Gz9+cgBbvHbN/4OKHrLcpbw0eY9b9+BsQmvmYGfBwiVumQcgn8wmFiqRTqBrTa3BA==",
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4056,111 +4056,6 @@
         "onnxruntime-node": "^1.23.2",
         "sharp": "^0.32.6",
         "sql.js": "^1.11.0"
-      }
-    },
-    "node_modules/agentic-flow/node_modules/@ruvector/ruvllm": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm/-/ruvllm-0.2.4.tgz",
-      "integrity": "sha512-cNAkcKZIqqy+3fxOb1z8bS1cJzJgsUpqNIdMk29RDr+a5g/fLgmHTVEzdBW6kHfDTc5tFUr10Juh9K6w0cKufg==",
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "commander": "^12.0.0",
-        "ora": "^5.4.1"
-      },
-      "bin": {
-        "ruvllm": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "optionalDependencies": {
-        "@ruvector/ruvllm-darwin-arm64": "0.2.0",
-        "@ruvector/ruvllm-darwin-x64": "0.2.0",
-        "@ruvector/ruvllm-linux-arm64-gnu": "0.2.0",
-        "@ruvector/ruvllm-linux-x64-gnu": "0.2.0",
-        "@ruvector/ruvllm-win32-x64-msvc": "0.2.0"
-      }
-    },
-    "node_modules/agentic-flow/node_modules/@ruvector/ruvllm-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-darwin-arm64/-/ruvllm-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-3oEMNEoGJqfTJXf1Th49HPTlETMxLzlBc1yBY1RqCMoqSrNKsM66+3Npx0O/GdYfFnKRU2wa/mlLPuBY2lUqYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/agentic-flow/node_modules/@ruvector/ruvllm-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-darwin-x64/-/ruvllm-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-Niu9oG9hkbDJ1IpfXluRRfO4vwPwCdISW+ff1H+NjmIk8028CIg2w5iq3qbIaj6WzTQ9YqA68V5aMD9t0w8A6g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/agentic-flow/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-linux-arm64-gnu/-/ruvllm-linux-arm64-gnu-0.2.0.tgz",
-      "integrity": "sha512-ykOqwiqRbf29idXYMmuDdZqOsRMbYgzpWhmk/BcSRVBMUsO4W2Q0UkgLZgt6PIKxSf1k2qt8x8uSmO5tYTD8Iw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/agentic-flow/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-linux-x64-gnu/-/ruvllm-linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-8JHH7ft00rqCRyiP0wuAThOVwSodj0gaTZcG1jBBqtnwApmdmTWN8EpuffrHHhhRO+Uvny6T5r7TiAh+Xu+QuQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/agentic-flow/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ruvector/ruvllm-win32-x64-msvc/-/ruvllm-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-ksm+AZVqkkYLVq2Rbc7Rx+gSH7egFWlcH3E5dQpro98Oslc7jUH+uNDRjDVUS3lZXchV+Ot5WPLM4pClRxFm9w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/agentic-flow/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     "ws": ">=8.21.0",
     "@grpc/grpc-js": ">=1.14.4",
     "form-data": ">=4.0.6",
-    "http-proxy-middleware": ">=3.0.7"
+    "http-proxy-middleware": ">=3.0.7",
+    "@ruvector/ruvllm": ">=2.5.7"
   },
   "devDependencies": {
     "@openai/codex": "^0.98.0",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -79,7 +79,8 @@
     "@opentelemetry/otlp-grpc-exporter-base": ">=0.220.0",
     "@opentelemetry/otlp-transformer": ">=0.220.0",
     "agentdb": ">=3.0.0-alpha.17",
-    "agentic-flow": ">=2.0.14"
+    "agentic-flow": ">=2.0.14",
+    "@ruvector/ruvllm": ">=2.5.7"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/v3/@claude-flow/cli/__tests__/neural-status-training-backend-2549.test.ts
+++ b/v3/@claude-flow/cli/__tests__/neural-status-training-backend-2549.test.ts
@@ -55,3 +55,29 @@ describe('#2549 — training backend capability reporting', () => {
     expect(stats._contrastiveTrainer).not.toBe('unavailable');
   });
 });
+
+describe('#2549 follow-up — native checkpoint capability gate', () => {
+  it('nativeCheckpointsSupported reflects the resolved ruvllm version (>=2.5.7)', async () => {
+    const { nativeCheckpointsSupported } = await import('../src/ruvector/lora-adapter.js');
+    if (!ruvllmResolves()) {
+      expect(nativeCheckpointsSupported()).toBe(false);
+      return;
+    }
+    const req = createRequire(import.meta.url);
+    const { dirname, join } = await import('node:path');
+    const { existsSync, readFileSync } = await import('node:fs');
+    let dir = dirname(req.resolve('@ruvector/ruvllm'));
+    let version = '0.0.0';
+    for (let i = 0; i < 5; i++) {
+      const p = join(dir, 'package.json');
+      if (existsSync(p)) {
+        const pkg = JSON.parse(readFileSync(p, 'utf-8'));
+        if (pkg.name === '@ruvector/ruvllm') { version = pkg.version; break; }
+      }
+      dir = dirname(dir);
+    }
+    const [maj, min, pat] = version.split('.').map(Number);
+    const expected = maj > 2 || (maj === 2 && (min > 5 || (min === 5 && pat >= 7)));
+    expect(nativeCheckpointsSupported()).toBe(expected);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/neural.ts
+++ b/v3/@claude-flow/cli/src/commands/neural.ts
@@ -543,8 +543,19 @@ const statusCommand: Command = {
           {
             component: 'Training Pipeline',
             status: stats._trainingBackend === 'ruvllm' ? output.success('Available') : output.dim(stats._trainingBackend || 'Unavailable'),
+            // Checkpoint capability is version-gated: saveCheckpoint(path)
+            // was a silent no-op before @ruvector/ruvllm 2.5.7 (#2549).
             details: stats._trainingBackend === 'ruvllm'
-              ? 'native @ruvector/ruvllm pipeline'
+              ? await (async () => {
+                  try {
+                    const { nativeCheckpointsSupported } = await import('../ruvector/lora-adapter.js');
+                    return nativeCheckpointsSupported()
+                      ? 'native @ruvector/ruvllm pipeline + disk checkpoints'
+                      : 'native @ruvector/ruvllm pipeline (checkpoints need >=2.5.7)';
+                  } catch {
+                    return 'native @ruvector/ruvllm pipeline';
+                  }
+                })()
               : 'JS fallback',
           },
           await (async () => {

--- a/v3/@claude-flow/cli/src/ruvector/lora-adapter.ts
+++ b/v3/@claude-flow/cli/src/ruvector/lora-adapter.ts
@@ -155,6 +155,31 @@ export function resolveTrainingBackend(): 'ruvllm' | 'js-fallback' {
   }
 }
 
+/**
+ * Whether the resolved @ruvector/ruvllm persists checkpoints to disk.
+ * saveCheckpoint(path) was a silent no-op (private, void, wrote 0 bytes)
+ * before 2.5.7 — status surfaces must not advertise checkpoints against
+ * older versions. Reads the resolved package's version; the package does
+ * not export ./package.json, so walk up from the resolved entry instead.
+ */
+export function nativeCheckpointsSupported(): boolean {
+  try {
+    const req = createRequire(import.meta.url);
+    let dir = dirname(req.resolve('@ruvector/ruvllm'));
+    for (let i = 0; i < 5; i++) {
+      const pkgPath = join(dir, 'package.json');
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        if (pkg.name !== '@ruvector/ruvllm') { dir = dirname(dir); continue; }
+        const [maj, min, pat] = String(pkg.version).split('.').map(Number);
+        return maj > 2 || (maj === 2 && (min > 5 || (min === 5 && pat >= 7)));
+      }
+      dir = dirname(dir);
+    }
+  } catch { /* unresolved — no native checkpoints */ }
+  return false;
+}
+
 async function loadTrainingPipeline(adapter: LoRAAdapter): Promise<any> {
   if (pipelineLoaded) return ruvllmPipeline;
   pipelineLoaded = true;
@@ -529,11 +554,17 @@ export class LoRAAdapter {
    * Falls back to writing our own weight JSON if ruvllm is unavailable.
    */
   async saveCheckpoint(path: string): Promise<boolean> {
+    // Parent dir must exist for BOTH paths: ruvllm <2.5.7 never wrote a
+    // file at all, and the JS fallback's writeFileSync throws ENOENT on a
+    // missing dir — which the catch silently converted to `false` (#2549).
+    try {
+      mkdirSync(dirname(path), { recursive: true });
+    } catch { /* fs errors surface on write below */ }
     const pipeline = await loadTrainingPipeline(this);
     if (pipeline) {
       try {
         pipeline.saveCheckpoint(path);
-        // Verify ruvllm actually wrote the file (some versions are no-op)
+        // Verify ruvllm actually wrote the file (<2.5.7 is a silent no-op)
         const fs = await import('fs');
         if (fs.existsSync(path)) return true;
       } catch { /* fall through to JS fallback */ }

--- a/v3/package.json
+++ b/v3/package.json
@@ -68,7 +68,8 @@
       "vitest": ">=4.1.0",
       "@vitest/coverage-v8": ">=4.1.0",
       "handlebars": ">=4.7.9",
-      "protobufjs": ">=8.6.0"
+      "protobufjs": ">=8.6.0",
+      "@ruvector/ruvllm": ">=2.5.7"
     }
   }
 }

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   '@vitest/coverage-v8': '>=4.1.0'
   handlebars: '>=4.7.9'
   protobufjs: '>=8.6.0'
+  '@ruvector/ruvllm': '>=2.5.7'
 
 importers:
 
@@ -524,8 +525,8 @@ importers:
   '@claude-flow/providers':
     dependencies:
       '@ruvector/ruvllm':
-        specifier: ^0.2.3
-        version: 0.2.4
+        specifier: '>=2.5.7'
+        version: 2.5.7
       events:
         specifier: ^3.3.0
         version: 3.3.0
@@ -5584,26 +5585,10 @@ packages:
       '@ruvector/router-linux-x64-gnu': 0.1.30
       '@ruvector/router-win32-x64-msvc': 0.1.30
 
-  /@ruvector/ruvllm-darwin-arm64@0.2.0:
-    resolution: {integrity: sha512-3oEMNEoGJqfTJXf1Th49HPTlETMxLzlBc1yBY1RqCMoqSrNKsM66+3Npx0O/GdYfFnKRU2wa/mlLPuBY2lUqYQ==}
-    engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@ruvector/ruvllm-darwin-arm64@2.0.1:
     resolution: {integrity: sha512-giZb+TbErKLgURLC3CSmJKJl0bnJn+jFZk488ppyzrR6YGft6kO329Twnd+TiJNDxVOMgZefwVdsbF9jrUIgAQ==}
     engines: {node: '>= 18'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@ruvector/ruvllm-darwin-x64@0.2.0:
-    resolution: {integrity: sha512-Niu9oG9hkbDJ1IpfXluRRfO4vwPwCdISW+ff1H+NjmIk8028CIg2w5iq3qbIaj6WzTQ9YqA68V5aMD9t0w8A6g==}
-    engines: {node: '>= 18'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
@@ -5616,26 +5601,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@ruvector/ruvllm-linux-arm64-gnu@0.2.0:
-    resolution: {integrity: sha512-ykOqwiqRbf29idXYMmuDdZqOsRMbYgzpWhmk/BcSRVBMUsO4W2Q0UkgLZgt6PIKxSf1k2qt8x8uSmO5tYTD8Iw==}
-    engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@ruvector/ruvllm-linux-arm64-gnu@2.0.1:
     resolution: {integrity: sha512-+u6Fe/Dsy4Y11m9IUmuoUeFtoUWc1ZVXxGB4JYomNDll63D03a0cpeKKaslgwOfFlfXlrFcs/eDrsYr07tQP5g==}
     engines: {node: '>= 18'}
     cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@ruvector/ruvllm-linux-x64-gnu@0.2.0:
-    resolution: {integrity: sha512-8JHH7ft00rqCRyiP0wuAThOVwSodj0gaTZcG1jBBqtnwApmdmTWN8EpuffrHHhhRO+Uvny6T5r7TiAh+Xu+QuQ==}
-    engines: {node: '>= 18'}
-    cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -5654,14 +5623,6 @@ packages:
     dev: false
     optional: true
 
-  /@ruvector/ruvllm-win32-x64-msvc@0.2.0:
-    resolution: {integrity: sha512-ksm+AZVqkkYLVq2Rbc7Rx+gSH7egFWlcH3E5dQpro98Oslc7jUH+uNDRjDVUS3lZXchV+Ot5WPLM4pClRxFm9w==}
-    engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@ruvector/ruvllm-win32-x64-msvc@2.0.1:
     resolution: {integrity: sha512-sRGNOMAcyC5p/nITnR0HLFUEObZ9Mh/T1erNiqhKrNUqIPZM1qAYBgN3xmZp02isdiTilRpxQihz3j4EzGPXIw==}
     engines: {node: '>= 18'}
@@ -5670,26 +5631,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@ruvector/ruvllm@0.2.4:
-    resolution: {integrity: sha512-cNAkcKZIqqy+3fxOb1z8bS1cJzJgsUpqNIdMk29RDr+a5g/fLgmHTVEzdBW6kHfDTc5tFUr10Juh9K6w0cKufg==}
+  /@ruvector/ruvllm@2.5.7:
+    resolution: {integrity: sha512-XxvUsPZaiIfK5/n1/Vgv3Gz9+cgBbvHbN/4OKHrLcpbw0eY9b9+BsQmvmYGfBwiVumQcgn8wmFiqRTqBrTa3BA==}
     engines: {node: '>= 18'}
     hasBin: true
-    dependencies:
-      chalk: 4.1.2
-      commander: 12.1.0
-      ora: 5.4.1
-    optionalDependencies:
-      '@ruvector/ruvllm-darwin-arm64': 0.2.0
-      '@ruvector/ruvllm-darwin-x64': 0.2.0
-      '@ruvector/ruvllm-linux-arm64-gnu': 0.2.0
-      '@ruvector/ruvllm-linux-x64-gnu': 0.2.0
-      '@ruvector/ruvllm-win32-x64-msvc': 0.2.0
-
-  /@ruvector/ruvllm@2.5.6:
-    resolution: {integrity: sha512-B29ej1aJCNN7UCiIj0wtDMLCe01UWA7KMPTSAriGeey13aNYnstsTD+lz3tkglLSMSdwf9ozQ+N4lVQXvc96+A==}
-    engines: {node: '>= 18'}
-    hasBin: true
-    requiresBuild: true
     dependencies:
       chalk: 4.1.2
       commander: 12.1.0
@@ -5700,7 +5645,6 @@ packages:
       '@ruvector/ruvllm-linux-arm64-gnu': 2.0.1
       '@ruvector/ruvllm-linux-x64-gnu': 2.0.1
       '@ruvector/ruvllm-win32-x64-msvc': 2.0.1
-    optional: true
 
   /@ruvector/rvagent-wasm@0.1.0:
     resolution: {integrity: sha512-zhcnU7XfBEfDwkDFscehq6qGU/TW4LNr287xHHXCuNsaTBPlb8YSnkuMNWg6BBIK/X+UdWAsyYESN5jbNQEaBQ==}
@@ -6927,7 +6871,7 @@ packages:
       '@ruvector/gnn': 0.1.25
       '@ruvector/graph-node': 0.1.26
       '@ruvector/router': 0.1.26
-      '@ruvector/ruvllm': 0.2.4
+      '@ruvector/ruvllm': 2.5.7
       '@ruvector/sona': 0.1.5
       ajv: 8.17.1
       chalk: 5.6.2
@@ -6988,7 +6932,7 @@ packages:
       '@ruvector/gnn': 0.1.25
       '@ruvector/graph-node': 0.1.26
       '@ruvector/router': 0.1.30
-      '@ruvector/ruvllm': 0.2.4
+      '@ruvector/ruvllm': 2.5.7
       '@ruvector/sona': 0.1.7
       ajv: 8.18.0
       chalk: 5.6.2
@@ -7053,7 +6997,7 @@ packages:
       '@ruvector/gnn': 0.1.25
       '@ruvector/graph-node': 2.0.3
       '@ruvector/router': 0.1.30
-      '@ruvector/ruvllm': 2.5.6
+      '@ruvector/ruvllm': 2.5.7
       '@ruvector/rvf': 0.1.9
       '@ruvector/rvf-node': 0.1.8
       '@ruvector/rvf-solver': 0.1.8
@@ -7209,7 +7153,7 @@ packages:
       '@ruvector/core': 0.1.30
       '@ruvector/edge-full': 0.1.0
       '@ruvector/router': 0.1.30
-      '@ruvector/ruvllm': 0.2.4
+      '@ruvector/ruvllm': 2.5.7
       '@ruvector/tiny-dancer': 0.1.22
       '@supabase/supabase-js': 2.89.0
       '@xenova/transformers': 2.17.2
@@ -7265,7 +7209,7 @@ packages:
       '@ruvector/core': 0.1.30
       '@ruvector/edge-full': 0.1.0
       '@ruvector/router': 0.1.30
-      '@ruvector/ruvllm': 0.2.4
+      '@ruvector/ruvllm': 2.5.7
       '@ruvector/tiny-dancer': 0.1.18
       '@supabase/supabase-js': 2.89.0
       axios: 1.13.2
@@ -7322,7 +7266,7 @@ packages:
       '@ruvector/core': 0.1.30
       '@ruvector/edge-full': 0.1.0
       '@ruvector/router': 0.1.26
-      '@ruvector/ruvllm': 0.2.4
+      '@ruvector/ruvllm': 2.5.7
       '@ruvector/tiny-dancer': 0.1.22
       '@supabase/supabase-js': 2.89.0
       '@xenova/transformers': 2.17.2
@@ -10470,7 +10414,7 @@ packages:
       kolorist: 1.8.0
       prompts: 2.4.2
     optionalDependencies:
-      '@ruvector/ruvllm': 2.5.6
+      '@ruvector/ruvllm': 2.5.7
     dev: false
     optional: true
 
@@ -12000,7 +11944,7 @@ packages:
       '@ruvector/diskann': '>=0.1.0'
       '@ruvector/pi-brain': '>=0.1.0'
       '@ruvector/router': '>=0.1.0'
-      '@ruvector/ruvllm': '>=2.0.0'
+      '@ruvector/ruvllm': '>=2.5.7'
     peerDependenciesMeta:
       '@ruvector/diskann':
         optional: true


### PR DESCRIPTION
Closes the last #2549 follow-up: ruflo now actively uses the checkpoint persistence shipped upstream in @ruvector/ruvllm@2.5.7 (RuVector#637).

## Changes
- **Version floors**: `@ruvector/ruvllm >=2.5.7` in ruflo wrapper overrides (what users install), root npm overrides, and v3 pnpm overrides (dev tree) — lock regenerated per the #2540→#2552 lesson
- **mkdir before checkpoint write** in `LoRAAdapter.saveCheckpoint`: the JS fallback threw ENOENT on missing parent dirs and silently returned false — `neural train`'s checkpoint never landed even post-2.5.7
- **Version-gated capability reporting**: `nativeCheckpointsSupported()` — `neural status` shows 'disk checkpoints' only when the resolved ruvllm is >=2.5.7
- Removed a stale npm-installed `@ruvector/ruvllm@0.2.4` real-directory that had been shadowing pnpm resolution in the dev tree since April

## Proof
```
neural train -p coordination -e 2
→ .claude-flow/neural/lora-checkpoint-1783118502552.json
  format: ruvllm-checkpoint | version: 1 | bytes: 48226
```
Regression suite (2549 tests): 4/4. tsc clean.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01S7GYqnVUVxBfZ5W8znqry3