### PR TITLE
feat(mcp): ADR-179 + implementation — MCP 2026-07-28 spec support in our own server

### DIFF
--- a/.agents/skills/memory-management/SKILL.md
+++ b/.agents/skills/memory-management/SKILL.md
@@ -28,15 +28,34 @@ AgentDB memory system with HNSW vector search. Provides 150x-12,500x faster patt
 ## Commands
 
 ### Store Pattern
-Store a pattern or knowledge item in memory
+Store a pattern or knowledge item in memory.
+
+> **Fail closed — do not trust the store's success output.** On Ruflo 3.25.6
+> the hybrid backend can print/return success while the write is not durably
+> persisted: after committing the row, the store path runs a
+> `wal_checkpoint(PASSIVE)` pragma whose failure is swallowed as "non-fatal"
+> (`memory-bridge.ts`), so a rejected/disallowed checkpoint still reports
+> `success: true`. **Always verify with a read-back and treat a missing or
+> mismatched value as a failed write** — never report a successful store on
+> the strength of the console message alone.
 
 ```bash
+# 1. Store
 npx @claude-flow/cli memory store --key "[key]" --value "[value]" --namespace patterns
+
+# 2. Verify persistence (fail closed): the retrieved value MUST match what
+#    was written. If retrieve returns nothing or a different value, the store
+#    did NOT persist — report failure, do not claim success.
+npx @claude-flow/cli memory retrieve --key "[key]" --namespace patterns
 ```
 
-**Example:**
+**Example (with verification):**
 ```bash
 npx @claude-flow/cli memory store --key "auth-jwt-pattern" --value "JWT validation with refresh tokens" --namespace patterns
+# Confirm it actually persisted before relying on it:
+npx @claude-flow/cli memory retrieve --key "auth-jwt-pattern" --namespace patterns
+# → must echo "JWT validation with refresh tokens". If empty/different, the
+#   write failed silently — retry on a supported backend or surface the error.
 ```
 
 ### Semantic Search

--- a/.agents/skills/memory-management/SKILL.md
+++ b/.agents/skills/memory-management/SKILL.md
@@ -55,12 +55,12 @@ npx @claude-flow/cli memory search --query "authentication best practices" --lim
 Retrieve a specific memory entry by key
 
 ```bash
-npx @claude-flow/cli memory get --key "[key]" --namespace [namespace]
+npx @claude-flow/cli memory retrieve --key "[key]" --namespace [namespace]
 ```
 
 **Example:**
 ```bash
-npx @claude-flow/cli memory get --key "auth-jwt-pattern" --namespace patterns
+npx @claude-flow/cli memory retrieve --key "auth-jwt-pattern" --namespace patterns
 ```
 
 ### List Entries
@@ -82,11 +82,12 @@ Delete a memory entry
 npx @claude-flow/cli memory delete --key "[key]" --namespace [namespace]
 ```
 
-### Initialize HNSW Index
-Initialize HNSW vector search index
+### Build HNSW Index
+The HNSW vector index is built on demand during search — pass `--build-hnsw`
+to (re)build it before the query runs (enables the ANN speedup).
 
 ```bash
-npx @claude-flow/cli memory init --enable-hnsw
+npx @claude-flow/cli memory search --query "[search terms]" --build-hnsw
 ```
 
 ### Memory Stats

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -33,12 +33,12 @@ Comprehensive security scanning and vulnerability detection. Includes input vali
 Run comprehensive security analysis on the codebase
 
 ```bash
-npx @claude-flow/cli security scan --depth full
+npx @claude-flow/cli security scan --depth deep
 ```
 
 **Example:**
 ```bash
-npx @claude-flow/cli security scan --depth full --output security-report.json
+npx @claude-flow/cli security scan --depth deep --output security-report.json
 ```
 
 ### Input Validation Check

--- a/.agents/skills/swarm-orchestration/SKILL.md
+++ b/.agents/skills/swarm-orchestration/SKILL.md
@@ -72,16 +72,17 @@ Check the current swarm status
 npx @claude-flow/cli swarm status --verbose
 ```
 
-### Orchestrate Task
-Orchestrate a task across multiple agents
+### Orchestrate an Objective
+Orchestrate an objective across multiple agents (the `task orchestrate`
+subcommand was replaced by `swarm start` in v3.25).
 
 ```bash
-npx @claude-flow/cli task orchestrate --task "[task]" --strategy adaptive
+npx @claude-flow/cli swarm start --objective "[objective]" --strategy adaptive
 ```
 
 **Example:**
 ```bash
-npx @claude-flow/cli task orchestrate --task "refactor auth module" --strategy parallel --max-agents 4
+npx @claude-flow/cli swarm start --objective "refactor auth module" --strategy parallel
 ```
 
 ### List Agents

--- a/.claude/commands/coordination/swarm-init.md
+++ b/.claude/commands/coordination/swarm-init.md
@@ -80,6 +80,6 @@ mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
 ## See Also
 
 - `agent spawn` - Create swarm agents
-- `task orchestrate` - Coordinate task execution
+- `swarm start` - Orchestrate objectives across the swarm
 - `swarm status` - Check swarm state
 - `swarm monitor` - Real-time monitoring

--- a/.claude/commands/coordination/task-orchestrate.md
+++ b/.claude/commands/coordination/task-orchestrate.md
@@ -1,25 +1,31 @@
 # task-orchestrate
 
-Orchestrate complex tasks across the swarm.
+> **Renamed in v3.25:** the `task orchestrate` subcommand no longer exists.
+> Task orchestration is now driven by `swarm start`. The `task` command
+> covers lifecycle only (`create`, `list`, `status`, `cancel`, `assign`,
+> `retry`). Use the commands below.
+
+Orchestrate complex objectives across the swarm.
 
 ## Usage
 ```bash
-npx claude-flow task orchestrate [options]
+npx claude-flow swarm start [options]
 ```
 
 ## Options
-- `--task <description>` - Task description
-- `--strategy <type>` - Orchestration strategy
-- `--priority <level>` - Task priority (low, medium, high, critical)
+- `--objective <description>` - What the swarm should accomplish
+- `--strategy <type>` - Orchestration strategy (e.g. `parallel`)
+- `--parallel` - Run agents concurrently
+- `--monitor` - Stream progress while the swarm runs
 
 ## Examples
 ```bash
-# Orchestrate development task
-npx claude-flow task orchestrate --task "Implement user authentication"
+# Orchestrate a development objective
+npx claude-flow swarm start --objective "Implement user authentication"
 
-# High priority task
-npx claude-flow task orchestrate --task "Fix production bug" --priority critical
-
-# With specific strategy
-npx claude-flow task orchestrate --task "Refactor codebase" --strategy parallel
+# Parallel strategy with live monitoring
+npx claude-flow swarm start --objective "Refactor codebase" --strategy parallel --monitor
 ```
+
+> Initialize the swarm topology first with `swarm init` (see
+> [swarm-init](./swarm-init.md)).

--- a/.claude/commands/sparc/orchestrator.md
+++ b/.claude/commands/sparc/orchestrator.md
@@ -68,8 +68,8 @@ npx claude-flow swarm init --topology hierarchical --strategy auto --max-agents 
 # Spawn coordinator agent
 npx claude-flow agent spawn --type coordinator --capabilities "task-planning,resource-management"
 
-# Orchestrate tasks
-npx claude-flow task orchestrate --task "feature development" --strategy parallel --deps "auth,ui,api"
+# Orchestrate the objective across the swarm
+npx claude-flow swarm start --objective "feature development" --strategy parallel
 ```
 
 ## Orchestration Patterns

--- a/.claude/skills/dual-mode/dual-collect.md
+++ b/.claude/skills/dual-mode/dual-collect.md
@@ -61,7 +61,7 @@ npx claude-flow@v3alpha memory search -q "{{filter}}" -n {{namespace}}
 
 # Get detailed entries
 {{#each results}}
-npx claude-flow@v3alpha memory get -k "{{this.key}}" -n {{namespace}}
+npx claude-flow@v3alpha memory retrieve -k "{{this.key}}" -n {{namespace}}
 {{/each}}
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,7 +405,7 @@ npx claude-flow@v3alpha memory search -q "authentication patterns"
 npx claude-flow@v3alpha doctor --fix
 
 # Security scan
-npx claude-flow@v3alpha security scan --depth full
+npx claude-flow@v3alpha security scan --depth deep
 
 # Performance benchmark
 npx claude-flow@v3alpha performance benchmark --suite all

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -2826,7 +2826,7 @@ npx ruflo@latest swarm init --v3-mode
 npx ruflo@latest memory search -q "authentication patterns"
 
 # Run security scan
-npx ruflo@latest security scan --depth full
+npx ruflo@latest security scan --depth deep
 
 # Performance benchmark
 npx ruflo@latest performance benchmark --suite all
@@ -2972,7 +2972,7 @@ Real-world scenarios and pre-built workflows for common tasks.
 
 | Scenario | What It Solves | How To Do It |
 |----------|----------------|--------------|
-| **Security Audit** | Find vulnerabilities before attackers do | `npx ruflo@latest security scan --depth full` |
+| **Security Audit** | Find vulnerabilities before attackers do | `npx ruflo@latest security scan --depth deep` |
 | **Dependency Scan** | Identify vulnerable packages and suggest upgrades | `npx ruflo@latest security cve --check` |
 | **Compliance Check** | Ensure code meets security standards | `npx ruflo@latest security audit` |
 
@@ -6076,7 +6076,7 @@ npx ruflo@latest security defend -i "test" -o json
 npx ruflo@latest security defend --stats
 
 # Full security audit
-npx ruflo@latest security scan --depth full
+npx ruflo@latest security scan --depth deep
 ```
 
 ### MCP Tools

--- a/v3/@claude-flow/cli/.claude/agents/v3/security-architect-aidefence.md
+++ b/v3/@claude-flow/cli/.claude/agents/v3/security-architect-aidefence.md
@@ -140,7 +140,7 @@ hooks:
     # ═══════════════════════════════════════════════════════════════
     echo "🔒 Running comprehensive security validation..."
 
-    npx claude-flow@v3alpha security scan --depth full --output-format json > /tmp/security-scan.json 2>/dev/null
+    npx claude-flow@v3alpha security scan --depth deep --output-format json > /tmp/security-scan.json 2>/dev/null
     VULNERABILITIES=$(jq -r '.vulnerabilities | length' /tmp/security-scan.json 2>/dev/null || echo "0")
     CRITICAL_COUNT=$(jq -r '.vulnerabilities | map(select(.severity == "critical")) | length' /tmp/security-scan.json 2>/dev/null || echo "0")
     HIGH_COUNT=$(jq -r '.vulnerabilities | map(select(.severity == "high")) | length' /tmp/security-scan.json 2>/dev/null || echo "0")

--- a/v3/@claude-flow/cli/.claude/agents/v3/security-architect.md
+++ b/v3/@claude-flow/cli/.claude/agents/v3/security-architect.md
@@ -58,7 +58,7 @@ hooks:
     echo "✅ Security architecture analysis complete"
 
     # 1. Run comprehensive security validation
-    npx claude-flow@v3alpha security scan --depth full --output-format json > /tmp/security-scan.json 2>/dev/null
+    npx claude-flow@v3alpha security scan --depth deep --output-format json > /tmp/security-scan.json 2>/dev/null
     VULNERABILITIES=$(jq -r '.vulnerabilities | length' /tmp/security-scan.json 2>/dev/null || echo "0")
     CRITICAL_COUNT=$(jq -r '.vulnerabilities | map(select(.severity == "critical")) | length' /tmp/security-scan.json 2>/dev/null || echo "0")
 
@@ -834,7 +834,7 @@ mcp__claude-flow__memory_usage({
 
 ```bash
 # Full security scan
-npx claude-flow@v3alpha security scan --depth full
+npx claude-flow@v3alpha security scan --depth deep
 
 # CVE-specific checks
 npx claude-flow@v3alpha security cve --check CVE-2024-001

--- a/v3/@claude-flow/cli/CLAUDE.md
+++ b/v3/@claude-flow/cli/CLAUDE.md
@@ -337,7 +337,7 @@ npx @claude-flow/cli@latest memory search --query "authentication patterns"
 npx @claude-flow/cli@latest doctor --fix
 
 # Security scan
-npx @claude-flow/cli@latest security scan --depth full
+npx @claude-flow/cli@latest security scan --depth deep
 
 # Performance benchmark
 npx @claude-flow/cli@latest performance benchmark --suite all

--- a/v3/@claude-flow/cli/__tests__/mcp-stdio-bridge.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-stdio-bridge.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration test for the stdio MCP transport unified onto @claude-flow/mcp
+ * (ADR-179). Exercises the REAL ruflo tool registry through the same
+ * buildBridgedMcpServer() that backs `ruflo mcp start`, driving
+ * MCPServer.processRequest exactly as handleMCPMessage does — no child
+ * process, so it runs anywhere the package is built.
+ *
+ * Closes the coverage gaps: real 300+ tool registration + dispatch, protocol
+ * negotiation over the bridge, stateless 2026-07-28 requests, and MRTR.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildBridgedMcpServer } from '../src/mcp-server.js';
+import { inputRequired } from '@claude-flow/mcp';
+import type { MCPServer } from '@claude-flow/mcp/server';
+
+type Frame = { jsonrpc: string; id?: string | number; result?: any; error?: { code: number; message: string } };
+
+const initialize = (server: MCPServer, protocolVersion: string): Promise<Frame> =>
+  server.processRequest({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion, capabilities: {}, clientInfo: { name: 'test', version: '1' } },
+  }) as Promise<Frame>;
+
+describe('stdio MCP bridge (ADR-179 unification)', () => {
+  let server: MCPServer;
+
+  beforeAll(async () => {
+    server = await buildBridgedMcpServer('test-session');
+  }, 60_000);
+
+  describe('protocol negotiation', () => {
+    it('negotiates a legacy 2024-11-05 client up to 2025-11-25 and keeps the ruflo identity', async () => {
+      const res = await initialize(server, '2024-11-05');
+      expect(res.result.protocolVersion).toBe('2025-11-25');
+      expect(res.result.serverInfo).toEqual({ name: 'ruflo', version: '3.0.0' });
+    });
+
+    it('negotiates a 2026-07-28 client to 2026-07-28', async () => {
+      const res = await initialize(server, '2026-07-28');
+      expect(res.result.protocolVersion).toBe('2026-07-28');
+    });
+  });
+
+  describe('real tool registry', () => {
+    beforeAll(async () => { await initialize(server, '2025-11-25'); });
+
+    it('registers the full ruflo tool registry through the bridge (none dropped)', async () => {
+      const res = (await server.processRequest({ jsonrpc: '2.0', id: 2, method: 'tools/list' })) as Frame;
+      const tools = res.result.tools as Array<{ name: string; inputSchema: unknown }>;
+      // The registry is 300+ tools; assert a conservative floor so the test is
+      // robust to additions but still catches a registration regression.
+      expect(tools.length).toBeGreaterThan(300);
+      // Real schemas are advertised (not the empty fallback)
+      const agentList = tools.find((t) => t.name === 'agent_list');
+      expect(agentList).toBeDefined();
+      expect(agentList!.inputSchema).toBeTruthy();
+    });
+
+    it('dispatches a real read-only tool and returns its result', async () => {
+      const res = (await server.processRequest({
+        jsonrpc: '2.0', id: 3, method: 'tools/call',
+        params: { name: 'agent_list', arguments: {} },
+      })) as Frame;
+      expect(res.result.isError).toBe(false);
+      const text = res.result.content[0].text as string;
+      expect(text).toContain('agents');
+    });
+
+    it('dispatches swarm_status', async () => {
+      const res = (await server.processRequest({
+        jsonrpc: '2.0', id: 4, method: 'tools/call',
+        params: { name: 'swarm_status', arguments: {} },
+      })) as Frame;
+      expect(res.result.isError).toBe(false);
+    });
+
+    it('returns an isError result for an unknown tool (not a crash)', async () => {
+      const res = (await server.processRequest({
+        jsonrpc: '2.0', id: 5, method: 'tools/call',
+        params: { name: 'definitely_not_a_tool', arguments: {} },
+      })) as Frame;
+      expect(res.result.isError).toBe(true);
+      expect(res.result.content[0].text).toMatch(/not found/i);
+    });
+
+    it('does not reject loose arguments (validateInput:false preserves raw stdio behavior)', async () => {
+      // agent_list has an inputSchema but the bridge disables execute-time
+      // validation, so an empty/loose call still reaches the handler.
+      const res = (await server.processRequest({
+        jsonrpc: '2.0', id: 6, method: 'tools/call',
+        params: { name: 'agent_list', arguments: { bogus: 123 } },
+      })) as Frame;
+      expect(res.result.isError).toBe(false);
+    });
+  });
+
+  describe('stateless 2026-07-28 requests over the bridge', () => {
+    it('serves a tool call without initialize when the request carries the 2026-07-28 protocol header', async () => {
+      // Fresh server so no prior initialize/session exists.
+      const stateless = await buildBridgedMcpServer('stateless-session');
+      const res = (await stateless.processRequest({
+        jsonrpc: '2.0', id: 7, method: 'tools/call',
+        params: { name: 'agent_list', arguments: {} },
+        meta: { protocolVersion: '2026-07-28', transport: 'http', clientKey: '127.0.0.1' },
+      } as any)) as Frame;
+      expect(res.error).toBeUndefined();
+      expect(res.result.isError).toBe(false);
+    });
+  });
+
+  describe('MRTR over the bridge', () => {
+    it('pauses and resumes a tool for a 2026-07-28 client', async () => {
+      const s = await buildBridgedMcpServer('mrtr-session');
+      // Register a synthetic MRTR tool alongside the real registry.
+      s.registerTool({
+        name: 'confirm_action',
+        description: 'Requires confirmation',
+        inputSchema: { type: 'object', properties: {} },
+        handler: async () =>
+          inputRequired('Confirm?', async (answer) => `confirmed:${answer}`, { type: 'string', enum: ['yes', 'no'] }),
+      });
+      const meta = { protocolVersion: '2026-07-28' };
+
+      const paused = (await s.processRequest({
+        jsonrpc: '2.0', id: 8, method: 'tools/call',
+        params: { name: 'confirm_action', arguments: {} }, meta,
+      } as any)) as Frame;
+      expect(paused.result.type).toBe('input_required');
+      expect(paused.result.continuationToken).toBeTruthy();
+
+      const resumed = (await s.processRequest({
+        jsonrpc: '2.0', id: 9, method: 'tools/call',
+        params: { continuationToken: paused.result.continuationToken, input: 'yes' }, meta,
+      } as any)) as Frame;
+      expect(resumed.result.isError).toBe(false);
+      expect(resumed.result.content[0].text).toContain('confirmed:yes');
+    });
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@claude-flow/cli-core": "3.7.0-alpha.5",
-    "@claude-flow/mcp": "3.0.0-alpha.8",
+    "@claude-flow/mcp": "3.0.0-alpha.10",
     "@claude-flow/neural": "3.0.0-alpha.9",
     "@claude-flow/shared": "3.0.0-alpha.7",
     "@noble/ed25519": "2.3.0",

--- a/v3/@claude-flow/cli/src/init/claudemd-generator.ts
+++ b/v3/@claude-flow/cli/src/init/claudemd-generator.ts
@@ -214,7 +214,7 @@ function securitySection(): string {
 - Always use parameterized queries (prevent injection)
 
 \`\`\`bash
-npx @claude-flow/cli@latest security scan --depth full
+npx @claude-flow/cli@latest security scan --depth deep
 npx @claude-flow/cli@latest security audit --report
 \`\`\`
 

--- a/v3/@claude-flow/cli/src/mcp-server.ts
+++ b/v3/@claude-flow/cli/src/mcp-server.ts
@@ -526,56 +526,8 @@ export class MCPServerManager extends EventEmitter {
     if (this.bridgedServer) {
       return this.bridgedServer;
     }
-
-    const { createMCPServer } = await import('@claude-flow/mcp');
-    const { listMCPTools, callMCPTool } = await import('./mcp-client.js');
-
-    // Route the package's internal logs to stderr — stdout is reserved for
-    // JSON-RPC frames (writeFrame), same constraint as the raw stdio loop.
-    const logger = {
-      debug: () => {},
-      info: () => {},
-      warn: (msg: string, data?: unknown) => process.stderr.write(`[mcp] WARN ${msg}${data ? ' ' + JSON.stringify(data) : ''}\n`),
-      error: (msg: string, data?: unknown) => process.stderr.write(`[mcp] ERROR ${msg}${data ? ' ' + JSON.stringify(data) : ''}\n`),
-    };
-
-    const server = createMCPServer(
-      { name: 'ruflo', version: '3.0.0', transport: 'in-process' },
-      logger
-    );
-
-    // Bridge every ruflo tool into the server's registry. validate:false so a
-    // tool whose declared schema is imperfect is never dropped, and
-    // validateInput:false so we preserve the raw stdio path's behavior of
-    // passing arguments straight to the handler (the real schema is still
-    // advertised in tools/list). callMCPTool already runs the ADR-146
-    // content-boundary guardrail internally.
-    const bridged = listMCPTools().map((tool) => ({
-      name: tool.name,
-      description: tool.description || tool.name,
-      inputSchema: tool.inputSchema || { type: 'object', properties: {} },
-      validateInput: false,
-      handler: async (input: unknown, ctx?: { sessionId?: string }) => {
-        const toolName = tool.name;
-        try {
-          const result = await callMCPTool(
-            toolName,
-            (input as Record<string, unknown>) || {},
-            { sessionId: ctx?.sessionId ?? sessionId }
-          );
-          trackRequest(toolName, true);
-          return result;
-        } catch (error) {
-          trackRequest(toolName, false);
-          throw error;
-        }
-      },
-    })) as unknown as Parameters<MCPServer['registerTools']>[0];
-
-    server.registerTools(bridged, { validate: false });
-
-    this.bridgedServer = server;
-    return server;
+    this.bridgedServer = await buildBridgedMcpServer(sessionId);
+    return this.bridgedServer;
   }
 
   /**
@@ -922,3 +874,76 @@ export async function getMCPServerStatus(): Promise<MCPServerStatus> {
 }
 
 export default MCPServerManager;
+
+/**
+ * Dependency seams for {@link buildBridgedMcpServer}, so the bridge can be
+ * unit-tested with the real ruflo tool registry (default) or fakes.
+ */
+export interface BridgedServerDeps {
+  createMCPServer?: typeof import('@claude-flow/mcp')['createMCPServer'];
+  listMCPTools?: typeof import('./mcp-client.js')['listMCPTools'];
+  callMCPTool?: typeof import('./mcp-client.js')['callMCPTool'];
+}
+
+/**
+ * Build a spec-compliant @claude-flow/mcp server with ruflo's tool registry
+ * bridged in. This is the single implementation behind the stdio transport
+ * (and is exercised directly by the stdio-bridge integration test), so stdio
+ * and HTTP/WS share one protocol layer: version negotiation
+ * (2025-11-25 / 2026-07-28), standard error codes, MRTR, and capabilities
+ * all come from the package rather than a hand-rolled handler (ADR-179).
+ */
+export async function buildBridgedMcpServer(
+  sessionId: string,
+  deps: BridgedServerDeps = {}
+): Promise<MCPServer> {
+  const createMCPServer = deps.createMCPServer ?? (await import('@claude-flow/mcp')).createMCPServer;
+  const mcpClient = await import('./mcp-client.js');
+  const listMCPTools = deps.listMCPTools ?? mcpClient.listMCPTools;
+  const callMCPTool = deps.callMCPTool ?? mcpClient.callMCPTool;
+
+  // Route the package's internal logs to stderr — stdout is reserved for
+  // JSON-RPC frames (writeFrame), same constraint as the raw stdio loop.
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (msg: string, data?: unknown) => process.stderr.write(`[mcp] WARN ${msg}${data ? ' ' + JSON.stringify(data) : ''}\n`),
+    error: (msg: string, data?: unknown) => process.stderr.write(`[mcp] ERROR ${msg}${data ? ' ' + JSON.stringify(data) : ''}\n`),
+  };
+
+  const server = createMCPServer(
+    { name: 'ruflo', version: '3.0.0', transport: 'in-process' },
+    logger
+  );
+
+  // Bridge every ruflo tool into the server's registry. validate:false so a
+  // tool whose declared schema is imperfect is never dropped, and
+  // validateInput:false so we preserve the raw stdio path's behavior of
+  // passing arguments straight to the handler (the real schema is still
+  // advertised in tools/list). callMCPTool already runs the ADR-146
+  // content-boundary guardrail internally.
+  const bridged = listMCPTools().map((tool) => ({
+    name: tool.name,
+    description: tool.description || tool.name,
+    inputSchema: tool.inputSchema || { type: 'object', properties: {} },
+    validateInput: false,
+    handler: async (input: unknown, ctx?: { sessionId?: string }) => {
+      const toolName = tool.name;
+      try {
+        const result = await callMCPTool(
+          toolName,
+          (input as Record<string, unknown>) || {},
+          { sessionId: ctx?.sessionId ?? sessionId }
+        );
+        trackRequest(toolName, true);
+        return result;
+      } catch (error) {
+        trackRequest(toolName, false);
+        throw error;
+      }
+    },
+  })) as unknown as Parameters<MCPServer['registerTools']>[0];
+
+  server.registerTools(bridged, { validate: false });
+  return server;
+}

--- a/v3/@claude-flow/cli/src/mcp-server.ts
+++ b/v3/@claude-flow/cli/src/mcp-server.ts
@@ -27,6 +27,11 @@ import * as os from 'os';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { trackRequest } from './mcp-tools/request-tracker.js';
+// Type-only — erased at compile time, so it does not eagerly load the package
+// (the value is still imported lazily via dynamic import in getBridgedServer).
+// Imported from the /server subpath: the barrel's re-export of this class
+// doesn't carry its members through tsc's bundler resolution here.
+import type { MCPServer } from '@claude-flow/mcp/server';
 
 // ESM-compatible __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -90,6 +95,9 @@ export class MCPServerManager extends EventEmitter {
   private server?: Server;
   private startTime?: Date;
   private healthCheckInterval?: NodeJS.Timeout;
+  // Lazily-built @claude-flow/mcp server that backs the stdio protocol layer,
+  // so stdio and HTTP/WS share one spec-compliant implementation (ADR-179).
+  private bridgedServer?: MCPServer;
 
   constructor(options: MCPServerOptions = {}) {
     super();
@@ -507,14 +515,77 @@ export class MCPServerManager extends EventEmitter {
   }
 
   /**
-   * Handle incoming MCP message
+   * Build (once) the @claude-flow/mcp server that backs the stdio protocol
+   * layer, bridging ruflo's tool registry into it. This is what unifies stdio
+   * with the HTTP/WS transport onto a single spec-compliant implementation:
+   * protocol negotiation (2025-11-25 / 2026-07-28), standard error codes,
+   * MRTR, and capabilities all come from @claude-flow/mcp instead of a
+   * hand-rolled 2024-11-05 handler (ADR-179).
+   */
+  private async getBridgedServer(sessionId: string): Promise<MCPServer> {
+    if (this.bridgedServer) {
+      return this.bridgedServer;
+    }
+
+    const { createMCPServer } = await import('@claude-flow/mcp');
+    const { listMCPTools, callMCPTool } = await import('./mcp-client.js');
+
+    // Route the package's internal logs to stderr — stdout is reserved for
+    // JSON-RPC frames (writeFrame), same constraint as the raw stdio loop.
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: (msg: string, data?: unknown) => process.stderr.write(`[mcp] WARN ${msg}${data ? ' ' + JSON.stringify(data) : ''}\n`),
+      error: (msg: string, data?: unknown) => process.stderr.write(`[mcp] ERROR ${msg}${data ? ' ' + JSON.stringify(data) : ''}\n`),
+    };
+
+    const server = createMCPServer(
+      { name: 'ruflo', version: '3.0.0', transport: 'in-process' },
+      logger
+    );
+
+    // Bridge every ruflo tool into the server's registry. validate:false so a
+    // tool whose declared schema is imperfect is never dropped, and
+    // validateInput:false so we preserve the raw stdio path's behavior of
+    // passing arguments straight to the handler (the real schema is still
+    // advertised in tools/list). callMCPTool already runs the ADR-146
+    // content-boundary guardrail internally.
+    const bridged = listMCPTools().map((tool) => ({
+      name: tool.name,
+      description: tool.description || tool.name,
+      inputSchema: (tool.inputSchema as Record<string, unknown>) || { type: 'object', properties: {} },
+      validateInput: false,
+      handler: async (input: unknown, ctx?: { sessionId?: string }) => {
+        const toolName = tool.name;
+        try {
+          const result = await callMCPTool(
+            toolName,
+            (input as Record<string, unknown>) || {},
+            { sessionId: ctx?.sessionId ?? sessionId }
+          );
+          trackRequest(toolName, true);
+          return result;
+        } catch (error) {
+          trackRequest(toolName, false);
+          throw error;
+        }
+      },
+    })) as unknown as Parameters<MCPServer['registerTools']>[0];
+
+    server.registerTools(bridged, { validate: false });
+
+    this.bridgedServer = server;
+    return server;
+  }
+
+  /**
+   * Handle incoming MCP message by delegating to the bridged
+   * @claude-flow/mcp server. Notifications (no id) get no response.
    */
   private async handleMCPMessage(
     message: { jsonrpc: string; id?: string | number; method?: string; params?: unknown },
     sessionId: string
   ): Promise<{ jsonrpc: string; id?: string | number; result?: unknown; error?: { code: number; message: string } } | null> {
-    const { listMCPTools, callMCPTool, hasTool } = await import('./mcp-client.js');
-
     if (!message.method) {
       return {
         jsonrpc: '2.0',
@@ -523,91 +594,25 @@ export class MCPServerManager extends EventEmitter {
       };
     }
 
-    const params = (message.params || {}) as Record<string, unknown>;
+    // JSON-RPC notifications (no id) receive no response.
+    if (message.id === undefined) {
+      if (message.method === 'notifications/initialized') {
+        console.error(
+          `[${new Date().toISOString()}] INFO [claude-flow-mcp] (${sessionId}) Client initialized`
+        );
+      }
+      return null;
+    }
 
     try {
-      switch (message.method) {
-        case 'initialize':
-          return {
-            jsonrpc: '2.0',
-            id: message.id,
-            result: {
-              protocolVersion: '2024-11-05',
-              serverInfo: { name: 'ruflo', version: '3.0.0' },
-              capabilities: {
-                tools: { listChanged: true },
-                resources: { subscribe: true, listChanged: true },
-              },
-            },
-          };
-
-        case 'tools/list':
-          const tools = listMCPTools();
-          return {
-            jsonrpc: '2.0',
-            id: message.id,
-            result: {
-              tools: tools.map(tool => ({
-                name: tool.name,
-                description: tool.description,
-                inputSchema: tool.inputSchema,
-              })),
-            },
-          };
-
-        case 'tools/call':
-          const toolName = params.name as string;
-          const toolParams = (params.arguments || {}) as Record<string, unknown>;
-
-          if (!hasTool(toolName)) {
-            return {
-              jsonrpc: '2.0',
-              id: message.id,
-              error: { code: -32601, message: `Tool not found: ${toolName}` },
-            };
-          }
-
-          try {
-            const result = await callMCPTool(toolName, toolParams, { sessionId });
-            trackRequest(toolName, true);
-            return {
-              jsonrpc: '2.0',
-              id: message.id,
-              result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
-            };
-          } catch (error) {
-            trackRequest(toolName, false);
-            return {
-              jsonrpc: '2.0',
-              id: message.id,
-              error: {
-                code: -32603,
-                message: error instanceof Error ? error.message : 'Tool execution failed',
-              },
-            };
-          }
-
-        case 'notifications/initialized':
-          // Client notification - no response needed
-          console.error(
-            `[${new Date().toISOString()}] INFO [claude-flow-mcp] (${sessionId}) Client initialized`
-          );
-          return null;
-
-        case 'ping':
-          return {
-            jsonrpc: '2.0',
-            id: message.id,
-            result: {},
-          };
-
-        default:
-          return {
-            jsonrpc: '2.0',
-            id: message.id,
-            error: { code: -32601, message: `Method not found: ${message.method}` },
-          };
-      }
+      const server = await this.getBridgedServer(sessionId);
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: message.id,
+        method: message.method,
+        params: (message.params || {}) as Record<string, unknown>,
+      });
+      return response as { jsonrpc: string; id?: string | number; result?: unknown; error?: { code: number; message: string } };
     } catch (error) {
       console.error(
         `[${new Date().toISOString()}] ERROR [claude-flow-mcp] Error handling ${message.method}:`,

--- a/v3/@claude-flow/cli/src/mcp-server.ts
+++ b/v3/@claude-flow/cli/src/mcp-server.ts
@@ -553,7 +553,7 @@ export class MCPServerManager extends EventEmitter {
     const bridged = listMCPTools().map((tool) => ({
       name: tool.name,
       description: tool.description || tool.name,
-      inputSchema: (tool.inputSchema as Record<string, unknown>) || { type: 'object', properties: {} },
+      inputSchema: tool.inputSchema || { type: 'object', properties: {} },
       validateInput: false,
       handler: async (input: unknown, ctx?: { sessionId?: string }) => {
         const toolName = tool.name;

--- a/v3/@claude-flow/codex/.agents/skills/security-audit/SKILL.md
+++ b/v3/@claude-flow/codex/.agents/skills/security-audit/SKILL.md
@@ -27,7 +27,7 @@ Security scanning and vulnerability detection.
 Run comprehensive security analysis
 
 ```bash
-npx @claude-flow/cli security scan --depth full
+npx @claude-flow/cli security scan --depth deep
 ```
 
 ### Input Validation Check

--- a/v3/@claude-flow/codex/src/generators/skill-md.ts
+++ b/v3/@claude-flow/codex/src/generators/skill-md.ts
@@ -424,8 +424,8 @@ export async function generateBuiltInSkill(
         {
           name: 'Full Security Scan',
           description: 'Run comprehensive security analysis on the codebase',
-          command: 'npx @claude-flow/cli security scan --depth full',
-          example: 'npx @claude-flow/cli security scan --depth full --output security-report.json',
+          command: 'npx @claude-flow/cli security scan --depth deep',
+          example: 'npx @claude-flow/cli security scan --depth deep --output security-report.json',
         },
         {
           name: 'Input Validation Check',

--- a/v3/@claude-flow/codex/tests/generators.test.ts
+++ b/v3/@claude-flow/codex/tests/generators.test.ts
@@ -556,7 +556,7 @@ describe('generateBuiltInSkill', () => {
     expect(result.skillMd).toContain('name: security-audit');
     expect(result.skillMd).toContain('security scanning');
     expect(result.skillMd).toContain('Full Security Scan');
-    expect(result.skillMd).toContain('--depth full');
+    expect(result.skillMd).toContain('--depth deep');
   });
 
   it('should generate performance-analysis skill', async () => {

--- a/v3/@claude-flow/mcp/__tests__/spec-2026-07-28.test.ts
+++ b/v3/@claude-flow/mcp/__tests__/spec-2026-07-28.test.ts
@@ -410,6 +410,51 @@ describe('MCP 2026-07-28 specification', () => {
     });
   });
 
+  describe('embedding support (stdio unification, ADR-179)', () => {
+    it('derives serverInfo from config so an embedding host keeps its identity', async () => {
+      const server = createMCPServer(
+        { name: 'ruflo', version: '3.0.0', transport: 'in-process' },
+        createMockLogger()
+      );
+      const response = await server.processRequest(initializeRequest(PROTOCOL_2025_11_25));
+      const result = response.result as { serverInfo: { name: string; version: string } };
+      expect(result.serverInfo.name).toBe('ruflo');
+      expect(result.serverInfo.version).toBe('3.0.0');
+      await server.stop();
+    });
+
+    it('validateInput:false skips execute-time validation but still advertises the schema', async () => {
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        createMockLogger()
+      );
+      server.registerTools(
+        [{
+          name: 'bridged',
+          description: 'A bridged tool with a strict schema but lenient runtime',
+          inputSchema: { type: 'object', properties: { key: { type: 'string' } }, required: ['key'] },
+          validateInput: false,
+          handler: async (input: unknown) => ({ received: input }),
+        }],
+        { validate: false }
+      );
+
+      // tools/list advertises the real schema
+      const list = await server.processRequest({ jsonrpc: '2.0', id: 30, method: 'tools/list' });
+      const tool = (list.result as { tools: Array<{ name: string; inputSchema: { required?: string[] } }> })
+        .tools.find((t) => t.name === 'bridged');
+      expect(tool?.inputSchema.required).toEqual(['key']);
+
+      // ...but a call missing the required field is NOT rejected (validateInput:false)
+      const call = await server.processRequest({
+        jsonrpc: '2.0', id: 31, method: 'tools/call',
+        params: { name: 'bridged', arguments: {} },
+      });
+      expect((call.result as { isError: boolean }).isError).toBe(false);
+      await server.stop();
+    });
+  });
+
   describe('deprecated methods stay functional', () => {
     it('still routes logging/setLevel for 2026-07-28 clients, with a warning', async () => {
       const logger = createMockLogger();

--- a/v3/@claude-flow/mcp/__tests__/spec-2026-07-28.test.ts
+++ b/v3/@claude-flow/mcp/__tests__/spec-2026-07-28.test.ts
@@ -285,6 +285,90 @@ describe('MCP 2026-07-28 specification', () => {
       manager.destroy();
     });
 
+    it('validates resume input against the advertised inputSchema', async () => {
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        createMockLogger()
+      );
+      let handlerReached = false;
+      server.registerTool({
+        name: 'guarded',
+        description: 'Guards a privileged action behind a confirm enum',
+        inputSchema: { type: 'object', properties: {} },
+        handler: async () =>
+          inputRequired(
+            'confirm?',
+            async (answer) => { handlerReached = true; return `did ${answer}`; },
+            { type: 'string', enum: ['yes', 'no'] }
+          ),
+      });
+
+      const meta = { protocolVersion: PROTOCOL_2026_07_28 };
+      const paused = (await server.processRequest({
+        jsonrpc: '2.0', id: 20, method: 'tools/call',
+        params: { name: 'guarded', arguments: {} }, meta,
+      })).result as InputRequiredResult;
+
+      // Value outside the advertised enum must be rejected before the callback
+      const rejected = await server.processRequest({
+        jsonrpc: '2.0', id: 21, method: 'tools/call',
+        params: { continuationToken: paused.continuationToken, input: 'DROP TABLE' }, meta,
+      });
+
+      expect(rejected.error?.code).toBe(ErrorCodes.INVALID_PARAMS);
+      expect(handlerReached).toBe(false);
+      // Token is single-use even on a rejected resume — cannot retry with a valid value
+      expect(server.getContinuationManager().getPendingCount()).toBe(0);
+      await server.stop();
+    });
+
+    it('binds a continuation to its creating client (leaked-token replay protection)', async () => {
+      const manager = createContinuationManager(createMockLogger());
+      const wire = manager.register(inputRequired('x', async () => 'y'), 'tool', 'client-A');
+
+      // Different client presenting a leaked token is refused
+      await expect(manager.resume(wire.continuationToken, undefined, 'client-B'))
+        .rejects.toThrow(/does not belong to this client/);
+      // And the token is burned, so the legitimate client can't reuse it either
+      expect(manager.getPendingCount()).toBe(0);
+      manager.destroy();
+    });
+
+    it('allows the same client to resume its own continuation', async () => {
+      const manager = createContinuationManager(createMockLogger());
+      const wire = manager.register(inputRequired('x', async () => 'ok'), 'tool', 'client-A');
+      await expect(manager.resume(wire.continuationToken, undefined, 'client-A')).resolves.toBe('ok');
+      manager.destroy();
+    });
+
+    it('rejects a cross-session resume through the server', async () => {
+      const server = createMCPServer({ name: 'Test', transport: 'in-process' }, createMockLogger());
+      server.registerTool({
+        name: 'confirm-x',
+        description: 'confirm',
+        inputSchema: { type: 'object', properties: {} },
+        handler: async () => inputRequired('proceed?', async () => 'done'),
+      });
+
+      // Client A initializes (2026-07-28) and pauses a tool
+      await server.processRequest(initializeRequest(PROTOCOL_2026_07_28));
+      const paused = (await server.processRequest({
+        jsonrpc: '2.0', id: 22, method: 'tools/call',
+        params: { name: 'confirm-x', arguments: {} },
+      })).result as InputRequiredResult;
+      expect(paused.type).toBe('input_required');
+
+      // Client B initializes — replaces currentSession, so the resume now
+      // carries B's session id and must be refused.
+      await server.processRequest(initializeRequest(PROTOCOL_2026_07_28));
+      const replay = await server.processRequest({
+        jsonrpc: '2.0', id: 23, method: 'tools/call',
+        params: { continuationToken: paused.continuationToken, input: 'yes' },
+      });
+      expect(replay.error?.code).toBe(ErrorCodes.INVALID_PARAMS);
+      await server.stop();
+    });
+
     it('supports chained round trips (resume returns another input_required)', async () => {
       const server = createMCPServer(
         { name: 'Test', transport: 'in-process', statelessMode: true },

--- a/v3/@claude-flow/mcp/__tests__/spec-2026-07-28.test.ts
+++ b/v3/@claude-flow/mcp/__tests__/spec-2026-07-28.test.ts
@@ -1,0 +1,412 @@
+/**
+ * @claude-flow/mcp - MCP 2026-07-28 Specification Tests (ADR-179)
+ *
+ * Covers: protocol version negotiation, opt-in stateless mode, MRTR
+ * (InputRequiredResult + continuations), error-code standardization,
+ * transport-header helpers, deprecations, and OAuth hardening (RFC 9207).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createMCPServer,
+  createContinuationManager,
+  inputRequired,
+  isPendingInputRequest,
+  negotiateProtocolVersion,
+  isStatelessProtocol,
+  supportsMrtr,
+  extractMcpName,
+  PROTOCOL_2025_11_25,
+  PROTOCOL_2026_07_28,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  DEPRECATED_METHODS_2026_07_28,
+  ErrorCodes,
+  createOAuthManager,
+} from '../src/index.js';
+import type { ILogger, MCPRequest, MCPResponse } from '../src/types.js';
+import type { InputRequiredResult } from '../src/mrtr.js';
+
+const createMockLogger = (): ILogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const initializeRequest = (protocolVersion: string): MCPRequest => ({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion,
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '1.0.0' },
+  },
+});
+
+describe('MCP 2026-07-28 specification', () => {
+  describe('protocol negotiation', () => {
+    it('supports both revisions, newest first', () => {
+      expect(SUPPORTED_PROTOCOL_VERSIONS).toEqual([PROTOCOL_2026_07_28, PROTOCOL_2025_11_25]);
+    });
+
+    it('echoes a supported requested version', () => {
+      expect(negotiateProtocolVersion(PROTOCOL_2026_07_28)).toBe(PROTOCOL_2026_07_28);
+      expect(negotiateProtocolVersion(PROTOCOL_2025_11_25)).toBe(PROTOCOL_2025_11_25);
+    });
+
+    it('falls back to 2025-11-25 for unknown or missing versions', () => {
+      expect(negotiateProtocolVersion('2025-06-18')).toBe(PROTOCOL_2025_11_25);
+      expect(negotiateProtocolVersion(undefined)).toBe(PROTOCOL_2025_11_25);
+    });
+
+    it('classifies stateless and MRTR support by revision', () => {
+      expect(isStatelessProtocol(PROTOCOL_2026_07_28)).toBe(true);
+      expect(isStatelessProtocol(PROTOCOL_2025_11_25)).toBe(false);
+      expect(supportsMrtr(PROTOCOL_2026_07_28)).toBe(true);
+      expect(supportsMrtr(PROTOCOL_2025_11_25)).toBe(false);
+    });
+
+    it('marks roots, sampling, and logging deprecated', () => {
+      expect(DEPRECATED_METHODS_2026_07_28.has('sampling/createMessage')).toBe(true);
+      expect(DEPRECATED_METHODS_2026_07_28.has('logging/setLevel')).toBe(true);
+      expect(DEPRECATED_METHODS_2026_07_28.has('roots/list')).toBe(true);
+      expect(DEPRECATED_METHODS_2026_07_28.has('tools/call')).toBe(false);
+    });
+  });
+
+  describe('standard error codes', () => {
+    it('no longer conflates authorization failure with SERVER_NOT_INITIALIZED', () => {
+      expect(ErrorCodes.SERVER_NOT_INITIALIZED).toBe(-32002);
+      expect(ErrorCodes.AUTHORIZATION_FAILED).toBe(-32003);
+      expect(ErrorCodes.AUTHORIZATION_FAILED).not.toBe(ErrorCodes.SERVER_NOT_INITIALIZED);
+    });
+  });
+
+  describe('transport header helpers', () => {
+    it('derives Mcp-Name for tool, prompt, and resource requests', () => {
+      expect(extractMcpName({ method: 'tools/call', params: { name: 'my-tool' } })).toBe('my-tool');
+      expect(extractMcpName({ method: 'prompts/get', params: { name: 'my-prompt' } })).toBe('my-prompt');
+      expect(extractMcpName({ method: 'resources/read', params: { uri: 'file:///x' } })).toBe('file:///x');
+      expect(extractMcpName({ method: 'tools/list', params: {} })).toBeUndefined();
+    });
+  });
+
+  describe('server version negotiation', () => {
+    let server: ReturnType<typeof createMCPServer>;
+
+    beforeEach(() => {
+      server = createMCPServer({ name: 'Test', transport: 'in-process' }, createMockLogger());
+    });
+
+    afterEach(async () => {
+      await server.stop();
+    });
+
+    it('echoes 2026-07-28 when requested and omits deprecated capabilities', async () => {
+      const response = await server.processRequest(initializeRequest(PROTOCOL_2026_07_28));
+      const result = response.result as { protocolVersion: string; capabilities: Record<string, unknown> };
+
+      expect(result.protocolVersion).toBe(PROTOCOL_2026_07_28);
+      expect(result.capabilities.tools).toBeDefined();
+      expect(result.capabilities.resources).toBeDefined();
+      expect(result.capabilities.prompts).toBeDefined();
+      expect(result.capabilities.sampling).toBeUndefined();
+      expect(result.capabilities.logging).toBeUndefined();
+    });
+
+    it('keeps 2025-11-25 sessions unchanged, including sampling capability', async () => {
+      const response = await server.processRequest(initializeRequest(PROTOCOL_2025_11_25));
+      const result = response.result as { protocolVersion: string; capabilities: Record<string, unknown> };
+
+      expect(result.protocolVersion).toBe(PROTOCOL_2025_11_25);
+      expect(result.capabilities.sampling).toBeDefined();
+      expect(result.capabilities.logging).toBeDefined();
+    });
+
+    it('falls back to 2025-11-25 for pre-2026 clients', async () => {
+      const response = await server.processRequest(initializeRequest('2025-06-18'));
+      const result = response.result as { protocolVersion: string };
+      expect(result.protocolVersion).toBe(PROTOCOL_2025_11_25);
+    });
+  });
+
+  describe('stateless mode', () => {
+    afterEach(vi.restoreAllMocks);
+
+    it('rejects uninitialized requests when stateful (legacy behavior preserved)', async () => {
+      const server = createMCPServer({ name: 'Test', transport: 'in-process' }, createMockLogger());
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+      });
+      expect(response.error?.code).toBe(ErrorCodes.SERVER_NOT_INITIALIZED);
+      await server.stop();
+    });
+
+    it('serves requests without initialize when statelessMode is enabled', async () => {
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        createMockLogger()
+      );
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'ping',
+      });
+      expect(response.error).toBeUndefined();
+      expect((response.result as { pong: boolean }).pong).toBe(true);
+      await server.stop();
+    });
+
+    it('serves requests statelessly when the transport saw a 2026-07-28 protocol header', async () => {
+      const server = createMCPServer({ name: 'Test', transport: 'in-process' }, createMockLogger());
+      server.registerTool({
+        name: 'echo',
+        description: 'Echo input',
+        inputSchema: { type: 'object', properties: { value: { type: 'string' } } },
+        handler: async (input: unknown) => input,
+      });
+
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'echo', arguments: { value: 'hi' } },
+        meta: { protocolVersion: PROTOCOL_2026_07_28, transport: 'http', clientKey: '127.0.0.1' },
+      });
+
+      expect(response.error).toBeUndefined();
+      const result = response.result as { isError: boolean; content: Array<{ text?: string }> };
+      expect(result.isError).toBe(false);
+      expect(result.content[0].text).toContain('hi');
+      await server.stop();
+    });
+  });
+
+  describe('MRTR (multi round-trip requests)', () => {
+    const registerConfirmTool = (server: ReturnType<typeof createMCPServer>) => {
+      server.registerTool({
+        name: 'confirm-delete',
+        description: 'Deletes records after confirmation',
+        inputSchema: { type: 'object', properties: {} },
+        handler: async () =>
+          inputRequired(
+            'Confirm deletion of 42 records',
+            async (answer) => (answer === 'yes' ? 'deleted 42 records' : 'aborted'),
+            { type: 'string', enum: ['yes', 'no'] }
+          ),
+      });
+    };
+
+    it('pauses and resumes a tool across two round trips on 2026-07-28', async () => {
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        createMockLogger()
+      );
+      registerConfirmTool(server);
+
+      const first = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'confirm-delete', arguments: {} },
+        meta: { protocolVersion: PROTOCOL_2026_07_28 },
+      });
+
+      const paused = first.result as InputRequiredResult;
+      expect(paused.type).toBe('input_required');
+      expect(paused.message).toContain('Confirm deletion');
+      expect(paused.continuationToken).toBeTruthy();
+      expect(paused.inputSchema?.enum).toEqual(['yes', 'no']);
+      expect(server.getContinuationManager().getPendingCount()).toBe(1);
+
+      const second = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 6,
+        method: 'tools/call',
+        params: { continuationToken: paused.continuationToken, input: 'yes' },
+        meta: { protocolVersion: PROTOCOL_2026_07_28 },
+      });
+
+      const final = second.result as { isError: boolean; content: Array<{ text?: string }> };
+      expect(final.isError).toBe(false);
+      expect(final.content[0].text).toContain('deleted 42 records');
+      expect(server.getContinuationManager().getPendingCount()).toBe(0);
+      await server.stop();
+    });
+
+    it('rejects unknown continuation tokens', async () => {
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        createMockLogger()
+      );
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'tools/call',
+        params: { continuationToken: 'bogus', input: 'yes' },
+      });
+      expect(response.error?.code).toBe(ErrorCodes.INVALID_PARAMS);
+      await server.stop();
+    });
+
+    it('downgrades input_required to a terminal error for 2025-11-25 sessions', async () => {
+      const server = createMCPServer({ name: 'Test', transport: 'in-process' }, createMockLogger());
+      registerConfirmTool(server);
+
+      await server.processRequest(initializeRequest(PROTOCOL_2025_11_25));
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 8,
+        method: 'tools/call',
+        params: { name: 'confirm-delete', arguments: {} },
+      });
+
+      const result = response.result as { isError: boolean; content: Array<{ text?: string }> };
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('2026-07-28');
+      expect(server.getContinuationManager().getPendingCount()).toBe(0);
+      await server.stop();
+    });
+
+    it('identifies pending input requests created by the helper', () => {
+      const pending = inputRequired('need input', async () => 'ok');
+      expect(isPendingInputRequest(pending)).toBe(true);
+      expect(isPendingInputRequest({ message: 'need input' })).toBe(false);
+      expect(isPendingInputRequest(null)).toBe(false);
+    });
+
+    it('expires continuations after their TTL', async () => {
+      const manager = createContinuationManager(createMockLogger(), { ttl: -1 });
+      const wire = manager.register(inputRequired('x', async () => 'y'), 'tool');
+      await expect(manager.resume(wire.continuationToken, 'input')).rejects.toThrow(/expired/i);
+      manager.destroy();
+    });
+
+    it('supports chained round trips (resume returns another input_required)', async () => {
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        createMockLogger()
+      );
+      server.registerTool({
+        name: 'two-step',
+        description: 'Requires two inputs',
+        inputSchema: { type: 'object', properties: {} },
+        handler: async () =>
+          inputRequired('first?', async (a) =>
+            inputRequired('second?', async (b) => `${a}+${b}`)
+          ),
+      });
+
+      const meta = { protocolVersion: PROTOCOL_2026_07_28 };
+      const r1 = await server.processRequest({
+        jsonrpc: '2.0', id: 9, method: 'tools/call',
+        params: { name: 'two-step', arguments: {} }, meta,
+      });
+      const p1 = r1.result as InputRequiredResult;
+      expect(p1.type).toBe('input_required');
+
+      const r2 = await server.processRequest({
+        jsonrpc: '2.0', id: 10, method: 'tools/call',
+        params: { continuationToken: p1.continuationToken, input: 'a' }, meta,
+      });
+      const p2 = r2.result as InputRequiredResult;
+      expect(p2.type).toBe('input_required');
+      expect(p2.message).toBe('second?');
+
+      const r3 = await server.processRequest({
+        jsonrpc: '2.0', id: 11, method: 'tools/call',
+        params: { continuationToken: p2.continuationToken, input: 'b' }, meta,
+      });
+      const final = r3.result as { content: Array<{ text?: string }> };
+      expect(final.content[0].text).toContain('a+b');
+      await server.stop();
+    });
+  });
+
+  describe('deprecated methods stay functional', () => {
+    it('still routes logging/setLevel for 2026-07-28 clients, with a warning', async () => {
+      const logger = createMockLogger();
+      const server = createMCPServer(
+        { name: 'Test', transport: 'in-process', statelessMode: true },
+        logger
+      );
+      const response = await server.processRequest({
+        jsonrpc: '2.0',
+        id: 12,
+        method: 'logging/setLevel',
+        params: { level: 'debug' },
+        meta: { protocolVersion: PROTOCOL_2026_07_28 },
+      });
+      expect((response.result as { success: boolean }).success).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Deprecated'),
+        expect.objectContaining({ method: 'logging/setLevel' })
+      );
+      await server.stop();
+    });
+  });
+
+  describe('OAuth hardening (RFC 9207 / MCP 2026-07-28)', () => {
+    const oauthConfig = {
+      clientId: 'client-1',
+      authorizationEndpoint: 'https://auth.example.com/authorize',
+      tokenEndpoint: 'https://auth.example.com/token',
+      redirectUri: 'https://app.example.com/callback',
+      issuer: 'https://auth.example.com',
+    };
+
+    afterEach(vi.restoreAllMocks);
+
+    it('rejects a code exchange when iss is missing', async () => {
+      const manager = createOAuthManager(createMockLogger(), oauthConfig);
+      const { state } = manager.createAuthorizationRequest();
+      await expect(manager.exchangeCode('code', state)).rejects.toThrow(/iss.*RFC 9207/);
+      manager.destroy();
+    });
+
+    it('rejects a code exchange when iss does not match the configured issuer', async () => {
+      const manager = createOAuthManager(createMockLogger(), oauthConfig);
+      const { state } = manager.createAuthorizationRequest();
+      await expect(
+        manager.exchangeCode('code', state, { iss: 'https://evil.example.com' })
+      ).rejects.toThrow(/does not match/);
+      manager.destroy();
+    });
+
+    it('accepts a matching iss and binds tokens to the issuer', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ access_token: 'at', token_type: 'Bearer', expires_in: 3600 }),
+      })) as unknown as typeof fetch);
+
+      const manager = createOAuthManager(createMockLogger(), oauthConfig);
+      const { state } = manager.createAuthorizationRequest();
+      const tokens = await manager.exchangeCode('code', state, { iss: oauthConfig.issuer });
+
+      expect(tokens.accessToken).toBe('at');
+      expect(tokens.issuer).toBe(oauthConfig.issuer);
+      expect(await manager.getAccessToken()).toBe('at');
+      manager.destroy();
+      vi.unstubAllGlobals();
+    });
+
+    it('refuses to present tokens bound to a different issuer', async () => {
+      const logger = createMockLogger();
+      const manager = createOAuthManager(logger, oauthConfig);
+      // Simulate storage carrying tokens minted by another server
+      await (manager as unknown as { tokenStorage: { save: (k: string, t: unknown) => Promise<void> } })
+        .tokenStorage.save('default', {
+          accessToken: 'foreign',
+          tokenType: 'Bearer',
+          issuer: 'https://other.example.com',
+        });
+
+      expect(await manager.getAccessToken()).toBeNull();
+      expect(logger.warn).toHaveBeenCalled();
+      manager.destroy();
+    });
+  });
+});

--- a/v3/@claude-flow/mcp/__tests__/websocket-transport.test.ts
+++ b/v3/@claude-flow/mcp/__tests__/websocket-transport.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Real WebSocket transport integration test. Boots an MCPServer on the ws
+ * transport, connects an actual ws client, and drives the JSON-RPC lifecycle
+ * end-to-end — closing the gap where only stdio/http/in-process were exercised.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { WebSocket } from 'ws';
+import { createMCPServer } from '../src/index.js';
+import type { ILogger, MCPServer } from '../src/server.js';
+
+const noopLogger: ILogger = { debug() {}, info() {}, warn() {}, error() {} };
+const PORT = 39217;
+const URL = `ws://127.0.0.1:${PORT}/ws`;
+
+describe('WebSocket transport', () => {
+  let server: MCPServer;
+
+  beforeAll(async () => {
+    server = createMCPServer(
+      { name: 'ruflo', version: '3.0.0', transport: 'websocket', host: '127.0.0.1', port: PORT },
+      noopLogger
+    );
+    server.registerTool({
+      name: 'echo',
+      description: 'Echo the input back',
+      inputSchema: { type: 'object', properties: { value: { type: 'string' } } },
+      handler: async (input: unknown) => input,
+    });
+    await server.start();
+  }, 20_000);
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  /** Open a socket, run one request/response round trip, close. */
+  const rpc = (payload: object): Promise<any> =>
+    new Promise((resolve, reject) => {
+      const ws = new WebSocket(URL);
+      const timer = setTimeout(() => { ws.close(); reject(new Error('ws rpc timeout')); }, 8000);
+      ws.on('open', () => ws.send(JSON.stringify(payload)));
+      ws.on('message', (data) => {
+        clearTimeout(timer);
+        ws.close();
+        resolve(JSON.parse(data.toString()));
+      });
+      ws.on('error', (err) => { clearTimeout(timer); reject(err); });
+    });
+
+  it('completes the initialize handshake over a real socket', async () => {
+    const res = await rpc({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'ws-test', version: '1' } },
+    });
+    expect(res.result.protocolVersion).toBe('2025-11-25');
+    expect(res.result.serverInfo.name).toBe('ruflo');
+  });
+
+  it('negotiates a 2026-07-28 client over WebSocket', async () => {
+    const res = await rpc({
+      jsonrpc: '2.0', id: 2, method: 'initialize',
+      params: { protocolVersion: '2026-07-28', capabilities: {}, clientInfo: { name: 'ws-test', version: '1' } },
+    });
+    expect(res.result.protocolVersion).toBe('2026-07-28');
+  });
+
+  it('lists and calls a tool over WebSocket', async () => {
+    // Each rpc() uses its own connection; the server tracks the last session,
+    // so initialize then exercise on fresh sockets in sequence.
+    await rpc({
+      jsonrpc: '2.0', id: 3, method: 'initialize',
+      params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'ws-test', version: '1' } },
+    });
+    const list = await rpc({ jsonrpc: '2.0', id: 4, method: 'tools/list' });
+    expect(list.result.tools.some((t: { name: string }) => t.name === 'echo')).toBe(true);
+
+    const call = await rpc({
+      jsonrpc: '2.0', id: 5, method: 'tools/call',
+      params: { name: 'echo', arguments: { value: 'hello-ws' } },
+    });
+    expect(call.result.isError).toBe(false);
+    expect(call.result.content[0].text).toContain('hello-ws');
+  });
+});

--- a/v3/@claude-flow/mcp/package.json
+++ b/v3/@claude-flow/mcp/package.json
@@ -1,14 +1,20 @@
 {
   "name": "@claude-flow/mcp",
-  "version": "3.0.0-alpha.9",
+  "version": "3.0.0-alpha.10",
   "type": "module",
   "description": "Standalone MCP (Model Context Protocol) server - stdio/http/websocket transports, connection pooling, tool registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./dist/*.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js"
+    }
   },
   "scripts": {
     "test": "vitest run",

--- a/v3/@claude-flow/mcp/src/index.ts
+++ b/v3/@claude-flow/mcp/src/index.ts
@@ -122,6 +122,7 @@ export {
 // Multi Round-Trip Requests (MCP 2026-07-28)
 export {
   ContinuationManager,
+  ContinuationError,
   createContinuationManager,
   inputRequired,
   isPendingInputRequest,

--- a/v3/@claude-flow/mcp/src/index.ts
+++ b/v3/@claude-flow/mcp/src/index.ts
@@ -96,10 +96,41 @@ export type {
   CompletionReference,
   CompletionArgument,
   CompletionResult,
+  // MCP 2026-07-28 types
+  MCPRequestMeta,
 } from './types.js';
 
 // Error handling
 export { ErrorCodes, MCPServerError } from './types.js';
+
+// Protocol negotiation (MCP 2026-07-28, ADR-179)
+export {
+  PROTOCOL_2025_11_25,
+  PROTOCOL_2026_07_28,
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  negotiateProtocolVersion,
+  isStatelessProtocol,
+  supportsMrtr,
+  DEPRECATED_METHODS_2026_07_28,
+  MCP_METHOD_HEADER,
+  MCP_NAME_HEADER,
+  MCP_PROTOCOL_VERSION_HEADER,
+  extractMcpName,
+} from './protocol.js';
+
+// Multi Round-Trip Requests (MCP 2026-07-28)
+export {
+  ContinuationManager,
+  createContinuationManager,
+  inputRequired,
+  isPendingInputRequest,
+} from './mrtr.js';
+export type {
+  InputRequiredResult,
+  PendingInputRequest,
+  ContinuationManagerOptions,
+} from './mrtr.js';
 
 // Server
 import { MCPServer, createMCPServer } from './server.js';
@@ -174,12 +205,15 @@ export {
   InMemoryTokenStorage,
   createGitHubOAuthConfig,
   createGoogleOAuthConfig,
+  registerOAuthClient,
 } from './oauth.js';
 export type {
   OAuthConfig,
   OAuthTokens,
   TokenStorage,
   AuthorizationRequest,
+  ClientRegistrationMetadata,
+  ClientRegistrationResult,
 } from './oauth.js';
 
 // Transport layer

--- a/v3/@claude-flow/mcp/src/mrtr.ts
+++ b/v3/@claude-flow/mcp/src/mrtr.ts
@@ -1,0 +1,179 @@
+/**
+ * @claude-flow/mcp - Multi Round-Trip Requests (MRTR, MCP 2026-07-28)
+ *
+ * Tools can return an InputRequiredResult to request user input
+ * mid-execution instead of holding a long-lived stream. The client resumes
+ * by re-invoking tools/call with the continuation token and the input.
+ */
+
+import { EventEmitter } from 'events';
+import { randomBytes } from 'crypto';
+import type { JSONSchema, ILogger } from './types.js';
+
+/** Wire-format result returned to the client when a tool needs input. */
+export interface InputRequiredResult {
+  type: 'input_required';
+  continuationToken: string;
+  message: string;
+  inputSchema?: JSONSchema;
+}
+
+const PENDING_INPUT = Symbol.for('claude-flow.mcp.pendingInput');
+
+/**
+ * In-process representation of a paused tool: carries the resume callback,
+ * which never crosses the wire. Create via inputRequired().
+ */
+export interface PendingInputRequest<TInput = unknown> {
+  [PENDING_INPUT]: true;
+  message: string;
+  inputSchema?: JSONSchema;
+  resume: (input: TInput) => Promise<unknown>;
+}
+
+/**
+ * Pause a tool until the client supplies input. Return this from a tool
+ * handler; the resume callback receives the client-provided input and may
+ * itself return another inputRequired() to chain round trips.
+ *
+ * @example
+ * handler: async (input) => inputRequired(
+ *   'Confirm deletion of 42 records',
+ *   async (answer) => answer === 'yes' ? doDelete() : 'aborted',
+ *   { type: 'string', enum: ['yes', 'no'] }
+ * )
+ */
+export function inputRequired<TInput = unknown>(
+  message: string,
+  resume: (input: TInput) => Promise<unknown>,
+  inputSchema?: JSONSchema
+): PendingInputRequest<TInput> {
+  return { [PENDING_INPUT]: true, message, inputSchema, resume };
+}
+
+export function isPendingInputRequest(value: unknown): value is PendingInputRequest {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<PropertyKey, unknown>)[PENDING_INPUT] === true
+  );
+}
+
+export interface ContinuationManagerOptions {
+  /** How long a continuation stays resumable (ms). Default: 5 minutes. */
+  ttl?: number;
+  /** Max concurrently pending continuations. Default: 100. */
+  maxPending?: number;
+  /** Expiry sweep interval (ms). Default: 30 seconds. */
+  cleanupInterval?: number;
+}
+
+interface StoredContinuation {
+  pending: PendingInputRequest;
+  toolName: string;
+  expiresAt: number;
+}
+
+/**
+ * Tracks paused tool executions by continuation token.
+ *
+ * NOTE: continuations are held in this process's memory, so a resume must
+ * reach the same instance that paused — route MRTR resumes with sticky
+ * affinity (e.g. on the continuation token) when load balancing.
+ */
+export class ContinuationManager extends EventEmitter {
+  private readonly continuations = new Map<string, StoredContinuation>();
+  private readonly ttl: number;
+  private readonly maxPending: number;
+  private cleanupTimer?: NodeJS.Timeout;
+
+  constructor(
+    private readonly logger: ILogger,
+    options: ContinuationManagerOptions = {}
+  ) {
+    super();
+    this.ttl = options.ttl ?? 5 * 60 * 1000;
+    this.maxPending = options.maxPending ?? 100;
+    this.cleanupTimer = setInterval(
+      () => this.evictExpired(),
+      options.cleanupInterval ?? 30 * 1000
+    );
+    this.cleanupTimer.unref?.();
+  }
+
+  /** Store a paused tool and return the wire-format result for the client. */
+  register(pending: PendingInputRequest, toolName: string): InputRequiredResult {
+    if (this.continuations.size >= this.maxPending) {
+      this.evictExpired();
+      if (this.continuations.size >= this.maxPending) {
+        throw new Error(`Maximum pending continuations (${this.maxPending}) reached`);
+      }
+    }
+
+    const token = randomBytes(24).toString('base64url');
+    this.continuations.set(token, {
+      pending,
+      toolName,
+      expiresAt: Date.now() + this.ttl,
+    });
+
+    this.logger.debug('Continuation registered', { toolName, pending: this.continuations.size });
+    this.emit('continuation:registered', { token, toolName });
+
+    return {
+      type: 'input_required',
+      continuationToken: token,
+      message: pending.message,
+      inputSchema: pending.inputSchema,
+    };
+  }
+
+  /**
+   * Resume a paused tool with client-provided input. Single-use: the token
+   * is consumed even if the resume callback throws. The result may itself
+   * be another PendingInputRequest (chained round trips).
+   */
+  async resume(token: string, input: unknown): Promise<unknown> {
+    const stored = this.continuations.get(token);
+    if (!stored || stored.expiresAt <= Date.now()) {
+      this.continuations.delete(token);
+      throw new Error('Unknown or expired continuation token');
+    }
+
+    this.continuations.delete(token);
+    this.emit('continuation:resumed', { token, toolName: stored.toolName });
+
+    return stored.pending.resume(input);
+  }
+
+  getPendingCount(): number {
+    return this.continuations.size;
+  }
+
+  private evictExpired(): void {
+    const now = Date.now();
+    for (const [token, stored] of this.continuations) {
+      if (stored.expiresAt <= now) {
+        this.continuations.delete(token);
+        this.logger.debug('Continuation expired', { toolName: stored.toolName });
+        this.emit('continuation:expired', { token, toolName: stored.toolName });
+      }
+    }
+  }
+
+  destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+    this.continuations.clear();
+    this.removeAllListeners();
+  }
+}
+
+export function createContinuationManager(
+  logger: ILogger,
+  options?: ContinuationManagerOptions
+): ContinuationManager {
+  return new ContinuationManager(logger, options);
+}

--- a/v3/@claude-flow/mcp/src/mrtr.ts
+++ b/v3/@claude-flow/mcp/src/mrtr.ts
@@ -7,8 +7,17 @@
  */
 
 import { EventEmitter } from 'events';
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
 import type { JSONSchema, ILogger } from './types.js';
+import { validateSchema, formatValidationErrors } from './schema-validator.js';
+
+/** Raised when a resume request fails validation or client-binding checks. */
+export class ContinuationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContinuationError';
+  }
+}
 
 /** Wire-format result returned to the client when a tool needs input. */
 export interface InputRequiredResult {
@@ -72,6 +81,12 @@ interface StoredContinuation {
   pending: PendingInputRequest;
   toolName: string;
   expiresAt: number;
+  /**
+   * Identity of the client that paused the tool. A resume must present the
+   * same key, so a leaked token can't be replayed by a different client.
+   * Undefined when the caller had no identity (e.g. stdio single-client).
+   */
+  clientKey?: string;
 }
 
 /**
@@ -101,8 +116,16 @@ export class ContinuationManager extends EventEmitter {
     this.cleanupTimer.unref?.();
   }
 
-  /** Store a paused tool and return the wire-format result for the client. */
-  register(pending: PendingInputRequest, toolName: string): InputRequiredResult {
+  /**
+   * Store a paused tool and return the wire-format result for the client.
+   * Pass the creating client's identity (from the request meta) so the
+   * resume can be bound to it.
+   */
+  register(
+    pending: PendingInputRequest,
+    toolName: string,
+    clientKey?: string
+  ): InputRequiredResult {
     if (this.continuations.size >= this.maxPending) {
       this.evictExpired();
       if (this.continuations.size >= this.maxPending) {
@@ -115,6 +138,7 @@ export class ContinuationManager extends EventEmitter {
       pending,
       toolName,
       expiresAt: Date.now() + this.ttl,
+      clientKey,
     });
 
     this.logger.debug('Continuation registered', { toolName, pending: this.continuations.size });
@@ -132,18 +156,61 @@ export class ContinuationManager extends EventEmitter {
    * Resume a paused tool with client-provided input. Single-use: the token
    * is consumed even if the resume callback throws. The result may itself
    * be another PendingInputRequest (chained round trips).
+   *
+   * @param clientKey identity of the resuming client, checked against the
+   *   client that created the continuation (leaked-token replay protection).
+   * @throws ContinuationError on unknown/expired token, client mismatch, or
+   *   input that fails the advertised inputSchema.
    */
-  async resume(token: string, input: unknown): Promise<unknown> {
+  async resume(token: string, input: unknown, clientKey?: string): Promise<unknown> {
     const stored = this.continuations.get(token);
     if (!stored || stored.expiresAt <= Date.now()) {
       this.continuations.delete(token);
-      throw new Error('Unknown or expired continuation token');
+      throw new ContinuationError('Unknown or expired continuation token');
+    }
+
+    // Bind resume to the creating client. The token is consumed regardless
+    // so a mismatched attempt also burns the (now-compromised) token.
+    if (!this.clientKeysMatch(stored.clientKey, clientKey)) {
+      this.continuations.delete(token);
+      this.emit('continuation:rejected', { token, toolName: stored.toolName, reason: 'client-mismatch' });
+      throw new ContinuationError('Continuation token does not belong to this client');
+    }
+
+    // Enforce the advertised inputSchema — resume gets the same validation
+    // fresh tools/call arguments get, so the schema is a real contract.
+    if (stored.pending.inputSchema) {
+      const validation = validateSchema(input, stored.pending.inputSchema);
+      if (!validation.valid) {
+        this.continuations.delete(token);
+        this.emit('continuation:rejected', { token, toolName: stored.toolName, reason: 'invalid-input' });
+        throw new ContinuationError(`Invalid input: ${formatValidationErrors(validation.errors)}`);
+      }
     }
 
     this.continuations.delete(token);
     this.emit('continuation:resumed', { token, toolName: stored.toolName });
 
     return stored.pending.resume(input);
+  }
+
+  /**
+   * Constant-time comparison of client identities. A continuation created
+   * without an identity (stdio) accepts a resume without one.
+   */
+  private clientKeysMatch(stored?: string, provided?: string): boolean {
+    if (stored === undefined) {
+      return provided === undefined;
+    }
+    if (provided === undefined) {
+      return false;
+    }
+    const a = Buffer.from(stored, 'utf-8');
+    const b = Buffer.from(provided, 'utf-8');
+    if (a.length !== b.length) {
+      return false;
+    }
+    return timingSafeEqual(a, b);
   }
 
   getPendingCount(): number {

--- a/v3/@claude-flow/mcp/src/oauth.ts
+++ b/v3/@claude-flow/mcp/src/oauth.ts
@@ -24,6 +24,13 @@ export interface OAuthConfig {
   redirectUri: string;
   /** Scopes to request */
   scopes?: string[];
+  /**
+   * Expected authorization server issuer identifier (MCP 2026-07-28 auth
+   * hardening). When set, the `iss` authorization-response parameter is
+   * required and validated per RFC 9207, and stored credentials are bound
+   * to this issuer — tokens minted by a different server are rejected.
+   */
+  issuer?: string;
   /** Token storage adapter */
   tokenStorage?: TokenStorage;
   /** Enable PKCE (default: true) */
@@ -42,6 +49,8 @@ export interface OAuthTokens {
   expiresIn?: number;
   expiresAt?: number;
   scope?: string;
+  /** Issuer that minted these tokens (credential binding, MCP 2026-07-28). */
+  issuer?: string;
 }
 
 /**
@@ -160,15 +169,41 @@ export class OAuthManager extends EventEmitter {
   }
 
   /**
-   * Exchange authorization code for tokens
+   * Exchange authorization code for tokens.
+   *
+   * Pass the `iss` parameter from the authorization response redirect when
+   * present. If `config.issuer` is set, `iss` is required and must match
+   * exactly (RFC 9207 mix-up attack prevention, MCP 2026-07-28).
    */
-  async exchangeCode(code: string, state: string): Promise<OAuthTokens> {
+  async exchangeCode(
+    code: string,
+    state: string,
+    options?: { iss?: string }
+  ): Promise<OAuthTokens> {
     const pending = this.pendingRequests.get(state);
     if (!pending) {
       throw new Error('Invalid or expired state parameter');
     }
 
     this.pendingRequests.delete(state);
+
+    if (this.config.issuer) {
+      if (!options?.iss) {
+        this.logger.error('Authorization response missing iss parameter', {
+          expected: this.config.issuer,
+        });
+        throw new Error(
+          'Authorization response missing required iss parameter (RFC 9207)'
+        );
+      }
+      if (options.iss !== this.config.issuer) {
+        this.logger.error('Authorization response issuer mismatch', {
+          expected: this.config.issuer,
+          received: options.iss,
+        });
+        throw new Error('Authorization response iss does not match expected issuer (RFC 9207)');
+      }
+    }
 
     const params = new URLSearchParams({
       grant_type: 'authorization_code',
@@ -268,6 +303,16 @@ export class OAuthManager extends EventEmitter {
       return null;
     }
 
+    // Credential binding (MCP 2026-07-28): never present tokens minted by a
+    // different authorization server than the one this manager targets.
+    if (this.config.issuer && tokens.issuer && tokens.issuer !== this.config.issuer) {
+      this.logger.warn('Stored tokens bound to a different issuer — refusing to use them', {
+        expected: this.config.issuer,
+        stored: tokens.issuer,
+      });
+      return null;
+    }
+
     // Check if token is expired (with 60 second buffer)
     if (tokens.expiresAt && Date.now() >= tokens.expiresAt - 60000) {
       if (tokens.refreshToken) {
@@ -324,6 +369,7 @@ export class OAuthManager extends EventEmitter {
       expiresIn: data.expires_in,
       expiresAt: data.expires_in ? Date.now() + data.expires_in * 1000 : undefined,
       scope: data.scope,
+      issuer: this.config.issuer,
     };
   }
 
@@ -403,6 +449,68 @@ export function oauthMiddleware(oauthManager: OAuthManager, storageKey: string =
 
     req.oauthToken = token;
     next();
+  };
+}
+
+/**
+ * Dynamic Client Registration metadata (RFC 7591). MCP 2026-07-28 requires
+ * `application_type` so authorization servers can enforce redirect-URI and
+ * secret-handling policy per client class.
+ */
+export interface ClientRegistrationMetadata {
+  redirect_uris: string[];
+  /** Required by MCP 2026-07-28. 'native' fits CLI/desktop MCP clients. */
+  application_type: 'web' | 'native';
+  client_name?: string;
+  token_endpoint_auth_method?: string;
+  grant_types?: string[];
+  response_types?: string[];
+  scope?: string;
+  [key: string]: unknown;
+}
+
+export interface ClientRegistrationResult {
+  clientId: string;
+  clientSecret?: string;
+  raw: Record<string, unknown>;
+}
+
+/**
+ * Register an OAuth client via Dynamic Client Registration (RFC 7591),
+ * always sending `application_type` per MCP 2026-07-28.
+ */
+export async function registerOAuthClient(
+  registrationEndpoint: string,
+  metadata: ClientRegistrationMetadata,
+  options?: { initialAccessToken?: string }
+): Promise<ClientRegistrationResult> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (options?.initialAccessToken) {
+    headers['Authorization'] = `Bearer ${options.initialAccessToken}`;
+  }
+
+  const response = await fetch(registrationEndpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(metadata),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Client registration failed: ${response.status} ${error}`);
+  }
+
+  const raw = (await response.json()) as Record<string, unknown>;
+  if (typeof raw.client_id !== 'string') {
+    throw new Error('Client registration response missing client_id');
+  }
+
+  return {
+    clientId: raw.client_id,
+    clientSecret: typeof raw.client_secret === 'string' ? raw.client_secret : undefined,
+    raw,
   };
 }
 

--- a/v3/@claude-flow/mcp/src/protocol.ts
+++ b/v3/@claude-flow/mcp/src/protocol.ts
@@ -1,0 +1,90 @@
+/**
+ * @claude-flow/mcp - Protocol Version Negotiation
+ *
+ * Dual-revision support: the legacy stateful 2025-11-25 revision and the
+ * stateless 2026-07-28 revision (MRTR, transport headers, deprecations).
+ * See ADR-179 for the adoption strategy.
+ */
+
+import type { MCPProtocolVersion, MCPRequest } from './types.js';
+
+export const PROTOCOL_2025_11_25: MCPProtocolVersion = '2025-11-25';
+export const PROTOCOL_2026_07_28: MCPProtocolVersion = '2026-07-28';
+
+export const LATEST_PROTOCOL_VERSION: MCPProtocolVersion = PROTOCOL_2026_07_28;
+
+/** Revisions this server implements, newest first. */
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly MCPProtocolVersion[] = [
+  PROTOCOL_2026_07_28,
+  PROTOCOL_2025_11_25,
+];
+
+/**
+ * Pick the protocol revision for a session.
+ *
+ * A supported requested version is echoed back. Unknown or missing versions
+ * fall back to 2025-11-25, NOT the latest: pre-2026 clients (e.g. Claude
+ * Code requesting 2025-06-18) historically received 2025-11-25 from this
+ * server and interoperate with it, while 2026-07-28 clients always request
+ * their revision explicitly.
+ */
+export function negotiateProtocolVersion(requested?: string): MCPProtocolVersion {
+  if (requested && SUPPORTED_PROTOCOL_VERSIONS.includes(requested)) {
+    return requested;
+  }
+  return PROTOCOL_2025_11_25;
+}
+
+/**
+ * The 2026-07-28 revision removes the initialize handshake and session
+ * management. Date-string versions compare lexicographically.
+ */
+export function isStatelessProtocol(version: MCPProtocolVersion): boolean {
+  return version >= PROTOCOL_2026_07_28;
+}
+
+/** MRTR (InputRequiredResult) is part of the 2026-07-28 revision. */
+export function supportsMrtr(version: MCPProtocolVersion): boolean {
+  return isStatelessProtocol(version);
+}
+
+/**
+ * Capabilities deprecated (still functional) in 2026-07-28:
+ * roots, sampling, and logging.
+ */
+export const DEPRECATED_METHODS_2026_07_28: ReadonlySet<string> = new Set([
+  'sampling/createMessage',
+  'logging/setLevel',
+  'roots/list',
+]);
+
+// ============================================================================
+// Transport Headers (2026-07-28)
+// ============================================================================
+
+/** Carried on every request so gateways can route without parsing bodies. */
+export const MCP_METHOD_HEADER = 'mcp-method';
+/** Carried on tool/resource/prompt requests: the tool/prompt name or resource URI. */
+export const MCP_NAME_HEADER = 'mcp-name';
+/** Protocol revision the client speaks; replaces initialize-time negotiation for stateless clients. */
+export const MCP_PROTOCOL_VERSION_HEADER = 'mcp-protocol-version';
+
+/**
+ * Derive the Mcp-Name header value for a request, per the 2026-07-28
+ * transport-header rules: tool/prompt name or resource URI, when present.
+ */
+export function extractMcpName(request: Pick<MCPRequest, 'method' | 'params'>): string | undefined {
+  const params = request.params as { name?: unknown; uri?: unknown } | undefined;
+
+  switch (request.method) {
+    case 'tools/call':
+    case 'prompts/get':
+      return typeof params?.name === 'string' ? params.name : undefined;
+    case 'resources/read':
+    case 'resources/subscribe':
+    case 'resources/unsubscribe':
+      return typeof params?.uri === 'string' ? params.uri : undefined;
+    default:
+      return undefined;
+  }
+}

--- a/v3/@claude-flow/mcp/src/server.ts
+++ b/v3/@claude-flow/mcp/src/server.ts
@@ -22,6 +22,7 @@ import type {
   TransportType,
   ILogger,
   ToolContext,
+  ToolRegistrationOptions,
 } from './types.js';
 import { MCPServerError, ErrorCodes } from './types.js';
 import { ToolRegistry, createToolRegistry } from './tool-registry.js';
@@ -64,8 +65,9 @@ const DEFAULT_CONFIG: Partial<MCPServerConfig> = {
 export interface IMCPServer {
   start(): Promise<void>;
   stop(): Promise<void>;
-  registerTool(tool: MCPTool): boolean;
-  registerTools(tools: MCPTool[]): { registered: number; failed: string[] };
+  processRequest(request: MCPRequest): Promise<MCPResponse>;
+  registerTool(tool: MCPTool, options?: ToolRegistrationOptions): boolean;
+  registerTools(tools: MCPTool[], options?: ToolRegistrationOptions): { registered: number; failed: string[] };
   getHealthStatus(): Promise<{
     healthy: boolean;
     error?: string;
@@ -96,10 +98,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   private currentSession?: MCPSession;
   private resourceSubscriptions: Map<string, Set<string>> = new Map(); // sessionId -> subscribed URIs
 
-  private readonly serverInfo = {
-    name: 'Claude-Flow MCP Server V3',
-    version: '3.0.0',
-  };
+  private readonly serverInfo: { name: string; version: string };
 
   // MCP protocol revision is negotiated per session (2025-11-25 or
   // 2026-07-28, see protocol.ts). Spec-required YYYY-MM-DD date string
@@ -129,6 +128,10 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   ) {
     super();
     this.config = { ...DEFAULT_CONFIG, ...config } as MCPServerConfig;
+    this.serverInfo = {
+      name: this.config.name || 'Claude-Flow MCP Server V3',
+      version: this.config.version || '3.0.0',
+    };
 
     this.toolRegistry = createToolRegistry(logger);
     this.sessionManager = createSessionManager(logger, {
@@ -305,12 +308,15 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
   }
 
-  registerTool(tool: MCPTool): boolean {
-    return this.toolRegistry.register(tool);
+  registerTool(tool: MCPTool, options?: ToolRegistrationOptions): boolean {
+    return this.toolRegistry.register(tool, options);
   }
 
-  registerTools(tools: MCPTool[]): { registered: number; failed: string[] } {
-    return this.toolRegistry.registerBatch(tools);
+  registerTools(
+    tools: MCPTool[],
+    options?: ToolRegistrationOptions
+  ): { registered: number; failed: string[] } {
+    return this.toolRegistry.registerBatch(tools, options);
   }
 
   unregisterTool(name: string): boolean {

--- a/v3/@claude-flow/mcp/src/server.ts
+++ b/v3/@claude-flow/mcp/src/server.ts
@@ -421,6 +421,16 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     return requested !== undefined && isStatelessProtocol(requested);
   }
 
+  /**
+   * Stable identity for MRTR continuation binding. Prefers the session id
+   * (stateful), then the transport-provided client key (stateless HTTP:
+   * client IP). Undefined for single-client transports with neither (stdio),
+   * where cross-client replay isn't possible anyway.
+   */
+  private clientKeyFor(request: MCPRequest): string | undefined {
+    return this.currentSession?.id ?? request.meta?.clientKey;
+  }
+
   /** Negotiated protocol revision governing this request. */
   private effectiveProtocolVersion(request: MCPRequest): MCPProtocolVersion {
     if (this.isStatelessRequest(request)) {
@@ -687,7 +697,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     // MRTR resume: re-enter a paused tool instead of a fresh invocation
     if (params?.continuationToken) {
       try {
-        const raw = await this.continuationManager.resume(params.continuationToken, params.input);
+        const raw = await this.continuationManager.resume(
+          params.continuationToken,
+          params.input,
+          this.clientKeyFor(request)
+        );
         return this.finalizeToolResult(request, params.name ?? 'continuation', raw);
       } catch (error) {
         return this.createErrorResponse(
@@ -767,7 +781,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         };
       }
 
-      const inputRequiredResult = this.continuationManager.register(raw, toolName);
+      const inputRequiredResult = this.continuationManager.register(
+        raw,
+        toolName,
+        this.clientKeyFor(request)
+      );
       return {
         jsonrpc: '2.0',
         id: request.id,

--- a/v3/@claude-flow/mcp/src/server.ts
+++ b/v3/@claude-flow/mcp/src/server.ts
@@ -33,6 +33,19 @@ import { TaskManager, createTaskManager } from './task-manager.js';
 import { createTransport, TransportManager, createTransportManager } from './transport/index.js';
 import { RateLimiter, createRateLimiter, type RateLimitConfig } from './rate-limiter.js';
 import { SamplingManager, createSamplingManager, type SamplingConfig, type LLMProvider } from './sampling.js';
+import {
+  PROTOCOL_2025_11_25,
+  negotiateProtocolVersion,
+  isStatelessProtocol,
+  supportsMrtr,
+  DEPRECATED_METHODS_2026_07_28,
+} from './protocol.js';
+import {
+  ContinuationManager,
+  createContinuationManager,
+  isPendingInputRequest,
+  type PendingInputRequest,
+} from './mrtr.js';
 
 const DEFAULT_CONFIG: Partial<MCPServerConfig> = {
   name: 'Claude-Flow MCP Server V3',
@@ -75,6 +88,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   private readonly transportManager: TransportManager;
   private readonly rateLimiter: RateLimiter;
   private readonly samplingManager: SamplingManager;
+  private readonly continuationManager: ContinuationManager;
   private transport?: ITransport;
   private running = false;
   private startTime?: Date;
@@ -87,9 +101,9 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     version: '3.0.0',
   };
 
-  // MCP protocol version — spec-required YYYY-MM-DD date string (#1874).
-  // Claude Code's Zod validator rejects any other shape.
-  private readonly protocolVersion: MCPProtocolVersion = '2025-11-25';
+  // MCP protocol revision is negotiated per session (2025-11-25 or
+  // 2026-07-28, see protocol.ts). Spec-required YYYY-MM-DD date string
+  // (#1874) — Claude Code's Zod validator rejects any other shape.
 
   // Full MCP 2025-11-25 capabilities
   private capabilities: MCPCapabilities = {
@@ -138,6 +152,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       perSessionLimit: 50,
     });
     this.samplingManager = createSamplingManager(logger);
+    this.continuationManager = createContinuationManager(logger);
 
     if (this.config.connectionPool) {
       this.connectionPool = createConnectionPool(
@@ -190,6 +205,13 @@ export class MCPServer extends EventEmitter implements IMCPServer {
    */
   registerLLMProvider(provider: LLMProvider, isDefault: boolean = false): void {
     this.samplingManager.registerProvider(provider, isDefault);
+  }
+
+  /**
+   * Get continuation manager for MRTR (MCP 2026-07-28) inspection
+   */
+  getContinuationManager(): ContinuationManager {
+    return this.continuationManager;
   }
 
   async start(): Promise<void> {
@@ -265,6 +287,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       this.taskManager.destroy();
       this.resourceSubscriptions.clear();
       this.rateLimiter.destroy();
+      this.continuationManager.destroy();
 
       if (this.connectionPool) {
         await this.connectionPool.clear();
@@ -375,6 +398,37 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     return result;
   }
 
+  /**
+   * Process a single JSON-RPC request. Public entry point for in-process
+   * transports and embedding hosts; network transports route here via
+   * onRequest.
+   */
+  async processRequest(request: MCPRequest): Promise<MCPResponse> {
+    return this.handleRequest(request);
+  }
+
+  /**
+   * Whether this request is served without the initialize handshake or a
+   * session (MCP 2026-07-28 stateless protocol). Opt-in via config
+   * statelessMode, or per-request when the transport saw a stateless
+   * Mcp-Protocol-Version header (ADR-179).
+   */
+  private isStatelessRequest(request: MCPRequest): boolean {
+    if (this.config.statelessMode) {
+      return true;
+    }
+    const requested = request.meta?.protocolVersion;
+    return requested !== undefined && isStatelessProtocol(requested);
+  }
+
+  /** Negotiated protocol revision governing this request. */
+  private effectiveProtocolVersion(request: MCPRequest): MCPProtocolVersion {
+    if (this.isStatelessRequest(request)) {
+      return negotiateProtocolVersion(request.meta?.protocolVersion);
+    }
+    return this.currentSession?.protocolVersion ?? PROTOCOL_2025_11_25;
+  }
+
   private async handleRequest(request: MCPRequest): Promise<MCPResponse> {
     const startTime = performance.now();
     this.requestStats.total++;
@@ -384,10 +438,15 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       method: request.method,
     });
 
-    // Rate limiting check (skip for initialize)
+    const stateless = this.isStatelessRequest(request);
+
+    // Rate limiting check (skip for initialize). In stateless mode there is
+    // no session, so bucket by the transport-provided client identity.
     if (request.method !== 'initialize') {
-      const sessionId = this.currentSession?.id;
-      const rateLimitResult = this.rateLimiter.check(sessionId);
+      const rateLimitKey = stateless
+        ? request.meta?.clientKey
+        : this.currentSession?.id;
+      const rateLimitResult = this.rateLimiter.check(rateLimitKey);
       if (!rateLimitResult.allowed) {
         this.requestStats.failed++;
         return {
@@ -400,25 +459,29 @@ export class MCPServer extends EventEmitter implements IMCPServer {
           },
         };
       }
-      this.rateLimiter.consume(sessionId);
+      this.rateLimiter.consume(rateLimitKey);
     }
 
     try {
+      // Stateful clients keep the initialize handshake even when the server
+      // allows stateless traffic — both revisions are served side by side.
       if (request.method === 'initialize') {
         return await this.handleInitialize(request);
       }
 
-      const session = this.getOrCreateSession();
+      if (!stateless) {
+        const session = this.getOrCreateSession();
 
-      if (!session.isInitialized && request.method !== 'initialized') {
-        return this.createErrorResponse(
-          request.id,
-          ErrorCodes.SERVER_NOT_INITIALIZED,
-          'Server not initialized'
-        );
+        if (!session.isInitialized && request.method !== 'initialized') {
+          return this.createErrorResponse(
+            request.id,
+            ErrorCodes.SERVER_NOT_INITIALIZED,
+            'Server not initialized'
+          );
+        }
+
+        this.sessionManager.updateActivity(session.id);
       }
-
-      this.sessionManager.updateActivity(session.id);
 
       const response = await this.routeRequest(request);
 
@@ -481,13 +544,17 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       );
     }
 
+    const negotiated = negotiateProtocolVersion(params.protocolVersion);
+
     const session = this.sessionManager.createSession(this.config.transport);
-    this.sessionManager.initializeSession(session.id, params);
+    // Store the NEGOTIATED revision, not the client-requested one — it
+    // governs MRTR availability and deprecations for the session's lifetime.
+    this.sessionManager.initializeSession(session.id, { ...params, protocolVersion: negotiated });
     this.currentSession = session;
 
     const result: MCPInitializeResult = {
-      protocolVersion: this.protocolVersion,
-      capabilities: this.capabilities,
+      protocolVersion: negotiated,
+      capabilities: this.getCapabilities(negotiated),
       serverInfo: this.serverInfo,
       instructions: 'Claude-Flow MCP Server V3 ready for tool execution',
     };
@@ -495,6 +562,8 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     this.logger.info('Session initialized', {
       sessionId: session.id,
       clientInfo: params.clientInfo,
+      requestedProtocolVersion: params.protocolVersion,
+      negotiatedProtocolVersion: negotiated,
     });
 
     return {
@@ -504,7 +573,31 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     };
   }
 
+  /**
+   * Capabilities advertised for a negotiated revision. 2026-07-28 deprecates
+   * roots, sampling, and logging: the methods stay functional, but are no
+   * longer advertised to clients speaking the new revision.
+   */
+  private getCapabilities(version: MCPProtocolVersion): MCPCapabilities {
+    if (!isStatelessProtocol(version)) {
+      return this.capabilities;
+    }
+    return {
+      tools: this.capabilities.tools,
+      resources: this.capabilities.resources,
+      prompts: this.capabilities.prompts,
+    };
+  }
+
   private async routeRequest(request: MCPRequest): Promise<MCPResponse> {
+    const version = this.effectiveProtocolVersion(request);
+
+    if (DEPRECATED_METHODS_2026_07_28.has(request.method) && isStatelessProtocol(version)) {
+      this.logger.warn('Deprecated MCP method called (deprecated in 2026-07-28, still functional)', {
+        method: request.method,
+      });
+    }
+
     switch (request.method) {
       // Tool methods
       case 'tools/list':
@@ -583,7 +676,27 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   }
 
   private async handleToolsCall(request: MCPRequest): Promise<MCPResponse> {
-    const params = request.params as { name: string; arguments?: Record<string, unknown> };
+    const params = request.params as {
+      name?: string;
+      arguments?: Record<string, unknown>;
+      // MRTR resume (MCP 2026-07-28): continuation token + client input
+      continuationToken?: string;
+      input?: unknown;
+    };
+
+    // MRTR resume: re-enter a paused tool instead of a fresh invocation
+    if (params?.continuationToken) {
+      try {
+        const raw = await this.continuationManager.resume(params.continuationToken, params.input);
+        return this.finalizeToolResult(request, params.name ?? 'continuation', raw);
+      } catch (error) {
+        return this.createErrorResponse(
+          request.id,
+          ErrorCodes.INVALID_PARAMS,
+          error instanceof Error ? error.message : 'Continuation resume failed'
+        );
+      }
+    }
 
     if (!params?.name) {
       return this.createErrorResponse(
@@ -594,7 +707,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
 
     const context: ToolContext = {
-      sessionId: this.currentSession?.id || 'unknown',
+      sessionId: this.currentSession?.id || request.meta?.clientKey || 'unknown',
       requestId: request.id,
       orchestrator: this.orchestrator,
       swarmCoordinator: this.swarmCoordinator,
@@ -606,16 +719,12 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       context
     );
 
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result,
-    };
+    return this.finalizeToolResult(request, params.name, result);
   }
 
   private async handleToolExecution(request: MCPRequest): Promise<MCPResponse> {
     const context: ToolContext = {
-      sessionId: this.currentSession?.id || 'unknown',
+      sessionId: this.currentSession?.id || request.meta?.clientKey || 'unknown',
       requestId: request.id,
       orchestrator: this.orchestrator,
       swarmCoordinator: this.swarmCoordinator,
@@ -627,11 +736,71 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       context
     );
 
+    return this.finalizeToolResult(request, request.method, result);
+  }
+
+  /**
+   * Turn a tool handler outcome into a JSON-RPC response, registering MRTR
+   * continuations for 2026-07-28 clients. Legacy sessions get a terminal
+   * error result instead — MRTR needs the new revision.
+   */
+  private finalizeToolResult(
+    request: MCPRequest,
+    toolName: string,
+    raw: unknown
+  ): MCPResponse {
+    if (isPendingInputRequest(raw)) {
+      const version = this.effectiveProtocolVersion(request);
+      if (!supportsMrtr(version)) {
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {
+            content: [{
+              type: 'text',
+              text: `Tool requires additional input: ${raw.message}. ` +
+                'Re-invoke the tool with the required input included in its arguments ' +
+                '(multi round-trip requests need MCP protocol 2026-07-28).',
+            }],
+            isError: true,
+          },
+        };
+      }
+
+      const inputRequiredResult = this.continuationManager.register(raw, toolName);
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        result: inputRequiredResult,
+      };
+    }
+
+    // Resumed continuations return raw handler output; fresh calls arrive
+    // already wrapped by the tool registry.
+    const result = this.isToolCallResult(raw)
+      ? raw
+      : {
+          content: [{
+            type: 'text' as const,
+            text: typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2),
+          }],
+          isError: false,
+        };
+
     return {
       jsonrpc: '2.0',
       id: request.id,
       result,
     };
+  }
+
+  private isToolCallResult(value: unknown): value is { content: unknown[]; isError: boolean } {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      Array.isArray((value as { content?: unknown }).content) &&
+      typeof (value as { isError?: unknown }).isError === 'boolean'
+    );
   }
 
   // ============================================================================

--- a/v3/@claude-flow/mcp/src/tool-registry.ts
+++ b/v3/@claude-flow/mcp/src/tool-registry.ts
@@ -15,6 +15,7 @@ import type {
   ILogger,
 } from './types.js';
 import { validateSchema, formatValidationErrors } from './schema-validator.js';
+import { isPendingInputRequest, type PendingInputRequest } from './mrtr.js';
 
 interface ToolMetadata {
   tool: MCPTool;
@@ -271,7 +272,7 @@ export class ToolRegistry extends EventEmitter {
     name: string,
     input: Record<string, unknown>,
     context?: ToolContext
-  ): Promise<ToolCallResult> {
+  ): Promise<ToolCallResult | PendingInputRequest> {
     const startTime = performance.now();
     const metadata = this.tools.get(name);
 
@@ -314,6 +315,13 @@ export class ToolRegistry extends EventEmitter {
 
       const duration = performance.now() - startTime;
       this.updateAverageExecutionTime(metadata, duration);
+
+      // MRTR (MCP 2026-07-28): a paused tool carries its resume callback and
+      // must reach the server unwrapped for continuation registration.
+      if (isPendingInputRequest(result)) {
+        this.emit('tool:completed', { name, duration, success: true, inputRequired: true });
+        return result;
+      }
 
       this.logger.debug('Tool executed', {
         name,

--- a/v3/@claude-flow/mcp/src/tool-registry.ts
+++ b/v3/@claude-flow/mcp/src/tool-registry.ts
@@ -283,8 +283,10 @@ export class ToolRegistry extends EventEmitter {
       };
     }
 
-    // Validate input against schema (security feature)
-    if (metadata.tool.inputSchema) {
+    // Validate input against schema (security feature). Opt out per-tool via
+    // validateInput:false for handlers that validate themselves or bridged
+    // tools whose declared schema is advisory only.
+    if (metadata.tool.inputSchema && metadata.tool.validateInput !== false) {
       const validation = validateSchema(input, metadata.tool.inputSchema);
       if (!validation.valid) {
         const errorMsg = formatValidationErrors(validation.errors);

--- a/v3/@claude-flow/mcp/src/transport/http.ts
+++ b/v3/@claude-flow/mcp/src/transport/http.ts
@@ -22,6 +22,11 @@ import type {
   ILogger,
   AuthConfig,
 } from '../types.js';
+import {
+  MCP_METHOD_HEADER,
+  MCP_PROTOCOL_VERSION_HEADER,
+  extractMcpName,
+} from '../protocol.js';
 
 export interface HttpTransportConfig {
   host: string;
@@ -197,7 +202,9 @@ export class HttpTransport extends EventEmitter implements ITransport {
         credentials: true,
         maxAge: 86400,
         methods: ['GET', 'POST', 'OPTIONS'],
-        allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+        // Mcp-* headers: MCP 2026-07-28 gateway-routing transport headers
+        allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID', 'Mcp-Method', 'Mcp-Name', 'Mcp-Protocol-Version'],
+        exposedHeaders: ['Mcp-Method', 'Mcp-Name', 'Mcp-Protocol-Version'],
       }));
     }
 
@@ -382,6 +389,39 @@ export class HttpTransport extends EventEmitter implements ITransport {
         error: { code: -32600, message: 'Missing method' },
       });
       return;
+    }
+
+    // MCP 2026-07-28 transport headers: gateways route on Mcp-Method without
+    // parsing bodies, so a header/body mismatch means something rewrote one
+    // of them — reject rather than serve a misrouted request.
+    const headerMethod = req.header(MCP_METHOD_HEADER);
+    if (headerMethod && headerMethod !== message.method) {
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: { code: -32600, message: 'Mcp-Method header does not match request body method' },
+      });
+      return;
+    }
+
+    // Attach transport metadata (never serialized back out): protocol
+    // revision from the header drives stateless-mode negotiation; the client
+    // IP buckets rate limiting when no session exists.
+    const headerVersion = req.header(MCP_PROTOCOL_VERSION_HEADER);
+    message.meta = {
+      transport: 'http',
+      ...(headerVersion ? { protocolVersion: headerVersion } : {}),
+      ...(req.ip ? { clientKey: req.ip } : {}),
+    };
+
+    // Echo routing headers so gateways can classify responses symmetrically
+    res.setHeader('Mcp-Method', message.method);
+    const mcpName = extractMcpName(message);
+    if (mcpName) {
+      res.setHeader('Mcp-Name', mcpName);
+    }
+    if (headerVersion) {
+      res.setHeader('Mcp-Protocol-Version', headerVersion);
     }
 
     if (message.id === undefined) {

--- a/v3/@claude-flow/mcp/src/types.ts
+++ b/v3/@claude-flow/mcp/src/types.ts
@@ -32,6 +32,23 @@ export interface MCPRequest extends MCPMessage {
   id: RequestId;
   method: string;
   params?: Record<string, unknown>;
+  /**
+   * Transport-populated request metadata (MCP 2026-07-28). Never part of the
+   * JSON-RPC wire payload — transports attach it from headers/connection
+   * state so the server can negotiate per-request in stateless mode.
+   */
+  meta?: MCPRequestMeta;
+}
+
+export interface MCPRequestMeta {
+  /** From the Mcp-Protocol-Version header (2026-07-28 stateless clients). */
+  protocolVersion?: MCPProtocolVersion;
+  transport?: TransportType;
+  /**
+   * Connection/auth identity for rate limiting and tool context when no
+   * session exists (stateless mode). E.g. client IP or token fingerprint.
+   */
+  clientKey?: string;
 }
 
 export interface MCPNotification extends MCPMessage {
@@ -115,6 +132,13 @@ export interface MCPServerConfig {
   enableCaching?: boolean;
   cacheTTL?: number;
   logLevel?: 'debug' | 'info' | 'warn' | 'error';
+  /**
+   * MCP 2026-07-28 stateless mode (opt-in, ADR-179). Requests are served
+   * without the initialize handshake or a session, enabling round-robin
+   * load balancing. Stateful clients on the same server keep working —
+   * initialize is still honored when sent.
+   */
+  statelessMode?: boolean;
 }
 
 // ============================================================================
@@ -646,7 +670,11 @@ export const ErrorCodes = {
   REQUEST_CANCELLED: -32800,
   RATE_LIMITED: -32000,
   AUTHENTICATION_REQUIRED: -32001,
-  AUTHORIZATION_FAILED: -32002,
+  // -32003, not -32002: MCP 2026-07-28 standardizes error codes, and
+  // authorization failure must not be conflated with SERVER_NOT_INITIALIZED
+  // (which -32002 historically carried). Missing resources use the standard
+  // JSON-RPC INVALID_PARAMS (-32602), not an MCP-specific code.
+  AUTHORIZATION_FAILED: -32003,
 } as const;
 
 export class MCPServerError extends Error {

--- a/v3/@claude-flow/mcp/src/types.ts
+++ b/v3/@claude-flow/mcp/src/types.ts
@@ -253,6 +253,13 @@ export interface MCPTool<TInput = unknown, TOutput = unknown> {
   cacheable?: boolean;
   cacheTTL?: number;
   timeout?: number;
+  /**
+   * Validate call input against inputSchema before invoking the handler
+   * (default true). Set false for tools whose handler does its own
+   * validation, or bridged/legacy tools whose declared schema is advisory —
+   * the schema is still advertised in tools/list either way.
+   */
+  validateInput?: boolean;
 }
 
 export interface ToolCallResult {

--- a/v3/docs/adr/ADR-179-mcp-2026-07-28-spec-adoption.md
+++ b/v3/docs/adr/ADR-179-mcp-2026-07-28-spec-adoption.md
@@ -1,6 +1,6 @@
 # ADR-179: MCP 2026-07-28 Specification Adoption and SDK v2 Migration Strategy
 
-**Status**: Proposed
+**Status**: Accepted — Phases 1–2 implemented in `@claude-flow/mcp` (2026-07-12): error-code split, transport headers, dual-version negotiation, opt-in stateless mode, MRTR, RFC 9207 `iss` validation + DCR `application_type`
 **Date**: 2026-07-12
 **References**: [MCP SDK beta announcement (2026-07-28 spec)](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/), ADR-012 (MCP Security Features), ADR-166 (MCP Bridge RCE Remediation)
 

--- a/v3/docs/adr/ADR-179-mcp-2026-07-28-spec-adoption.md
+++ b/v3/docs/adr/ADR-179-mcp-2026-07-28-spec-adoption.md
@@ -1,6 +1,6 @@
 # ADR-179: MCP 2026-07-28 Specification Adoption and SDK v2 Migration Strategy
 
-**Status**: Accepted — Phases 1–2 implemented in `@claude-flow/mcp` (2026-07-12): error-code split, transport headers, dual-version negotiation, opt-in stateless mode, MRTR, RFC 9207 `iss` validation + DCR `application_type`
+**Status**: Accepted — Phases 1–2 implemented in `@claude-flow/mcp` (2026-07-12): error-code split, transport headers, dual-version negotiation, opt-in stateless mode, MRTR, RFC 9207 `iss` validation + DCR `application_type`. **CLI stdio transport unified onto `@claude-flow/mcp`** (2026-07-12): the hand-rolled 2024-11-05 stdio handler in `@claude-flow/cli/src/mcp-server.ts` now delegates to the package (bridging the 314-tool registry), so stdio and HTTP/WS share one spec-compliant implementation.
 **Date**: 2026-07-12
 **References**: [MCP SDK beta announcement (2026-07-28 spec)](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/), ADR-012 (MCP Security Features), ADR-166 (MCP Bridge RCE Remediation)
 
@@ -22,6 +22,8 @@ The spec revision is not incremental — it changes the protocol's architectural
 ### Why this hits ruflo harder than most projects
 
 Ruflo has **two independent MCP surfaces**, and neither is insulated by an SDK upgrade path:
+
+> **Integration note (2026-07-12):** the CLI historically had *two* MCP code paths — `startHttpServer` used `@claude-flow/mcp`, but the default **stdio** transport (`startStdioServer`, what Claude Code invokes via `npx ruflo mcp start`) was a *separate* hand-rolled JSON-RPC loop hardcoding `protocolVersion: '2024-11-05'`. The stdio path has since been unified onto `@claude-flow/mcp` (`handleMCPMessage` → `MCPServer.processRequest`, with the ruflo tool registry bridged in via `registerTools({ validate: false })` and per-tool `validateInput: false` to preserve the raw path's pass-through behavior). Both transports now negotiate 2025-11-25/2026-07-28 from the same implementation. The stdio I/O hardening (stdout-frame isolation, `setBlocking` for large frames, bounded buffer, memory auto-init) is retained; only the protocol/dispatch layer changed.
 
 **Surface 1 — hand-rolled server (`v3/@claude-flow/mcp`)**. Our 314-tool MCP server does not depend on `@modelcontextprotocol/sdk`; it implements JSON-RPC, stdio/HTTP/WebSocket transports, connection pooling, and the tool registry directly. Every spec-affected area is load-bearing code we own:
 

--- a/v3/docs/adr/ADR-179-mcp-2026-07-28-spec-adoption.md
+++ b/v3/docs/adr/ADR-179-mcp-2026-07-28-spec-adoption.md
@@ -1,0 +1,108 @@
+# ADR-179: MCP 2026-07-28 Specification Adoption and SDK v2 Migration Strategy
+
+**Status**: Proposed
+**Date**: 2026-07-12
+**References**: [MCP SDK beta announcement (2026-07-28 spec)](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/), ADR-012 (MCP Security Features), ADR-166 (MCP Bridge RCE Remediation)
+
+---
+
+## Context
+
+The Model Context Protocol project has published beta SDK releases targeting the **2026-07-28 specification revision**, which becomes final on July 28, 2026. Betas exist for all four Tier 1 SDKs: Python (`mcp` v2.0.0b1), TypeScript (v2, split packages such as `@modelcontextprotocol/server@beta`), Go (v1.7.0-pre.1), and C# (v2.0.0-preview.1).
+
+The spec revision is not incremental — it changes the protocol's architectural core:
+
+1. **Stateless protocol**: the `initialize` handshake and session management are removed. Servers become round-robin load-balanceable with no sticky sessions.
+2. **Multi Round-Trip Requests (MRTR)**: tools can return `InputRequiredResult` to request user input mid-execution, replacing long-lived streams for elicitation.
+3. **Transport headers**: every request carries `Mcp-Method` (plus `Mcp-Name` on tool/resource/prompt requests) so gateways can route without parsing JSON-RPC bodies.
+4. **Authorization hardening**: RFC 9207 `iss` validation, `application_type` in Dynamic Client Registration, credentials bound to their issuing server.
+5. **Standard error codes**: missing resources return JSON-RPC `-32602` instead of the MCP-specific `-32002`.
+6. **Deprecations**: roots, sampling, and logging capabilities are deprecated (still functional).
+
+### Why this hits ruflo harder than most projects
+
+Ruflo has **two independent MCP surfaces**, and neither is insulated by an SDK upgrade path:
+
+**Surface 1 — hand-rolled server (`v3/@claude-flow/mcp`)**. Our 314-tool MCP server does not depend on `@modelcontextprotocol/sdk`; it implements JSON-RPC, stdio/HTTP/WebSocket transports, connection pooling, and the tool registry directly. Every spec-affected area is load-bearing code we own:
+
+| Spec change | Affected module | Current state |
+|---|---|---|
+| Stateless protocol | `session-manager.ts`, `server.ts` | Protocol pinned to `2025-11-25` (`server.ts:92`); full initialize/session lifecycle |
+| MRTR | `tool-registry.ts`, `task-manager.ts` | No mid-execution input mechanism |
+| Transport headers | `transport/` | Headers not emitted or routed on |
+| Error codes | `types.ts:638` (`ErrorCodes`) | `SERVER_NOT_INITIALIZED` and `AUTHORIZATION_FAILED` both mapped to `-32002` |
+| Auth hardening | `oauth.ts` | No RFC 9207 `iss` validation, no `application_type` in DCR |
+| Deprecations | `sampling.ts` (`sampling/createMessage`, `server.ts:546`), logging | Sampling is an active feature with provider registration |
+
+There is no codemod for us — the TypeScript `v1-to-v2` codemod targets SDK consumers, not independent implementations.
+
+**Surface 2 — SDK client (`ruflo/src/ruvocal`)**. The ruvocal app depends on `@modelcontextprotocol/sdk@^1.26.0` (client pool, HTTP client, tool invocation). TypeScript SDK v2 splits the monolith into focused packages, goes ESM-only, requires Node.js 20+, and adopts Standard Schema for tool validation. The current `^1.26.0` caret range is safe (v2 ships as new package names / a new major), but the migration itself is a real work item.
+
+**What protects us**: the announcement commits to interop — "old servers and new clients keep interoperating" — and TypeScript v1.x receives bug fixes for at least six months post-v2. Current stable versions remain recommended for production. So there is no forcing function before the spec finalizes, but the stateless model and error-code change will eventually be what new clients and gateways expect.
+
+---
+
+## Decision
+
+Adopt the 2026-07-28 specification **incrementally and dual-version**, keeping `2025-11-25` support intact until the ecosystem moves. No beta SDKs in production.
+
+### 1. Hold the line now (pre-finalization, before 2026-07-28)
+
+- **Do not** adopt any beta SDK in a published package. If a spike needs one, pin the exact beta version in a branch, never in `main`.
+- Add an explicit upper bound to ruvocal: `"@modelcontextprotocol/sdk": "^1.26.0 <2"` (defensive; v2 restructuring makes accidental major-bumps via transitive tooling a real risk — see the #2112 overrides lesson).
+- Land the **zero-risk forward-compatible changes** in `@claude-flow/mcp` immediately, since they are valid under both spec revisions:
+  - Split `ErrorCodes`: `AUTHORIZATION_FAILED` moves off `-32002` (it never should have shared a code with `SERVER_NOT_INITIALIZED`); resource-not-found paths return `-32602` with a descriptive message.
+  - Emit `Mcp-Method` / `Mcp-Name` headers on outbound HTTP requests and tolerate them inbound. Headers are additive and ignored by old peers.
+
+### 2. Dual protocol-version support in `@claude-flow/mcp` (at finalization)
+
+- Introduce `MCPProtocolVersion = '2025-11-25' | '2026-07-28'` negotiation. When a client connects statelessly (no `initialize`), serve the new revision; when it sends `initialize`, run the existing session lifecycle unchanged.
+- Make **stateless mode opt-in per transport** (`StreamableHTTPOptions`-style flag, mirroring the Go SDK's `Stateless = true` approach), defaulting to stateful until our own consumers (Claude Code, the MCP bridge, metaharness `mcp-scan`) are verified against it.
+- `session-manager.ts` becomes a compatibility layer, not a required path. Session-scoped state that tools rely on (memory namespaces, rate-limiter buckets keyed by session) must be re-keyed to connection/auth identity so stateless requests still resolve them.
+
+### 3. MRTR support in the tool registry
+
+- Add `InputRequiredResult` as a first-class tool return type in `tool-registry.ts` / `task-manager.ts`. This directly benefits swarm tools that currently fake elicitation via long-polling or memory handshakes.
+- Gate behind the negotiated protocol version; on `2025-11-25` connections, an `InputRequiredResult` is downgraded to a terminal error instructing the client to re-invoke with the needed input.
+
+### 4. Authorization hardening (`oauth.ts`)
+
+- Implement RFC 9207 `iss` validation and `application_type` in DCR regardless of protocol version — this is pure security posture and aligns with ADR-166's remediation direction. Track under `@claude-flow/security` review.
+
+### 5. Deprecated capabilities: keep, isolate, don't grow
+
+- `sampling/createMessage`, roots, and logging stay functional (deprecated ≠ removed), but are frozen: no new features, and `sampling.ts` gets a deprecation note pointing at the agent-native alternative (Task-tool agents / `metallm_delegate`).
+
+### 6. ruvocal SDK v2 migration (post-stable, not before)
+
+- Migrate only after TypeScript v2 is stable, using the official codemod (`npx @modelcontextprotocol/codemod v1-to-v2 .`) as the starting point. ruvocal is already ESM and Node 20+, so the split-package + Standard Schema changes are the bulk of the work.
+- The v1.x six-month bug-fix window is the deadline anchor: complete migration within that window.
+
+---
+
+## Consequences
+
+**Positive**
+- Stateless mode removes the sticky-session constraint on the HTTP transport — the connection-pool and any future multi-instance deployment get horizontal scaling for free.
+- MRTR gives swarm tools a spec-blessed elicitation mechanism, replacing ad-hoc memory-handshake patterns.
+- Error-code and header changes shipped early mean gateways and new clients work against us on day one of finalization.
+- Owning the server implementation means no forced SDK-major migration for Surface 1 — we adopt at our own pace.
+
+**Negative / trade-offs**
+- Owning the implementation also means we pay full engineering cost for every spec change; the dual-version negotiation layer is complexity the SDK crowd gets for free.
+- Re-keying session-scoped state (rate limiting, memory namespaces) to auth identity is the riskiest single piece — done wrong it either breaks tool state or opens a cross-tenant leak. It needs its own security review before stateless mode defaults on.
+- Two protocol versions live in the codebase for at least one release cycle; test matrix doubles for the MCP package.
+
+**Explicitly rejected alternatives**
+- *Replace `@claude-flow/mcp` with the official SDK*: rejected — the package exists precisely because we need connection pooling, a 314-tool registry, rate limiting, and three transports under one roof; v2's split packages still wouldn't cover that, and a rewrite has higher regression risk than tracking the spec.
+- *Adopt betas now*: rejected — public APIs may change before stable, and the announcement itself recommends stable versions for production.
+- *Ignore until clients break*: rejected — the `-32002` error-code mismatch and missing transport headers would silently degrade behavior behind gateways well before hard failures appear.
+
+---
+
+## Implementation Notes
+
+- Phase 1 (now): error-code split + header emission in `@claude-flow/mcp`; ruvocal upper-bound pin. PATCH release.
+- Phase 2 (spec finalization): version negotiation + opt-in stateless transport + MRTR. MINOR release (backward-compatible addition).
+- Phase 3 (TS SDK v2 stable): ruvocal migration; flip stateless default only after Claude Code and metaharness `mcp-scan` verify against it. Flipping the default is a MAJOR-worthy behavior change per the versioning policy.
+- CI: add a protocol-conformance smoke that runs the same tool-call suite over both negotiated versions.

--- a/v3/docs/adr/README.md
+++ b/v3/docs/adr/README.md
@@ -29,6 +29,7 @@ All ADRs are located in [`/v3/implementation/adrs/`](../../implementation/adrs/)
 | [ADR-046](../../implementation/adrs/ADR-046-ruflo-rebrand.md) | Dual Umbrella: claude-flow + ruflo | Accepted |
 | [ADR-047](../../implementation/adrs/ADR-047-fast-mode-integration.md) | Fast Mode Integration | Proposed |
 | [ADR-178](ADR-178-dream-cycle-security-vmg-repe-ipi.md) | Verifiable Memory Governance and RepE IPI Detection | Proposed |
+| [ADR-179](ADR-179-mcp-2026-07-28-spec-adoption.md) | MCP 2026-07-28 Spec Adoption and SDK v2 Migration | Proposed |
 
 ## Summary Documents
 

--- a/v3/docs/adr/README.md
+++ b/v3/docs/adr/README.md
@@ -29,7 +29,7 @@ All ADRs are located in [`/v3/implementation/adrs/`](../../implementation/adrs/)
 | [ADR-046](../../implementation/adrs/ADR-046-ruflo-rebrand.md) | Dual Umbrella: claude-flow + ruflo | Accepted |
 | [ADR-047](../../implementation/adrs/ADR-047-fast-mode-integration.md) | Fast Mode Integration | Proposed |
 | [ADR-178](ADR-178-dream-cycle-security-vmg-repe-ipi.md) | Verifiable Memory Governance and RepE IPI Detection | Proposed |
-| [ADR-179](ADR-179-mcp-2026-07-28-spec-adoption.md) | MCP 2026-07-28 Spec Adoption and SDK v2 Migration | Proposed |
+| [ADR-179](ADR-179-mcp-2026-07-28-spec-adoption.md) | MCP 2026-07-28 Spec Adoption and SDK v2 Migration | Accepted |
 
 ## Summary Documents
 

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/aidefence':
     dependencies:
@@ -102,7 +102,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/cli':
     dependencies:
@@ -110,8 +110,8 @@ importers:
         specifier: 3.7.0-alpha.5
         version: link:../cli-core
       '@claude-flow/mcp':
-        specifier: 3.0.0-alpha.8
-        version: 3.0.0-alpha.8
+        specifier: 3.0.0-alpha.10
+        version: link:../mcp
       '@claude-flow/neural':
         specifier: 3.0.0-alpha.9
         version: link:../neural
@@ -197,7 +197,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/deployment':
     dependencies:
@@ -210,7 +210,7 @@ importers:
         version: 25.0.2(typescript@5.9.3)
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/embeddings':
     dependencies:
@@ -260,7 +260,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/hooks':
     dependencies:
@@ -292,7 +292,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/integration':
     dependencies:
@@ -337,7 +337,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/memory':
     dependencies:
@@ -386,7 +386,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugin-agent-federation':
     dependencies:
@@ -436,7 +436,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugins':
     dependencies:
@@ -464,7 +464,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/providers':
     dependencies:
@@ -489,7 +489,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/security':
     dependencies:
@@ -505,7 +505,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/shared':
     dependencies:
@@ -539,7 +539,7 @@ importers:
         version: 7.2.0
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
       ws:
         specifier: ^8.16.0
         version: 8.19.0
@@ -551,7 +551,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/testing':
     devDependencies:
@@ -569,7 +569,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
 packages:
 
@@ -723,20 +723,6 @@ packages:
   /@borewit/text-codec@0.2.1:
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
     requiresBuild: true
-
-  /@claude-flow/mcp@3.0.0-alpha.8:
-    resolution: {integrity: sha512-lP1t8GMWDl9RxnwMZrjMukZkyglhge7Znhj1PbUiUQ94kHcN+dAxUkA75HM1n7BONbIDcE/CS8qN2ril5KgzNg==}
-    dependencies:
-      ajv: 8.18.0
-      cors: 2.8.6
-      express: 4.22.1
-      helmet: 7.2.0
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
 
   /@claude-flow/shared@3.0.0-alpha.7:
     resolution: {integrity: sha512-5iehTHguBFjlyZqy+fRoKfZVL/nFeE93A94nUUKJvu8y7AmhfpVqtQAZbmKztwQGJ5rv7iBb3Kwl1MUo3K5QkA==}
@@ -6330,7 +6316,7 @@ packages:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
     dev: true
 
   /@vitest/expect@4.1.8:


### PR DESCRIPTION
## Summary

ADR-179 plus a full native implementation of the [MCP 2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/) in ruflo's **own** MCP server (`@claude-flow/mcp`) — no SDK adoption — unified across every transport, security-hardened, and covered by committed tests.

## What's implemented (`@claude-flow/mcp`, → 3.0.0-alpha.10)

- **Dual protocol-version negotiation** (`protocol.ts`): serves `2025-11-25` and `2026-07-28` side by side; unknown/pre-2026 versions fall back to `2025-11-25`.
- **Opt-in stateless mode**: `config.statelessMode` or per-request `Mcp-Protocol-Version` header skips the `initialize`/session gate.
- **MRTR** (`mrtr.ts`): `inputRequired()` pauses a tool; client resumes via `tools/call { continuationToken, input }`; chained round trips; downgraded to a terminal error for legacy sessions.
- **Transport headers** (`transport/http.ts`): emit/validate `Mcp-Method`/`Mcp-Name`/`Mcp-Protocol-Version`, reject header/body mismatch.
- **Standard error codes**: `AUTHORIZATION_FAILED` split `-32002` → `-32003`.
- **Deprecations**: roots/sampling/logging stay functional, unadvertised to new-revision clients.
- **OAuth hardening** (`oauth.ts`): RFC 9207 `iss` validation, issuer-bound credentials, DCR with required `application_type`.

## Security hardening

Adversarial review confirmed no auth bypass, no header injection, OAuth changes a net gain. Two MRTR findings fixed: resume input now schema-validated (was decorative); continuation tokens bound to the creating client (constant-time compare, token burned on mismatch).

## Integration — unified across all transports

The default **stdio** transport (`npx ruflo mcp start`) was a separate hand-rolled loop hardcoding `2024-11-05`, bypassing the package. Now `handleMCPMessage` delegates to `MCPServer.processRequest` via `buildBridgedMcpServer()`, with the 314-tool ruflo registry bridged in (`registerTools({ validate: false })`, per-tool `validateInput: false`) — no tool dropped, pass-through behavior preserved. stdio I/O hardening (stdout-frame isolation, `setBlocking`, bounded buffer, memory auto-init) retained; only the protocol/dispatch layer changed.

**Behavior changes**: stdio `initialize` now negotiates `2025-11-25`/`2026-07-28` (was `2024-11-05`); tool errors return as `isError` results (spec form).

## CLI now compiles

The CLI's apparent "393 errors" were cascade from unbuilt workspace deps (`cli-core`, `shared`, `swarm`, `memory`, `neural`); the canonical `pnpm -r build` builds them in order. With deps built, one genuine source error remained (a redundant cast in the bridge) — fixed. The CLI now typechecks with **0 errors**, emits `dist/src`, and the compiled server runs the real 327-tool registry.

## Verification (committed tests)

- **`@claude-flow/mcp`: 98 tests pass** — spec suite (negotiation, stateless, MRTR + hardening, error codes, headers, deprecations, OAuth, embedding enablers) **+ real WebSocket transport test** (boots a ws server, connects a ws client: initialize, 2026-07-28 negotiation, tools/list + tools/call).
- **CLI: `__tests__/mcp-stdio-bridge.test.ts`, 9 tests pass** — drives the REAL ruflo registry through `buildBridgedMcpServer()`: 2024-11-05→2025-11-25 and 2026-07-28 negotiation, 300+ tools registered (none dropped, real schemas), real dispatch (`agent_list`, `swarm_status`), unknown-tool `isError`, loose-arg pass-through, stateless 2026-07-28 requests, and MRTR pause/resume over the bridge.
- CLI typechecks 0 errors, builds, compiled server verified running the real 327-tool stdio path with zero non-JSON stdout frames.

## Files

- `@claude-flow/mcp/src/`: `protocol.ts`, `mrtr.ts` (new); `server.ts`, `transport/http.ts`, `oauth.ts`, `tool-registry.ts`, `types.ts`, `index.ts`, `package.json`
- `@claude-flow/mcp/__tests__/`: `spec-2026-07-28.test.ts`, `websocket-transport.test.ts`
- `@claude-flow/cli/src/mcp-server.ts` + `package.json`; `@claude-flow/cli/__tests__/mcp-stdio-bridge.test.ts`
- `v3/docs/adr/ADR-179-*.md`, `README.md`

## Follow-ups (not in this PR)

- Publish `@claude-flow/mcp@3.0.0-alpha.10` so external CLI installs pick up the new code (workspace linked locally).
- Surface `statelessMode` as a CLI flag on the HTTP transport.
- ruvocal `@modelcontextprotocol/sdk` v2 client migration (Phase 3, post-stable).

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01WpQSTvyCr5cubaMWPpBwvK