### PR TITLE
fix(intelligence): add runaway-storage guard to pending-insights file

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -587,6 +587,16 @@ function recordEdit(file, success) {
     sessionId: sessionGet('sessionId') || null,
   });
   fs.appendFileSync(PENDING_PATH, entry + '\n', 'utf-8');
+  // Runaway-storage guard: pending-insights is append-only and only drained by
+  // consolidation. If it grows past ~512KB (thousands of un-consolidated edits
+  // — e.g. the daemon never ran), keep only the most recent 2000 lines so it
+  // can never grow unbounded. Cheap (a statSync per edit; rewrite only when over).
+  try {
+    if (fs.statSync(PENDING_PATH).size > 512 * 1024) {
+      const lines = fs.readFileSync(PENDING_PATH, 'utf-8').split('\n').filter(Boolean);
+      if (lines.length > 2000) fs.writeFileSync(PENDING_PATH, lines.slice(-2000).join('\n') + '\n', 'utf-8');
+    }
+  } catch (e) { /* non-fatal */ }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Auto-patched by `@claude-flow/cli doctor` (v3.25.4) during a scheduled verification run
- Adds a size guard to `.claude/helpers/intelligence.cjs` `recordEdit()`: if `pending-insights` exceeds 512 KB, trims to the most recent 2000 lines
- Prevents unbounded file growth when the consolidation daemon is not running (one `statSync` per edit; rewrite only when the threshold is crossed)

## Test plan

- [ ] Run `npx @claude-flow/cli@alpha doctor` — no regression in doctor output
- [ ] Confirm `recordEdit()` calls still function normally below the 512 KB threshold
- [ ] Verify trimming is non-fatal when `statSync` throws (e.g. file does not exist yet)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_011FKphpJJRQvftUTDgVJ5cy

---
_Generated by [Claude Code](https://claude.ai/code/session_011FKphpJJRQvftUTDgVJ5cy)_