### PR TITLE
ci: fast lockfile-drift guard (catch pnpm-lock mismatch early, #2562)

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -263,7 +263,7 @@ jobs:
   # #2267 + #2257 regression guards — fast, no install, run first so any
   # YAML or router regression is caught at PR-time, not at scheduled cron.
   static-regression-guards:
-    name: Static regression guards (#2267 YAML + #2257 router)
+    name: Static regression guards (#2267 YAML + #2257 router + #2562 lockfile)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -276,6 +276,28 @@ jobs:
         run: node scripts/smoke-workflows-yaml.mjs
       - name: "#2257 — router patterns must be word-boundary-anchored"
         run: node --import tsx scripts/smoke-router-regex.mjs
+      # #2562 — FAST lockfile-drift guard. Editing any v3 workspace manifest
+      # (esp. v3/@claude-flow/cli deps) without regenerating v3/pnpm-lock.yaml
+      # makes --frozen-lockfile fail in EVERY downstream install job (~34 red
+      # jobs, cascading — the #2540→#2552→#2562 recurrence). `--lockfile-only`
+      # verifies lock↔manifest consistency in seconds WITHOUT downloading
+      # anything, failing once here with a clear fix instead of 34× later.
+      - name: Setup pnpm (lockfile guard)
+        uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: "#2562 — v3/pnpm-lock.yaml must match workspace package.json (frozen-lockfile drift)"
+        working-directory: v3
+        run: |
+          if pnpm install --frozen-lockfile --lockfile-only 2>lock-err.log; then
+            echo "✓ v3/pnpm-lock.yaml is consistent with all workspace manifests"
+          else
+            echo "::error title=Lockfile drift::v3/pnpm-lock.yaml is OUT OF SYNC with a package.json. Editing v3 workspace deps requires regenerating the lock in the SAME commit."
+            echo "::error title=How to fix::Run  cd v3 && pnpm install --lockfile-only && git add pnpm-lock.yaml  then commit."
+            echo "--- pnpm reported ---"
+            grep -A25 "OUTDATED_LOCKFILE\|not up to date\|don't match" lock-err.log | head -40 || cat lock-err.log | head -40
+            exit 1
+          fi
 
   test:
     name: Test V3 Packages


### PR DESCRIPTION
Adds a fast early CI guard for the recurring pnpm-lock drift that has now bitten three times (#2540→#2552→#2562).

## Problem
Editing any v3 workspace `package.json` (esp. `@claude-flow/cli` deps) without regenerating `v3/pnpm-lock.yaml` makes `pnpm install --frozen-lockfile` fail in **every** downstream job — ~34 red jobs, all with the same opaque `ERR_PNPM_OUTDATED_LOCKFILE` buried in each install step.

## Fix
A `--lockfile-only --frozen-lockfile` step in the existing fast `static-regression-guards` job: verifies lock↔manifest consistency in ~0.2s (no package downloads), failing **once, early, with a clear remediation** instead of 34× late:
```
::error::v3/pnpm-lock.yaml is OUT OF SYNC with a package.json...
::error::Fix: cd v3 && pnpm install --lockfile-only && git add pnpm-lock.yaml
```

Validated: YAML parses (53 jobs), guard passes on main's clean lock in 238ms, and reproduces the exact drift error that caused #2562's 34 failures.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01S7GYqnVUVxBfZ5W8znqry3