### PR TITLE
chore(release): 3.25.4 — re-sign helpers manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.25.3",
+  "version": "3.25.4",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.25.3",
+  "version": "3.25.4",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,12 +1,12 @@
 {
   "manifest": {
-    "version": "3.23.0",
+    "version": "3.25.4",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "bc4d2d26823d49b3ab1dded2946b66369f1f67bd76b4c30dca9f3b6df3cca8f0",
-      "intelligence.cjs": "760cb82ed2000031abc1ac1fa90a014e7d91d93966e3aa4741b07ab7aff8d066"
+      "intelligence.cjs": "bd1f8e4b034944aee1df0391dc47ac2e8cc4b3aa542c65407a59d49620bbf76b"
     }
   },
-  "signature": "of5l9RP68iPcmcC5dckDv+KIOiENJKifWxYKwQTwAiXiyRNNZuMwQ8y8Bd8+wGviTRxIzBfSuxL1nuJ/rX3xDQ==",
+  "signature": "F3TIRoNcQTCkNeMEk5Isah5CWkV/zddUKR/6pieOlAWoYgI2BEUO7avQj8B8UP4vhvgT9TSgbYsis2UnnnQyBg==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/package-lock.json
+++ b/v3/@claude-flow/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.25.3",
+  "version": "3.25.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@claude-flow/cli",
-      "version": "3.25.3",
+      "version": "3.25.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.25.3",
+  "version": "3.25.4",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Metadata-only patch: re-signs \`.claude/helpers/helpers.manifest.json\` to close the loop from 3.25.3.

3.25.3 [#2593](https://github.com/ruvnet/ruflo/pull/2602) shipped the CI guard for stale manifests but couldn't self-repair its own release because the GCP signing secret wasn't accessible from the publish env. 3.25.4 re-signs the manifest properly.

No source or dependency changes.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)