### PR TITLE
chore: lock file update from verification run npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "url": "https://github.com/sponsors/ruvnet"
       },
       "optionalDependencies": {
-        "@claude-flow/codex": "^3.0.0",
+        "@claude-flow/codex": "^3.0.1",
         "@claude-flow/plugin-gastown-bridge": "^0.1.3",
         "@ruvector/attention": "^0.1.3",
         "@ruvector/core": "^0.1.30",


### PR DESCRIPTION
## Summary

- `package-lock.json`: `@claude-flow/codex` optional dependency resolved from `^3.0.0` to `^3.0.1` as a side effect of `npm install` during the automated verification run (needed to satisfy `@noble/ed25519` for the witness verification check).

## Test plan

- [ ] Verify `npm ci` succeeds cleanly on this branch
- [ ] Confirm no functional changes — only lock file version pin updated

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_017txwUbZwNEPKHYYaCo2NzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017txwUbZwNEPKHYYaCo2NzZ)_