### PR TITLE
refactor(security): single source of truth for RUFLO_HELPERS_PUBKEY (ADR-323)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/helpers-pubkey-single-source.test.ts
+++ b/v3/@claude-flow/cli/__tests__/helpers-pubkey-single-source.test.ts
@@ -1,0 +1,113 @@
+/**
+ * ADR-323: single source of truth for RUFLO_HELPERS_PUBKEY.
+ *
+ * The Ed25519 pubkey used to authenticate the signed helpers manifest was
+ * hardcoded identically in TWO places (helper-signing.ts + verify-helpers.mjs),
+ * kept in sync only by a `// KEEP IN SYNC` comment. ADR-323 extracts it to a
+ * single plain-.js module (src/init/helpers-pubkey.js) that both consumers
+ * import.
+ *
+ * These tests verify the WIRING (London-school: assert the interactions/output
+ * of the consolidation, not the crypto internals — helper-signing.test.ts
+ * already covers verify/reject behavior). They guard the duplication-prevention
+ * invariant so a future accidental re-hardcode fails CI:
+ *   1. helpers-pubkey.js exports exactly one well-formed PEM binding.
+ *   2. helper-signing.ts's re-export IS that same value (one source, not two).
+ *   3. verify-helpers.mjs holds NO PEM literal of its own — only the import.
+ *   4. verify-helpers.mjs's CRITICAL array still has all 4 entries (guards the
+ *      incidental `statusline.cjs` drop from abandoned PR #2684).
+ *   5. Built dist artifact matches src byte-for-byte (build-gated, see note).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createPublicKey } from 'node:crypto';
+
+import { RUFLO_HELPERS_PUBKEY as PUBKEY_FROM_SOURCE_FILE } from '../src/init/helpers-pubkey.js';
+import * as pubkeyModule from '../src/init/helpers-pubkey.js';
+import { RUFLO_HELPERS_PUBKEY as PUBKEY_FROM_SIGNING } from '../src/init/helper-signing.js';
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const VERIFY_HELPERS_PATH = join(PKG_ROOT, 'scripts', 'verify-helpers.mjs');
+const DIST_PUBKEY_PATH = join(PKG_ROOT, 'dist', 'src', 'init', 'helpers-pubkey.js');
+const PEM_HEADER = '-----BEGIN PUBLIC KEY-----';
+const PEM_FOOTER = '-----END PUBLIC KEY-----';
+
+describe('ADR-323 §1 — helpers-pubkey.js is a single, well-formed constant', () => {
+  it('exports exactly one binding named RUFLO_HELPERS_PUBKEY', () => {
+    expect(Object.keys(pubkeyModule)).toEqual(['RUFLO_HELPERS_PUBKEY']);
+  });
+
+  it('the exported value is a well-formed PEM public key', () => {
+    expect(typeof PUBKEY_FROM_SOURCE_FILE).toBe('string');
+    expect(PUBKEY_FROM_SOURCE_FILE.startsWith(PEM_HEADER)).toBe(true);
+    expect(PUBKEY_FROM_SOURCE_FILE.trimEnd().endsWith(PEM_FOOTER)).toBe(true);
+    // Well-formed enough for Node to parse as a real public key (not just a
+    // string that looks like PEM). This does NOT re-test signing — it only
+    // asserts the constant is a usable key, which is the module's contract.
+    expect(() => createPublicKey(PUBKEY_FROM_SOURCE_FILE)).not.toThrow();
+    expect(createPublicKey(PUBKEY_FROM_SOURCE_FILE).asymmetricKeyType).toBe('ed25519');
+  });
+});
+
+describe('ADR-323 §2 — helper-signing.ts re-exports the SAME source, not a copy', () => {
+  it('helper-signing.ts RUFLO_HELPERS_PUBKEY is value-identical to helpers-pubkey.js', () => {
+    // Strict equality proves there is genuinely ONE constant re-exported, not a
+    // second literal that happens to match today. If someone reintroduced a
+    // duplicate literal in helper-signing.ts, a later drift would break this.
+    expect(PUBKEY_FROM_SIGNING).toBe(PUBKEY_FROM_SOURCE_FILE);
+  });
+});
+
+describe('ADR-323 §3 — verify-helpers.mjs holds no PEM literal, only the import', () => {
+  const source = readFileSync(VERIFY_HELPERS_PATH, 'utf-8');
+
+  it('does NOT contain a hardcoded BEGIN PUBLIC KEY literal', () => {
+    // The whole point of the ADR: the constant must not be duplicated here.
+    // If a future edit re-hardcodes it, this regression test fails.
+    expect(source).not.toContain(PEM_HEADER);
+  });
+
+  it('imports RUFLO_HELPERS_PUBKEY from the single-source module', () => {
+    expect(source).toContain("from '../src/init/helpers-pubkey.js'");
+    expect(source).toMatch(/import\s*\{\s*RUFLO_HELPERS_PUBKEY\s*\}\s*from\s*['"]\.\.\/src\/init\/helpers-pubkey\.js['"]/);
+  });
+});
+
+describe('ADR-323 §4 — verify-helpers.mjs CRITICAL array is intact (guards PR #2684 drop)', () => {
+  const source = readFileSync(VERIFY_HELPERS_PATH, 'utf-8');
+
+  it("has exactly the 4 original entries, including 'statusline.cjs'", () => {
+    const match = source.match(/const\s+CRITICAL\s*=\s*(\[[^\]]*\])/);
+    expect(match, 'CRITICAL array literal not found in verify-helpers.mjs').not.toBeNull();
+    const entries = JSON.parse(match![1].replace(/'/g, '"'));
+    expect(entries).toEqual([
+      'auto-memory-hook.mjs',
+      'hook-handler.cjs',
+      'intelligence.cjs',
+      'statusline.cjs',
+    ]);
+    // Explicit guard for the specific incidental regression in abandoned #2684.
+    expect(entries).toContain('statusline.cjs');
+    expect(entries).toHaveLength(4);
+  });
+});
+
+describe('ADR-323 §5 — built dist artifact matches the source constant', () => {
+  // Build-gated by design: vitest run does NOT invoke `npm run build`, and the
+  // rest of this suite doesn't either, so requiring a fresh dist as a hard
+  // precondition would make CI flaky on unbuilt trees. Instead this runs only
+  // when dist/ is present (i.e. after a build — the state that actually matters
+  // for a publish/CI flow, which builds before packing). When absent it skips
+  // rather than fails, so the file is safe to run standalone pre-build. The
+  // stronger byte-for-byte guarantee at publish time is covered by the
+  // prepublishOnly chain (sign-helpers.mjs → verify-helpers.mjs).
+  it.skipIf(!existsSync(DIST_PUBKEY_PATH))(
+    'dist/src/init/helpers-pubkey.js exports the byte-identical PEM',
+    async () => {
+      const distModule = await import(DIST_PUBKEY_PATH);
+      expect(distModule.RUFLO_HELPERS_PUBKEY).toBe(PUBKEY_FROM_SOURCE_FILE);
+    },
+  );
+});

--- a/v3/@claude-flow/cli/scripts/verify-helpers.mjs
+++ b/v3/@claude-flow/cli/scripts/verify-helpers.mjs
@@ -17,19 +17,13 @@ import { readFileSync, existsSync } from 'node:fs';
 import { createHash, verify as edVerify } from 'node:crypto';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { RUFLO_HELPERS_PUBKEY } from '../src/init/helpers-pubkey.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = join(__dirname, '..');
 const HELPERS_DIR = resolve(process.argv[2] || join(PKG_ROOT, '.claude', 'helpers'));
 // Keep in sync with sign-helpers.mjs:CRITICAL and src/init/helper-refresh.ts:CRITICAL_HELPERS.
 const CRITICAL = ['auto-memory-hook.mjs', 'hook-handler.cjs', 'intelligence.cjs', 'statusline.cjs'];
-
-// KEEP IN SYNC with src/init/helper-signing.ts:RUFLO_HELPERS_PUBKEY.
-// Rotated 2026-07-14 (v3.29.0) after the previous private key was exposed in
-// a Claude Code session transcript. Old GCP secret v1 destroyed.
-const RUFLO_HELPERS_PUBKEY = `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAyLl9cG+V/C+ffKWaSwvOsHdXSWmB5e3x1z9NUNvq6Ys=
------END PUBLIC KEY-----`;
 
 function die(msg) { console.error(`[verify-helpers] ${msg}`); process.exit(1); }
 

--- a/v3/@claude-flow/cli/src/init/helper-signing.ts
+++ b/v3/@claude-flow/cli/src/init/helper-signing.ts
@@ -7,29 +7,20 @@
  * postinstall (or disk tampering) could overwrite them, and the refresh would
  * faithfully propagate the tampered code. This gate closes that: every helper
  * is verified against a ruflo-signed manifest before install, and a mismatch is
- * REFUSED (fail-closed). The public key is baked in below; the private key is
- * never in the repo (see scripts/sign-helpers.mjs).
+ * REFUSED (fail-closed). The public key lives in ./helpers-pubkey.js (ADR-323,
+ * single source of truth shared with scripts/verify-helpers.mjs) and is
+ * re-exported below; the private key is never in the repo (see
+ * scripts/sign-helpers.mjs).
  *
  * Native Node crypto (RFC 8032 Ed25519), zero external deps — same primitive as
  * src/appliance/rvfa-signing.ts.
  */
 import { createHash, verify as edVerify } from 'crypto';
+import { RUFLO_HELPERS_PUBKEY } from './helpers-pubkey.js';
 
-/**
- * Ruflo helper-signing PUBLIC key (safe to commit). The matching private key is
- * held out-of-repo and provided to scripts/sign-helpers.mjs at publish time via
- * $RUFLO_HELPERS_SIGNING_KEY. Rotating the key = replace this constant + re-sign.
- *
- * ROTATED 2026-07-14 (v3.29.0): the previous key was accidentally exposed in a
- * Claude Code session transcript. Old GCP secret version 1 was destroyed (not
- * disabled) so it cannot be re-enabled; new v2 generated here. Users on old
- * ruflo versions keep the old pubkey and verify old manifests successfully;
- * upgrading to v3.29.0+ atomically picks up this new pubkey along with the
- * new-key-signed manifest.
- */
-export const RUFLO_HELPERS_PUBKEY = `-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAyLl9cG+V/C+ffKWaSwvOsHdXSWmB5e3x1z9NUNvq6Ys=
------END PUBLIC KEY-----`;
+// Re-exported so existing consumers of `RUFLO_HELPERS_PUBKEY` from this module
+// keep working unchanged (ADR-323) — the key itself now lives in helpers-pubkey.js.
+export { RUFLO_HELPERS_PUBKEY };
 
 export const HELPERS_MANIFEST_FILE = 'helpers.manifest.json';
 

--- a/v3/@claude-flow/cli/src/init/helpers-pubkey.js
+++ b/v3/@claude-flow/cli/src/init/helpers-pubkey.js
@@ -1,0 +1,19 @@
+/**
+ * Ruflo helper-signing PUBLIC key (safe to commit). The matching private key is
+ * held out-of-repo and provided to scripts/sign-helpers.mjs at publish time via
+ * $RUFLO_HELPERS_SIGNING_KEY. Rotating the key = replace this constant + re-sign.
+ *
+ * ROTATED 2026-07-14 (v3.29.0): the previous key was accidentally exposed in a
+ * Claude Code session transcript. Old GCP secret version 1 was destroyed (not
+ * disabled) so it cannot be re-enabled; new v2 generated here. Users on old
+ * ruflo versions keep the old pubkey and verify old manifests successfully;
+ * upgrading to v3.29.0+ atomically picks up this new pubkey along with the
+ * new-key-signed manifest.
+ *
+ * Single source of truth (ADR-323): src/init/helper-signing.ts re-exports this
+ * constant for TypeScript consumers; scripts/verify-helpers.mjs imports it
+ * directly. Rotate the key here ONLY — do not reintroduce a second copy.
+ */
+export const RUFLO_HELPERS_PUBKEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAyLl9cG+V/C+ffKWaSwvOsHdXSWmB5e3x1z9NUNvq6Ys=
+-----END PUBLIC KEY-----`;

--- a/v3/@claude-flow/cli/tsconfig.json
+++ b/v3/@claude-flow/cli/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": ".",
     "composite": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "allowJs": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"],

--- a/v3/docs/adr/ADR-323-helpers-pubkey-single-source.md
+++ b/v3/docs/adr/ADR-323-helpers-pubkey-single-source.md
@@ -1,0 +1,82 @@
+# ADR-323: Single Source of Truth for `RUFLO_HELPERS_PUBKEY`
+
+- **Status**: Proposed
+- **Date**: 2026-07-15
+- **Deciders**: ruflo core
+- **Issue**: [#2675](https://github.com/ruvnet/ruflo/issues/2675)
+- **Related**: [ADR-322](ADR-322-sign-helpers-secret-capture-hardening.md) (sibling `sign-helpers.mjs` hardening ADR from the same rotation incident — that ADR fixes secret-*capture* at signing time; this ADR fixes pubkey *duplication* at verification time. Distinct problems, same script family, deliberately not re-litigated here), [ADR-174](ADR-174-memory-distillation-self-optimization.md) (the Ed25519 helper-signing/auto-refresh mechanism both scripts serve)
+
+> **Numbering note**: a local scan of `v3/docs/adr/` on this branch (freshly cut from `main`) reports **319** as the highest number in use. That check alone is insufficient — ADR-322 itself documents renumbering from 320→322 after colliding with PR #2687, and at the time of this draft the collision is still live: PR #2687 (`v3/docs/adr/ADR-320-*.md`, `ADR-321-*.md`) and PR #2678 (`ADR-320-*.md`, `ADR-321-*.md`, `ADR-322-*.md`, all three with *different* content than #2687's or this repo's ADR-322) are both open simultaneously, plus six independent "dream cycle" bot PRs all separately claim `ADR-179` for unrelated topics. I checked open PRs via `gh pr list --state open --limit 100` (twice, covering ~130 PRs total) and inspected `gh pr diff --name-only` for every PR whose title referenced an ADR number, to confirm no open PR currently claims `ADR-323` or higher — none did, and a text search (`gh search prs "ADR-323"` through `"ADR-330"`) found no matches either. Given the density of collisions already observed at 320–322, this is a best-effort check, not a guarantee: another agent could claim 323 in a PR opened after this scan. Whoever accepts this ADR should re-run the same check immediately before merge.
+
+## Context
+
+`RUFLO_HELPERS_PUBKEY` — the Ed25519 public key that authenticates the signed helpers manifest (ADR-174) — is declared as an identical string constant in two places:
+
+- `v3/@claude-flow/cli/src/init/helper-signing.ts` — the runtime verifier, used by the CLI's auto-refresh path (`autoRefreshHelpersIfStale`) to validate helpers before writing them into a user's project.
+- `v3/@claude-flow/cli/scripts/verify-helpers.mjs` — the `prepublishOnly` verifier, run at publish time (after `sign-helpers.mjs`) to fail the release closed if the on-disk manifest doesn't match what's shipping.
+
+Both copies carry a `// KEEP IN SYNC` comment and must be updated together on every key rotation. During the 2026-07-14 rotation (v3.29.0, PR #2673, prompted by the private key leak documented in ADR-322's Context) updating both copies correctly was a manual, easy-to-miss step — the issue reports it "almost" went out of sync. Missing one copy produces a silent split: the on-disk manifest verifies against the runtime pubkey but fails the prepublish check (or vice versa), which either blocks a legitimate publish or — worse — ships a manifest that the *runtime* verifier can't validate, causing `autoRefreshHelpersIfStale` to fail-closed with a tamper warning for every user who installs that version (the exact failure shape of issue #2593 / ADR-174's original regression, for an unrelated root cause).
+
+**A relevant fact this ADR does not act on but must record**: an unreviewed, unmerged PR (#2684, `loop/T1-consolidate-pubkey`) already exists implementing the issue's literal suggestion — importing `RUFLO_HELPERS_PUBKEY` from `../dist/src/init/helper-signing.js` in `verify-helpers.mjs`. It was produced by an autonomous local-LLM loop ("maker=local-coder, verifier=local-verify"), is not merged, and — notably — its diff also silently drops `'statusline.cjs'` from `verify-helpers.mjs`'s `CRITICAL` array (four entries on `main` today, three in that PR), an unrelated regression introduced incidentally while making the "obvious" fix. That PR is evidence *for* doing this consolidation (the fix is small and mechanical enough that an autonomous loop reached for it unprompted) and *against* merging it as-is without the scrutiny this ADR provides.
+
+## Decision
+
+Extract `RUFLO_HELPERS_PUBKEY` to a **plain `.js` file**, not a compiled-TypeScript re-export. Concretely: create `v3/@claude-flow/cli/src/init/helpers-pubkey.js` (plain ES module, no TypeScript syntax) holding the constant, then:
+
+- `src/init/helper-signing.ts` imports it: `import { RUFLO_HELPERS_PUBKEY } from './helpers-pubkey.js';` and re-exports it (keeping `helper-signing.ts`'s existing public export surface unchanged for any other consumer already importing `RUFLO_HELPERS_PUBKEY` from there).
+- `scripts/verify-helpers.mjs` imports the same file directly: `import { RUFLO_HELPERS_PUBKEY } from '../src/init/helpers-pubkey.js';` — no `dist/` in the path at all.
+- `scripts/sign-helpers.mjs` does not need the pubkey (it only ever handles the private key), so it is unaffected.
+
+This makes `helpers-pubkey.js` the single source of truth; both consumers point at the same bytes on disk, with no compilation step between "the source of truth" and "what `verify-helpers.mjs` reads."
+
+### Why this over the issue's proposed dist-import (Alternative 1)
+
+The issue's own suggestion — `import { RUFLO_HELPERS_PUBKEY } from '../dist/src/init/helper-signing.js';` — is **technically sound as far as path resolution goes**, and I verified this rather than taking it on faith:
+
+- `tsconfig.json` sets `outDir: "./dist"`, `rootDir: "."`. Compiling `src/init/helper-signing.ts` produces `dist/src/init/helper-signing.js`. From `scripts/`, `../dist/src/init/helper-signing.js` resolves to exactly that file. The path in the issue is correct.
+- No script in this package currently imports from `dist/` internally (confirmed by grep across `scripts/`), but `package.json`'s `exports` map already publishes `"./dist/*": "./dist/*"` as a public subpath contract — so dist-relative imports aren't a wholly novel pattern for this package, just a new one for its own build scripts.
+- `prepublishOnly` does run `sign-helpers.mjs` then `verify-helpers.mjs` in that order today (confirmed by reading `package.json` directly), so *within* `prepublishOnly`, `sign-helpers.mjs` having already run doesn't help — what matters is whether `dist/` exists and is current when `prepublishOnly` fires at all. That is **not** an npm-lifecycle guarantee: this package has no `prepare` script, so nothing forces `npm run build` before `npm publish`. It is a *documented human/CI convention* only (`CLAUDE.md`'s publish playbook runs `npm run build` immediately before `npm publish`). If someone runs `npm publish` directly against an unbuilt or stale tree, the dist-import either throws `ERR_MODULE_NOT_FOUND` (missing `dist/`) or silently reads a stale pubkey (present but outdated `dist/`, e.g. mid-rotation). I traced both failure modes: both are fail-closed in effect (a missing-dist crash aborts `prepublishOnly`; a stale pubkey causes the Ed25519 check to fail against a signature made with the current private key), just with a worse error message than the script's own clean `die()` calls in the missing-`dist` case.
+- The decisive finding, though, is `verify-helpers.mjs`'s own documented standalone usage: its header comment says "Optional arg: path to a helpers dir (e.g. an extracted `npm pack` tarball)" — i.e. this script is meant to be runnable on its own, outside a full `prepublishOnly` chain, against an arbitrary checkout (CI verification job, manual audit of a published tarball, etc.). In a fresh clone or a CI job that hasn't run `npm run build`, a `dist/`-relative import breaks that standalone use case outright; a plain-`.js`-file import does not, because it never depends on `tsc` having run. This is a real, load-bearing use case the dist-import approach would silently regress, not a hypothetical.
+- Separately: `helpers-manifest-guard.yml` (the CI guard for this script family) only does static `package.json`/string checks today — it does not actually execute `verify-helpers.mjs` against a built or unbuilt tree, so a `dist`-import regression of the kind above would not be caught by existing CI as it stands.
+
+Given both approaches are equally correct on the happy path, and the plain-`.js`-file approach has no failure mode the dist-import approach has, dist-import buys nothing here — it's an unforced dependency on build ordering, in a script whose own documentation promises it doesn't need one.
+
+**Feasibility of the plain-`.js` approach in TypeScript**: this package's `tsconfig.base.json` sets `moduleResolution: "bundler"`, and `src/init/*.ts` already imports sibling `.ts` files via `.js`-suffixed relative paths as its established convention (e.g. `executor.ts` imports `from './settings-generator.js'`, `from './helper-refresh.js'`, etc., all of which are `.ts` source files resolved through their compiled-`.js` name). Importing an actual plain `.js` file the same way (`from './helpers-pubkey.js'`) is consistent with that existing pattern, not a new one.
+
+## Alternatives considered
+
+- **Import from `dist/` (the issue's original proposal).** Rejected — see above: no functional advantage over the plain-`.js` file, and it silently breaks `verify-helpers.mjs`'s documented standalone/tarball-verification usage in any environment where `dist/` isn't freshly built (CI job, ad hoc audit, fresh clone), a real regression risk with no compensating benefit.
+- **Leave both copies as-is, rely on the `// KEEP IN SYNC` comment.** Rejected — this is the status quo the issue reports as an actual near-miss during the 2026-07-14 rotation; comments are not enforced.
+- **Add a CI check that diffs the two hardcoded constants for byte-equality, without removing the duplication.** Rejected as insufficient on its own — it would catch drift after the fact but doesn't remove the two-places-to-remember burden this issue is about; could be a *complementary* CI hardening (see Validation) but not a substitute for a single source.
+- **Merge PR #2684 as-is.** Rejected for this ADR — that PR implements the dist-import path this ADR argues against, and separately drops `'statusline.cjs'` from `CRITICAL` (an unrelated regression), so it should not be merged without revision regardless of which pubkey-consolidation approach is accepted.
+
+## Consequences
+
+**Positive**:
+- One file (`helpers-pubkey.js`) is the only place `RUFLO_HELPERS_PUBKEY` bytes live; a key rotation touches exactly one file plus the manifest re-sign, removing the class of near-miss the issue reports.
+- No new build-order dependency: `verify-helpers.mjs` can run standalone against any checkout, built or not, preserving its documented tarball-verification use case.
+- `helper-signing.ts`'s existing export surface (`export const RUFLO_HELPERS_PUBKEY`) is unchanged for any other consumer, since it re-exports rather than requiring callers to switch import paths.
+- Behavioral parity is exact — the imported constant is byte-identical to what's hardcoded today; no signature-verification behavior changes.
+
+**Negative / trade-offs**:
+- Introduces one plain-`.js` file inside an otherwise all-TypeScript `src/init/` directory — a minor stylistic inconsistency, mitigated by keeping the file to a single exported constant with no logic.
+- `PR #2684` (already open, unreviewed) implements the rejected dist-import alternative; landing this ADR's approach means that PR needs to be closed or substantially revised rather than merged as-is — a small amount of coordination overhead this ADR creates.
+- Does not, by itself, add CI enforcement that the single source stays byte-identical to whatever gets signed — that risk is structurally reduced (one file, not two) but not mechanically verified. Deferred to Validation/implementation, not blocking this decision.
+
+## Validation
+
+1. **Byte-identity**: after extraction, `diff <(node -e "console.log(require('./src/init/helpers-pubkey.js').RUFLO_HELPERS_PUBKEY)") <(node -e "console.log(require('./dist/src/init/helper-signing.js').RUFLO_HELPERS_PUBKEY)")` (or the TS-source equivalent pre-build) confirms `helper-signing.ts`'s re-export matches the extracted constant exactly.
+2. **Runtime verifier unaffected**: existing `helper-signing.ts` unit tests (manifest verify/reject cases) pass unchanged, proving the re-export preserves current behavior.
+3. **Standalone invocation**: `node scripts/verify-helpers.mjs <path-to-extracted-tarball>` succeeds in a checkout where `npm run build` has *not* been run — the regression case the dist-import alternative would fail, and the specific scenario this ADR's approach is chosen to preserve.
+4. **`prepublishOnly` end-to-end**: unchanged — `sign-helpers.mjs` then `verify-helpers.mjs` still both run and pass on a real rotation/publish rehearsal.
+5. **(Optional hardening, not required for acceptance)**: extend `helpers-manifest-guard.yml` to actually execute `verify-helpers.mjs` (currently it only does static `package.json` checks), which would catch both this class of drift and any future accidental reintroduction of a duplicated constant.
+
+## References
+
+- Issue [#2675](https://github.com/ruvnet/ruflo/issues/2675) — this consolidation request.
+- PR [#2673](https://github.com/ruvnet/ruflo/pull/2673) — the 2026-07-14 key rotation that surfaced the duplication risk.
+- PR [#2684](https://github.com/ruvnet/ruflo/pull/2684) (open, unreviewed) — autonomous-loop implementation of the rejected dist-import alternative; also drops `statusline.cjs` from `CRITICAL` incidentally.
+- [ADR-322](ADR-322-sign-helpers-secret-capture-hardening.md) — sibling hardening ADR from the same incident family (secret *capture*, not pubkey *duplication*).
+- [ADR-174](ADR-174-memory-distillation-self-optimization.md) — the Ed25519 helper-signing/auto-refresh mechanism this constant authenticates.
+- `v3/@claude-flow/cli/src/init/helper-signing.ts`, `v3/@claude-flow/cli/scripts/verify-helpers.mjs`, `v3/@claude-flow/cli/scripts/sign-helpers.mjs` — the three files in this script family.
+- `.github/workflows/helpers-manifest-guard.yml` — existing static CI guard for this script family (issue #2593); does not currently execute either script.

--- a/v3/docs/adr/README.md
+++ b/v3/docs/adr/README.md
@@ -39,6 +39,7 @@ All ADRs are located in [`/v3/implementation/adrs/`](../../implementation/adrs/)
 | [ADR-308](ADR-308-cognitum-public-api-contract.md) | Cognitum Public API and Server Contract | Proposed |
 | [ADR-309](ADR-309-funnel-governance-privacy-ecosystem.md) | Funnel Governance, Privacy, and Ecosystem Policy | Proposed |
 | [ADR-310](ADR-310-funnel-rollout-measurement-emergency-controls.md) | Funnel Rollout, Measurement, and Emergency Controls | Proposed |
+| [ADR-323](ADR-323-helpers-pubkey-single-source.md) | Single Source of Truth for `RUFLO_HELPERS_PUBKEY` | Proposed |
 
 ## Summary Documents
 


### PR DESCRIPTION
## Summary
- `RUFLO_HELPERS_PUBKEY` was hardcoded identically in both `src/init/helper-signing.ts` and `scripts/verify-helpers.mjs`, kept in sync only by a `// KEEP IN SYNC` comment — the exact class of hazard that almost caused a divergence during the 2026-07-14 key rotation (PR #2673).
- Extracts the constant to a new plain-`.js` module, `src/init/helpers-pubkey.js`, which both consumers import directly.
- `helper-signing.ts` imports + re-exports it — its public API (`RUFLO_HELPERS_PUBKEY`, `verifyHelpersManifest`, etc.) is unchanged for any other consumer.
- `verify-helpers.mjs` imports it directly with **no `dist/` in the path** — this preserves its documented standalone/tarball-verification use case (running against an extracted `npm pack` tarball without a prior build).
- `tsconfig.json` gains `"allowJs": true` — required so the plain `.js` file is actually included in the TS build and copied into `dist/`, otherwise the compiled `dist/src/init/helper-signing.js`'s relative import would throw `ERR_MODULE_NOT_FOUND` for real installed users.

**Deliberately rejects the issue's own suggestion** (importing from `../dist/src/init/helper-signing.js`) — see [ADR-323](https://github.com/ruvnet/ruflo/blob/main/v3/docs/adr/ADR-323-helpers-pubkey-single-source.md) for the full tradeoff analysis. Short version: a dist-import is build-order-dependent and silently breaks `verify-helpers.mjs`'s standalone use case in any unbuilt checkout (fresh clone, CI job that hasn't built yet, ad hoc tarball audit); the plain-`.js`-file approach has no such failure mode.

Also flagged in the ADR: an abandoned, unreviewed PR (#2684, autonomous-loop output) already attempted this same fix via the dist-import path, and incidentally dropped `'statusline.cjs'` from `verify-helpers.mjs`'s `CRITICAL` array. This PR does not touch `CRITICAL` at all — verified unchanged (still 4 entries including `statusline.cjs`).

No change to `sign-helpers.mjs` (it only ever handles the private key, never the pubkey) or to any verification/signing behavior — this is pure duplication removal.

Closes #2675

## Test plan
- [x] `npm run build` (tsc) — zero errors; `dist/src/init/helpers-pubkey.js` confirmed present post-build, byte-identical PEM vs. source
- [x] New test suite `__tests__/helpers-pubkey-single-source.test.ts` — 7 tests: single well-formed PEM export, `helper-signing.ts`'s re-export is `toBe`-identical (not just equal) to the source module, `verify-helpers.mjs` contains no hardcoded PEM literal (regression guard), `CRITICAL` array integrity guard, dist-artifact byte match (build-gated, skips gracefully pre-build)
- [x] Pre-existing `__tests__/helper-signing.test.ts` — 6/6 still passing, zero test-file edits (proves no runtime behavior change)
- [x] `node scripts/verify-helpers.mjs` standalone — pubkey import resolves with no module-resolution error (only fails on a pre-existing, unrelated stale-manifest-version mismatch)
- [x] Full package `vitest run` — no new failures introduced

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)