### PR TITLE
fix(auth): ship OAuth export guard and compatibility fix

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -2006,6 +2006,7 @@ jobs:
           pnpm --filter @claude-flow/security run build
           test -f @claude-flow/security/dist/index.js \
             || (echo "::error::@claude-flow/security/dist/index.js missing after build"; exit 1)
+          node @claude-flow/security/scripts/verify-oauth-exports.mjs
 
       - name: Run guardrail smoke
         shell: bash

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.5",
+  "version": "3.32.6",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.5"
+    "@claude-flow/cli": "^3.32.6"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.5",
+  "version": "3.32.6",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
@@ -112,7 +112,7 @@
   },
   "optionalDependencies": {
     "@claude-flow/memory": "^3.0.0-alpha.21",
-    "@claude-flow/security": "^3.0.0-alpha.10",
+    "@claude-flow/security": "^3.0.0-alpha.11",
     "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "ruvector": "^0.2.27"

--- a/v3/@claude-flow/security/__tests__/oauth-export-surface.test.ts
+++ b/v3/@claude-flow/security/__tests__/oauth-export-surface.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import * as security from '../src/index.js';
+
+describe('OAuth public export surface', () => {
+  it('exports every primitive required by ruflo auth', () => {
+    for (const name of [
+      'authorizeUrl',
+      'exchangeCode',
+      'refreshToken',
+      'exchangeManualCode',
+      'generatePkce',
+      'CallbackServer',
+      'openBrowser',
+      'createKeychainAdapter',
+      'OAuthError',
+    ] as const) {
+      expect(security[name]).toBeTypeOf('function');
+    }
+    expect(security.OOB_REDIRECT_URI).toBeTypeOf('string');
+  });
+});

--- a/v3/@claude-flow/security/package.json
+++ b/v3/@claude-flow/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/security",
-  "version": "3.0.0-alpha.10",
+  "version": "3.0.0-alpha.11",
   "type": "module",
   "description": "Security module - CVE fixes, input validation, path security",
   "main": "dist/index.js",
@@ -11,7 +11,9 @@
   },
   "scripts": {
     "test": "vitest run",
-    "build": "tsc"
+    "test:oauth-surface": "vitest run __tests__/oauth-export-surface.test.ts __tests__/oauth-pkce.test.ts __tests__/oauth-browser.test.ts",
+    "build": "tsc && node scripts/verify-oauth-exports.mjs",
+    "prepublishOnly": "npm run build && npm run test:oauth-surface"
   },
   "dependencies": {
     "@noble/ed25519": "^2.1.0",

--- a/v3/@claude-flow/security/scripts/verify-oauth-exports.mjs
+++ b/v3/@claude-flow/security/scripts/verify-oauth-exports.mjs
@@ -1,0 +1,29 @@
+/**
+ * Release and CI guard for the OAuth surface consumed by `ruflo auth`.
+ * This deliberately imports the built package entry point, rather than
+ * source files, so a stale or incomplete npm artifact cannot pass.
+ */
+const security = await import('../dist/index.js');
+
+const requiredFunctions = [
+  'authorizeUrl',
+  'exchangeCode',
+  'refreshToken',
+  'exchangeManualCode',
+  'generatePkce',
+  'openBrowser',
+  'createKeychainAdapter',
+];
+const requiredClasses = ['CallbackServer', 'OAuthError'];
+
+const missing = [
+  ...requiredFunctions.filter((name) => typeof security[name] !== 'function'),
+  ...requiredClasses.filter((name) => typeof security[name] !== 'function'),
+  ...(typeof security.OOB_REDIRECT_URI === 'string' ? [] : ['OOB_REDIRECT_URI']),
+];
+
+if (missing.length > 0) {
+  throw new Error(`@claude-flow/security is missing required OAuth exports: ${missing.join(', ')}`);
+}
+
+console.log(`OAuth export surface verified (${requiredFunctions.length + requiredClasses.length + 1} exports)`);


### PR DESCRIPTION
## Fix\nPublishes a rebuilt @claude-flow/security package that includes the OAuth and keychain entry-point exports required by ruflo auth login.\n\n## Guard\n- Security build imports dist/index.js and verifies the required OAuth surface.\n- V3 CI runs the same artifact guard after the security build.\n- Added targeted OAuth public-surface coverage.\n\n## Release\nsecurity 3.0.0-alpha.11 -> CLI 3.32.6 -> ruflo 3.32.6.