### PR TITLE
fix(deps): sync pnpm-lock.yaml @claude-flow/security specifier (no-agentbbs-smoke red on main)

### DIFF
--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
         specifier: ^3.0.0-alpha.21
         version: link:../memory
       '@claude-flow/security':
-        specifier: ^3.0.0-alpha.10
+        specifier: ^3.0.0-alpha.12
         version: link:../security
       agentdb:
         specifier: ^3.0.0-alpha.17


### PR DESCRIPTION
## Problem

`no-agentbbs-smoke` CI is RED on `main` (`076ccf3`, run 29611470597, failed 2026-07-17T20:30Z).

`pnpm install --frozen-lockfile` fails with:
```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with @claude-flow/cli/package.json
specifiers in the lockfile ({"@claude-flow/security":"^3.0.0-alpha.10"})
don't match specs in package.json ({"@claude-flow/security":"^3.0.0-alpha.12"})
```

## Root cause

Two commits bumped `@claude-flow/security` in `v3/@claude-flow/cli/package.json` without regenerating the lockfile:
- `14c41d7` (#2711): `^3.0.0-alpha.10` → `^3.0.0-alpha.11`
- `076ccf3` (#2712): `^3.0.0-alpha.11` → `^3.0.0-alpha.12`

The lockfile specifier stayed at `^3.0.0-alpha.10`.

## Fix

Update the single specifier line in `v3/pnpm-lock.yaml` (`^3.0.0-alpha.10` → `^3.0.0-alpha.12`).

The resolved version is `link:../security` (workspace link) — only the specifier string needs to match package.json. No code change, no version bump, no transitive dep changes.

**Diff: 1 file, +1/-1.**

## Verification

Independent detached-HEAD worktree (`/tmp/ruflo-verify-T9`), CI-faithful sequence:

| Gate | Check | Result |
|------|-------|--------|
| 1 | `pnpm install --frozen-lockfile` (was `ERR_PNPM_OUTDATED_LOCKFILE`) | ✅ exit 0 |
| 2 | `pnpm -r --no-bail build` | ✅ exit 0 |
| 3 | Remove agentbbs from node_modules (CI Rule 3) | ✅ removed, verified gone |
| 4 | `bash scripts/smoke-agentbbs.sh` | ✅ 8 passed, 0 failed |

All 4 gates pass. The CI-blocking `ERR_PNPM_OUTDATED_LOCKFILE` is resolved.