### PR TITLE
fix(security): statusline CVE counter reads real scan findings, not hardcoded 3 (#2694)

### DIFF
--- a/v3/@claude-flow/cli/.claude/helpers/statusline.js
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.js
@@ -167,39 +167,27 @@ function getV3Progress() {
 
 // Get security status based on actual scans
 function getSecurityStatus() {
-  // Check for security scan results in memory
+  // ponytail: read the NEWEST scan in .claude/security-scans/ and surface its
+  // real findings count. Previously hardcoded totalCves=3 and counted scan
+  // *files* as "CVEs fixed", fabricating "⚠ 3 CVEs" for every project.
   const scanResultsPath = path.join(process.cwd(), '.claude', 'security-scans');
-  let cvesFixed = 0;
-  const totalCves = 3;
-
-  if (fs.existsSync(scanResultsPath)) {
-    try {
-      const scans = fs.readdirSync(scanResultsPath).filter(f => f.endsWith('.json'));
-      // Each successful scan file = 1 CVE addressed
-      cvesFixed = Math.min(totalCves, scans.length);
-    } catch (e) {
-      // Ignore
+  if (!fs.existsSync(scanResultsPath)) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+  try {
+    const files = fs.readdirSync(scanResultsPath).filter(f => f.endsWith('.json'));
+    if (files.length === 0) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+    let newest = files[0];
+    let newestMtime = -1;
+    for (const f of files) {
+      const st = fs.statSync(path.join(scanResultsPath, f));
+      if (st.mtimeMs > newestMtime) { newestMtime = st.mtimeMs; newest = f; }
     }
+    const scan = JSON.parse(fs.readFileSync(path.join(scanResultsPath, newest), 'utf-8'));
+    const totalCves = scan.summary?.total ?? scan.totalFindings ?? scan.findings?.length ?? 0;
+    const status = totalCves > 0 ? 'IN_PROGRESS' : 'CLEAN';
+    return { status, cvesFixed: 0, totalCves };
+  } catch (e) {
+    return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
   }
-
-  // Also check .swarm/security for audit results
-  const auditPath = path.join(process.cwd(), '.swarm', 'security');
-  if (fs.existsSync(auditPath)) {
-    try {
-      const audits = fs.readdirSync(auditPath).filter(f => f.includes('audit'));
-      cvesFixed = Math.min(totalCves, Math.max(cvesFixed, audits.length));
-    } catch (e) {
-      // Ignore
-    }
-  }
-
-  const status = cvesFixed >= totalCves ? 'CLEAN' : cvesFixed > 0 ? 'IN_PROGRESS' : 'PENDING';
-
-  return {
-    status,
-    cvesFixed,
-    totalCves,
-  };
 }
 
 // Get swarm status

--- a/v3/@claude-flow/cli/__tests__/issue-2694-cve-counter.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2694-cve-counter.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression test for issue #2694: the statusline CVE counter was fabricated.
+ * `getSecurityStatus` hardcoded `totalCves = 3` and counted `.json` scan
+ * *files* as "CVEs fixed", so every project unconditionally showed "⚠ 3 CVEs"
+ * and reached CLEAN by writing 3 arbitrary JSON files. After the fix it reads
+ * the NEWEST scan file and surfaces the real findings count.
+ *
+ * Pure unit test against funnel/local-signals.ts — no CLI binary, no network.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getSecurityStatus } from '../src/funnel/local-signals.js';
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'issue-2694-cve-'));
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function scanDir() {
+  return join(cwd, '.claude', 'security-scans');
+}
+
+describe('getSecurityStatus — issue #2694 (CVE counter not fabricated)', () => {
+  it('returns PENDING/0/0 when no .claude/security-scans/ dir exists (NOT 3)', () => {
+    const s = getSecurityStatus(cwd);
+    expect(s).toEqual({ status: 'PENDING', cvesFixed: 0, totalCves: 0 });
+    expect(s.totalCves).not.toBe(3);
+  });
+
+  it('returns PENDING/0/0 when the scan dir exists but has no .json files', () => {
+    mkdirSync(scanDir(), { recursive: true });
+    const s = getSecurityStatus(cwd);
+    expect(s).toEqual({ status: 'PENDING', cvesFixed: 0, totalCves: 0 });
+  });
+
+  it('returns CLEAN/0/0 for a scan with 0 findings', () => {
+    mkdirSync(scanDir(), { recursive: true });
+    writeFileSync(
+      join(scanDir(), 'scan-deps-quick.json'),
+      JSON.stringify({ findings: [], totalFindings: 0, summary: { total: 0 } }),
+    );
+    const s = getSecurityStatus(cwd);
+    expect(s).toEqual({ status: 'CLEAN', cvesFixed: 0, totalCves: 0 });
+  });
+
+  it('returns IN_PROGRESS/0/N for a scan with N>0 findings', () => {
+    mkdirSync(scanDir(), { recursive: true });
+    writeFileSync(
+      join(scanDir(), 'scan-deps-quick.json'),
+      JSON.stringify({ findings: [{}, {}], totalFindings: 2, summary: { total: 2 } }),
+    );
+    const s = getSecurityStatus(cwd);
+    expect(s).toEqual({ status: 'IN_PROGRESS', cvesFixed: 0, totalCves: 2 });
+  });
+
+  it('does NOT produce totalCves:3 or CLEAN from 3 empty .json files (the old fabrication)', () => {
+    // Pre-fix: 3 scan files -> cvesFixed = min(3, 3) = 3 -> status CLEAN.
+    // Post-fix: each file has 0 findings -> totalCves = 0 -> CLEAN (real).
+    // The key regression guard: totalCves must reflect findings, not file count.
+    mkdirSync(scanDir(), { recursive: true });
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(
+        join(scanDir(), `scan-${i}.json`),
+        JSON.stringify({ findings: [], totalFindings: 0, summary: { total: 0 } }),
+      );
+    }
+    const s = getSecurityStatus(cwd);
+    expect(s.totalCves).toBe(0);
+    expect(s.cvesFixed).toBe(0);
+    expect(s.status).toBe('CLEAN');
+  });
+
+  it('reads the NEWEST scan by mtime when several exist', async () => {
+    mkdirSync(scanDir(), { recursive: true });
+    // Old scan: 5 findings
+    writeFileSync(
+      join(scanDir(), 'scan-old.json'),
+      JSON.stringify({ findings: [{}, {}, {}, {}, {}], totalFindings: 5, summary: { total: 5 } }),
+    );
+    // Bump mtime into the future so the newer file is unambiguously newest.
+    const future = new Date(Date.now() + 60_000);
+    writeFileSync(
+      join(scanDir(), 'scan-new.json'),
+      JSON.stringify({ findings: [{}], totalFindings: 1, summary: { total: 1 } }),
+    );
+    // statSync U2 the file's mtime to the future timestamp for determinism.
+    const { utimesSync } = await import('fs');
+    utimesSync(join(scanDir(), 'scan-new.json'), future, future);
+    const s = getSecurityStatus(cwd);
+    expect(s.totalCves).toBe(1);
+    expect(s.status).toBe('IN_PROGRESS');
+  });
+
+  it('falls back to totalFindings / findings.length when summary.total is absent', () => {
+    mkdirSync(scanDir(), { recursive: true });
+    writeFileSync(
+      join(scanDir(), 'scan-deps-quick.json'),
+      JSON.stringify({ findings: [{}, {}, {}], totalFindings: 3 }),
+    );
+    const s = getSecurityStatus(cwd);
+    expect(s.totalCves).toBe(3);
+    expect(s.status).toBe('IN_PROGRESS');
+  });
+
+  it('returns PENDING/0/0 when the newest scan file is unparseable', () => {
+    mkdirSync(scanDir(), { recursive: true });
+    writeFileSync(join(scanDir(), 'scan-broken.json'), '{not valid json');
+    const s = getSecurityStatus(cwd);
+    expect(s).toEqual({ status: 'PENDING', cvesFixed: 0, totalCves: 0 });
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/security-scan-persistence.test.ts
+++ b/v3/@claude-flow/cli/__tests__/security-scan-persistence.test.ts
@@ -63,15 +63,19 @@ describe('security scan — result persistence (statusline CVE counter wiring)',
     });
   });
 
-  it('getSecurityStatus reflects the real scan afterward — no longer stuck at PENDING/0', () => {
+  it('getSecurityStatus reflects the real scan afterward — CLEAN when 0 findings', () => {
+    // The scan target is an empty fixture (no deps, no source) so it has 0
+    // findings. Pre-#2694 this returned cvesFixed>=1 because the old code
+    // counted scan *files* as fixed CVEs; now it reads the scan's findings.
     execFileSync(
       process.execPath,
       [CLI_BIN, 'security', 'scan', '--target', scanTarget, '--depth', 'quick', '--type', 'deps'],
       { encoding: 'utf-8', timeout: 30_000 },
     );
     const after = getSecurityStatus(scanTarget);
-    expect(after.cvesFixed).toBeGreaterThanOrEqual(1);
-    expect(after.status).not.toBe('PENDING');
+    expect(after.cvesFixed).toBe(0);
+    expect(after.totalCves).toBe(0);
+    expect(after.status).toBe('CLEAN');
   });
 
   it('repeated scans overwrite the deterministic filename rather than accumulate', () => {

--- a/v3/@claude-flow/cli/src/funnel/local-signals.ts
+++ b/v3/@claude-flow/cli/src/funnel/local-signals.ts
@@ -18,31 +18,29 @@ export interface SecurityStatus {
 }
 
 export function getSecurityStatus(cwd: string = process.cwd()): SecurityStatus {
+  // ponytail: read the NEWEST scan in .claude/security-scans/ and surface its
+  // real findings count. Previously this hardcoded totalCves=3 and counted
+  // scan *files* as "CVEs fixed", fabricating "⚠ 3 CVEs" for every project.
+  // cvesFixed stays 0 — no mechanism tracks actual fixes yet.
   const scanResultsPath = path.join(cwd, '.claude', 'security-scans');
-  let cvesFixed = 0;
-  const totalCves = 3;
-
-  if (fs.existsSync(scanResultsPath)) {
-    try {
-      const scans = fs.readdirSync(scanResultsPath).filter((f: string) => f.endsWith('.json'));
-      cvesFixed = Math.min(totalCves, scans.length);
-    } catch {
-      // Ignore
+  if (!fs.existsSync(scanResultsPath)) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+  try {
+    const files = fs.readdirSync(scanResultsPath).filter((f: string) => f.endsWith('.json'));
+    if (files.length === 0) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+    let newest = files[0];
+    let newestMtime = -1;
+    for (const f of files) {
+      const st = fs.statSync(path.join(scanResultsPath, f));
+      if (st.mtimeMs > newestMtime) { newestMtime = st.mtimeMs; newest = f; }
     }
+    const scan = JSON.parse(fs.readFileSync(path.join(scanResultsPath, newest), 'utf-8'));
+    const totalCves: number =
+      scan.summary?.total ?? scan.totalFindings ?? scan.findings?.length ?? 0;
+    const status: SecurityStatus['status'] = totalCves > 0 ? 'IN_PROGRESS' : 'CLEAN';
+    return { status, cvesFixed: 0, totalCves };
+  } catch {
+    return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
   }
-
-  const auditPath = path.join(cwd, '.swarm', 'security');
-  if (fs.existsSync(auditPath)) {
-    try {
-      const audits = fs.readdirSync(auditPath).filter((f: string) => f.includes('audit'));
-      cvesFixed = Math.min(totalCves, Math.max(cvesFixed, audits.length));
-    } catch {
-      // Ignore
-    }
-  }
-
-  const status = cvesFixed >= totalCves ? 'CLEAN' : cvesFixed > 0 ? 'IN_PROGRESS' : 'PENDING';
-  return { status, cvesFixed, totalCves };
 }
 
 export interface SwarmStatus {

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -680,7 +680,7 @@ export async function executeUpgrade(targetDir: string, upgradeSettings = false)
         initialized: new Date().toISOString(),
         status: 'PENDING',
         cvesFixed: 0,
-        totalCves: 3,
+        totalCves: 0,
         lastScan: null,
         _note: 'Run: npx @claude-flow/cli@latest security scan'
       };
@@ -1685,7 +1685,7 @@ async function writeInitialMetrics(
       initialized: new Date().toISOString(),
       status: 'PENDING',
       cvesFixed: 0,
-      totalCves: 3,
+      totalCves: 0,
       lastScan: null,
       _note: 'Run: npx @claude-flow/cli@latest security scan'
     };

--- a/v3/@claude-flow/hooks/src/statusline/index.ts
+++ b/v3/@claude-flow/hooks/src/statusline/index.ts
@@ -428,15 +428,17 @@ export class StatuslineGenerator {
       return this.dataSources.getSecurityStatus();
     }
 
-    // Try to read from audit file
+    // ponytail: read .claude-flow/security/audit-status.json if present.
+    // Defaults are 0 (not the old fabricated 3) so a fresh project no longer
+    // shows "⚠ 3 CVEs" out of nowhere.
     const auditPath = join(this.projectRoot, '.claude-flow', 'security', 'audit-status.json');
     try {
       if (existsSync(auditPath)) {
         const data = JSON.parse(readFileSync(auditPath, 'utf-8'));
         return {
-          status: data.status ?? 'CLEAN',
-          cvesFixed: data.cvesFixed ?? 3,
-          totalCves: data.totalCves ?? 3,
+          status: data.status ?? 'PENDING',
+          cvesFixed: data.cvesFixed ?? 0,
+          totalCves: data.totalCves ?? 0,
         };
       }
     } catch {
@@ -444,9 +446,9 @@ export class StatuslineGenerator {
     }
 
     return {
-      status: 'CLEAN',
-      cvesFixed: 3,
-      totalCves: 3,
+      status: 'PENDING',
+      cvesFixed: 0,
+      totalCves: 0,
     };
   }
 
@@ -682,7 +684,7 @@ export function parseStatuslineData(json: string): StatuslineData | null {
     const data = JSON.parse(json);
     return {
       v3Progress: data.v3Progress ?? { domainsCompleted: 0, totalDomains: 5, dddProgress: 0, modulesCount: 0, filesCount: 0, linesCount: 0 },
-      security: data.security ?? { status: 'PENDING', cvesFixed: 0, totalCves: 3 },
+      security: data.security ?? { status: 'PENDING', cvesFixed: 0, totalCves: 0 },
       swarm: data.swarm ?? { activeAgents: 0, maxAgents: 15, coordinationActive: false },
       hooks: data.hooks ?? { status: 'INACTIVE', patternsLearned: 0, routingAccuracy: 0, totalOperations: 0 },
       performance: data.performance ?? { flashAttentionTarget: '2.49x-7.47x', searchImprovement: '150x', memoryReduction: '50%' },

--- a/v3/@claude-flow/mcp/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/mcp/.claude/helpers/statusline.cjs
@@ -207,39 +207,27 @@ function getV3Progress() {
 
 // Get security status based on actual scans
 function getSecurityStatus() {
-  // Check for security scan results in memory
+  // ponytail: read the NEWEST scan in .claude/security-scans/ and surface its
+  // real findings count. Previously hardcoded totalCves=3 and counted scan
+  // *files* as "CVEs fixed", fabricating "⚠ 3 CVEs" for every project.
   const scanResultsPath = path.join(process.cwd(), '.claude', 'security-scans');
-  let cvesFixed = 0;
-  const totalCves = 3;
-
-  if (fs.existsSync(scanResultsPath)) {
-    try {
-      const scans = fs.readdirSync(scanResultsPath).filter(f => f.endsWith('.json'));
-      // Each successful scan file = 1 CVE addressed
-      cvesFixed = Math.min(totalCves, scans.length);
-    } catch (e) {
-      // Ignore
+  if (!fs.existsSync(scanResultsPath)) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+  try {
+    const files = fs.readdirSync(scanResultsPath).filter(f => f.endsWith('.json'));
+    if (files.length === 0) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+    let newest = files[0];
+    let newestMtime = -1;
+    for (const f of files) {
+      const st = fs.statSync(path.join(scanResultsPath, f));
+      if (st.mtimeMs > newestMtime) { newestMtime = st.mtimeMs; newest = f; }
     }
+    const scan = JSON.parse(fs.readFileSync(path.join(scanResultsPath, newest), 'utf-8'));
+    const totalCves = scan.summary?.total ?? scan.totalFindings ?? scan.findings?.length ?? 0;
+    const status = totalCves > 0 ? 'IN_PROGRESS' : 'CLEAN';
+    return { status, cvesFixed: 0, totalCves };
+  } catch (e) {
+    return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
   }
-
-  // Also check .swarm/security for audit results
-  const auditPath = path.join(process.cwd(), '.swarm', 'security');
-  if (fs.existsSync(auditPath)) {
-    try {
-      const audits = fs.readdirSync(auditPath).filter(f => f.includes('audit'));
-      cvesFixed = Math.min(totalCves, Math.max(cvesFixed, audits.length));
-    } catch (e) {
-      // Ignore
-    }
-  }
-
-  const status = cvesFixed >= totalCves ? 'CLEAN' : cvesFixed > 0 ? 'IN_PROGRESS' : 'PENDING';
-
-  return {
-    status,
-    cvesFixed,
-    totalCves,
-  };
 }
 
 // Get swarm status

--- a/v3/@claude-flow/mcp/.claude/helpers/statusline.js
+++ b/v3/@claude-flow/mcp/.claude/helpers/statusline.js
@@ -131,39 +131,27 @@ function getV3Progress() {
 
 // Get security status based on actual scans
 function getSecurityStatus() {
-  // Check for security scan results in memory
+  // ponytail: read the NEWEST scan in .claude/security-scans/ and surface its
+  // real findings count. Previously hardcoded totalCves=3 and counted scan
+  // *files* as "CVEs fixed", fabricating "⚠ 3 CVEs" for every project.
   const scanResultsPath = path.join(process.cwd(), '.claude', 'security-scans');
-  let cvesFixed = 0;
-  const totalCves = 3;
-
-  if (fs.existsSync(scanResultsPath)) {
-    try {
-      const scans = fs.readdirSync(scanResultsPath).filter(f => f.endsWith('.json'));
-      // Each successful scan file = 1 CVE addressed
-      cvesFixed = Math.min(totalCves, scans.length);
-    } catch (e) {
-      // Ignore
+  if (!fs.existsSync(scanResultsPath)) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+  try {
+    const files = fs.readdirSync(scanResultsPath).filter(f => f.endsWith('.json'));
+    if (files.length === 0) return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
+    let newest = files[0];
+    let newestMtime = -1;
+    for (const f of files) {
+      const st = fs.statSync(path.join(scanResultsPath, f));
+      if (st.mtimeMs > newestMtime) { newestMtime = st.mtimeMs; newest = f; }
     }
+    const scan = JSON.parse(fs.readFileSync(path.join(scanResultsPath, newest), 'utf-8'));
+    const totalCves = scan.summary?.total ?? scan.totalFindings ?? scan.findings?.length ?? 0;
+    const status = totalCves > 0 ? 'IN_PROGRESS' : 'CLEAN';
+    return { status, cvesFixed: 0, totalCves };
+  } catch (e) {
+    return { status: 'PENDING', cvesFixed: 0, totalCves: 0 };
   }
-
-  // Also check .swarm/security for audit results
-  const auditPath = path.join(process.cwd(), '.swarm', 'security');
-  if (fs.existsSync(auditPath)) {
-    try {
-      const audits = fs.readdirSync(auditPath).filter(f => f.includes('audit'));
-      cvesFixed = Math.min(totalCves, Math.max(cvesFixed, audits.length));
-    } catch (e) {
-      // Ignore
-    }
-  }
-
-  const status = cvesFixed >= totalCves ? 'CLEAN' : cvesFixed > 0 ? 'IN_PROGRESS' : 'PENDING';
-
-  return {
-    status,
-    cvesFixed,
-    totalCves,
-  };
 }
 
 // Get swarm status


### PR DESCRIPTION
## Fix for #2694

The statusline CVE counter was fabricated: `getSecurityStatus()` hardcoded `totalCves = 3` and counted scan **files** (not findings) as "CVEs fixed". Every project unconditionally showed "⚠ 3 CVEs" and reached CLEAN by writing 3 arbitrary JSON files.

### Changes (8 files, +211/-125)
- **5 copies of `getSecurityStatus()`** (cli/funnel/local-signals.ts, hooks/statusline/index.ts, 3 helper .js/.cjs copies): now reads the **newest** scan in `.claude/security-scans/` and surfaces its real findings count (`summary.total ?? totalFindings ?? findings.length`). `cvesFixed` stays 0 — no mechanism tracks actual fixes yet (honest vs fabricated).
- **executor.ts**: two init/upgrade defaults `totalCves: 3 → 0`.
- **hooks/statusline/index.ts**: no-audit-file default changed from `CLEAN/3/3` to `PENDING/0/0`; `parseStatuslineData` default `totalCves: 3 → 0`.
- **New regression test** `issue-2694-cve-counter.test.ts` (8 cases): no-dir, empty-dir, 0-findings (CLEAN), N-findings (IN_PROGRESS), the old fabrication scenario (3 empty files → 0 not 3), newest-by-mtime, fallback chain, unparseable JSON.
- **Updated** `security-scan-persistence.test.ts` to assert CLEAN/0/0.

### Verification
Independent worktree checkout of this branch. All 8 test cases pass (13 assertions). No residual `totalCves: 3` / `cvesFixed: 3` in production code. All JS/CJS copies pass `node --check`.

Closes #2694