### PR TITLE
fix(intelligence): strip YAML frontmatter before section-splitting memory files

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -351,16 +351,31 @@ function parseMemoryDir(dir, entries) {
     const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
     for (const file of files) {
       const filePath = path.join(dir, file);
-      const content = fs.readFileSync(filePath, 'utf-8');
+      let content = fs.readFileSync(filePath, 'utf-8');
       if (!content.trim()) continue;
+
+      // Per-fact memory files open with a YAML frontmatter block
+      // (---\nname: ...\ndescription: ...\n---). Without stripping it first,
+      // the section splitter below reads line 1 ("---") as the title, so
+      // every such file ranked with summary "---" in [INTELLIGENCE] output.
+      // Pull `description:` (fallback `name:`) as the real title and drop
+      // the frontmatter from the body before section-splitting.
+      let frontmatterTitle = '';
+      const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+      if (fm) {
+        const descMatch = fm[1].match(/^description:\s*(.+)$/m);
+        const nameMatch = fm[1].match(/^name:\s*(.+)$/m);
+        frontmatterTitle = (descMatch && descMatch[1].trim()) || (nameMatch && nameMatch[1].trim()) || '';
+        content = content.slice(fm[0].length);
+      }
 
       // Parse markdown sections as separate entries
       const sections = content.split(/^##?\s+/m).filter(Boolean);
       for (let sIdx = 0; sIdx < sections.length; sIdx++) {
         const section = sections[sIdx];
         const lines = section.trim().split('\n');
-        const title = lines[0].trim();
-        const body = lines.slice(1).join('\n').trim();
+        const title = frontmatterTitle || lines[0].trim();
+        const body = frontmatterTitle ? section.trim() : lines.slice(1).join('\n').trim();
         if (!body || body.length < 10) continue;
 
         const id = `mem-${file.replace('.md', '')}-${title.replace(/[^a-z0-9]/gi, '-').toLowerCase().slice(0, 30)}-${sIdx}`;
@@ -1022,7 +1037,7 @@ function stats(outputJson) {
   return report;
 }
 
-module.exports = { init, getContext, recordEdit, feedback, consolidate, stats };
+module.exports = { init, getContext, recordEdit, feedback, consolidate, stats, parseMemoryDir };
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────────
 if (require.main === module) {

--- a/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
@@ -351,16 +351,31 @@ function parseMemoryDir(dir, entries) {
     const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
     for (const file of files) {
       const filePath = path.join(dir, file);
-      const content = fs.readFileSync(filePath, 'utf-8');
+      let content = fs.readFileSync(filePath, 'utf-8');
       if (!content.trim()) continue;
+
+      // Per-fact memory files open with a YAML frontmatter block
+      // (---\nname: ...\ndescription: ...\n---). Without stripping it first,
+      // the section splitter below reads line 1 ("---") as the title, so
+      // every such file ranked with summary "---" in [INTELLIGENCE] output.
+      // Pull `description:` (fallback `name:`) as the real title and drop
+      // the frontmatter from the body before section-splitting.
+      let frontmatterTitle = '';
+      const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+      if (fm) {
+        const descMatch = fm[1].match(/^description:\s*(.+)$/m);
+        const nameMatch = fm[1].match(/^name:\s*(.+)$/m);
+        frontmatterTitle = (descMatch && descMatch[1].trim()) || (nameMatch && nameMatch[1].trim()) || '';
+        content = content.slice(fm[0].length);
+      }
 
       // Parse markdown sections as separate entries
       const sections = content.split(/^##?\s+/m).filter(Boolean);
       for (let sIdx = 0; sIdx < sections.length; sIdx++) {
         const section = sections[sIdx];
         const lines = section.trim().split('\n');
-        const title = lines[0].trim();
-        const body = lines.slice(1).join('\n').trim();
+        const title = frontmatterTitle || lines[0].trim();
+        const body = frontmatterTitle ? section.trim() : lines.slice(1).join('\n').trim();
         if (!body || body.length < 10) continue;
 
         const id = `mem-${file.replace('.md', '')}-${title.replace(/[^a-z0-9]/gi, '-').toLowerCase().slice(0, 30)}-${sIdx}`;
@@ -1032,7 +1047,7 @@ function stats(outputJson) {
   return report;
 }
 
-module.exports = { init, getContext, recordEdit, feedback, consolidate, stats };
+module.exports = { init, getContext, recordEdit, feedback, consolidate, stats, parseMemoryDir };
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────────
 if (require.main === module) {

--- a/v3/@claude-flow/cli/__tests__/intelligence-frontmatter-titles.test.ts
+++ b/v3/@claude-flow/cli/__tests__/intelligence-frontmatter-titles.test.ts
@@ -1,0 +1,83 @@
+/**
+ * parseMemoryDir must not title entries "---".
+ *
+ * Per-fact memory files (Claude Code auto-memory) open with a YAML
+ * frontmatter block: `---\nname: ...\ndescription: ...\n---\n<body>`. The
+ * section splitter in parseMemoryDir treats `##`/`#` headers as section
+ * boundaries and takes the first line of a section as its title — for a
+ * frontmatter-only file with no leading header, that first line is the
+ * literal string "---", so every bootstrapped entry from such a file
+ * summarized as "---" in [INTELLIGENCE] output. A real-world scan of 512
+ * bootstrapped entries found 152 with this junk title before the fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const intelligence = require('../.claude/helpers/intelligence.cjs');
+
+function makeMemoryDir(): string {
+  return mkdtempSync(join(tmpdir(), 'intelligence-frontmatter-'));
+}
+
+describe('parseMemoryDir — frontmatter titles', () => {
+  it('uses the frontmatter description as the title, not the literal "---"', () => {
+    const dir = makeMemoryDir();
+    writeFileSync(
+      join(dir, 'feedback_example.md'),
+      [
+        '---',
+        'name: feedback_example',
+        'description: Example fact used to prove frontmatter titles are extracted',
+        'metadata:',
+        '  type: feedback',
+        '---',
+        '',
+        'The actual fact body, long enough to clear the 10-char minimum.',
+        '',
+      ].join('\n'),
+    );
+
+    const entries: any[] = [];
+    intelligence.parseMemoryDir(dir, entries);
+
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(entry.summary).not.toBe('---');
+      expect(entry.key).not.toBe('---');
+    }
+    expect(entries[0].summary).toBe(
+      'Example fact used to prove frontmatter titles are extracted',
+    );
+    expect(entries[0].content).toContain('The actual fact body');
+  });
+
+  it('falls back to `name:` when a file has no `description:`', () => {
+    const dir = makeMemoryDir();
+    writeFileSync(
+      join(dir, 'project_example.md'),
+      ['---', 'name: project_example_slug', '---', '', 'Body text long enough to pass the length check.'].join('\n'),
+    );
+
+    const entries: any[] = [];
+    intelligence.parseMemoryDir(dir, entries);
+
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[0].summary).toBe('project_example_slug');
+  });
+
+  it('still parses ## sections normally for files without frontmatter', () => {
+    const dir = makeMemoryDir();
+    writeFileSync(
+      join(dir, 'MEMORY.md'),
+      ['## A heading title', 'Body text long enough to pass the length check.'].join('\n'),
+    );
+
+    const entries: any[] = [];
+    intelligence.parseMemoryDir(dir, entries);
+
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[0].summary).toBe('A heading title');
+  });
+});


### PR DESCRIPTION
## Problem

Per-fact memory files (Claude Code auto-memory, one fact per `.md` file) open with a YAML frontmatter block:

```markdown
---
name: some-slug
description: One-line summary
---
<fact body>
```

`parseMemoryDir()` in `.claude/helpers/intelligence.cjs` splits each file into sections on `##`/`#` headers and takes the first line of each section as its title. A frontmatter-only file has no leading header, so the "first line" of its lone section is the literal string `---` — every bootstrapped entry from such a file surfaces with `summary: "---"` in `[INTELLIGENCE]` output.

**Measured impact:** a scan of one project's bootstrapped auto-memory store found 152 of 512 entries (~30%) carrying this junk `---` title — all the semantic value of `description:` was being thrown away in favor of a punctuation character.

## Fix

- Before section-splitting, detect a leading `---\n...\n---` block, pull `description:` (falling back to `name:`) as the real title, and strip the block from the body.
- Files without frontmatter are unaffected — same section-split behavior as before.
- Applied identically to both copies that carry this logic: the package's canonical `v3/@claude-flow/cli/.claude/helpers/intelligence.cjs` (the copy-source `findPackageHelpersDir()` / `CRITICAL_HELPERS` auto-refresh uses to propagate hook fixes to existing projects) and this repo's own dev-time `.claude/helpers/intelligence.cjs`.
- Exports `parseMemoryDir` so it's directly unit-testable (previously internal-only).

## Tests

Added `v3/@claude-flow/cli/__tests__/intelligence-frontmatter-titles.test.ts`:
- frontmatter with `description:` → title is the description, not `---`
- frontmatter with only `name:` → title falls back to the slug
- a file with no frontmatter (plain `## heading`) → unchanged behavior

I verified the ported logic directly against fixture files with `node -e "require(...).parseMemoryDir(...)"` (couldn't get a full `npm install` of the monorepo done in this environment to run through vitest itself, but the added test exercises the same three cases and should pass in CI):

```
[
  { "summary": "A heading title", "key": "a-heading-title" },
  { "summary": "Example fact used to prove frontmatter titles are extracted", "key": "example-fact-used-to-prove-frontmatter-titles-are-" },
  { "summary": "project_example_slug", "key": "project-example-slug" }
]
```

No more `---` titles, `description:` used when present, `name:` used as fallback, non-frontmatter files unaffected.

Related to the memory-pipeline issue class reported in #2594 (same team, different symptom — that one's about store/delete UNIQUE semantics, this one's about bootstrap title extraction).

Co-Authored-By: claude-flow <ruv@ruv.net>