### PR TITLE
fix(intelligence): add runaway-storage guard for pending-insights file

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -587,6 +587,16 @@ function recordEdit(file, success) {
     sessionId: sessionGet('sessionId') || null,
   });
   fs.appendFileSync(PENDING_PATH, entry + '\n', 'utf-8');
+  // Runaway-storage guard: pending-insights is append-only and only drained by
+  // consolidation. If it grows past ~512KB (thousands of un-consolidated edits
+  // — e.g. the daemon never ran), keep only the most recent 2000 lines so it
+  // can never grow unbounded. Cheap (a statSync per edit; rewrite only when over).
+  try {
+    if (fs.statSync(PENDING_PATH).size > 512 * 1024) {
+      const lines = fs.readFileSync(PENDING_PATH, 'utf-8').split('\n').filter(Boolean);
+      if (lines.length > 2000) fs.writeFileSync(PENDING_PATH, lines.slice(-2000).join('\n') + '\n', 'utf-8');
+    }
+  } catch (e) { /* non-fatal */ }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a runaway-storage guard to `.claude/helpers/intelligence.cjs` in `recordEdit()`: when `pending-insights.jsonl` exceeds 512 KB, only the most recent 2 000 lines are retained
- Prevents unbounded file growth when the consolidation daemon is not running (e.g. fresh checkouts, CI runners, scheduled verification environments)
- Guard is non-fatal: wrapped in try/catch so any I/O error is silently ignored

## Details

`pending-insights.jsonl` is append-only and is only drained by the consolidation background worker. In environments where the daemon never starts the file can grow indefinitely, consuming disk and slowing subsequent reads. The fix adds a cheap `statSync` check per `recordEdit` call and rewrites the file only when both thresholds are exceeded.

## Test plan

- [ ] Run `npx ruflo@latest doctor` and confirm no new warnings
- [ ] Simulate daemon-absent scenario: write >2 000 edit records and verify the file is trimmed to 2 000 lines
- [ ] Confirm existing consolidation tests still pass (`npm test --workspace v3/@claude-flow/hooks`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHxACHRErsJj4fAWvZH5Vw)_