### PR TITLE
chore(verify): package-lock version sync + intelligence.cjs storage guard

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -587,6 +587,16 @@ function recordEdit(file, success) {
     sessionId: sessionGet('sessionId') || null,
   });
   fs.appendFileSync(PENDING_PATH, entry + '\n', 'utf-8');
+  // Runaway-storage guard: pending-insights is append-only and only drained by
+  // consolidation. If it grows past ~512KB (thousands of un-consolidated edits
+  // — e.g. the daemon never ran), keep only the most recent 2000 lines so it
+  // can never grow unbounded. Cheap (a statSync per edit; rewrite only when over).
+  try {
+    if (fs.statSync(PENDING_PATH).size > 512 * 1024) {
+      const lines = fs.readFileSync(PENDING_PATH, 'utf-8').split('\n').filter(Boolean);
+      if (lines.length > 2000) fs.writeFileSync(PENDING_PATH, lines.slice(-2000).join('\n') + '\n', 'utf-8');
+    }
+  } catch (e) { /* non-fatal */ }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.25.1",
+  "version": "3.25.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.25.1",
+      "version": "3.25.6",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",


### PR DESCRIPTION
## Summary

Changes produced during the scheduled 2026-07-09 verification run:

- **`package-lock.json`**: version field synced from 3.25.1 → 3.25.6 to match the published npm package after `npm install` was run to satisfy the witness verifier's `@noble/ed25519` dependency.
- **`.claude/helpers/intelligence.cjs`**: runaway-storage guard added to `recordEdit()` — caps `pending-insights` at 2000 lines / 512 KB when the consolidation daemon is not running (non-fatal, one `statSync` per edit).

> Note: The `intelligence.cjs` storage guard duplicates work already in PRs #2611 and #2615. Whichever lands first, the others can be closed as duplicates.

## Verification run results (2026-07-09T19:03:22Z)

Overall severity: **MEDIUM** (no HIGH findings)

| Check | Result |
|---|---|
| Witness signature | FAIL — exit 2, source-only checkout missing `dist/` (recurring — commented on #2609) |
| Published package smoke | PARTIAL — federation exports OK (v1.0.0-alpha.17); CLI version 3.25.6 confirmed via `npm view` |
| Federation breaker smoke | PASS — all 3 invariants verified |
| Doctor health check | PASS — 13 passed, 8 warnings |
| npm registry consistency | PASS — main pkgs all at 3.25.6; federation plugin missing `v3alpha` tag (LOW) |
| CI status on main | PASS — 3 consecutive successful runs (latest 2026-07-09T15:00Z) |
| Open issue triage | INFO — #2616 dream-cycle issue only, no crash/regression signals |
| ADR-104 transport smoke | FAIL — `agentic-flow` blocked by proxy 403 on `sharp` (recurring — commented on #2524) |

Comments posted on #2609 (witness, occurrence 4+, @ruvnet tagged) and #2524 (transport smoke, occurrence 3, @ruvnet tagged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhL1fkQRwBqkZTwLZn7ksM)_