### PR TITLE
fix: unblock high verification issues

### DIFF
--- a/.github/workflows/no-phantom-agentic-flow-subpath.yml
+++ b/.github/workflows/no-phantom-agentic-flow-subpath.yml
@@ -16,6 +16,9 @@
 #      remains allowed (that is the intentional optional-path).
 #   2. verification/witness-fixes.json's `ADR-104-transport` entry must
 #      NOT declare `agentic-flow/transport/loader` as its `marker`.
+#   3. ADR-104's supported smoke import target is the federation plugin
+#      loader, and that loader owns a WebSocket fallback for current
+#      agentic-flow releases that do not export `./transport/loader`.
 name: no-phantom-agentic-flow-subpath
 
 on:
@@ -23,11 +26,17 @@ on:
     branches: [main]
     paths:
       - 'v3/@claude-flow/plugin-agent-federation/src/**'
+      - 'v3/@claude-flow/plugin-agent-federation/dist/**'
+      - 'v3/docs/adr/ADR-104-federation-wire-transport.md'
+      - 'scripts/smoke-adr104-transport.mjs'
       - 'verification/witness-fixes.json'
       - '.github/workflows/no-phantom-agentic-flow-subpath.yml'
   pull_request:
     paths:
       - 'v3/@claude-flow/plugin-agent-federation/src/**'
+      - 'v3/@claude-flow/plugin-agent-federation/dist/**'
+      - 'v3/docs/adr/ADR-104-federation-wire-transport.md'
+      - 'scripts/smoke-adr104-transport.mjs'
       - 'verification/witness-fixes.json'
       - '.github/workflows/no-phantom-agentic-flow-subpath.yml'
   workflow_dispatch:
@@ -80,3 +89,6 @@ jobs:
             }
             console.log('OK — ADR-104-transport marker is \"' + adr104.marker + '\" (not the phantom subpath).');
           "
+
+      - name: Rule 3 — ADR-104 smoke import target must be plugin loader
+        run: node scripts/smoke-adr104-transport.mjs

--- a/plugins/ruflo-core/scripts/witness/verify.mjs
+++ b/plugins/ruflo-core/scripts/witness/verify.mjs
@@ -73,16 +73,23 @@ const summary = {
   missing: fileResults.filter(r => r.status === 'missing').length,
 };
 
-// Issue #1880 — heuristic: if *every* manifest entry is missing AND at
-// least one references a `/dist/` path, the checkout was source-only
-// (no `npm run build`). That's a precondition failure, not a regression.
-// Anything more nuanced (partial dist build, real regressions, etc.)
-// still lands in the normal exit-1 path.
+// Issue #1880 / #2528 — heuristic: if the only missing entries are
+// generated `/dist/` artifacts and no marker regressed, the checkout was
+// source-only (dependencies may be installed, but no build ran). That's a
+// precondition failure, not a regression. Source-file drift is still
+// reported in the JSON summary, but the operator action is the same:
+// install + build before verifying the dist-layer witness entries.
 const allMissing = fileResults.length > 0
                 && summary.missing === fileResults.length;
-const referencesDist = fileResults.some(r => r.file && r.file.includes(`${sep}dist${sep}`)
-                                          || (r.file && r.file.includes('/dist/')));
-if (allMissing && referencesDist) {
+const missingResults = fileResults.filter(r => r.status === 'missing');
+const missingOnlyDist = missingResults.length > 0
+  && missingResults.every(r => r.file && (
+    r.file.includes(`${sep}dist${sep}`) || r.file.includes('/dist/')
+  ));
+const referencesDist = fileResults.some(r => r.file && (
+  r.file.includes(`${sep}dist${sep}`) || r.file.includes('/dist/')
+));
+if ((allMissing && referencesDist) || (missingOnlyDist && summary.regressed === 0)) {
   if (asJson) {
     console.log(JSON.stringify(
       { ok: false, precondition: 'dist-not-built', signature: sig, summary },

--- a/scripts/smoke-adr104-transport.mjs
+++ b/scripts/smoke-adr104-transport.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Regression guard for #2618.
+ *
+ * ADR-104 external verification must import the federation plugin's loader,
+ * not the unexported `agentic-flow/transport/loader` subpath.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+const sourcePath = resolve(root, 'v3/@claude-flow/plugin-agent-federation/src/transport/midstream-aware-loader.ts');
+const distPath = resolve(root, 'v3/@claude-flow/plugin-agent-federation/dist/transport/midstream-aware-loader.js');
+
+if (!existsSync(sourcePath)) {
+  console.error(`smoke-adr104-transport: missing source loader: ${sourcePath}`);
+  process.exit(1);
+}
+
+const source = readFileSync(sourcePath, 'utf8');
+if (!source.includes('class WebSocketFallbackTransport')) {
+  console.error('smoke-adr104-transport: plugin-owned WebSocket fallback is missing');
+  process.exit(1);
+}
+if (!source.includes("source: 'websocket-fallback'")) {
+  console.error('smoke-adr104-transport: loader does not expose websocket-fallback source');
+  process.exit(1);
+}
+
+if (!existsSync(distPath)) {
+  console.log('smoke-adr104-transport: source fallback OK; dist loader not present in this source checkout');
+  console.log('Build before external ADR-104 transport verification to test the published import path.');
+  process.exit(0);
+}
+
+const mod = await import(distPath);
+if (typeof mod.loadFederationTransport !== 'function') {
+  console.error('smoke-adr104-transport: dist loader does not export loadFederationTransport()');
+  process.exit(1);
+}
+
+console.log('smoke-adr104-transport: plugin loader import path OK');

--- a/scripts/smoke-witness-verify-precondition.mjs
+++ b/scripts/smoke-witness-verify-precondition.mjs
@@ -28,9 +28,9 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 const REPO_ROOT = process.cwd();
 const VERIFY = resolve(REPO_ROOT, 'plugins/ruflo-core/scripts/witness/verify.mjs');
@@ -96,11 +96,12 @@ console.log('\nCase 1: @noble/ed25519 not installed (source-only)');
   rmSync(tmp, { recursive: true, force: true });
 }
 
-// ── Case 2: all manifest files missing → exit 2 (precondition) ──────
+// ── Case 2: dist files missing → exit 2 (precondition) ──────────────
 // Point verify.mjs at an isolated root that DOES have @noble/ed25519
-// reachable (symlinked from the real install) but has none of the
-// manifest's dist/ files — mimicking a clean clone with no build run.
-console.log('\nCase 2: all manifest files missing (source-only, deps installed)');
+// reachable (symlinked from the real install), has source files copied
+// from the checkout, but has none of the manifest's dist/ files —
+// mimicking a clean clone with dependencies installed and no build run.
+console.log('\nCase 2: dist manifest files missing (source-only, deps installed)');
 {
   const tmp = mkdtempSync(join(tmpdir(), 'witness-smoke-nobuild-'));
   // Make @noble/ed25519 reachable by symlinking node_modules.
@@ -114,6 +115,16 @@ console.log('\nCase 2: all manifest files missing (source-only, deps installed)'
       // fs.symlinkSync via spawnSync to avoid extra import for the rare-path branch.
       spawnSync('ln', ['-s', src, dst]);
     } catch { /* best-effort */ }
+  }
+
+  const realManifest = JSON.parse(readFileSync(REAL_MANIFEST, 'utf8'));
+  for (const fix of realManifest.manifest.fixes) {
+    if (fix.file.includes('/dist/')) continue;
+    const src = resolve(REPO_ROOT, fix.file);
+    const dst = resolve(tmp, fix.file);
+    if (!existsSync(src)) continue;
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(src, dst);
   }
 
   const out = spawnSync('node', [VERIFY, '--manifest', REAL_MANIFEST, '--root', tmp, '--json'], {
@@ -133,30 +144,36 @@ console.log('\nCase 2: all manifest files missing (source-only, deps installed)'
   );
   record(
     'output carries a precondition tag',
-    /noble-ed25519-not-installed|dist-not-built/.test(out.stdout + out.stderr),
+    /dist-not-built/.test(out.stdout + out.stderr),
     `combined output=${(out.stdout + out.stderr).slice(0, 400)}`,
   );
 
   rmSync(tmp, { recursive: true, force: true });
 }
 
-// ── Case 3: built tree → never exit 2 (precondition is one-way) ─────
-// On a built tree the verifier may produce 0 (clean) or 1 (some real
-// regression caught) — both mean verification actually ran. What it
-// must NEVER produce here is exit 2, because that would mean a built
-// tree was mis-classified as "needs install/build" and the scheduled
-// runner would silently skip filing real regressions.
-console.log('\nCase 3: built tree never reports precondition');
+// ── Case 3: current checkout classification is explicit ─────────────
+// This CI job installs deps but intentionally does not build dist. Local
+// dev runs often have dist from a prior build. Accept either shape, but
+// require the machine-readable reason to be precise.
+console.log('\nCase 3: current checkout classification is explicit');
 {
-  const out = spawnSync('node', [VERIFY, '--manifest', REAL_MANIFEST], {
+  const out = spawnSync('node', [VERIFY, '--manifest', REAL_MANIFEST, '--json'], {
     encoding: 'utf8',
     cwd: REPO_ROOT,
   });
-  record(
-    'exit code is NOT 2 (built tree should never be flagged as a precondition miss)',
-    out.status !== 2,
-    `got exit=${out.status}, tail=${(out.stdout + out.stderr).slice(-300)}`,
-  );
+  if (out.status === 2) {
+    record(
+      'exit 2 is specifically dist-not-built, not missing dependency',
+      /"precondition":\s*"dist-not-built"/.test(out.stdout),
+      `got exit=2, stdout=${out.stdout.slice(0, 300)}, stderr=${out.stderr.slice(0, 300)}`,
+    );
+  } else {
+    record(
+      'built/current tree verification actually ran',
+      out.status === 0 || out.status === 1,
+      `got exit=${out.status}, tail=${(out.stdout + out.stderr).slice(-300)}`,
+    );
+  }
 }
 
 console.log('');

--- a/v3/@claude-flow/plugin-agent-federation/__tests__/unit/midstream-aware-loader.test.ts
+++ b/v3/@claude-flow/plugin-agent-federation/__tests__/unit/midstream-aware-loader.test.ts
@@ -4,9 +4,10 @@
  *
  * The loader's job is narrow: when MIDSTREAMER_QUIC_NATIVE=1 AND a
  * real (non-stub) midstreamer module is importable, return it.
- * Otherwise, fall through to the agentic-flow loader. These tests
- * verify both branches by stubbing the dynamic import / mocking the
- * agentic-flow loader where needed.
+ * Otherwise, fall through to the agentic-flow loader and then the
+ * plugin-owned WebSocket fallback if that loader is unavailable. These
+ * tests verify the branch selection by stubbing dynamic imports where
+ * needed.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -30,6 +31,24 @@ vi.mock('agentic-flow/transport/loader', async () => {
       // Marker so we can assert which branch resolved
       __mockSource: 'agentic-flow-mock',
     })),
+  };
+});
+
+vi.mock('ws', async () => {
+  class MockWebSocket {
+    on() {}
+    send(_data: string, cb?: (err?: Error) => void) { cb?.(); }
+    close() {}
+  }
+  class MockWebSocketServer {
+    on(event: string, handler: () => void) {
+      if (event === 'listening') queueMicrotask(handler);
+    }
+    close(cb?: () => void) { cb?.(); }
+  }
+  return {
+    default: MockWebSocket,
+    WebSocketServer: MockWebSocketServer,
   };
 });
 
@@ -103,6 +122,6 @@ describe('loadFederationTransport — ADR-120 Step 2', () => {
       expect.arrayContaining(['transport', 'source']),
     );
     // `source` must be one of the two documented values.
-    expect(['midstreamer-native', 'agentic-flow-loader']).toContain(loaded.source);
+    expect(['midstreamer-native', 'agentic-flow-loader', 'websocket-fallback']).toContain(loaded.source);
   });
 });

--- a/v3/@claude-flow/plugin-agent-federation/package.json
+++ b/v3/@claude-flow/plugin-agent-federation/package.json
@@ -21,10 +21,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@noble/ed25519": "^2.0.0"
+    "@noble/ed25519": "^2.0.0",
+    "ws": "^8.20.0"
   },
   "peerDependencies": {
-    "agentic-flow": ">=2.0.12-fix.8 <2.0.13",
+    "agentic-flow": ">=2.0.12-fix.8 <3.0.0",
     "midstreamer": ">=0.3.1"
   },
   "peerDependenciesMeta": {
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@claude-flow/shared": "workspace:*",
     "@claude-flow/security": "workspace:*",
+    "@types/ws": "^8.18.1",
     "agentic-flow": "2.0.12-fix.8",
     "typescript": "^5.4.0",
     "vitest": "^4.1.0"

--- a/v3/@claude-flow/plugin-agent-federation/src/transport/midstream-aware-loader.ts
+++ b/v3/@claude-flow/plugin-agent-federation/src/transport/midstream-aware-loader.ts
@@ -52,6 +52,7 @@ export interface AgentTransport {
 export interface QuicTransportConfig {
   port?: number;
   host?: string;
+  serverName?: string;
   [key: string]: unknown;
 }
 
@@ -110,9 +111,101 @@ export interface LoadedFederationTransport {
   /** The live transport. Send/receive against this. */
   transport: AgentTransport;
   /** Which loader branch resolved. Useful for logs/metrics. */
-  source: 'midstreamer-native' | 'agentic-flow-loader';
+  source: 'midstreamer-native' | 'agentic-flow-loader' | 'websocket-fallback';
   /** Free-form note when a probe failed (helps explain a fallback). */
   fallbackReason?: string;
+}
+
+type WebSocketLike = {
+  on: (event: string, handler: (...args: unknown[]) => void) => void;
+  send: (data: string, cb?: (err?: Error) => void) => void;
+  close: () => void;
+};
+
+type WebSocketServerLike = {
+  on: (event: string, handler: (...args: unknown[]) => void) => void;
+  close: (cb?: () => void) => void;
+};
+
+/**
+ * Plugin-owned ADR-104 WebSocket fallback. This closes issue #2618's
+ * failure mode: current `agentic-flow` releases do not export
+ * `agentic-flow/transport/loader`, so the federation plugin must not
+ * depend on that subpath for its baseline wire transport.
+ */
+class WebSocketFallbackTransport implements AgentTransport {
+  [key: string]: unknown;
+
+  private handlers: Array<(address: string, message: AgentMessage) => void> = [];
+  private server: WebSocketServerLike | null = null;
+  private sockets = new Set<WebSocketLike>();
+
+  constructor(private readonly config: QuicTransportConfig = {}) {}
+
+  async send(address: string, message: AgentMessage): Promise<void> {
+    const { default: WebSocket } = await import('ws');
+    const url = address.includes('://') ? address : `ws://${address}`;
+    const socket = new WebSocket(url) as WebSocketLike;
+
+    await new Promise<void>((resolve, reject) => {
+      socket.on('open', () => {
+        socket.send(JSON.stringify(message), (err?: Error) => {
+          socket.close();
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      socket.on('error', (err: unknown) => reject(err instanceof Error ? err : new Error(String(err))));
+    });
+  }
+
+  onMessage(handler: (address: string, message: AgentMessage) => void): void {
+    this.handlers.push(handler);
+  }
+
+  async listen(port = Number(this.config.port ?? 0), host = String(this.config.host ?? '0.0.0.0')): Promise<void> {
+    const { WebSocketServer } = await import('ws');
+    const server = new WebSocketServer({ port, host }) as WebSocketServerLike;
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      server.on('listening', () => resolve());
+      server.on('error', (err: unknown) => reject(err instanceof Error ? err : new Error(String(err))));
+      server.on('connection', (socket: unknown, request: unknown) => {
+        const ws = socket as WebSocketLike;
+        this.sockets.add(ws);
+        const remoteAddress = ((request as { socket?: { remoteAddress?: string; remotePort?: number } })?.socket);
+        const address = remoteAddress?.remoteAddress
+          ? `${remoteAddress.remoteAddress}${remoteAddress.remotePort ? `:${remoteAddress.remotePort}` : ''}`
+          : 'unknown';
+
+        ws.on('message', (data: unknown) => {
+          try {
+            const raw = typeof data === 'string'
+              ? data
+              : Buffer.isBuffer(data)
+                ? data.toString('utf8')
+                : String(data);
+            const message = JSON.parse(raw) as AgentMessage;
+            for (const handler of this.handlers) handler(address, message);
+          } catch {
+            // Drop malformed frames. Signature/envelope validation happens
+            // above this layer in inbound-dispatcher.
+          }
+        });
+        ws.on('close', () => this.sockets.delete(ws));
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    for (const socket of this.sockets) socket.close();
+    this.sockets.clear();
+    if (this.server) {
+      await new Promise<void>((resolve) => this.server?.close(resolve));
+      this.server = null;
+    }
+  }
 }
 
 /**
@@ -217,8 +310,9 @@ async function probeMidstreamerTransport(
  *
  * Failure mode: if midstreamer is requested but rejects (stub, init
  * error, missing package), this function falls through to the
- * agentic-flow loader silently — the federation peer always gets a
- * transport (WebSocket fallback in the worst case, per ADR-104).
+ * agentic-flow loader. If current agentic-flow does not export its
+ * historical loader subpath, the plugin-owned WebSocket fallback is
+ * used directly (ADR-104, #2618).
  */
 export async function loadFederationTransport(
   config?: QuicTransportConfig,
@@ -229,17 +323,17 @@ export async function loadFederationTransport(
   }
 
   const transport = await loadAgenticFlowQuicTransport(config);
-  if (!transport) {
-    throw new Error(
-      'No federation transport available. Install `agentic-flow` ' +
-        '(default) or `midstreamer` and set `MIDSTREAMER_QUIC_NATIVE=1` ' +
-        '(per ADR-120). Both are now optional peer dependencies — at ' +
-        'least one must be present at runtime.',
-    );
+  if (transport) {
+    return {
+      transport,
+      source: 'agentic-flow-loader',
+      fallbackReason: probe?.reason,
+    };
   }
+
   return {
-    transport,
-    source: 'agentic-flow-loader',
-    fallbackReason: probe?.reason,
+    transport: new WebSocketFallbackTransport(config),
+    source: 'websocket-fallback',
+    fallbackReason: probe?.reason ?? 'agentic-flow transport loader unavailable; using plugin-owned WebSocket fallback',
   };
 }

--- a/v3/docs/adr/ADR-104-federation-wire-transport.md
+++ b/v3/docs/adr/ADR-104-federation-wire-transport.md
@@ -1,10 +1,10 @@
-# ADR-104 — Federation wire transport: agentic-flow loader (WS today, QUIC roadmap)
+# ADR-104 — Federation wire transport: plugin-owned WS fallback (QUIC roadmap)
 
 - Status: **Accepted — Implemented (transport selection); pending native QUIC for v2**
 - Date: 2026-05-09
 - Authors: claude (drafted with rUv)
 - Supersedes / extends: [ADR-097 — Federation budget circuit breaker](./ADR-097-federation-budget-circuit-breaker.md)
-- Related upstream: [ruvnet/agentic-flow#153](https://github.com/ruvnet/agentic-flow/pull/153)
+- Related upstream: [ruvnet/agentic-flow#153](https://github.com/ruvnet/agentic-flow/pull/153), ruvnet/ruflo#2618
 
 ## Context
 
@@ -34,13 +34,13 @@ The published QUIC transport is **API-only**. The native build that would unstub
 
 ## Decision
 
-**Adopt agentic-flow's `loadQuicTransport()` loader pattern with WebSocket fallback for v1; native QUIC remains the v2 target.**
+**Adopt the federation plugin's `loadFederationTransport()` loader with a plugin-owned WebSocket fallback for v1; native QUIC remains the v2 target.**
 
 We:
 
 1. **Backported `loadQuicTransport()` + `WebSocketFallbackTransport` from the OUTER repo's `quic-loader.ts` into the published inner `agentic-flow` package** (PR [ruvnet/agentic-flow#153](https://github.com/ruvnet/agentic-flow/pull/153)). The loader detects native QUIC availability (today: false) and selects WebSocket. Same `AgentTransport` interface for both backends — federation code never branches on transport.
 2. **Published `agentic-flow@2.0.12-fix.1` on the `fix` dist-tag** so federation can consume the working transport without waiting for upstream merge. When upstream merges + cuts a release, federation re-points to the official version with no code change.
-3. **Federation plugin imports `agentic-flow/transport/loader`**, not `./transport/quic` (the stub). The loader's `getTransportCapabilities()` answer drives the doctor surface — operators see `selectedBackend: 'websocket'` today and will see `selectedBackend: 'quic'` automatically when the native binding lands and `AGENTIC_FLOW_QUIC_NATIVE=1`.
+3. **Federation plugin imports its own loader, `@claude-flow/plugin-agent-federation/dist/transport/midstream-aware-loader.js`**, not `agentic-flow/transport/loader`. Current `agentic-flow` releases do not export `./transport/loader`; external ADR-104 smoke scripts that import that subpath fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` (#2618). The plugin loader still probes `midstreamer` and `agentic-flow` opportunistically, but it owns the baseline WebSocket fallback itself.
 
 ## Validated end-to-end (2026-05-09)
 
@@ -84,8 +84,8 @@ mac (darwin/arm64) → ruvultra:9101 (linux/x64) over tailscale, real bytes on t
 | Upstream fix (loader + WS fallback) | Open PR | [ruvnet/agentic-flow#153](https://github.com/ruvnet/agentic-flow/pull/153) |
 | Patched npm release | Published | `agentic-flow@2.0.12-fix.1` (`fix` dist-tag) |
 | End-to-end mac↔ruvultra over tailscale | Verified | This ADR's "Validated" section |
-| Federation plugin wiring (`agentic-flow/transport/loader` integration) | TODO | Tracked as ADR-104 phase 2 — depends on upstream merge timing |
-| 12h verification routine — QUIC check | TODO | Update [`trig_01DKn9PZUJfqCrugRVwac5LX`](https://claude.ai/code/routines/trig_01DKn9PZUJfqCrugRVwac5LX) with Check 8 (real-network smoke against `agentic-flow@fix`) |
+| Federation plugin wiring (`loadFederationTransport()` integration) | Implemented | `v3/@claude-flow/plugin-agent-federation/src/transport/midstream-aware-loader.ts` |
+| 12h verification routine — transport check | Implemented in repo; external runner must call plugin loader | Check 8 should import `@claude-flow/plugin-agent-federation/dist/transport/midstream-aware-loader.js`, not `agentic-flow/transport/loader` |
 | Native QUIC binding (real upgrade path) | Deferred | Tracked upstream at agentic-flow#15-21 |
 
 ## Operator-visible signal

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/aidefence':
     dependencies:
@@ -102,7 +102,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/cli':
     dependencies:
@@ -197,7 +197,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/deployment':
     dependencies:
@@ -210,7 +210,7 @@ importers:
         version: 25.0.2(typescript@5.9.3)
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/embeddings':
     dependencies:
@@ -260,7 +260,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/hooks':
     dependencies:
@@ -292,7 +292,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/integration':
     dependencies:
@@ -337,7 +337,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/memory':
     dependencies:
@@ -386,7 +386,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugin-agent-federation':
     dependencies:
@@ -396,6 +396,9 @@ importers:
       midstreamer:
         specifier: '>=0.3.1'
         version: 0.3.1(@types/node@20.19.27)
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
     devDependencies:
       '@claude-flow/security':
         specifier: workspace:*
@@ -403,6 +406,9 @@ importers:
       '@claude-flow/shared':
         specifier: workspace:*
         version: link:../shared
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       agentic-flow:
         specifier: 2.0.12-fix.8
         version: 2.0.12-fix.8(@types/node@20.19.27)
@@ -430,7 +436,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugins':
     dependencies:
@@ -458,7 +464,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/providers':
     dependencies:
@@ -483,7 +489,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/security':
     dependencies:
@@ -499,7 +505,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/shared':
     dependencies:
@@ -533,7 +539,7 @@ importers:
         version: 7.2.0
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
       ws:
         specifier: ^8.16.0
         version: 8.19.0
@@ -545,7 +551,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/testing':
     devDependencies:
@@ -563,7 +569,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
 packages:
 
@@ -6324,7 +6330,7 @@ packages:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
     dev: true
 
   /@vitest/expect@4.1.8:
@@ -6783,7 +6789,7 @@ packages:
       tiktoken: 1.0.22
       ulid: 3.0.2
       vite: 7.3.0(@types/node@20.19.27)(yaml@2.8.2)
-      ws: 8.18.3
+      ws: 8.20.0
       yaml: 2.8.2
       zod: 3.25.76
     transitivePeerDependencies:
@@ -6957,7 +6963,7 @@ packages:
       ruvector-onnx-embeddings-wasm: 0.1.2
       tiktoken: 1.0.22
       ulid: 3.0.2
-      ws: 8.18.3
+      ws: 8.20.0
       yaml: 2.8.2
       zod: 3.25.76
     optionalDependencies:
@@ -7013,7 +7019,7 @@ packages:
       tiktoken: 1.0.22
       ulid: 3.0.2
       validator: 13.15.26
-      ws: 8.19.0
+      ws: 8.20.0
       yaml: 2.8.2
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13049,6 +13055,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}


### PR DESCRIPTION
## Summary

Fixes the active repo-side causes behind the open high verification cluster:

- #2618: ADR-104 transport verification no longer depends on the unexported `agentic-flow/transport/loader` subpath. The federation plugin now owns a WebSocket fallback and documents the supported smoke import target: `@claude-flow/plugin-agent-federation/dist/transport/midstream-aware-loader.js`.
- #2528 / #2047 / #2515: witness verification now treats source checkout + missing dist artifacts as a precondition failure even when source markers are present/drifted, instead of reporting it as a real verification failure.
- Adds `scripts/smoke-adr104-transport.mjs` and extends the existing no-phantom-subpath workflow guard.

## Verification

- `pnpm --dir v3 --filter @claude-flow/plugin-agent-federation build`
- `pnpm --dir v3 --filter @claude-flow/plugin-agent-federation test -- __tests__/unit/midstream-aware-loader.test.ts`
- `node scripts/smoke-adr104-transport.mjs`
- `node scripts/smoke-witness-verify-precondition.mjs`
- `node plugins/ruflo-core/scripts/witness/verify.mjs --manifest verification/macos/manifest.md.json --json` => exit 0, missing=0

## Notes

#2286 was separately verified against the published 3.25.6 packages: `npx -y @claude-flow/cli@alpha --version` returned `ruflo v3.25.6` within 60s; `npx -y ruflo@alpha --version` returned immediately. That issue appears stale and should be closed independently.
