### PR TITLE
fix(security): harden sign-helpers.mjs secret capture (ADR-322)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -963,18 +963,30 @@ RUFLO_HELPERS_SIGNING_SECRET=ruflo-helpers-signing-key RUFLO_HELPERS_SIGNING_PRO
 (`ruv-dev` also holds `ruflo-config-signing-key` and `NPM_TOKEN` — likely the right project
 for other ruflo release-time secrets too.)
 
-**Handling the signing key without leaking it (learned 2026-07-14, hard way):** when
-sign-helpers.mjs runs via `execFileSync('gcloud', ...)` on Windows, Node fails to find
-`gcloud` (needs the `.cmd` suffix), so the script bails and users reach for
-`gcloud secrets versions access latest --secret=ruflo-helpers-signing-key` in the shell —
-which by default prints the PEM to stdout, which becomes tool-call output in Claude
-Code and lands in the session transcript. That happened, the key was leaked, GCP secret
-v1 was destroyed and a fresh v2 was rotated in (commit 0052b1b06 / PR #2673). **Rules:**
-- NEVER invoke `gcloud secrets versions access` in a way that lets the payload reach
-  tool output. Always redirect to a file in the same command: `gcloud … > ~/.ruflo/helpers-signing.key 2>&1 | grep -v BEGIN`.
-- On Windows, prefer `RUFLO_HELPERS_SIGNING_KEY=~/.ruflo/helpers-signing.key` over the
-  GCP env var, because the fallback file path doesn't go through the broken
-  `execFileSync('gcloud')` path.
+**Handling the signing key without leaking it (ADR-322, supersedes the 2026-07-14
+postmortem):** `sign-helpers.mjs` now resolves `gcloud.cmd` on Windows, so the GCP
+Secret Manager path (`RUFLO_HELPERS_SIGNING_SECRET`) works cross-platform and the
+raw-`gcloud`-in-the-shell workaround that caused the original leak (commit 0052b1b06 /
+PR #2673 — GCP secret v1 destroyed, v2 rotated in) should never be needed again. If the
+GCP path still fails for some other reason (expired token, `gcloud` missing, wrong
+project), use the sanctioned stdin fallback — safe by construction, since the PEM
+travels through an in-kernel pipe and never touches a captured tool-output stream:
+
+```bash
+gcloud secrets versions access latest --secret=ruflo-helpers-signing-key \
+  | node scripts/sign-helpers.mjs --stdin-key
+```
+
+**Rules:**
+- NEVER run `gcloud secrets versions access ...` on its own and redirect/paste the
+  output by hand — that is exactly the shape that leaked the key. Always pipe directly
+  into `--stdin-key` as shown above.
+- `sign-helpers.mjs` refuses to fetch from GCP Secret Manager at all when stdout is an
+  interactive TTY (no `RUFLO_HELPERS_ALLOW_TTY=1` set); it prints the `--stdin-key`
+  alternative and exits 1 rather than let anyone improvise a workaround.
+- `RUFLO_HELPERS_SIGNING_KEY=<pem-file-path>` (e.g.
+  `RUFLO_HELPERS_SIGNING_KEY=~/.ruflo/helpers-signing.key`) remains supported unchanged
+  for local/air-gapped signing.
 - If a rotation IS needed, keep the private half in `~/.ruflo/helpers-signing.key`
   only, print ONLY the public half (via `Ed25519 pub export` from Node crypto), upload
   new private via `gcloud secrets versions add … --data-file=`, then

--- a/v3/@claude-flow/cli/__tests__/sign-helpers-secret-hardening.test.ts
+++ b/v3/@claude-flow/cli/__tests__/sign-helpers-secret-hardening.test.ts
@@ -1,0 +1,246 @@
+/**
+ * London-school (mockist) tests for ADR-322's secret-capture hardening of
+ * scripts/sign-helpers.mjs. Every external boundary — the `gcloud` subprocess
+ * (execFileSync), the filesystem (readFileSync), the home dir (homedir) and
+ * process.exit — is mocked; the tests verify INTERACTIONS (which binary is
+ * invoked, whether stdin is consulted, whether gcloud is called at all), never
+ * real GCP or real key files.
+ *
+ * The script top-level-executes when run as `node scripts/sign-helpers.mjs`,
+ * but guards that behind an import.meta.url === argv[1] check, so importing it
+ * here exercises only the exported loadPrivateKey / scanCapturedOutputForLeak.
+ *
+ * Covers all four ADR-322 behaviors:
+ *   1. win32 → `gcloud.cmd`, non-win32 → `gcloud`.
+ *   2. `--stdin-key` reads the PEM from fd 0.
+ *   3. TTY refusal gate on the GCP-secret branch (+ ALLOW_TTY override).
+ *   4. Resolution order: GCP-secret path wins over `--stdin-key`.
+ *   5. Output-scan safety net trips on a real leaked-key marker.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => true),
+}));
+vi.mock('node:os', () => ({ homedir: vi.fn(() => '/home/testuser') }));
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { loadPrivateKey, scanCapturedOutputForLeak } from '../scripts/sign-helpers.mjs';
+
+const execFileSyncMock = vi.mocked(execFileSync);
+const readFileSyncMock = vi.mocked(readFileSync);
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_ISTTY = process.stdout.isTTY;
+const ORIGINAL_ARGV = process.argv;
+const ORIGINAL_ENV = process.env;
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+/** Force process.platform, since loadPrivateKey branches on it at call time. */
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readFileSyncMock.mockReturnValue('DEFAULT_PEM');
+  // Fresh env per test so leftover RUFLO_* vars can't cross-contaminate.
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.RUFLO_HELPERS_SIGNING_SECRET;
+  delete process.env.RUFLO_HELPERS_SIGNING_PROJECT;
+  delete process.env.RUFLO_HELPERS_SIGNING_KEY;
+  delete process.env.RUFLO_HELPERS_ALLOW_TTY;
+  process.argv = ['node', '/some/path/sign-helpers.mjs']; // no --stdin-key by default
+  process.stdout.isTTY = false;
+  setPlatform('linux');
+  // process.exit must not really exit — throw so control flow stops like the real thing.
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`__EXIT__${code}`);
+  }) as never);
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  setPlatform(ORIGINAL_PLATFORM);
+  process.stdout.isTTY = ORIGINAL_ISTTY;
+  process.argv = ORIGINAL_ARGV;
+  process.env = ORIGINAL_ENV;
+  exitSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe('ADR-322 §1 — Windows spawn fix: gcloud.cmd on win32, gcloud elsewhere', () => {
+  it('invokes `gcloud.cmd` (not `gcloud`) on win32', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    setPlatform('win32');
+    execFileSyncMock.mockReturnValue('WIN_PEM');
+
+    const pem = loadPrivateKey();
+
+    expect(pem).toBe('WIN_PEM');
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock.mock.calls[0][0]).toBe('gcloud.cmd');
+    expect(execFileSyncMock.mock.calls[0][1]).toEqual(
+      ['secrets', 'versions', 'access', 'latest', '--secret', 'ruflo-helpers-signing-key'],
+    );
+  });
+
+  it('invokes `gcloud` (not `gcloud.cmd`) on non-win32', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    setPlatform('linux');
+    execFileSyncMock.mockReturnValue('LINUX_PEM');
+
+    const pem = loadPrivateKey();
+
+    expect(pem).toBe('LINUX_PEM');
+    expect(execFileSyncMock.mock.calls[0][0]).toBe('gcloud');
+  });
+
+  it('appends --project when RUFLO_HELPERS_SIGNING_PROJECT is set', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    process.env.RUFLO_HELPERS_SIGNING_PROJECT = 'ruv-dev';
+    execFileSyncMock.mockReturnValue('PEM');
+
+    loadPrivateKey();
+
+    expect(execFileSyncMock.mock.calls[0][1]).toEqual(
+      ['secrets', 'versions', 'access', 'latest', '--secret', 'ruflo-helpers-signing-key', '--project', 'ruv-dev'],
+    );
+  });
+
+  it('captures both streams into JS (stdio pipe, never inherited)', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 's';
+    execFileSyncMock.mockReturnValue('PEM');
+
+    loadPrivateKey();
+
+    expect(execFileSyncMock.mock.calls[0][2]).toMatchObject({
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  });
+
+  it('exits 1 (does not throw the PEM) when gcloud fetch fails', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 's';
+    execFileSyncMock.mockImplementation(() => { throw new Error('gcloud: command not found'); });
+
+    expect(() => loadPrivateKey()).toThrow('__EXIT__1');
+    // The error message must not echo any secret material.
+    const logged = errorSpy.mock.calls.flat().join(' ');
+    expect(logged).toContain("failed to read GCP secret");
+    expect(logged).not.toMatch(/PRIVATE KEY/);
+  });
+});
+
+describe('ADR-322 §2 — --stdin-key reads the PEM from fd 0', () => {
+  it('reads stdin (fd 0) and does NOT invoke gcloud', () => {
+    process.argv = ['node', 'sign-helpers.mjs', '--stdin-key'];
+    readFileSyncMock.mockImplementation(((fd: unknown) =>
+      fd === 0 ? 'STDIN_PEM' : 'WRONG_SOURCE') as never);
+
+    const pem = loadPrivateKey();
+
+    expect(pem).toBe('STDIN_PEM');
+    expect(readFileSyncMock).toHaveBeenCalledWith(0, 'utf-8');
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('ADR-322 §3 — TTY refusal gate (GCP-secret branch only)', () => {
+  it('refuses (exit 1) and does NOT call gcloud when secret set + TTY + no override', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    process.stdout.isTTY = true;
+
+    expect(() => loadPrivateKey()).toThrow('__EXIT__1');
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    const logged = errorSpy.mock.calls.flat().join(' ');
+    expect(logged).toContain('refusing to fetch from GCP Secret Manager');
+    expect(logged).toContain('--stdin-key'); // names the safe alternative
+  });
+
+  it('proceeds to fetch when RUFLO_HELPERS_ALLOW_TTY=1 overrides the gate', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    process.env.RUFLO_HELPERS_ALLOW_TTY = '1';
+    process.stdout.isTTY = true;
+    execFileSyncMock.mockReturnValue('PEM_VIA_OVERRIDE');
+
+    const pem = loadPrivateKey();
+
+    expect(pem).toBe('PEM_VIA_OVERRIDE');
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT gate when stdout is not a TTY (e.g. CI/pipe)', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    process.stdout.isTTY = false;
+    execFileSyncMock.mockReturnValue('CI_PEM');
+
+    expect(loadPrivateKey()).toBe('CI_PEM');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('ADR-322 — resolution order: GCP secret wins over --stdin-key', () => {
+  it('consults gcloud, NOT stdin, when both the secret env var and --stdin-key are present', () => {
+    process.env.RUFLO_HELPERS_SIGNING_SECRET = 'ruflo-helpers-signing-key';
+    process.argv = ['node', 'sign-helpers.mjs', '--stdin-key'];
+    execFileSyncMock.mockReturnValue('GCP_PEM');
+
+    const pem = loadPrivateKey();
+
+    expect(pem).toBe('GCP_PEM');
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    // fd 0 (stdin) must never be read on the winning GCP path.
+    expect(readFileSyncMock).not.toHaveBeenCalledWith(0, 'utf-8');
+  });
+});
+
+describe('ADR-322 §4 — output-scan safety net trips on a leaked key', () => {
+  const markers = [
+    'BEGIN PRIVATE KEY',
+    'BEGIN RSA PRIVATE KEY',
+    'BEGIN EC PRIVATE KEY',
+    'BEGIN OPENSSH PRIVATE KEY',
+  ];
+
+  for (const marker of markers) {
+    it(`aborts (exit 1, FATAL) when captured output contains "${marker}"`, () => {
+      const leaked = [
+        '[sign-helpers] signed 4 helpers → …',
+        `-----${marker}-----`,
+        'MIIEvQIBADANBg…',
+      ];
+
+      expect(() => scanCapturedOutputForLeak(leaked)).toThrow('__EXIT__1');
+      const logged = errorSpy.mock.calls.flat().join(' ');
+      expect(logged).toContain('FATAL: private key material detected');
+    });
+  }
+
+  it('does NOT trip on clean output (normal signing summary)', () => {
+    const clean = [
+      '[sign-helpers] signed 4 helpers → /pkg/.claude/helpers/helpers.manifest.json',
+      '  hook-handler.cjs: a1b2c3d4e5f60718…',
+      '  intelligence.cjs: 0f1e2d3c4b5a6978…',
+    ];
+
+    expect(() => scanCapturedOutputForLeak(clean)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('is load-bearing: proves the real scan block runs (not a re-implemented regex)', () => {
+    // Simulate the ADR-322 §4 / Validation-4 regression: a debug console.log of
+    // the PEM added inside the script. The exported scan is the SAME code the
+    // top-level run calls, so this exercises the real trip-wire.
+    const withDebugLog = ['console.log output', '-----BEGIN PRIVATE KEY-----\nMIIE…\n-----END PRIVATE KEY-----'];
+    expect(() => scanCapturedOutputForLeak(withDebugLog)).toThrow('__EXIT__1');
+  });
+});

--- a/v3/@claude-flow/cli/scripts/sign-helpers.mjs
+++ b/v3/@claude-flow/cli/scripts/sign-helpers.mjs
@@ -11,18 +11,34 @@
  *        RUFLO_HELPERS_SIGNING_SECRET=<secret-name>   (e.g. ruflo-helpers-signing-key)
  *        RUFLO_HELPERS_SIGNING_PROJECT=<gcp-project>  (optional; defaults to the
  *                                                       active gcloud project)
- *      Fetched via `gcloud secrets versions access latest`.
- *   2. RUFLO_HELPERS_SIGNING_KEY=<pem-file-path>       (local / air-gapped)
- *   3. ~/.ruflo/helpers-signing.key                    (dev default)
+ *      Fetched via `gcloud secrets versions access latest`. Refuses to run when
+ *      stdout is an interactive TTY (ADR-322) — set RUFLO_HELPERS_ALLOW_TTY=1 to
+ *      override, or prefer the --stdin-key pipe below instead.
+ *   2. --stdin-key                                     (safe fallback; reads a PEM
+ *        from stdin (fd 0) via a shell pipe, e.g.:
+ *          gcloud secrets versions access latest --secret=ruflo-helpers-signing-key \
+ *            | node scripts/sign-helpers.mjs --stdin-key
+ *        Never run `gcloud secrets versions access` on its own and redirect/paste
+ *        the output by hand — that shape is what leaked the v1 key. See ADR-322.)
+ *   3. RUFLO_HELPERS_SIGNING_KEY=<pem-file-path>       (local / air-gapped)
+ *   4. ~/.ruflo/helpers-signing.key                    (dev default)
  *
  * Usage:  RUFLO_HELPERS_SIGNING_SECRET=ruflo-helpers-signing-key node scripts/sign-helpers.mjs
+ *         gcloud secrets versions access latest --secret=ruflo-helpers-signing-key | node scripts/sign-helpers.mjs --stdin-key
  */
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { createHash, sign as edSign } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { homedir } from 'node:os';
+
+const capturedStdoutLines = [];
+const originalConsoleLog = console.log.bind(console);
+console.log = (...args) => {
+  capturedStdoutLines.push(args.map(String).join(' '));
+  originalConsoleLog(...args);
+};
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = join(__dirname, '..');
@@ -30,54 +46,86 @@ const HELPERS_DIR = join(PKG_ROOT, '.claude', 'helpers');
 // Keep in sync with src/init/helper-refresh.ts:CRITICAL_HELPERS.
 const CRITICAL = ['auto-memory-hook.mjs', 'hook-handler.cjs', 'intelligence.cjs', 'statusline.cjs'];
 
-function loadPrivateKey() {
+export function loadPrivateKey() {
   const secret = process.env.RUFLO_HELPERS_SIGNING_SECRET;
   if (secret) {
+    if (process.stdout.isTTY && !process.env.RUFLO_HELPERS_ALLOW_TTY) {
+      console.error(
+        '[sign-helpers] refusing to fetch from GCP Secret Manager in an interactive/logged ' +
+        'terminal. Use `gcloud secrets versions access latest --secret=<name> | node scripts/sign-helpers.mjs --stdin-key`, ' +
+        'or set RUFLO_HELPERS_SIGNING_KEY=<pem-file>. To override, set RUFLO_HELPERS_ALLOW_TTY=1.'
+      );
+      process.exit(1);
+    }
     const args = ['secrets', 'versions', 'access', 'latest', '--secret', secret];
     const project = process.env.RUFLO_HELPERS_SIGNING_PROJECT;
     if (project) args.push('--project', project);
+    const gcloudBin = process.platform === 'win32' ? 'gcloud.cmd' : 'gcloud';
     try {
       // stdio: key on stdout (captured), stderr captured too — NOT inherited.
       // Inheriting would forward gcloud's stderr verbatim into whatever log
       // is capturing this process's output (CI, terminal); this key material
       // is sensitive enough that we never want an uncontrolled passthrough,
       // even though gcloud's normal error paths don't echo secret payloads.
-      return execFileSync('gcloud', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+      return execFileSync(gcloudBin, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
     } catch (e) {
       console.error(`[sign-helpers] failed to read GCP secret '${secret}'. Is gcloud authed? (gcloud auth login)`);
       process.exit(1);
     }
   }
+  if (process.argv.includes('--stdin-key')) {
+    return readFileSync(0, 'utf-8');
+  }
   const keyPath = process.env.RUFLO_HELPERS_SIGNING_KEY || join(homedir(), '.ruflo', 'helpers-signing.key');
   if (!existsSync(keyPath)) {
     console.error(
-      `[sign-helpers] no signing key. Set RUFLO_HELPERS_SIGNING_SECRET (GCP) ` +
-      `or RUFLO_HELPERS_SIGNING_KEY (PEM path); tried ${keyPath}.`,
+      `[sign-helpers] no signing key. Set RUFLO_HELPERS_SIGNING_SECRET (GCP), pass --stdin-key ` +
+      `(pipe a PEM via stdin), or set RUFLO_HELPERS_SIGNING_KEY (PEM path); tried ${keyPath}.`,
     );
     process.exit(1);
   }
   return readFileSync(keyPath, 'utf-8');
 }
 
-const privateKeyPem = loadPrivateKey();
-
-const version = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf-8')).version;
-const files = {};
-for (const name of CRITICAL) {
-  const p = join(HELPERS_DIR, name);
-  if (!existsSync(p)) { console.error(`[sign-helpers] missing helper: ${p}`); process.exit(1); }
-  files[name] = createHash('sha256').update(readFileSync(p)).digest('hex');
+// Output-scanning safety net (ADR-322 §4): scan everything queued to console.log
+// during the run for private-key markers and abort before exiting normally.
+export function scanCapturedOutputForLeak(lines = capturedStdoutLines) {
+  const emitted = lines.join('\n');
+  if (/BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY/.test(emitted)) {
+    console.error('[sign-helpers] FATAL: private key material detected in script output. Aborting.');
+    process.exit(1);
+  }
 }
 
-const manifest = { version, files };
-// Canonical bytes: sorted file keys — MUST match helper-signing.ts.
-const sortedFiles = {};
-for (const k of Object.keys(manifest.files).sort()) sortedFiles[k] = manifest.files[k];
-const canonical = Buffer.from(JSON.stringify({ version: manifest.version, files: sortedFiles }), 'utf-8');
-const signature = edSign(null, canonical, privateKeyPem).toString('base64');
+function main() {
+  const privateKeyPem = loadPrivateKey();
 
-const signed = { manifest, signature, algorithm: 'ed25519' };
-const outPath = join(HELPERS_DIR, 'helpers.manifest.json');
-writeFileSync(outPath, JSON.stringify(signed, null, 2) + '\n', 'utf-8');
-console.log(`[sign-helpers] signed ${CRITICAL.length} helpers → ${outPath}`);
-for (const [n, h] of Object.entries(files)) console.log(`  ${n}: ${h.slice(0, 16)}…`);
+  const version = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf-8')).version;
+  const files = {};
+  for (const name of CRITICAL) {
+    const p = join(HELPERS_DIR, name);
+    if (!existsSync(p)) { console.error(`[sign-helpers] missing helper: ${p}`); process.exit(1); }
+    files[name] = createHash('sha256').update(readFileSync(p)).digest('hex');
+  }
+
+  const manifest = { version, files };
+  // Canonical bytes: sorted file keys — MUST match helper-signing.ts.
+  const sortedFiles = {};
+  for (const k of Object.keys(manifest.files).sort()) sortedFiles[k] = manifest.files[k];
+  const canonical = Buffer.from(JSON.stringify({ version: manifest.version, files: sortedFiles }), 'utf-8');
+  const signature = edSign(null, canonical, privateKeyPem).toString('base64');
+
+  const signed = { manifest, signature, algorithm: 'ed25519' };
+  const outPath = join(HELPERS_DIR, 'helpers.manifest.json');
+  writeFileSync(outPath, JSON.stringify(signed, null, 2) + '\n', 'utf-8');
+  console.log(`[sign-helpers] signed ${CRITICAL.length} helpers → ${outPath}`);
+  for (const [n, h] of Object.entries(files)) console.log(`  ${n}: ${h.slice(0, 16)}…`);
+
+  scanCapturedOutputForLeak();
+}
+
+// Run the signing only when invoked directly as a script (node scripts/sign-helpers.mjs),
+// not when imported by unit tests exercising loadPrivateKey / scanCapturedOutputForLeak.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/v3/docs/adr/ADR-322-sign-helpers-secret-capture-hardening.md
+++ b/v3/docs/adr/ADR-322-sign-helpers-secret-capture-hardening.md
@@ -1,0 +1,140 @@
+# ADR-322: Structurally Preventing Signing-Key Exposure in `sign-helpers.mjs`
+
+- **Status**: Accepted
+- **Date**: 2026-07-15
+- **Deciders**: ruflo core
+- **Issue**: [#2674](https://github.com/ruvnet/ruflo/issues/2674)
+- **Related**: [ADR-174](ADR-174-memory-distillation-self-optimization.md) (the Ed25519 helper-signing mechanism `sign-helpers.mjs` produces manifests for), [ADR-177](ADR-177-signed-config-propagation-to-installs.md) (sibling signing channel — `rvfa-signing`; same "never rotate a baked pubkey silently" constraint)
+
+> **Numbering note**: this ADR was drafted as ADR-320 on a branch cut from `main` before PR #2687 (issue #2630, ADR-320/ADR-321) merged, so a same-branch scan of `v3/docs/adr/` reported 319 as the highest number in use and 320 looked free. It collided with PR #2687's already-claimed ADR-320/321 and was renumbered to **ADR-322** once the collision was found. The local-file-tree check that determines "next ADR number" in this repo's tooling is necessary but not sufficient when sibling unmerged PRs also touch `v3/docs/adr/` — cross-checking open PRs (via the GitHub API/`gh pr list` + diff paths) before assigning a number would catch this class of collision earlier, though that check isn't always available to an agent without GitHub API access.
+
+## Context
+
+On 2026-07-14 the ruflo helpers-signing private key was exposed in a Claude Code session transcript and had to be rotated (GCP secret v1 destroyed, v2 issued — PR #2673, `RUFLO_HELPERS_PUBKEY` rotated in `v3/@claude-flow/cli/src/init/helper-signing.ts`). Root cause, reconstructed from `CLAUDE.md`'s "Handling the signing key without leaking it" postmortem and the current script:
+
+`v3/@claude-flow/cli/scripts/sign-helpers.mjs` fetches the private key with:
+
+```js
+execFileSync('gcloud', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
+```
+
+On Windows, Node's `execFileSync` cannot resolve `gcloud` (it needs the `.cmd` suffix) unless `shell: true` is set, so the fetch throws and the script exits. The script's own handling of the secret is already safe — `stdio: ['ignore', 'pipe', 'pipe']` captures both streams into JS strings, none of it is inherited to the parent's terminal. **The exposure did not happen inside this script.** It happened because, when the script fails, the intuitive human workaround is to run the equivalent `gcloud` command directly at the shell:
+
+```
+gcloud secrets versions access latest --secret=ruflo-helpers-signing-key
+```
+
+That command prints the PEM to its own stdout by design. Run inside a Claude Code Bash tool call, that stdout becomes tool-call output, which lands in the session transcript. There is no code path inside `sign-helpers.mjs` to fix here — the vector is a documented fallback instruction that routes a human to a command whose entire purpose is to print secret material.
+
+Three things are true simultaneously and all three need to hold for this class of incident to stop recurring:
+
+1. The primary path (`execFileSync('gcloud', …)`) must stop failing on Windows, so nobody is ever forced toward the workaround.
+2. If the primary path fails for some *other* reason (expired token, wrong project, missing `gcloud` entirely), the sanctioned fallback must be a shape that cannot print key material to a captured stream, even under a Claude-Code-in-the-loop workflow — not a documented discipline ("remember to redirect and grep") that depends on a human executing it perfectly under pressure.
+3. Defense in depth inside the script itself, since (1) and (2) address the *documented* paths — a future code change (e.g., an added debug log) is a second way this could regress, cheaply guarded against.
+
+**Blast radius while unaddressed**: every ruflo install ≤ 3.28.0 still trusts the old (compromised) pubkey. Anyone holding the leaked v1 key could sign a forged helpers manifest that such installs' auto-refresh (`autoRefreshHelpersIfStale`, ADR-174) would accept, until the install upgrades to ≥ 3.29.0. This ADR does not re-litigate the v1→v2 rotation (done, PR #2673) — it closes the gap that allowed the leak in the first place.
+
+## Decision
+
+Harden `sign-helpers.mjs`'s secret capture with three layered changes, all scoped to that one script (~90 lines) plus its `CLAUDE.md` runbook. No change to `helper-signing.ts`'s verification logic, the manifest format, or the pubkey — this is capture-time hardening only.
+
+### 1. Fix the Windows spawn bug (removes the forcing function)
+
+```js
+const gcloudBin = process.platform === 'win32' ? 'gcloud.cmd' : 'gcloud';
+return execFileSync(gcloudBin, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+```
+
+This is the highest-leverage single change: it makes the primary, already-safe path work on the platform that was driving people to the workaround. Every other change in this ADR is defense for the cases this fix doesn't cover (expired token, `gcloud` not installed, wrong project — any failure unrelated to the Windows binary name).
+
+### 2. Stdin-only fallback: `--stdin-key`
+
+Add a `--stdin-key` flag that reads the PEM from fd 0 instead of invoking `gcloud` at all:
+
+```js
+if (process.argv.includes('--stdin-key')) {
+  return readFileSync(0, 'utf-8'); // fd 0 = stdin
+}
+```
+
+The sanctioned fallback shape becomes:
+
+```
+gcloud secrets versions access latest --secret=ruflo-helpers-signing-key \
+  | node scripts/sign-helpers.mjs --stdin-key
+```
+
+This is safe under the exact conditions that caused the incident: in a shell pipeline, the left-hand command's stdout is connected to the right-hand command's stdin via an in-kernel pipe — it is never written to the pipeline's own combined stdout/stderr, so a harness capturing the Bash tool call's output never sees the PEM. This holds whether the pipeline runs interactively, in CI, or inside a Claude Code Bash tool call. It requires no human discipline (no "remember to redirect to a file and grep the log") — the shape itself is the guarantee.
+
+This supersedes the `CLAUDE.md` "Handling the signing key without leaking it" guidance (`gcloud … > ~/.ruflo/helpers-signing.key 2>&1 | grep -v BEGIN`), which is a manual, error-prone pattern (a wrong flag order silently reintroduces the leak) that this ADR's fallback makes unnecessary. That section should be replaced with the pipe-to-`--stdin-key` invocation once implemented.
+
+`RUFLO_HELPERS_SIGNING_KEY=<file>` (existing, file-based) and the `~/.ruflo/helpers-signing.key` dev default are unaffected — both already keep key material off any captured stream and remain fully supported, unchanged. `--stdin-key` is additive: a third resolution path, checked after the GCP-secret path and before the env-var-file path, documented as the recommended fallback when GCP fetch fails but a human still needs to run the signer locally.
+
+### 3. TTY refusal gate (defense in depth, GCP path only)
+
+Guard the GCP-secret branch specifically — not the whole script, since `--stdin-key` and `RUFLO_HELPERS_SIGNING_KEY` are already non-printing by construction and gating them too would just add friction with no safety benefit:
+
+```js
+if (secret && process.stdout.isTTY && !process.env.RUFLO_HELPERS_ALLOW_TTY) {
+  console.error(
+    '[sign-helpers] refusing to fetch from GCP Secret Manager in an interactive/logged ' +
+    'terminal. Use `gcloud … | node scripts/sign-helpers.mjs --stdin-key`, or set ' +
+    'RUFLO_HELPERS_SIGNING_KEY=<pem-file>. To override, set RUFLO_HELPERS_ALLOW_TTY=1.'
+  );
+  process.exit(1);
+}
+```
+
+This does not by itself close the original vector (the leak happened in a raw `gcloud` invocation *outside* this script, which no gate inside `sign-helpers.mjs` can intercept). Its value is narrower and real: it stops a human from reflexively re-deriving the unsafe `gcloud secrets versions access` command as a "just run what the script would run" workaround when they hit this gate, by naming the safe alternative in the same breath it refuses. `RUFLO_HELPERS_ALLOW_TTY=1` is the explicit opt-in for a developer who has read the warning and is deliberately eyeballing the fetch (e.g., verifying `gcloud` auth interactively before scripting it).
+
+### 4. Output-scanning safety net
+
+After signing completes, scan the script's own accumulated stdout buffer (everything queued to `console.log` during the run) for `BEGIN PRIVATE KEY` / `BEGIN EC PRIVATE KEY` / `BEGIN OPENSSH PRIVATE KEY` before the process exits normally:
+
+```js
+const emitted = capturedStdoutLines.join('\n');
+if (/BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY/.test(emitted)) {
+  console.error('[sign-helpers] FATAL: private key material detected in script output. Aborting.');
+  process.exit(1);
+}
+```
+
+This is a last-resort check against a *future* code change in this file (e.g., a debug `console.log(privateKeyPem)` added during troubleshooting) — it does not need to run on the raw `gcloud` output as a general filter, because that path is being eliminated by (1) and gated by (3). Scope: only this script's own `console.log`/`console.error` calls; it is not a general-purpose secret-scanning layer for arbitrary tool output (that is a much larger scope, out of scope for this ADR).
+
+## Alternatives considered
+
+- **Redirect-and-grep as the documented fallback (status quo, `CLAUDE.md` today).** Rejected as the *sanctioned* pattern — it depends on a human getting flag order and redirection right under time pressure, which is exactly how the incident happened. Left as a documented "if `--stdin-key` isn't available for some reason" footnote only, not the primary guidance.
+- **`shell: true` on the existing `execFileSync('gcloud', …)` call to fix Windows.** Rejected — enabling a shell reintroduces argument-injection risk for a command that will eventually carry secret names and project identifiers, for no benefit over just resolving the correct binary name.
+- **TTY gate on the whole script, not just the GCP branch.** Rejected — `--stdin-key` and `RUFLO_HELPERS_SIGNING_KEY` are non-printing by construction; gating those paths too adds a `RUFLO_HELPERS_ALLOW_TTY=1` tax to every local/CI invocation for zero additional safety.
+- **A full general-purpose "never let PRIVATE KEY reach any tool output" harness feature (e.g., an AIDefence-style scan on all Bash tool output repo-wide).** Out of scope here — real defense-in-depth, but a repo-wide harness/tooling change, not a `sign-helpers.mjs` change; tracked as a separate future concern if pursued, not folded into this ADR.
+- **Rotating to a fully offline (non-GCP) key custody model (e.g., hardware token only).** Rejected for this ADR — orthogonal to the capture-time bug; GCP Secret Manager centralized custody is a separate, already-accepted decision (implicit in ADR-174), not something this incident calls into question.
+
+## Consequences
+
+**Positive**:
+- The Windows fetch failure — the actual forcing function behind the incident — is fixed; the primary path works cross-platform.
+- The sanctioned fallback (`--stdin-key`) is safe by construction under the same Claude-Code-in-the-loop conditions that caused the leak, not safe-by-discipline.
+- `RUFLO_HELPERS_SIGNING_KEY=<file>` and the dev-default path are untouched — zero migration burden for anyone already using them.
+- The output-scan is cheap insurance against a future accidental regression inside this one file.
+
+**Negative / trade-offs**:
+- `--stdin-key` requires updating the `CLAUDE.md` runbook and any CI/release scripts that reference the old `gcloud | node` pattern implicitly — a one-time doc/script sync, not a behavior change for correctly-configured CI (CI does not run in a TTY, so gate (3) never fires there).
+- The TTY gate adds one more environment variable (`RUFLO_HELPERS_ALLOW_TTY`) to the script's already-multi-path resolution surface; mitigated by only gating the GCP branch and by a clear error message naming the escape hatches.
+- The output-scan only covers this script's own emitted lines — it provides no protection if a human still runs raw `gcloud` commands manually outside `sign-helpers.mjs`; that residual risk is accepted because (1) removes the reason to do so and (2)/(3) redirect toward the safe fallback at the point of failure.
+
+## Validation
+
+1. **Windows fetch success**: on a Windows runner (or `platform` mocked to `win32` in a unit test), `loadPrivateKey()` resolves `gcloud.cmd` and does not throw the "gcloud not found" error that previously forced the workaround.
+2. **`--stdin-key` end-to-end**: `printf '%s' "$TEST_PEM" | node scripts/sign-helpers.mjs --stdin-key` signs successfully using only piped input, with no `gcloud` invocation and no other env var set.
+3. **TTY refusal**: with `RUFLO_HELPERS_SIGNING_SECRET` set and stdout forced to a TTY (e.g. via `script -qc` or a mocked `process.stdout.isTTY = true` in a unit test), the script exits 1 with the documented message and does not call `gcloud`; setting `RUFLO_HELPERS_ALLOW_TTY=1` allows it through.
+4. **Output-scan trip-wire**: a deliberately introduced `console.log(privateKeyPem)` in a test fork of the script causes the run to abort with the FATAL message before exit — proving the scan is load-bearing, not dead code.
+5. **No regression on existing paths**: `RUFLO_HELPERS_SIGNING_KEY=<pem-file>` and the `~/.ruflo/helpers-signing.key` dev-default paths continue to sign successfully with no behavior change and no new prompts.
+
+## References
+
+- Issue [#2674](https://github.com/ruvnet/ruflo/issues/2674) — this hardening request.
+- PR [#2673](https://github.com/ruvnet/ruflo/pull/2673) — the v1→v2 key rotation this ADR follows up on.
+- PR [#2671](https://github.com/ruvnet/ruflo/pull/2671) — v3.29.0, shipped the rotated pubkey.
+- `CLAUDE.md` "Handling the signing key without leaking it" (root-cause postmortem, commit `0052b1b06`) and "Windows `prepublishOnly` failure" (adjacent Windows cross-platform gap in the same publish flow).
+- [ADR-174](ADR-174-memory-distillation-self-optimization.md) — the Ed25519 helper-signing/auto-refresh mechanism this script's output feeds.
+- `v3/@claude-flow/cli/src/init/helper-signing.ts` — verification side; `RUFLO_HELPERS_PUBKEY`, `canonicalManifestBytes()`.

--- a/v3/docs/adr/README.md
+++ b/v3/docs/adr/README.md
@@ -39,6 +39,7 @@ All ADRs are located in [`/v3/implementation/adrs/`](../../implementation/adrs/)
 | [ADR-308](ADR-308-cognitum-public-api-contract.md) | Cognitum Public API and Server Contract | Proposed |
 | [ADR-309](ADR-309-funnel-governance-privacy-ecosystem.md) | Funnel Governance, Privacy, and Ecosystem Policy | Proposed |
 | [ADR-310](ADR-310-funnel-rollout-measurement-emergency-controls.md) | Funnel Rollout, Measurement, and Emergency Controls | Proposed |
+| [ADR-322](ADR-322-sign-helpers-secret-capture-hardening.md) | Structurally Preventing Signing-Key Exposure in `sign-helpers.mjs` | Accepted |
 
 ## Summary Documents
 


### PR DESCRIPTION
## Summary
- Fixes the Windows `execFileSync('gcloud', ...)` spawn bug (missing `.cmd` suffix) that was the forcing function behind the 2026-07-14 signing-key leak (PR #2673) — it made the primary GCP path fail on Windows, pushing people toward a raw `gcloud secrets versions access` workaround whose stdout became captured tool output.
- Adds three layers of defense in depth so the same class of incident can't recur, all scoped to `sign-helpers.mjs` (~90 lines) plus its `CLAUDE.md` runbook:
  - `--stdin-key` fallback — reads the PEM from stdin via an in-kernel pipe, which never touches a captured tool-output stream, so `gcloud secrets versions access ... | node scripts/sign-helpers.mjs --stdin-key` is safe by construction.
  - TTY refusal gate — the GCP-secret fetch branch refuses to run in an interactive/logged terminal (unless `RUFLO_HELPERS_ALLOW_TTY=1`), naming the `--stdin-key` alternative instead of letting someone improvise the unsafe workaround.
  - Output-scanning safety net — scans everything the script ever `console.log`s for a `BEGIN ... PRIVATE KEY` marker and aborts before exiting normally if one is found.
- No change to `helper-signing.ts`'s verification logic, the manifest format, or the pubkey — this is capture-time hardening only.

See [ADR-322](https://github.com/ruvnet/ruflo/blob/main/v3/docs/adr/ADR-322-sign-helpers-secret-capture-hardening.md) (status: Accepted) for full design rationale and validation checklist.

Closes #2674

## Test plan
- [x] `node --check scripts/sign-helpers.mjs` — syntax clean
- [x] New mock-first (London-school) test suite `__tests__/sign-helpers-secret-hardening.test.ts` — 16/16 passing, covering: win32 `gcloud.cmd` vs `gcloud` resolution, `--stdin-key` reads fd 0, TTY refusal gate + `RUFLO_HELPERS_ALLOW_TTY` override, GCP-env-var-wins-over-`--stdin-key` resolution order, output-scan trip-wire against all 4 PEM marker variants (plain/RSA/EC/OPENSSH)
- [x] Pre-existing `__tests__/helper-signing.test.ts` — 6/6 still passing, no regression
- [x] Full package `vitest run` — no new failures introduced (69 pre-existing failures in unrelated suites: missing native `@ruvector/ruvllm-wasm` module, Docker integration tests requiring a running daemon, etc. — none touch `sign-helpers.mjs` or `helper-signing.ts`)
- [x] `tsc --noEmit` — no errors referencing changed files

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)