### PR TITLE
chore: sync package-lock.json version to 3.32.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.30.4",
+  "version": "3.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.30.4",
+      "version": "3.32.0",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",


### PR DESCRIPTION
## Summary

- Syncs `package-lock.json` version field from `3.30.4` to `3.32.0` to match `package.json`
- Change was produced as a side effect of running `npm install` during the scheduled verification run (needed to install `@noble/ed25519` for witness verification)
- No functional changes; lockfile version field only

## Test plan

- [ ] Confirm `npm ci` completes cleanly from this branch
- [ ] Verify no dependency resolution changes beyond the version field bump

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGUy2dR2PHKR1nF6v5Dj1N)_