### PR TITLE
feat(proxy): add policy-scoped client launcher

### DIFF
--- a/v3/@claude-flow/cli/__tests__/proxy-client-run.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-client-run.test.ts
@@ -1,0 +1,117 @@
+/** MetaHarness-compatible `ruflo proxy run` policy capability helpers. */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+let stateDir: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-client-run-test-'));
+  savedEnv = { ...process.env };
+  process.env.RUFLO_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  process.env = savedEnv;
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe('Meta-Proxy client launcher', () => {
+  it('only passes the local bearer token to a literal loopback endpoint', async () => {
+    const { proxyClientEndpoint, proxyClientEnvironment } = await import('../src/proxy/client-run.js');
+    fs.writeFileSync(path.join(stateDir, 'proxy-token'), 'local-token\n');
+    fs.writeFileSync(path.join(stateDir, 'proxy-config.toml'), 'bind = "127.0.0.1:22435"\n');
+
+    expect(proxyClientEndpoint()).toBe('http://127.0.0.1:22435');
+    expect(proxyClientEnvironment()).toEqual({
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:22435',
+      ANTHROPIC_AUTH_TOKEN: 'local-token',
+    });
+
+    fs.writeFileSync(path.join(stateDir, 'proxy-config.toml'), 'bind = "0.0.0.0:11435"\n');
+    expect(proxyClientEndpoint).toThrow(/non-loopback/i);
+  });
+
+  it('mints an eight-hour scoped policy capability without exposing the worktree path', async () => {
+    const { createProxyPolicyToken, proxyWorktreeFingerprint } = await import('../src/proxy/client-run.js');
+    const worktree = 'C:/tmp/herd/agent-a';
+    const token = createProxyPolicyToken('local-proxy-secret', 'economy', proxyWorktreeFingerprint(worktree), 0);
+    const [prefix, encoded, signature] = token.split('.');
+    const claim = JSON.parse(Buffer.from(encoded!, 'base64url').toString('utf8'));
+
+    expect(prefix).toBe('mh1');
+    expect(signature).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(claim).toMatchObject({ policy: 'economy', exp: 28_800 });
+    expect(claim.worktree).toMatch(/^[a-f0-9]{32}$/);
+    expect(JSON.stringify(claim)).not.toContain(worktree);
+  });
+
+  it('launches a real client with a scoped token after authenticated proxy readiness', async () => {
+    const { proxyBinaryPath, proxyPidFilePath } = await import('../src/proxy/paths.js');
+    const { runProxyClient } = await import('../src/proxy/client-run.js');
+    const observedPath = path.join(stateDir, 'observed-client-env.json');
+    const localToken = 'local-test-token';
+    const server = http.createServer((request, response) => {
+      if (request.url === '/status' && request.headers.authorization === `Bearer ${localToken}`) {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{}');
+        return;
+      }
+      response.writeHead(401);
+      response.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('test server did not expose a TCP port');
+
+    fs.mkdirSync(path.dirname(proxyBinaryPath()), { recursive: true });
+    fs.writeFileSync(proxyBinaryPath(), 'test binary marker');
+    fs.writeFileSync(proxyPidFilePath(), String(process.pid));
+    fs.writeFileSync(path.join(stateDir, 'proxy-token'), `${localToken}\n`);
+    fs.writeFileSync(path.join(stateDir, 'proxy-config.toml'), `bind = "127.0.0.1:${address.port}"\n`);
+
+    const script = [
+      "const fs = require('node:fs');",
+      "const [prefix, payload] = process.env.ANTHROPIC_AUTH_TOKEN.split('.');",
+      "fs.writeFileSync(process.argv[1], JSON.stringify({ base: process.env.ANTHROPIC_BASE_URL, prefix, claim: JSON.parse(Buffer.from(payload, 'base64url')) }));",
+    ].join(' ');
+    try {
+      const result = await runProxyClient([process.execPath, '-e', script, observedPath], 'critical', stateDir);
+      const observed = JSON.parse(fs.readFileSync(observedPath, 'utf8'));
+
+      expect(result).toMatchObject({ success: true, exitCode: 0, started: false, policy: 'critical' });
+      expect(observed).toMatchObject({ base: `http://127.0.0.1:${address.port}`, prefix: 'mh1', claim: { policy: 'critical' } });
+      expect(JSON.stringify(observed)).not.toContain(localToken);
+      expect(JSON.stringify(observed)).not.toContain(stateDir);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it('exposes MetaHarness-compatible run, path, login, and logout subcommands', async () => {
+    const { proxyCommand } = await import('../src/commands/proxy.js');
+    const commands = proxyCommand.subcommands?.map((command) => command.name) ?? [];
+    expect(commands).toEqual(expect.arrayContaining(['run', 'path', 'login', 'logout']));
+    const run = proxyCommand.subcommands?.find((command) => command.name === 'run');
+    expect(run?.options?.find((option) => option.name === 'policy')).toMatchObject({
+      default: 'standard', choices: ['critical', 'standard', 'economy'],
+    });
+  });
+
+  it('parses the documented policy and double-dash client boundary', async () => {
+    const { CommandParser } = await import('../src/parser.js');
+    const { proxyCommand } = await import('../src/commands/proxy.js');
+    const parser = new CommandParser();
+    parser.registerCommand(proxyCommand);
+
+    expect(parser.parse(['proxy', 'run', '--policy', 'critical', '--', 'claude'])).toMatchObject({
+      command: ['proxy', 'run'],
+      flags: { policy: 'critical' },
+      positional: ['claude'],
+    });
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/proxy-console-guidance.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-console-guidance.test.ts
@@ -51,6 +51,7 @@ describe('bare proxy console guidance', () => {
 
     expect(result).toMatchObject({ success: true, data: { installed: true, running: false } });
     expect(lines).toContain('Meta Proxy');
+    expect(lines).toContain('npx ruflo@latest proxy run --policy standard -- claude');
     expect(lines).toContain('npx ruflo@latest proxy start --service');
     expect(lines).toContain('npx ruflo@latest auth login');
     expect(lines).not.toContain('Sponsored downtime consent');
@@ -63,6 +64,7 @@ describe('bare proxy console guidance', () => {
 
     expect(lines).toContain('npx ruflo@latest proxy install --yes');
     expect(lines).toContain('Meta-Proxy v0.4.0');
+    expect(lines).toContain('npx ruflo@latest proxy run --policy standard -- claude');
     expect(lines).not.toContain('auth login');
   });
 });

--- a/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
@@ -23,6 +23,8 @@ import {
 } from '../proxy/lifecycle.js';
 import { proxyTokenPath } from '../proxy/paths.js';
 import { removeInjectedToken, startTokenRefreshPump } from '../proxy/token-bridge.js';
+import { runProxyClient, type ProxyWorktreePolicy } from '../proxy/client-run.js';
+import { authCommand } from './auth.js';
 
 /** Pinned and reviewed; later upgrades remain explicit commands. */
 export const DEFAULT_PROXY_RELEASE = '0.4.0';
@@ -42,8 +44,8 @@ export function proxyConsoleGuidance(status: ProxyStatus): string[] {
       'Next step',
       `  ${PROXY_COMMAND} install --yes    Install signed Meta-Proxy v${DEFAULT_PROXY_RELEASE}`,
       '',
-      'After installation, start it in the background:',
-      `  ${PROXY_COMMAND} start --service`,
+      'After installation, launch Claude through it:',
+      `  ${PROXY_COMMAND} run --policy standard -- claude`,
     ];
   }
 
@@ -51,10 +53,10 @@ export function proxyConsoleGuidance(status: ProxyStatus): string[] {
     return [
       '',
       'Next step',
-      `  ${PROXY_COMMAND} start --service    Start the proxy in the background`,
+      `  ${PROXY_COMMAND} run --policy standard -- claude    Start the proxy and launch Claude`,
       '',
-      'Foreground mode (shows live logs; Ctrl+C stops it):',
-      `  ${PROXY_COMMAND} start`,
+      'Or start only the background sidecar:',
+      `  ${PROXY_COMMAND} start --service`,
       '',
       'Optional: enable Cognitum cloud routing (local-only is the default):',
       `  ${AUTH_COMMAND} login`,
@@ -65,6 +67,7 @@ export function proxyConsoleGuidance(status: ProxyStatus): string[] {
   return [
     '',
     'Meta Proxy is ready.',
+    `  Claude:  ${PROXY_COMMAND} run --policy standard -- claude`,
     `  Logs:    ${PROXY_COMMAND} logs`,
     `  Stop:    ${PROXY_COMMAND} stop`,
     '',
@@ -278,6 +281,53 @@ const logsSub: Command = {
   },
 };
 
+const pathSub: Command = {
+  name: 'path',
+  description: 'Print the managed Meta-Proxy binary path',
+  action: async (): Promise<CommandResult> => {
+    const { proxyBinaryPath } = await import('../proxy/paths.js');
+    const binaryPath = proxyBinaryPath();
+    output.writeln(binaryPath);
+    return { success: true, data: { binaryPath } };
+  },
+};
+
+function authAlias(name: 'login' | 'logout'): Command {
+  return {
+    name,
+    description: name === 'login'
+      ? 'Sign in to Cognitum for Meta-Proxy cloud routing'
+      : 'Sign out of Cognitum and remove the local proxy bridge token',
+    action: async (ctx): Promise<CommandResult> => {
+      const action = authCommand.subcommands?.find((command) => command.name === name)?.action;
+      if (!action) {
+        const message = `ruflo auth ${name} is unavailable in this installation.`;
+        output.printError(message);
+        return { success: false, message, exitCode: 1 };
+      }
+      return (await action(ctx)) ?? { success: true };
+    },
+  };
+}
+
+const runSub: Command = {
+  name: 'run',
+  description: 'Launch a Claude-compatible client through Meta-Proxy with a scoped worktree policy',
+  options: [{
+    name: 'policy',
+    description: 'Routing policy for this worktree: critical, standard, or economy',
+    type: 'string',
+    default: 'standard',
+    choices: ['critical', 'standard', 'economy'],
+  }],
+  action: async (ctx): Promise<CommandResult> => {
+    const policy = (typeof ctx.flags.policy === 'string' ? ctx.flags.policy : 'standard') as ProxyWorktreePolicy;
+    const result = await runProxyClient(ctx.args, policy, ctx.cwd);
+    if (result.message) output.printError(result.message);
+    return { success: result.success, message: result.message, exitCode: result.exitCode, data: result };
+  },
+};
+
 const uninstallSub: Command = {
   name: 'uninstall',
   description: 'Stop the proxy (if running), remove the binary, token, and consent receipt',
@@ -298,4 +348,7 @@ const uninstallSub: Command = {
   },
 };
 
-export const proxyLifecycleSubcommands: Command[] = [installSub, updateSub, startSub, superviseSub, stopSub, statusSub, logsSub, uninstallSub];
+export const proxyLifecycleSubcommands: Command[] = [
+  installSub, updateSub, startSub, superviseSub, stopSub, statusSub, logsSub, pathSub,
+  authAlias('login'), authAlias('logout'), runSub, uninstallSub,
+];

--- a/v3/@claude-flow/cli/src/commands/proxy.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy.ts
@@ -413,6 +413,8 @@ export const proxyCommand: Command = {
     { command: 'ruflo proxy install --yes', description: 'Install the signed Meta-Proxy v0.4.0 binary' },
     { command: 'ruflo proxy start', description: 'Start meta-proxy in the foreground' },
     { command: 'ruflo proxy status', description: 'Show install + process status' },
+    { command: 'ruflo proxy login', description: 'Sign in to Cognitum (alias for ruflo auth login)' },
+    { command: 'ruflo proxy run --policy critical -- claude', description: 'Launch Claude through Meta-Proxy with a critical-worktree policy' },
     { command: 'ruflo proxy config --cloud --yes', description: 'Enable cloud routing (ADR-304)' },
     { command: 'ruflo proxy config --local-only', description: 'Revert to local-only routing' },
     { command: 'ruflo proxy sponsor-status', description: 'Show current sponsored-mode state' },

--- a/v3/@claude-flow/cli/src/proxy/client-run.ts
+++ b/v3/@claude-flow/cli/src/proxy/client-run.ts
@@ -1,0 +1,207 @@
+/**
+ * Launch Claude-compatible clients through the locally managed Meta-Proxy.
+ *
+ * This mirrors the v0.4.0 MetaHarness integration. The policy is a signed,
+ * short-lived capability: a proxy token is never passed directly to the
+ * client, and no filesystem path or repository name is disclosed upstream.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash, createHmac } from 'node:crypto';
+import * as fs from 'node:fs';
+import { proxyConfigPath, proxyTokenPath } from './paths.js';
+import { getProxyStatus, startBackground, ProxyAlreadyRunningError, type ProxyStatus } from './lifecycle.js';
+
+export type ProxyWorktreePolicy = 'critical' | 'standard' | 'economy';
+
+const POLICIES: ReadonlySet<string> = new Set(['critical', 'standard', 'economy']);
+const DEFAULT_BIND = '127.0.0.1:11435';
+
+export interface ProxyClientEnvironment {
+  ANTHROPIC_BASE_URL: string;
+  ANTHROPIC_AUTH_TOKEN: string;
+}
+
+export interface ProxyRunResult {
+  success: boolean;
+  exitCode: number;
+  message?: string;
+  started: boolean;
+  policy: ProxyWorktreePolicy;
+}
+
+/**
+ * Resolve the local endpoint which receives the bearer token. This must be a
+ * literal loopback address; a hostname or non-loopback bind could disclose
+ * the local token through a user-controlled config file.
+ */
+export function proxyClientEndpoint(): string {
+  let bind = DEFAULT_BIND;
+  try {
+    const raw = fs.readFileSync(proxyConfigPath(), 'utf8');
+    const match = raw.match(/^bind\s*=\s*"([^"]+)"\s*$/m);
+    if (match?.[1]) bind = match[1];
+  } catch {
+    // Meta-Proxy uses the documented default when the config is absent.
+  }
+
+  const match = bind.match(/^(127\.0\.0\.1|\[::1\]):([1-9]\d{0,4})$/);
+  const port = match ? Number.parseInt(match[2]!, 10) : 0;
+  if (!match || port > 65_535) {
+    throw new Error(`Refusing to route a client through non-loopback Meta-Proxy bind "${bind}".`);
+  }
+  return `http://${bind}`;
+}
+
+/** Environment passed only to the launched client, never written to disk. */
+export function proxyClientEnvironment(): ProxyClientEnvironment {
+  let token = '';
+  try {
+    token = fs.readFileSync(proxyTokenPath(), 'utf8').trim();
+  } catch {
+    // The explicit error below gives the operator an actionable recovery.
+  }
+  if (!token) {
+    throw new Error('Meta-Proxy token is unavailable. Start Meta-Proxy once to create its local token.');
+  }
+  return { ANTHROPIC_BASE_URL: proxyClientEndpoint(), ANTHROPIC_AUTH_TOKEN: token };
+}
+
+/** Stable correlation value; never expose a worktree path, prompt, or repo name. */
+export function proxyWorktreeFingerprint(cwd = process.cwd()): string {
+  return createHash('sha256').update(cwd).digest('hex').slice(0, 32);
+}
+
+/** Mint the Meta-Proxy v0.4.0+ policy capability using the local bearer secret. */
+export function createProxyPolicyToken(
+  proxyToken: string,
+  policy: ProxyWorktreePolicy,
+  worktree = proxyWorktreeFingerprint(),
+  now = Date.now(),
+): string {
+  if (!POLICIES.has(policy)) throw new Error(`Unknown worktree policy "${policy}".`);
+  const payload = Buffer.from(JSON.stringify({ policy, worktree, exp: Math.floor(now / 1_000) + 8 * 60 * 60 }))
+    .toString('base64url');
+  const signed = `mh1.${payload}`;
+  return `${signed}.${createHmac('sha256', proxyToken).update(signed).digest('base64url')}`;
+}
+
+/** Keep policy-token construction separately testable from process launch. */
+export function proxyClientEnvironmentForPolicy(
+  policy: ProxyWorktreePolicy,
+  cwd = process.cwd(),
+  clientEnv = proxyClientEnvironment(),
+): ProxyClientEnvironment {
+  return {
+    ...clientEnv,
+    ANTHROPIC_AUTH_TOKEN: createProxyPolicyToken(clientEnv.ANTHROPIC_AUTH_TOKEN, policy, proxyWorktreeFingerprint(cwd)),
+  };
+}
+
+async function waitForProxy(endpoint: string, token: string, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 1_000);
+      try {
+        const response = await fetch(`${endpoint}/status`, {
+          headers: { authorization: `Bearer ${token}` },
+          signal: controller.signal,
+        });
+        if (response.ok) return true;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      // The detached supervisor can take a moment to bind its loopback port.
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+/** The binary creates its local token on first launch, so wait for it once. */
+async function waitForProxyClientEnvironment(timeoutMs = 5_000): Promise<ProxyClientEnvironment | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return proxyClientEnvironment();
+    } catch {
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  return null;
+}
+
+async function ensureProxyRunning(): Promise<{ status: ProxyStatus; started: boolean }> {
+  const status = getProxyStatus();
+  if (status.running) return { status, started: false };
+  try {
+    await startBackground();
+    return { status: getProxyStatus(), started: true };
+  } catch (error) {
+    // A second `proxy run` can win the start lock after our status check.
+    if (error instanceof ProxyAlreadyRunningError) return { status: getProxyStatus(), started: false };
+    throw error;
+  }
+}
+
+/**
+ * Start the managed proxy if necessary, authenticate its health endpoint,
+ * and run a Claude-compatible client with scoped environment variables.
+ */
+export async function runProxyClient(
+  args: string[],
+  policy: ProxyWorktreePolicy,
+  cwd = process.cwd(),
+): Promise<ProxyRunResult> {
+  if (!POLICIES.has(policy)) {
+    return { success: false, exitCode: 2, message: '--policy must be one of: critical, standard, economy.', started: false, policy };
+  }
+
+  let started = false;
+  try {
+    ({ started } = await ensureProxyRunning());
+    const localEnv = await waitForProxyClientEnvironment();
+    if (!localEnv) {
+      return {
+        success: false,
+        exitCode: 1,
+        message: 'Meta-Proxy did not create its local token within 5 seconds. Run `ruflo proxy status` and inspect `ruflo proxy logs`.',
+        started,
+        policy,
+      };
+    }
+    if (!await waitForProxy(localEnv.ANTHROPIC_BASE_URL, localEnv.ANTHROPIC_AUTH_TOKEN)) {
+      return {
+        success: false,
+        exitCode: 1,
+        message: 'Meta-Proxy did not become ready within 5 seconds. Run `ruflo proxy status` and inspect `ruflo proxy logs`.',
+        started,
+        policy,
+      };
+    }
+
+    const commandArgs = args[0] === '--' ? args.slice(1) : args;
+    const command = commandArgs[0] || 'claude';
+    const result = spawnSync(command, commandArgs.slice(1), {
+      cwd,
+      stdio: 'inherit',
+      env: { ...process.env, ...proxyClientEnvironmentForPolicy(policy, cwd, localEnv) },
+      windowsHide: true,
+    });
+    if (result.error) {
+      return { success: false, exitCode: 1, message: `Could not start ${command}: ${result.error.message}`, started, policy };
+    }
+    return { success: result.status === 0, exitCode: result.status ?? 1, started, policy };
+  } catch (error) {
+    return {
+      success: false,
+      exitCode: 1,
+      message: error instanceof Error ? error.message : String(error),
+      started,
+      policy,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add `ruflo proxy run --policy <critical|standard|economy> -- <client>` compatible with MetaHarness
- auto-start the managed Meta-Proxy, authenticate `/status`, and launch Claude-compatible clients through loopback
- mint Meta-Proxy v0.4.0 short-lived HMAC policy capabilities keyed by a non-reversible worktree fingerprint
- add `proxy path`, `proxy login`, and `proxy logout` compatibility commands
- advertise the launcher from bare `ruflo proxy` guidance

## Safety
- refuses non-literal-loopback proxy binds before exposing the local bearer token
- passes a scoped policy token to the child, never the raw local proxy token
- launches with `shell: false` semantics via `spawnSync(command, args)`

## Validation
- TypeScript build passes
- focused proxy launcher/lifecycle/token/console tests: 19/19 pass
- full proxy group: 57 pass; 3 existing `proxy-verify.test.ts` failures use the stale v0.1.0 signature fixture against the newer pinned release key