### PR TITLE
feat(proxy): default install to signed Meta-Proxy v0.4.0

### DIFF
--- a/v3/@claude-flow/cli/__tests__/proxy-install-command.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-install-command.test.ts
@@ -1,16 +1,7 @@
 /**
- * `proxy install`'s Command.action logic — isolated via RUFLO_STATE_DIR,
- * install itself mocked out (real downloads belong in manual/E2E testing,
- * already verified against the real meta-proxy v0.1.0 release).
- *
- * Regression coverage for a real bug found during E2E testing: the
- * proxy-install consent grant must never happen before required flags are
- * validated. The original implementation checked consent (and, on --yes,
- * recorded it) BEFORE checking for --release — so `proxy install --yes`
- * with no --release recorded consent even though the command then failed,
- * which meant a LATER, parameter-complete `proxy install --release x.y.z`
- * silently skipped the disclosure the user should have seen once with real
- * information. Fixed by validating --release first.
+ * `proxy install` defaults to the reviewed, signed Meta-Proxy v0.4.0
+ * release. `--release` remains an explicit override; the default must still
+ * pass through the normal consent gate and signature-verifying installer.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -46,35 +37,36 @@ async function getInstallSub() {
   return sub;
 }
 
-describe('proxy install — parameter validation happens before any consent side-effect', () => {
-  it('--yes with no --release fails WITHOUT recording proxy-install consent', async () => {
+describe('proxy install - pinned release default', () => {
+  it('without --release shows disclosure without recording consent', async () => {
     const installSub = await getInstallSub();
-    const result = await installSub.action!(ctxWithFlags({ yes: true }));
-    expect(result?.success).toBe(false);
+    const result = await installSub.action!(ctxWithFlags({}));
 
+    expect(result?.success).toBe(true);
+    expect((result?.data as { confirmed?: boolean } | undefined)?.confirmed).toBe(false);
     const { hasConsent } = await import('../src/funnel/index.js');
     expect(hasConsent('proxy-install')).toBe(false);
   });
 
-  it('a later, parameter-complete call still shows the disclosure (consent was never silently granted)', async () => {
-    const installSub = await getInstallSub();
-
-    // First call: --yes but no --release — must fail, must not grant consent (asserted above).
-    await installSub.action!(ctxWithFlags({ yes: true }));
-
-    // Second call: --release present, but NO --yes this time — must show the
-    // disclosure and refuse (not silently proceed as if already consented).
-    const second = await installSub.action!(ctxWithFlags({ release: '0.1.0' }));
-    expect(second?.success).toBe(true);
-    expect((second?.data as { confirmed?: boolean } | undefined)?.confirmed).toBe(false);
-  });
-
-  it('missing --release is rejected even when consent already exists from a prior install', async () => {
-    const { recordConsent } = await import('../src/funnel/consent.js');
-    recordConsent('proxy-install', true, 'test-seed');
+  it('uses v0.4.0 when confirmed without a release override', async () => {
+    const installProxy = vi.fn().mockResolvedValue({ version: '0.4.0', binaryPath: '/tmp/meta-proxy', sha256: 'abc' });
+    vi.doMock('../src/proxy/install.js', () => ({ installProxy, uninstallProxy: vi.fn() }));
 
     const installSub = await getInstallSub();
     const result = await installSub.action!(ctxWithFlags({ yes: true }));
-    expect(result?.success).toBe(false);
+
+    expect(result?.success).toBe(true);
+    expect(installProxy).toHaveBeenCalledWith(expect.objectContaining({ version: '0.4.0' }));
+  });
+
+  it('honors an explicit release override', async () => {
+    const installProxy = vi.fn().mockResolvedValue({ version: '9.9.9', binaryPath: '/tmp/meta-proxy', sha256: 'abc' });
+    vi.doMock('../src/proxy/install.js', () => ({ installProxy, uninstallProxy: vi.fn() }));
+
+    const installSub = await getInstallSub();
+    const result = await installSub.action!(ctxWithFlags({ release: '9.9.9', yes: true }));
+
+    expect(result?.success).toBe(true);
+    expect(installProxy).toHaveBeenCalledWith(expect.objectContaining({ version: '9.9.9' }));
   });
 });

--- a/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
@@ -23,6 +23,9 @@ import {
 import { proxyTokenPath } from '../proxy/paths.js';
 import { removeInjectedToken, startTokenRefreshPump } from '../proxy/token-bridge.js';
 
+/** Pinned and reviewed; later upgrades remain explicit commands. */
+export const DEFAULT_PROXY_RELEASE = '0.4.0';
+
 const INSTALL_DISCLOSURE = [
   'Installing the Meta LLM Proxy (ADR-304/307).',
   '',
@@ -45,15 +48,13 @@ const installSub: Command = {
     // BEFORE subcommand dispatch, regardless of which command defines it. A
     // subcommand-local --version is silently swallowed by the CLI's own
     // `ruflo --version` handling — confirmed the hard way in E2E testing.
-    { name: 'release', description: 'Release version to install', type: 'string' },
+    { name: 'release', description: `Release version to install (default: ${DEFAULT_PROXY_RELEASE})`, type: 'string' },
     { name: 'yes', description: 'Skip the confirmation prompt', type: 'boolean', default: false },
   ],
   action: async (ctx): Promise<CommandResult> => {
-    // Validate required parameters BEFORE any consent side-effect — granting
-    // proxy-install consent on a call that was going to fail anyway (e.g.
-    // --yes with no --release) would permanently skip the disclosure on the
-    // next, parameter-complete attempt. Confirmed as a real bug in E2E testing.
-    const version = typeof ctx.flags.release === 'string' ? ctx.flags.release : undefined;
+    // Resolve the reviewed default before the consent gate. An explicit empty
+    // override still fails below without recording a consent receipt.
+    const version = typeof ctx.flags.release === 'string' ? ctx.flags.release : DEFAULT_PROXY_RELEASE;
     if (!version) {
       output.printError(
         'ruflo proxy install requires --release <x.y.z> — there is no version-discovery ' +
@@ -68,7 +69,7 @@ const installSub: Command = {
       output.writeln('');
       const confirmed = Boolean(ctx.flags.yes);
       if (!confirmed) {
-        output.writeln(`Re-run with --yes to confirm: ruflo proxy install --release ${version} --yes`);
+        output.writeln(`Re-run with --yes to confirm: ruflo proxy install --yes (installs ${version})`);
         return { success: true, data: { confirmed: false } };
       }
       recordConsent('proxy-install', true, 'proxy-install');
@@ -185,7 +186,7 @@ const statusSub: Command = {
     output.writeln(`Installed: ${status.installed ? 'yes' : 'no'}`);
     output.writeln(`Running: ${status.running ? `yes (pid ${status.pid})` : 'no'}`);
     if (status.stalePidFile) output.writeln('  (a stale PID file was found and will be cleared on next start)');
-    if (!status.installed) output.writeln('Run: ruflo proxy install --release <x.y.z>');
+    if (!status.installed) output.writeln(`Run: ruflo proxy install --yes (installs ${DEFAULT_PROXY_RELEASE})`);
     else if (!status.running) output.writeln('Run: ruflo proxy start');
     return { success: true, data: status };
   },

--- a/v3/@claude-flow/cli/src/commands/proxy.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy.ts
@@ -409,7 +409,7 @@ export const proxyCommand: Command = {
     trainingShareEnableSub, trainingShareDisableSub, trainingShareStatusSub,
   ],
   examples: [
-    { command: 'ruflo proxy install --release 0.1.0 --yes', description: 'Install the meta-proxy binary' },
+    { command: 'ruflo proxy install --yes', description: 'Install the signed Meta-Proxy v0.4.0 binary' },
     { command: 'ruflo proxy start', description: 'Start meta-proxy in the foreground' },
     { command: 'ruflo proxy status', description: 'Show install + process status' },
     { command: 'ruflo proxy config --cloud --yes', description: 'Enable cloud routing (ADR-304)' },

--- a/v3/docs/adr/ADR-307-proxy-runtime-packaging-lifecycle.md
+++ b/v3/docs/adr/ADR-307-proxy-runtime-packaging-lifecycle.md
@@ -151,3 +151,13 @@ The three client-side gaps found during the implementation review are closed:
 The bridge is implemented by meta-proxy v0.2.0 and ruflo's resident supervisor: only the short-lived
 access token crosses the process boundary, while ruflo retains the rotating refresh token in the OS
 keychain. Production installation is implemented through the signed public distribution channel.
+
+### v0.4.0 pinned install default (2026-07-17)
+
+`ruflo proxy install --yes` now selects the reviewed Meta-Proxy v0.4.0 release
+without requiring a user to discover and type a version. This is a pinned,
+reproducible default, not an unauthenticated "latest" lookup: the installer
+continues to verify the public distribution's Ed25519-signed `SHA256SUMS` and
+the selected platform archive before extraction. An operator keeps control of
+later changes through explicit `ruflo proxy update --release <x.y.z>` or an
+explicit `install --release <x.y.z>` override.


### PR DESCRIPTION
Makes uflo proxy install --yes select the reviewed, pinned v0.4.0 public release while retaining explicit version overrides and signature verification.\n\nValidation: focused proxy lifecycle tests (13 passing); full workspace typecheck is delegated to CI because this isolated worktree has no generated sibling package declarations.