### PR TITLE
fix(release): build CLI artifacts before publishing

### DIFF
--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.3",
+  "version": "3.32.4",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.3"
+    "@claude-flow/cli": "^3.32.4"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.32.3",
+    "version": "3.32.4",
     "files": {
       "auto-memory-hook.mjs": "e3e1033b24704992ddef6b31c7fa9dd7fcd9e1af7935dd77ef73402b916b31e6",
       "hook-handler.cjs": "f87ec28684bfc5fd0a54c46bd2a53a3fb037defe71d0ea4b8a5cb88a2cd87a3f",
@@ -8,6 +8,6 @@
       "statusline.cjs": "af2703bdd710fb52af3221669266771ba1684157f34d77de21373890b5c2a126"
     }
   },
-  "signature": "D2Utlq4bUJe8VgqtibmGrASrFEyzPh5/MQLn2peimcmNuQT8qHN6uMfmgosF1Q9TCi3G4TkZ2iKMYbZ5U/iaAQ==",
+  "signature": "sexJgMxhPXdN6hdOAUxiBupen/PSnwe93zxnEiqok8TkWlA9ltiajTkC2ImizGlSUhuYBP6yfLoNCvH+nNlXCw==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/catalog-manifest.json
+++ b/v3/@claude-flow/cli/catalog-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "generation": 1,
-  "generatedAt": "2026-07-17T18:58:54.457Z",
-  "gitSha": "a3f692e7",
+  "generatedAt": "2026-07-17T19:11:16.010Z",
+  "gitSha": "f9e0dcff",
   "catalog": {
     "agents": 164,
     "tools": 387,

--- a/v3/@claude-flow/cli/package-lock.json
+++ b/v3/@claude-flow/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.3",
+  "version": "3.32.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@claude-flow/cli",
-      "version": "3.32.3",
+      "version": "3.32.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.3",
+  "version": "3.32.4",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/scripts/prepare-publish.mjs
+++ b/v3/@claude-flow/cli/scripts/prepare-publish.mjs
@@ -9,6 +9,24 @@ const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(packageDir, '..', '..', '..');
 const pluginsDir = join(packageDir, 'plugins');
 
+// `dist` is intentionally ignored by Git, so publishing without a build can
+// create a tarball whose declared entry point does not exist. Build the only
+// emitted project reference CLI needs (`@claude-flow/swarm`) and then CLI.
+// Do not use `tsc --build`: it recursively rebuilds unrelated optional
+// workspace packages whose development-only dependencies are not required to
+// package this CLI.
+const compiler = join(packageDir, 'node_modules', 'typescript', 'bin', 'tsc');
+for (const buildDir of [resolve(packageDir, '..', 'swarm'), packageDir]) {
+  const build = spawnSync(process.execPath, [compiler], {
+    cwd: buildDir,
+    stdio: 'inherit',
+  });
+  if (build.error) throw build.error;
+  if (build.status !== 0) {
+    throw new Error(`TypeScript release build failed for ${buildDir} with exit code ${build.status ?? 'unknown'}`);
+  }
+}
+
 await cp(join(repoRoot, 'README.md'), join(packageDir, 'README.md'));
 await rm(pluginsDir, { recursive: true, force: true });
 await mkdir(pluginsDir, { recursive: true });


### PR DESCRIPTION
Repairs the 3.32.3 CLI packaging defect: dist is untracked and was omitted from the npm tarball. The CLI prepublish hook now builds Swarm then CLI before signing metadata.\n\nPublishes @claude-flow/cli and ruflo 3.32.4.\n\nValidated with the real prepublish hook, tarball file inspection (dist/src/index.js), and ESM entrypoint import.