### PR TITLE
fix(intelligence): add runaway-storage guard to pending-insights log

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -587,6 +587,16 @@ function recordEdit(file, success) {
     sessionId: sessionGet('sessionId') || null,
   });
   fs.appendFileSync(PENDING_PATH, entry + '\n', 'utf-8');
+  // Runaway-storage guard: pending-insights is append-only and only drained by
+  // consolidation. If it grows past ~512KB (thousands of un-consolidated edits
+  // — e.g. the daemon never ran), keep only the most recent 2000 lines so it
+  // can never grow unbounded. Cheap (a statSync per edit; rewrite only when over).
+  try {
+    if (fs.statSync(PENDING_PATH).size > 512 * 1024) {
+      const lines = fs.readFileSync(PENDING_PATH, 'utf-8').split('\n').filter(Boolean);
+      if (lines.length > 2000) fs.writeFileSync(PENDING_PATH, lines.slice(-2000).join('\n') + '\n', 'utf-8');
+    }
+  } catch (e) { /* non-fatal */ }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a runaway-storage guard in `.claude/helpers/intelligence.cjs` to prevent the append-only `pending-insights` file from growing unbounded when the consolidation daemon never runs.
- When the file exceeds 512 KB, only the most recent 2000 lines are kept. The `statSync` cost is negligible per edit; the rewrite fires only when the guard triggers.
- The guard is wrapped in a `try/catch` so any filesystem error is non-fatal.

## Details

`pending-insights` is append-only and is only drained by the background consolidation worker. In environments where the daemon never starts (CI, ephemeral containers, source-only checkouts), thousands of un-consolidated edits can accumulate indefinitely. This fix caps growth at a safe ceiling without changing normal-operation behaviour.

## Test plan

- [ ] Verify `intelligence.cjs` loads without errors: `node -e "require('./.claude/helpers/intelligence.cjs')"`
- [ ] Confirm guard does not fire under normal usage (file stays under 512 KB)
- [ ] Simulate oversized file: write >512 KB to `pending-insights`, call `recordEdit`, confirm file is trimmed to ≤2000 lines

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8Lzt9guWmHtN8NzcuovaG)_