### PR TITLE
chore(release): publish ruflo 3.32.3

### DIFF
--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.2",
+  "version": "3.32.3",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.2"
+    "@claude-flow/cli": "^3.32.3"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest": {
-    "version": "3.32.2",
+    "version": "3.32.3",
     "files": {
       "auto-memory-hook.mjs": "e3e1033b24704992ddef6b31c7fa9dd7fcd9e1af7935dd77ef73402b916b31e6",
       "hook-handler.cjs": "f87ec28684bfc5fd0a54c46bd2a53a3fb037defe71d0ea4b8a5cb88a2cd87a3f",
       "intelligence.cjs": "5a55d979cb7ba5c8c4f27f3b2e6d686fbb1045d180023b803da672a37e05b915",
-      "statusline.cjs": "f6fcaedad7b521248ba57c494eb1a0ce696679fa3f8709f81edf3fdecef369c2"
+      "statusline.cjs": "af2703bdd710fb52af3221669266771ba1684157f34d77de21373890b5c2a126"
     }
   },
-  "signature": "r7TaWKVLZ6gxssGRM31J6usZrRm1Y5TAZXNmOfeLn+7VzWMrH6pZZPGTfSv6WMW49j8Ko3aamDBtahasWybSAw==",
+  "signature": "D2Utlq4bUJe8VgqtibmGrASrFEyzPh5/MQLn2peimcmNuQT8qHN6uMfmgosF1Q9TCi3G4TkZ2iKMYbZ5U/iaAQ==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/catalog-manifest.json
+++ b/v3/@claude-flow/cli/catalog-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "generation": 1,
-  "generatedAt": "2026-07-16T22:58:16.729Z",
-  "gitSha": "8f88e6af",
+  "generatedAt": "2026-07-17T18:58:54.457Z",
+  "gitSha": "a3f692e7",
   "catalog": {
     "agents": 164,
     "tools": 387,

--- a/v3/@claude-flow/cli/package-lock.json
+++ b/v3/@claude-flow/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.2",
+  "version": "3.32.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@claude-flow/cli",
-      "version": "3.32.2",
+      "version": "3.32.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.2",
+  "version": "3.32.3",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Release\n\nPublishes the already-merged signed Meta-Proxy v0.4.0 default-install integration.\n\n- @claude-flow/cli 3.32.3\n- ruflo 3.32.3, explicitly depending on ^3.32.3\n- regenerated catalog and signed helper manifest\n\nValidated with both package publish dry-runs.