### PR TITLE
fix(adr-164): declare agentbbs in optionalDependencies (no-agentbbs-smoke red on main)

### DIFF
--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -112,6 +112,7 @@
   "optionalDependencies": {
     "@claude-flow/memory": "^3.0.0-alpha.21",
     "@claude-flow/security": "^3.0.0-alpha.10",
+    "agentbbs": "~0.1.0",
     "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "ruvector": "^0.2.27"

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@claude-flow/security':
         specifier: ^3.0.0-alpha.10
         version: link:../security
+      agentbbs:
+        specifier: ~0.1.0
+        version: 0.1.0
       agentdb:
         specifier: ^3.0.0-alpha.17
         version: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
@@ -6509,6 +6512,14 @@ packages:
     hasBin: true
     requiresBuild: true
     dev: false
+
+  /agentbbs@0.1.0:
+    resolution: {integrity: sha512-XOEjlgdObklxnZdA0yS6pAcKId99SsFwH5ZF5qNByWs6VsTht1oxjbuFhuapGV7fNnQ6Y2XLq0GbtZ7t+sQMbw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /agentdb@1.6.1:
     resolution: {integrity: sha512-OO/hwO+MYtqsgz+6CyrY2BCjcgRWGv5Ob7nFupNEt7m1ZchIArCwvBAcJgFMFNFqWxH6AN2ThiQKBmfXboBkPg==}


### PR DESCRIPTION
## What & why

The `no-agentbbs-smoke` CI workflow (ADR-164 §5.1.1 architectural constraint enforcement) has been **RED on main since ≥2026-07-14** (every run `failure`). The failing assertion was:

```
→ 3. optionalDependencies declares agentbbs ... FAIL: agentbbs not in package.json
```

### Root cause
`agentbbs` was **absent from every `package.json` in the repo** (and from `pnpm-lock.yaml`) — `git log -S '"agentbbs"'` is empty, so it was never declared. Yet the feature is **live and documented**:

- `v3/@claude-flow/cli/src/mcp-tools/agentbbs-tools.ts:17-18` — the module's own header states the ADR-164 contract:
  > "`agentbbs` lives in `optionalDependencies` — must NOT be a hard runtime dep"
- `loadAgentbbs()` (agentbbs-tools.ts:44) dynamically `import('agentbbs')`s the package and degrades gracefully to `{degraded:true, reason:'agentbbs-not-found'}` when it's missing.

So the smoke assertion (`scripts/smoke-agentbbs.sh:32-33`) is **correct**; the codebase was **non-compliant** — the declaration that ADR-164 §5.1.1 Rule 1/3 require was simply never added. `agentbbs@0.1.0` is published on npm (latest 0.2.1; `~0.1.0` → 0.1.0, matching the module header's documented version).

## The fix (minimal)
Add `"agentbbs": "~0.1.0"` to `optionalDependencies` in `v3/@claude-flow/cli/package.json` + regenerate `v3/pnpm-lock.yaml`.

```diff
   "optionalDependencies": {
     "@claude-flow/memory": "^3.0.0-alpha.21",
     "@claude-flow/security": "^3.0.0-alpha.10",
+    "agentbbs": "~0.1.0",
     "agentdb": "^3.0.0-alpha.17",
```

No source code touched. 2 files changed, 12 insertions(+).

## Verification (independent worktree, CI-faithful)
Ran in a **fresh detached-HEAD checkout** of this branch (`/tmp/ruflo-verify-T4`), reproducing the workflow's Rule 3 drill exactly:

| Gate | Result |
|------|--------|
| `pnpm install --frozen-lockfile` | exit 0 (lockfile in sync) |
| `pnpm -r --no-bail build` | exit 0 (all packages built) |
| agentbbs surgically removed (matches CI) | gone |
| `bash scripts/smoke-agentbbs.sh` | **8 passed, 0 failed** (was 7 passed, 1 failed) |

ADR-164 rules confirmed: Rule 1 (agentbbs not in `dependencies`) · Rule 2 (all usage guarded by `loadAgentbbs`/dynamic import) · Rule 3 (graceful degradation when removed) — all pass.

Note: the vitest suite (smoke step 7) asserts the `agentbbs-not-found` degraded path, which is why the CI workflow removes `agentbbs` from `node_modules` before running the smoke — exactly as this PR's CI run will do.

Refs: no-agentbbs-smoke run https://github.com/ruvnet/ruflo/actions/runs/29441674737
