### PR TITLE
fix(intelligence): cap pending-insights file at 2000 lines to prevent unbounded growth

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -587,6 +587,16 @@ function recordEdit(file, success) {
     sessionId: sessionGet('sessionId') || null,
   });
   fs.appendFileSync(PENDING_PATH, entry + '\n', 'utf-8');
+  // Runaway-storage guard: pending-insights is append-only and only drained by
+  // consolidation. If it grows past ~512KB (thousands of un-consolidated edits
+  // — e.g. the daemon never ran), keep only the most recent 2000 lines so it
+  // can never grow unbounded. Cheap (a statSync per edit; rewrite only when over).
+  try {
+    if (fs.statSync(PENDING_PATH).size > 512 * 1024) {
+      const lines = fs.readFileSync(PENDING_PATH, 'utf-8').split('\n').filter(Boolean);
+      if (lines.length > 2000) fs.writeFileSync(PENDING_PATH, lines.slice(-2000).join('\n') + '\n', 'utf-8');
+    }
+  } catch (e) { /* non-fatal */ }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a runaway-storage guard in `recordEdit()` inside `.claude/helpers/intelligence.cjs`
- If `pending-insights.ndjson` exceeds 512 KB (e.g. the daemon never ran and thousands of edits accumulated), only the most recent 2000 lines are kept
- One `statSync` per edit call; the rewrite only fires when the threshold is exceeded — negligible cost on normal runs

## Test plan

- [ ] Verify `recordEdit()` still appends entries normally when file is under 512 KB
- [ ] Verify that after exceeding 512 KB the file is trimmed to ≤ 2000 lines and the newest entries are preserved
- [ ] Verify the guard is non-fatal (errors caught silently)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01H8x7V8n4MNUEHuF6iseRmb

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8x7V8n4MNUEHuF6iseRmb)_