### PR TITLE
security: rotate helpers-signing key (RUFLO_HELPERS_PUBKEY v2)

### DIFF
--- a/v3/@claude-flow/cli/scripts/verify-helpers.mjs
+++ b/v3/@claude-flow/cli/scripts/verify-helpers.mjs
@@ -24,8 +24,11 @@ const HELPERS_DIR = resolve(process.argv[2] || join(PKG_ROOT, '.claude', 'helper
 // Keep in sync with sign-helpers.mjs:CRITICAL and src/init/helper-refresh.ts:CRITICAL_HELPERS.
 const CRITICAL = ['auto-memory-hook.mjs', 'hook-handler.cjs', 'intelligence.cjs', 'statusline.cjs'];
 
+// KEEP IN SYNC with src/init/helper-signing.ts:RUFLO_HELPERS_PUBKEY.
+// Rotated 2026-07-14 (v3.29.0) after the previous private key was exposed in
+// a Claude Code session transcript. Old GCP secret v1 destroyed.
 const RUFLO_HELPERS_PUBKEY = `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAhnFv74/CRcGWd0hL8zjyZ+52bIJ9SfcSgOutuKgo0Vg=
+MCowBQYDK2VwAyEAyLl9cG+V/C+ffKWaSwvOsHdXSWmB5e3x1z9NUNvq6Ys=
 -----END PUBLIC KEY-----`;
 
 function die(msg) { console.error(`[verify-helpers] ${msg}`); process.exit(1); }

--- a/v3/@claude-flow/cli/src/init/helper-signing.ts
+++ b/v3/@claude-flow/cli/src/init/helper-signing.ts
@@ -19,9 +19,16 @@ import { createHash, verify as edVerify } from 'crypto';
  * Ruflo helper-signing PUBLIC key (safe to commit). The matching private key is
  * held out-of-repo and provided to scripts/sign-helpers.mjs at publish time via
  * $RUFLO_HELPERS_SIGNING_KEY. Rotating the key = replace this constant + re-sign.
+ *
+ * ROTATED 2026-07-14 (v3.29.0): the previous key was accidentally exposed in a
+ * Claude Code session transcript. Old GCP secret version 1 was destroyed (not
+ * disabled) so it cannot be re-enabled; new v2 generated here. Users on old
+ * ruflo versions keep the old pubkey and verify old manifests successfully;
+ * upgrading to v3.29.0+ atomically picks up this new pubkey along with the
+ * new-key-signed manifest.
  */
 export const RUFLO_HELPERS_PUBKEY = `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAhnFv74/CRcGWd0hL8zjyZ+52bIJ9SfcSgOutuKgo0Vg=
+MCowBQYDK2VwAyEAyLl9cG+V/C+ffKWaSwvOsHdXSWmB5e3x1z9NUNvq6Ys=
 -----END PUBLIC KEY-----`;
 
 export const HELPERS_MANIFEST_FILE = 'helpers.manifest.json';


### PR DESCRIPTION
## Summary

Rotate `RUFLO_HELPERS_PUBKEY` — previous private key was accidentally exposed in a Claude Code session transcript today. Old GCP secret v1 destroyed; new v2 keypair generated + baked in.

## Why now

The prior key was captured in tool output during the v3.29.0 publish flow (issue #2671). Rotating before any future publish signs a manifest with the leaked key.

## Compatibility

Atomic per-version — no dual-pubkey transition needed:
- ruflo ≤ 3.28.0 → keeps old pubkey, verifies old-signed manifest ✓
- ruflo ≥ 3.29.0 → new pubkey + new-signed manifest ship together, verify cleanly

## Follow-ups (separate)

- Single source of truth for the pubkey (currently duplicated in `helper-signing.ts` + `scripts/verify-helpers.mjs`)
- Investigate whether `sign-helpers.mjs`'s gcloud call can capture without ever letting the key touch a tool-visible descriptor
- Windows-friendly `prepublishOnly` (the `mkdir -p` / `cp -r` chain uses POSIX shell, fails under cmd.exe)

## Post-merge

I'll re-run the v3.29.0 publish flow with the new key.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)