### PR TITLE
fix(metaharness): honor genome verdict exit codes instead of treating them as failure

### DIFF
--- a/plugins/ruflo-metaharness/scripts/genome.mjs
+++ b/plugins/ruflo-metaharness/scripts/genome.mjs
@@ -30,7 +30,9 @@ const ARGS = (() => {
 function main() {
   const r = runMetaharness(['genome', ARGS.path]);
   if (r.degraded) { emitDegradedJsonAndExit(r.reason); return; }
-  if (r.exitCode !== 0 || !r.json) {
+  // metaharness genome uses exit code as a verdict channel (0=ready, 1=needs-work,
+  // 2=blocked) — only a missing/unparseable payload is a real wrapper failure.
+  if (!r.json) {
     console.error(`genome: metaharness exited ${r.exitCode}`);
     if (r.stderr) console.error(r.stderr.slice(0, 400));
     process.exit(2);


### PR DESCRIPTION
## Summary

`metaharness genome` uses its exit code as a verdict channel (0=ready, 1=needs-work, 2=blocked), but `genome.mjs` treated any non-zero exit as a fatal failure and discarded a fully-valid JSON report.

## Fix

`plugins/ruflo-metaharness/scripts/genome.mjs` now only treats a missing/unparseable JSON payload as a wrapper failure. The verdict (embedded in the exit code and in `payload.verdict`) is surfaced to the caller instead of being swallowed.

```diff
- if (r.exitCode !== 0 || !r.json) {
+ if (!r.json) {
```

The `mcp__claude-flow__metaharness_genome` MCP tool wraps this same script, so it inherits the fix automatically.

## Test plan

- [x] Ran `genome.mjs` against a repo with a `ready` verdict (exit 0) — unaffected, still prints the report.
- [x] Mocked `_harness.mjs` to return `exitCode: 2` with a valid `verdict: "blocked"` JSON payload — before the fix this exited 2 and discarded the report; after the fix it prints the full payload and exits 0.

Fixes #2626