### PR TITLE
perf: memory-search hot loop, agenticow label lookup, npm packaging (opt sweep)

### DIFF
--- a/v3/@claude-flow/cli/package-lock.json
+++ b/v3/@claude-flow/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.20.0",
+  "version": "3.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@claude-flow/cli",
-      "version": "3.20.0",
+      "version": "3.21.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -75,8 +75,10 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
+    "!dist/**/*.tsbuildinfo",
     "bin",
-    "scripts",
+    "scripts/postinstall.cjs",
     ".claude",
     "plugins",
     "README.md"

--- a/v3/@claude-flow/cli/src/mcp-tools/agenticow-speculate-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agenticow-speculate-tools.ts
@@ -151,10 +151,17 @@ export const agenticowSpeculateTools: MCPTool[] = [
 
       // Build the generic {label, fn} candidates. Each fn ingests into its own
       // branch handle, then (for 'nearest') probes it so we can score.
+      // Map validated label → explicit branchPath so the branchPath() resolver
+      // below is O(1) instead of re-scanning + re-validating rawCandidates per
+      // candidate (explore() calls branchPath once per candidate → was O(n²)).
+      const explicitBranchPaths = new Map<string, string>();
       const candidates: SpeculativeCandidate<CandidateOutcome>[] = rawCandidates.map((c) => {
         const label = validateLabel(String(c.label));
         if (!Array.isArray(c.ingest) || c.ingest.length === 0) {
           throw new Error(`candidate ${label} must ingest at least one vector`);
+        }
+        if (typeof c.branchPath === 'string' && c.branchPath) {
+          explicitBranchPaths.set(label, c.branchPath);
         }
         const records = c.ingest.map((r) => ({
           ...(Number.isInteger(r.id) ? { id: r.id as number } : {}),
@@ -187,8 +194,8 @@ export const agenticowSpeculateTools: MCPTool[] = [
       };
 
       const branchPath = (label: string): string => {
-        const explicit = rawCandidates.find((c) => validateLabel(String(c.label)) === label)?.branchPath;
-        if (explicit) return resolveMemoryPath(String(explicit));
+        const explicit = explicitBranchPaths.get(label);
+        if (explicit) return resolveMemoryPath(explicit);
         return `${basePath}.spec-${safeSegment(label)}.rvf`;
       };
 

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -345,15 +345,14 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
  */
 function bm25Score(
   queryTerms: string[],
-  docContent: string,
+  docWords: string[],
+  docLength: number,
   avgDocLength: number,
   docCount: number,
   termDocFreqs: Map<string, number>,
 ): number {
   const k1 = 1.2;
   const b = 0.75;
-  const docWords = docContent.toLowerCase().split(/\s+/);
-  const docLength = docWords.length;
 
   let score = 0;
   for (const term of queryTerms) {
@@ -370,28 +369,40 @@ function bm25Score(
 }
 
 /**
- * Compute BM25 term document frequencies for a set of rows.
+ * Tokenize a corpus once per query. Each row is lowercased + split a single
+ * time; the resulting `{ contentLower, words }` feed BM25 term-frequency,
+ * per-doc BM25 scoring, and the #2558 coverage floor — which previously each
+ * re-lowercased+re-split the same content (3× string scans per row).
+ * Bit-identical to the prior split-per-consumer path.
+ */
+interface TokenizedDoc { contentLower: string; words: string[] }
+function tokenizeCorpus(rows: Array<{ content: string }>): TokenizedDoc[] {
+  return rows.map(row => {
+    const contentLower = (row.content || '').toLowerCase();
+    return { contentLower, words: contentLower.split(/\s+/) };
+  });
+}
+
+/**
+ * Compute BM25 term document frequencies over an already-tokenized corpus.
  */
 function computeTermDocFreqs(
   queryTerms: string[],
-  rows: Array<{ content: string }>,
+  docs: TokenizedDoc[],
 ): { termDocFreqs: Map<string, number>; avgDocLength: number } {
   const termDocFreqs = new Map<string, number>();
   let totalLength = 0;
 
-  for (const row of rows) {
-    const content = (row.content || '').toLowerCase();
-    const words = content.split(/\s+/);
-    totalLength += words.length;
-
+  for (const doc of docs) {
+    totalLength += doc.words.length;
     for (const term of queryTerms) {
-      if (content.includes(term)) {
+      if (doc.contentLower.includes(term)) {
         termDocFreqs.set(term, (termDocFreqs.get(term) || 0) + 1);
       }
     }
   }
 
-  return { termDocFreqs, avgDocLength: rows.length > 0 ? totalLength / rows.length : 1 };
+  return { termDocFreqs, avgDocLength: docs.length > 0 ? totalLength / docs.length : 1 };
 }
 
 // ===== Phase 2: TieredCache helpers =====
@@ -488,6 +499,11 @@ async function logAttestation(
   }
 }
 
+// Tracks db handles whose schema DDL has already been ensured, so getDb()
+// runs the CREATE…IF NOT EXISTS block at most once per handle instead of on
+// every bridge call. WeakSet so handles GC without leaking.
+const _schemaEnsuredDbs = new WeakSet<object>();
+
 /**
  * Get the AgentDB database handle and ensure memory_entries table exists.
  * Returns null if not available.
@@ -498,34 +514,41 @@ function getDb(registry: any): any | null {
 
   const db = agentdb.database;
 
-  // Ensure memory_entries table exists (idempotent)
-  try {
-    db.exec(`CREATE TABLE IF NOT EXISTS memory_entries (
-      id TEXT PRIMARY KEY,
-      key TEXT NOT NULL,
-      namespace TEXT DEFAULT 'default',
-      content TEXT NOT NULL,
-      type TEXT DEFAULT 'semantic',
-      embedding TEXT,
-      embedding_model TEXT DEFAULT 'local',
-      embedding_dimensions INTEGER,
-      tags TEXT,
-      metadata TEXT,
-      owner_id TEXT,
-      created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-      updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-      expires_at INTEGER,
-      last_accessed_at INTEGER,
-      access_count INTEGER DEFAULT 0,
-      status TEXT DEFAULT 'active',
-      UNIQUE(namespace, key)
-    )`);
-    // Ensure indexes
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_ns ON memory_entries(namespace)`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_key ON memory_entries(key)`);
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_status ON memory_entries(status)`);
-  } catch {
-    // Table already exists or db is read-only — that's fine
+  // Ensure memory_entries table exists (idempotent). The DDL is run at most
+  // once per db handle — re-parsing 4× CREATE…IF NOT EXISTS on every bridge
+  // call (store/search/get) was pure per-op overhead. Keyed by handle via a
+  // WeakSet so a new db instance re-ensures without a stale global flag.
+  if (!_schemaEnsuredDbs.has(db)) {
+    try {
+      db.exec(`CREATE TABLE IF NOT EXISTS memory_entries (
+        id TEXT PRIMARY KEY,
+        key TEXT NOT NULL,
+        namespace TEXT DEFAULT 'default',
+        content TEXT NOT NULL,
+        type TEXT DEFAULT 'semantic',
+        embedding TEXT,
+        embedding_model TEXT DEFAULT 'local',
+        embedding_dimensions INTEGER,
+        tags TEXT,
+        metadata TEXT,
+        owner_id TEXT,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+        expires_at INTEGER,
+        last_accessed_at INTEGER,
+        access_count INTEGER DEFAULT 0,
+        status TEXT DEFAULT 'active',
+        UNIQUE(namespace, key)
+      )`);
+      // Ensure indexes
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_ns ON memory_entries(namespace)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_key ON memory_entries(key)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_status ON memory_entries(status)`);
+      _schemaEnsuredDbs.add(db);
+    } catch {
+      // Table already exists or db is read-only — that's fine. Don't mark
+      // ensured on failure so a later writable call can retry.
+    }
   }
 
   // ─── #2256-followup: rescue agentdb.embedder when its transformers.js
@@ -672,6 +695,7 @@ export async function bridgeStoreEntry(options: {
 
     // Generate embedding via AgentDB's embedder
     let embeddingJson: string | null = null;
+    let embeddingArr: number[] | null = null;
     let dimensions = 0;
     let model = 'local';
 
@@ -681,7 +705,8 @@ export async function bridgeStoreEntry(options: {
         if (embedder) {
           const emb = await embedder.embed(value);
           if (emb) {
-            embeddingJson = JSON.stringify(Array.from(emb));
+            embeddingArr = Array.from(emb) as number[];
+            embeddingJson = JSON.stringify(embeddingArr);
             dimensions = emb.length;
             model = 'Xenova/all-MiniLM-L6-v2';
           }
@@ -765,7 +790,7 @@ export async function bridgeStoreEntry(options: {
       success: true,
       id,
       embedding: embeddingJson ? { dimensions, model } : undefined,
-      rawEmbedding: embeddingJson ? JSON.parse(embeddingJson) as number[] : undefined,
+      rawEmbedding: embeddingArr ?? undefined,
       guarded: true,
       cached: true,
       attested: true,
@@ -841,14 +866,19 @@ export async function bridgeSearchEntries(options: {
       return null;
     }
 
-    // Phase 2: Compute BM25 term stats for the corpus
+    // Phase 2: Compute BM25 term stats for the corpus. Tokenize the corpus a
+    // single time and reuse the per-doc `{contentLower, words}` for term-freq,
+    // BM25 scoring, and the coverage floor below.
     const queryTerms = queryStr.toLowerCase().split(/\s+/).filter(t => t.length > 1);
-    const { termDocFreqs, avgDocLength } = computeTermDocFreqs(queryTerms, rows);
+    const docs = tokenizeCorpus(rows);
+    const { termDocFreqs, avgDocLength } = computeTermDocFreqs(queryTerms, docs);
     const docCount = rows.length;
 
     const results: { id: string; key: string; content: string; score: number; namespace: string; provenance?: string }[] = [];
 
-    for (const row of rows) {
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      const doc = docs[i];
       let semanticScore = 0;
       let bm25ScoreVal = 0;
 
@@ -864,7 +894,7 @@ export async function bridgeSearchEntries(options: {
 
       // Phase 2: BM25 keyword scoring (replaces String.includes fallback)
       if (queryTerms.length > 0 && row.content) {
-        bm25ScoreVal = bm25Score(queryTerms, row.content, avgDocLength, docCount, termDocFreqs);
+        bm25ScoreVal = bm25Score(queryTerms, doc.words, doc.words.length, avgDocLength, docCount, termDocFreqs);
         // Normalize BM25 to 0-1 range (cap at 10 for normalization)
         bm25ScoreVal = Math.min(bm25ScoreVal / 10, 1.0);
       }
@@ -879,7 +909,7 @@ export async function bridgeSearchEntries(options: {
       // this restores that guarantee. `coverage` is the fraction of query
       // terms present in the document — a full-coverage hit must always be
       // recallable regardless of IDF.
-      const contentLower = String(row.content || '').toLowerCase();
+      const contentLower = doc.contentLower;
       const matchedTerms = queryTerms.filter(t => contentLower.includes(t)).length;
       const coverage = queryTerms.length > 0 ? matchedTerms / queryTerms.length : 0;
       const lexicalScore = Math.max(bm25ScoreVal, coverage);


### PR DESCRIPTION
## Optimization sweep

Behavior-preserving optimizations across surfaces shipped in 3.20–3.21, found by a 3-analyzer parallel sweep. Every guarded contract is untouched: #2558 recall fusion + coverage floor, ADR-171 promote-gate provenance (`oracle:test-exec`/`judge:fable` clear, `proxy:structural` never), and the `{degraded:true}` optional-dep path.

### memory-bridge.ts
| Change | Win | Risk |
|---|---|---|
| Schema DDL runs **once per db handle** (WeakSet) vs every bridge call | removes 4× `CREATE IF NOT EXISTS` parse per store/search/get | none (pure caching) |
| Search **tokenizes each row once/query** vs 3× lowercase+split (term-freq, BM25, coverage floor) | ~3× fewer string scans over ≤1000 rows/query | none — bit-identical semantics |
| Store drops redundant `stringify→parse` of the 384-float embedding | one parse/store | none — identical output |

### agenticow-speculate-tools.ts
`branchPath()` was an O(n) scan **re-running the `validateLabel` regex** per candidate; `explore()` calls it once per candidate → **O(n²)**. Now an O(1) `Map<label, branchPath>` built once during validation.

### packaging (`files`)
Stop publishing source maps (516 files, ~4.3 MB), `dist/tsbuildinfo` (192 KB), and dev-only scripts (benchmarks/beir/publish). Narrow `scripts` → just `postinstall.cjs`.

**Tarball 3.0 MB → 2.2 MB · unpacked 13.8 → 9.0 MB · 1446 → 911 files.** No runtime code loads any excluded artifact — the metaharness `doctor` checks resolve against `plugins/` (still published), verified.

### Verification
- Build clean
- **166 memory** tests + **23 agenticow/speculate** tests green
- `npm pack --dry-run`: 0 maps / tsbuildinfo / dev-scripts in tarball

### Skipped (deliberately)
- BLOB vector storage (needs schema migration + dual-read of legacy JSON rows)
- Removing per-write `wal_checkpoint` (load-bearing for #2558 WAL-blind readers)
- vitest `threads` pool (needs full-run cross-thread leak proof)
- agenticow read-handle cache / parallel forks (correctness risk near the promote-gate)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)