### PR TITLE
feat(funnel,statusline): accept + open subcommands, whole-row-clickable promo, Windows flash mitigations (v3.29.0)

### DIFF
--- a/.claude/helpers/hook-handler.cjs
+++ b/.claude/helpers/hook-handler.cjs
@@ -89,6 +89,10 @@ function spawnDetachedHookRefresh(subcommand) {
       detached: true,
       stdio: 'ignore',
       env: process.env,
+      // Windows: without this, npx.cmd's cmd.exe wrapper flashes a visible
+      // console window every time a hook fires a background refresh. Runs
+      // hidden instead. No-op on POSIX.
+      windowsHide: true,
     });
     child.unref();
   } catch (e) { /* best-effort only */ }

--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -42,12 +42,18 @@ const CONFIG = {
 const CWD = process.cwd();
 
 // ─── Delegation cache ───────────────────────────────────────────
-// Cache the CLI JSON result for 60s so rapid prompt re-renders
-// (Claude Code refreshes the statusline several times a second while
-// streaming) don't re-invoke the CLI each time. #2337: bumped 10s→60s
-// because 10s was far too short for how often Claude Code re-renders.
+// Cache the CLI JSON result so rapid prompt re-renders (Claude Code
+// refreshes the statusline several times a second while streaming) don't
+// re-invoke the CLI each time.
+// #2337 bumped 10s → 60s.
+// Followup for anthropics/claude-code#70200 (Windows console-flash bug —
+// claude.exe spawns hook/statusline subprocesses without CREATE_NO_WINDOW,
+// producing a visible cmd flash on every render): bumped 60s → 300s to
+// reduce the flash rate 5x on Windows until the upstream fix ships.
+// Tradeoff: stat/git counters update every 5min instead of every 1min;
+// promo/insight row still rotates on its own tighter 20s promoFresh clock.
 const CACHE_FILE = path.join(os.tmpdir(), 'ruflo-statusline-cache-' + require('crypto').createHash('md5').update(CWD).digest('hex').slice(0, 8) + '.json');
-const CACHE_TTL_MS = 60000;
+const CACHE_TTL_MS = 300000;
 
 // The promo/insight row is designed to rotate on a 20s cadence (funnel/
 // rotation.ts's ROTATION_SLOT_MS / funnel/promo.ts's insight-slot check —
@@ -229,7 +235,7 @@ function getStatuslineData() {
     try {
       const raw = execSync(
         cmd,
-        { encoding: 'utf-8', timeout: 8000, stdio: ['pipe', 'pipe', 'pipe'], cwd: CWD }
+        { encoding: 'utf-8', timeout: 8000, stdio: ['pipe', 'pipe', 'pipe'], cwd: CWD, windowsHide: true }
       ).trim();
       // The CLI may emit preamble lines before the JSON — find the first '{'.
       const jsonStart = raw.indexOf('{');
@@ -445,6 +451,11 @@ function safeExec(cmd, timeoutMs) {
       encoding: 'utf-8',
       timeout: timeoutMs || 2000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      // Windows: without this, every execSync spawns cmd.exe /d /s /c which
+      // flashes a visible console window every render (~1/min via the 60s
+      // cache TTL). windowsHide runs the child in a hidden window instead.
+      // No-op on POSIX. Fix for #2XXX (user report: "cmd prompt keeps opening").
+      windowsHide: true,
     }).trim();
   } catch {
     return '';
@@ -868,12 +879,16 @@ function getPromoRow(d) {
     if (/^(0|false|off|no)$/i.test(String(process.env.RUFLO_FUNNEL || ''))) return null;
     const promo = d && d.promo;
     if (!promo || typeof promo.text !== 'string') return null;
-    // Strip control chars / ANSI / bidi overrides and hard-cap length —
-    // promo copy is data and must never emit its own terminal sequences.
-    const text = promo.text
+    // Strip control chars / ANSI / bidi overrides — promo copy is data and
+    // must never emit its own terminal sequences. Hard-cap length AFTER the
+    // strip; append an ellipsis when the cap fires so the row visibly reads
+    // as truncated instead of chopping a word mid-character (was: silent
+    // slice(0,100) that could produce output that looked like corrupt data).
+    const MAX_LEN = 100;
+    const sanitized = promo.text
       .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, '')
-      .slice(0, 100)
-      .trim();
+      ;
+    const text = (sanitized.length > MAX_LEN ? sanitized.slice(0, MAX_LEN - 1).trimEnd() + '…' : sanitized).trim();
     if (text.length === 0) return null;
     // Split the label from the trailing "· manage: ruflo settings" instruction
     // so each part gets styling that matches what it actually IS:
@@ -896,9 +911,68 @@ function getPromoRow(d) {
     const DIM_OFF = '\u001b[22m';
     const BOLD_ON = '\u001b[1m';
     const BOLD_OFF = '\u001b[22m';
-    const linked = promo.url ? UL_ON + safeTerminalLink(label, promo.url) + UL_OFF : label;
-    if (!command) return linked;
-    return linked + DIM_ON + manageWord + DIM_OFF + BOLD_ON + command + BOLD_OFF;
+    const FG_BRIGHT_WHITE = '[97m';
+    // Reset FG to default so the caller's row-color code resumes coloring the
+    // rest of the row after the command portion. Without this the row-color
+    // escape wouldn't visibly re-apply because we already emitted an explicit FG.
+    const FG_DEFAULT = '[39m';
+    // Some hosts (Claude Code's Windows UI, cmd.exe, older mintty) don't
+    // render OSC 8 hyperlinks as clickable — the label just underlines and
+    // clicks do nothing. Append a "(domain)" suffix so the destination is
+    // visible/copyable everywhere. Wrap the suffix in OSC 8 too so terminals
+    // that DO support hyperlinks give users TWO click targets (label AND
+    // domain hint) instead of one — some Windows hosts render one but not
+    // the other depending on how the statusline row is parsed.
+    // Only for URLs (not educational tips), and only when the label doesn't
+    // already end in the domain to avoid duplication.
+    let visibleUrlHint = '';
+    if (promo.url) {
+      try {
+        const host = new URL(promo.url).hostname.replace(/^www\./, '');
+        // Strip the click-redirect wrapper so users see the FINAL destination,
+        // not funnel.ruv.io. If the URL is /v1/click/<id>?to=<encoded>, pull the target.
+        let displayHost = host;
+        try {
+          const to = new URL(promo.url).searchParams.get('to');
+          if (to) displayHost = new URL(to).hostname.replace(/^www\./, '');
+        } catch { /* not a click-redirect, keep the raw host */ }
+        if (displayHost && !label.toLowerCase().endsWith(displayHost.toLowerCase())) {
+          // safeTerminalLink returns the plain string if URL isn't allowlisted
+          // or the terminal can't do OSC 8 — either way the domain stays visible.
+          const clickableDomain = safeTerminalLink(displayHost, promo.url);
+          visibleUrlHint = DIM_ON + ' (' + clickableDomain + ')' + DIM_OFF;
+        }
+      } catch { /* malformed URL — omit hint, never break the row */ }
+    }
+    // "Entire row clickable" (user request) — wrap the whole assembled
+    // string in ONE OSC 8 hyperlink instead of just the label. The command
+    // portion keeps its bold + bright-white treatment (no underline) so it
+    // still VISUALLY reads as a shell command the user should type, not a
+    // link — but if the user clicks anywhere on the row (label, domain
+    // hint, connector, even the command text), the terminal opens the URL.
+    // Clicking DOES NOT execute the command; it just opens the target URL,
+    // which is safe. Terminals that ignore OSC 8 render the whole row as
+    // styled text and no click behavior — the previous fallback (visible
+    // domain suffix) still keeps the destination readable.
+    const wrapWholeRowInHyperlink = (assembled) => {
+      if (!promo.url) return assembled;
+      if (!terminalSupportsHyperlinks()) return assembled;
+      let parsed;
+      try { parsed = new URL(promo.url); } catch { return assembled; }
+      if (parsed.protocol !== 'https:') return assembled;
+      if (!PROMO_LINK_HOSTS.has(parsed.hostname)) return assembled;
+      const ESC = '';
+      return ESC + ']8;;' + parsed.href + ESC + '\\' + assembled + ESC + ']8;;' + ESC + '\\';
+    };
+    // Visual styling stays per-part. We only add the OSC 8 wrap around the
+    // combined string, so the whole row is one click target.
+    const labelStyled = promo.url ? UL_ON + label + UL_OFF : label;
+    if (!command) return wrapWholeRowInHyperlink(labelStyled + visibleUrlHint);
+    return wrapWholeRowInHyperlink(
+      labelStyled + visibleUrlHint
+      + DIM_ON + manageWord + DIM_OFF
+      + BOLD_ON + FG_BRIGHT_WHITE + command + FG_DEFAULT + BOLD_OFF
+    );
   } catch (e) {
     return null; // the promo row must never break the statusline
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.23.0"
+    "@claude-flow/cli": "^3.29.0"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/funnel.ts
+++ b/v3/@claude-flow/cli/src/commands/funnel.ts
@@ -5,9 +5,15 @@
  *   funnel status    effective state and which precedence source decided it
  *   funnel disable   user-level opt-out (all surfaces) + delete funnel data
  *   funnel enable    re-enable at the user tier (cannot override env/enterprise)
+ *   funnel accept    acknowledge the disclosure so rotation starts immediately
+ *   funnel open      open the currently-shown promo URL in the default browser
  *   funnel id        print the pseudonymous funnel ID, if one exists
  */
 
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import {
@@ -15,7 +21,9 @@ import {
   funnelStateDir,
   getDisclosure,
   getFunnelId,
+  promoEligible,
   readConsents,
+  recordDisclosureAccepted,
   recordDisclosureDeclined,
   recordDisclosureReenabled,
   resolveFunnelEnabled,
@@ -93,6 +101,117 @@ const enableSub: Command = {
   },
 };
 
+const acceptSub: Command = {
+  name: 'accept',
+  description: 'Acknowledge the disclosure so rotation starts immediately (skips the 24h grace window)',
+  action: async (): Promise<CommandResult> => {
+    const decision = resolveFunnelEnabled();
+    if (!decision.enabled) {
+      output.printWarning(
+        `Funnel is currently disabled by: ${decision.decidedBy}. Run 'ruflo funnel enable' first, then re-run accept.`
+      );
+      return { success: false, data: decision };
+    }
+    const current = getDisclosure();
+    if (current.state === 'disclosed_disabled') {
+      output.printWarning(
+        "Disclosure is in a declined state. Run 'ruflo funnel enable' first, then re-run accept."
+      );
+      return { success: false, data: current };
+    }
+    const rec = recordDisclosureAccepted();
+    const eligible = promoEligible();
+    output.printSuccess(
+      `Disclosure accepted (firstShownAt backdated to ${rec.firstShownAt}). Promo rotation eligible: ${eligible}.`
+    );
+    return { success: true, data: { record: rec, eligible } };
+  },
+};
+
+// Reads the memoized promo written by the statusline renderer. Same file
+// path as .claude/helpers/statusline.cjs's PROMO_MEMO_FILE — kept in sync
+// by convention. Returns null on any error so a broken memo can't crash
+// the subcommand.
+function readCurrentPromo(): { text: string; url?: string; kind?: string } | null {
+  try {
+    const memoPath = path.join(os.homedir(), '.ruflo', 'statusline-promo.json');
+    const raw = JSON.parse(fs.readFileSync(memoPath, 'utf-8'));
+    if (raw && raw.promo && typeof raw.promo === 'object') return raw.promo;
+  } catch { /* memo absent or corrupt — treat as "nothing shown yet" */ }
+  return null;
+}
+
+// Allowlist mirrors the OSC 8 hyperlink allowlist in the statusline renderer.
+// Never open a URL whose host isn't on this list, even if a corrupted memo
+// somehow lands one there — the memo is user-writable so we must not treat
+// it as trusted. Kept in sync with .claude/helpers/statusline.cjs's
+// PROMO_LINK_HOSTS.
+const OPEN_ALLOWED_HOSTS = new Set([
+  'cognitum.one', 'www.cognitum.one', 'docs.cognitum.one',
+  'agentics.org', 'www.agentics.org',
+  'funnel.ruv.io',
+  'cognitum-analytics-63rzcdswba-uc.a.run.app',
+]);
+
+// Open a URL using the platform's default browser handler. execFile (not
+// exec) — no shell involved, so nothing in the URL can be interpreted as a
+// shell command even in the pathological case where allowlisting is
+// bypassed. Runs detached + hidden so no cmd window flashes on Windows.
+function openInBrowser(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const platform = process.platform;
+    const [cmd, args] = platform === 'win32'
+      // "start" needs an empty title argument first, else the first quoted
+      // arg becomes the title and the URL is ignored. cmd /c is required to
+      // invoke the built-in start command.
+      ? ['cmd', ['/c', 'start', '""', url]]
+      : platform === 'darwin'
+        ? ['open', [url]]
+        : ['xdg-open', [url]];
+    execFile(cmd, args, { windowsHide: true }, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+const openSub: Command = {
+  name: 'open',
+  description: 'Open the currently-shown statusline promo URL in the default browser',
+  action: async (): Promise<CommandResult> => {
+    const promo = readCurrentPromo();
+    if (!promo) {
+      output.printWarning(
+        "No promo has been shown yet. Wait for the statusline to render one, then re-run 'ruflo funnel open'."
+      );
+      return { success: false };
+    }
+    if (!promo.url) {
+      output.printWarning(
+        `Current promo (kind=${promo.kind ?? 'unknown'}) has no URL. Nothing to open: "${promo.text}"`
+      );
+      return { success: false, data: promo };
+    }
+    let parsed: URL;
+    try { parsed = new URL(promo.url); } catch {
+      output.printError(`Promo URL is malformed: ${promo.url}`);
+      return { success: false, data: promo };
+    }
+    if (parsed.protocol !== 'https:' || !OPEN_ALLOWED_HOSTS.has(parsed.hostname)) {
+      output.printError(
+        `Refusing to open URL — not on the allowlist: ${parsed.protocol}//${parsed.hostname}`
+      );
+      return { success: false, data: { url: promo.url } };
+    }
+    try {
+      await openInBrowser(parsed.href);
+      output.printSuccess(`Opened: ${parsed.href}`);
+      return { success: true, data: { url: parsed.href } };
+    } catch (err) {
+      output.printError(`Failed to open URL: ${err instanceof Error ? err.message : String(err)}`);
+      output.writeln(`URL for manual copy: ${parsed.href}`);
+      return { success: false, data: { url: parsed.href } };
+    }
+  },
+};
+
 const idSub: Command = {
   name: 'id',
   description: 'Print the pseudonymous funnel ID (exists only with telemetry consent)',
@@ -110,9 +229,11 @@ const idSub: Command = {
 export const funnelCommand: Command = {
   name: 'funnel',
   description: 'Control the Cognitum lifecycle funnel surfaces (tips, enrollment, notices)',
-  subcommands: [statusSub, disableSub, enableSub, idSub],
+  subcommands: [statusSub, disableSub, enableSub, acceptSub, openSub, idSub],
   examples: [
     { command: 'ruflo funnel status', description: 'Effective state + deciding source' },
+    { command: 'ruflo funnel accept', description: 'Skip the 24h grace so rotation starts now' },
+    { command: 'ruflo funnel open', description: 'Open the current promo URL in the browser' },
     { command: 'ruflo funnel disable', description: 'Turn off every funnel surface' },
   ],
   action: statusSub.action,

--- a/v3/@claude-flow/cli/src/funnel/disclosure.ts
+++ b/v3/@claude-flow/cli/src/funnel/disclosure.ts
@@ -90,6 +90,19 @@ export function recordDisclosureReenabled(now: Date = new Date()): DisclosureRec
   return rec;
 }
 
+// Explicit user acknowledgement — bypasses the 24h grace so rotation starts
+// on the next render. The grace window's purpose is anti-flash (a single
+// glance can't count as "the user was told"); an explicit CLI action IS the
+// user saying they were told, so backdating firstShownAt past the window is
+// the correct semantics — not a policy hole. Stamps 1s past grace to avoid
+// clock-skew edge cases where now-grace lands exactly on the boundary.
+export function recordDisclosureAccepted(now: Date = new Date()): DisclosureRecord {
+  const backdated = new Date(now.getTime() - DISCLOSURE_GRACE_MS - 1000);
+  const rec: DisclosureRecord = { state: 'disclosed_enabled', firstShownAt: backdated.toISOString() };
+  writeStateJson(DISCLOSURE_FILE, rec);
+  return rec;
+}
+
 /**
  * Whether promotional/educational messages may render. True only after the
  * disclosure was shown AND its grace window has elapsed. While the window is

--- a/v3/@claude-flow/cli/src/funnel/index.ts
+++ b/v3/@claude-flow/cli/src/funnel/index.ts
@@ -20,6 +20,7 @@ export {
   DISCLOSURE_ROTATION_SLOT_MS,
   getDisclosure,
   promoEligible,
+  recordDisclosureAccepted,
   recordDisclosureDeclined,
   recordDisclosureReenabled,
   recordDisclosureShown,


### PR DESCRIPTION
## Summary

- **New `ruflo funnel accept`** — skip the 24h disclosure grace window so promo rotation starts immediately.
- **New `ruflo funnel open`** — open the currently-shown promo URL in the default browser. Terminal-independent (works even when the host swallows clicks — e.g., VS Code integrated terminal, where left-click pastes and Ctrl+Click hits Quick Open instead of following the OSC 8 link).
- **Whole promo row clickable** — one OSC 8 hyperlink wrapping the entire row instead of just the label. Visible `(domain)` suffix, bright-white command styling, ellipsis on truncation.
- **Windows console-flash mitigations** — `windowsHide: true` on 3 subprocess call sites + statusline cache TTL 60s → 300s.

Semver: **MINOR** (3.28.0 → 3.29.0) — additive, backward-compatible.

## Related

- Tracks #2669 (Windows cmd/console flash — upstream anthropics/claude-code#70200)
- Fixes the "promo row 3 missing on Windows" symptom reported in this thread
- Delivers `scratchpad/disclosure-copy-proposal.md` (not committed here — for separate PR to `cognitum-one/meta-proxy`)

## Test plan

- [x] `funnel.test.ts`: 121/122 pass (1 unrelated perf flake — `attributionUrl` <100ms for 1000 builds, got 191ms on Windows)
- [x] Manual: `ruflo funnel accept` writes backdated `firstShownAt`, next render shows rotating messages
- [x] Manual: `ruflo funnel open` opens correct URL in browser via `cmd /c start ""` / `open` / `xdg-open`
- [x] Manual: fresh disclosure state → first render creates state file → row rotates after accept
- [x] OSC 8 escape verified in raw output bytes (`od -c`) — whole-row wrap, both label and domain hint clickable

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)