### PR TITLE
fix(release): ship clean OAuth security artifact

### DIFF
--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.6",
+  "version": "3.32.7",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.6"
+    "@claude-flow/cli": "^3.32.7"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.6",
+  "version": "3.32.7",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
@@ -112,7 +112,7 @@
   },
   "optionalDependencies": {
     "@claude-flow/memory": "^3.0.0-alpha.21",
-    "@claude-flow/security": "^3.0.0-alpha.11",
+    "@claude-flow/security": "^3.0.0-alpha.12",
     "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "ruvector": "^0.2.27"

--- a/v3/@claude-flow/security/.npmignore
+++ b/v3/@claude-flow/security/.npmignore
@@ -1,0 +1,3 @@
+node_modules*
+*.tgz
+*.tsbuildinfo

--- a/v3/@claude-flow/security/package.json
+++ b/v3/@claude-flow/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/security",
-  "version": "3.0.0-alpha.11",
+  "version": "3.0.0-alpha.12",
   "type": "module",
   "description": "Security module - CVE fixes, input validation, path security",
   "main": "dist/index.js",


### PR DESCRIPTION
Publishes the OAuth export fix with an npm ignore policy so workspace test caches cannot enter the public security tarball. Releases security 3.0.0-alpha.12, CLI 3.32.7, and ruflo 3.32.7.