### PR TITLE
fix(proxy): notify a running meta-proxy daemon after every config write

### DIFF
--- a/v3/@claude-flow/cli/__tests__/proxy-reload.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-reload.test.ts
@@ -1,0 +1,170 @@
+/**
+ * `ruflo proxy` consent commands notify a running meta-proxy daemon
+ * (cognitum-one/meta-proxy#28's fix, mirrored client-side).
+ *
+ * The Rust proxy loads its config once at boot and never re-reads the file
+ * afterward, so `sponsor-enable`/`power-saver-enable`/`training-share-enable`
+ * (and their `-disable` counterparts) must call `POST /internal/reload-config`
+ * after writing the consent mirror, or an already-running daemon silently
+ * ignores the change until restarted.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import type { CommandContext } from '@claude-flow/cli-core/types';
+
+let stateDir: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-reload-test-'));
+  savedEnv = { ...process.env };
+  process.env.RUFLO_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  process.env = savedEnv;
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+const TEST_TOKEN = 'test-proxy-token-abc123';
+
+function seedConfig(bind: string): void {
+  fs.writeFileSync(path.join(stateDir, 'proxy-config.toml'), `bind = "${bind}"\n`, 'utf-8');
+  fs.writeFileSync(path.join(stateDir, 'proxy-token'), TEST_TOKEN, 'utf-8');
+}
+
+function ctx(flags: Record<string, unknown> = {}): CommandContext {
+  return { args: [], flags: { yes: true, _: [], ...flags }, cwd: process.cwd(), interactive: false };
+}
+
+/** A minimal stand-in for meta-proxy's /internal/reload-config endpoint. */
+async function startMockDaemon(): Promise<{ url: string; bind: string; calls: Array<{ path: string; auth: string | undefined }>; close: () => Promise<void> }> {
+  const calls: Array<{ path: string; auth: string | undefined }> = [];
+  const server = http.createServer((req, res) => {
+    calls.push({ path: req.url ?? '', auth: req.headers.authorization });
+    res.statusCode = 204;
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  const bind = `127.0.0.1:${port}`;
+  return {
+    url: `http://${bind}`,
+    bind,
+    calls,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('ruflo proxy consent commands notify a running daemon', () => {
+  it('sponsor-enable calls POST /internal/reload-config with the proxy token', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { sponsorEnableSub } = await import('../src/commands/proxy.js');
+    const result = await sponsorEnableSub.action!(ctx());
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(1);
+    expect(daemon.calls[0].path).toBe('/internal/reload-config');
+    expect(daemon.calls[0].auth).toBe(`Bearer ${TEST_TOKEN}`);
+  });
+
+  it('sponsor-disable also notifies the running daemon', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { sponsorEnableSub, sponsorDisableSub } = await import('../src/commands/proxy.js');
+    await sponsorEnableSub.action!(ctx());
+    daemon.calls.length = 0; // only count the disable call
+    const result = await sponsorDisableSub.action!(ctx());
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(1);
+    expect(daemon.calls[0].path).toBe('/internal/reload-config');
+  });
+
+  it('power-saver-enable notifies the running daemon', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { powerSaverEnableSub } = await import('../src/commands/proxy.js');
+    const result = await powerSaverEnableSub.action!(ctx());
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(1);
+    expect(daemon.calls[0].path).toBe('/internal/reload-config');
+  });
+
+  it('training-share-enable notifies the running daemon', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { trainingShareEnableSub } = await import('../src/commands/proxy.js');
+    const result = await trainingShareEnableSub.action!(ctx());
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(1);
+    expect(daemon.calls[0].path).toBe('/internal/reload-config');
+  });
+
+  it('config --cloud --yes notifies the running daemon', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { configSub } = await import('../src/commands/proxy.js');
+    const result = await configSub.action!(ctx({ cloud: true }));
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(1);
+    expect(daemon.calls[0].path).toBe('/internal/reload-config');
+  });
+
+  it('config --local-only notifies the running daemon', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { configSub } = await import('../src/commands/proxy.js');
+    const result = await configSub.action!(ctx({ 'local-only': true }));
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(1);
+    expect(daemon.calls[0].path).toBe('/internal/reload-config');
+  });
+
+  it('config with no flags (status read) does NOT notify the daemon', async () => {
+    const daemon = await startMockDaemon();
+    seedConfig(daemon.bind);
+    const { configSub } = await import('../src/commands/proxy.js');
+    const result = await configSub.action!(ctx({ yes: undefined }));
+    await daemon.close();
+
+    expect(result.success).toBe(true);
+    expect(daemon.calls).toHaveLength(0);
+  });
+
+  it('never fails the command when no daemon is running', async () => {
+    // No mock server started at all — proxy-config.toml points at a bind
+    // address nothing is listening on.
+    seedConfig('127.0.0.1:1'); // reserved port, guaranteed connection-refused
+    const { sponsorEnableSub } = await import('../src/commands/proxy.js');
+    const result = await sponsorEnableSub.action!(ctx());
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ confirmed: true });
+  });
+
+  it('never fails the command when the token file is missing', async () => {
+    fs.writeFileSync(path.join(stateDir, 'proxy-config.toml'), 'bind = "127.0.0.1:11435"\n', 'utf-8');
+    // No proxy-token file written at all.
+    const { sponsorEnableSub } = await import('../src/commands/proxy.js');
+    const result = await sponsorEnableSub.action!(ctx());
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/proxy.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy.ts
@@ -97,6 +97,47 @@ function writeDataPlane(plane: 'local' | 'cloud'): void {
   writeConfigLine('default_data_plane', `"${plane}"`);
 }
 
+/**
+ * Best-effort: ask an already-running meta-proxy daemon to reload its
+ * in-memory config from disk. The Rust binary loads config once at boot
+ * (`AppState.config`, see cognitum-one/meta-proxy `src/main.rs`) and never
+ * re-reads the file afterward — so a consent flag or data-plane toggle this
+ * command just wrote would otherwise sit inert until the daemon is
+ * restarted. Mirrors the same fix meta-proxy's own `login`/`logout` CLI
+ * gained in v0.4.1 (cognitum-one/meta-proxy#28): `POST /internal/reload-config`,
+ * gated on the exact proxy token. Swallows every error — "no daemon running
+ * right now" is the common, expected case (e.g. granting consent before the
+ * proxy has ever been started), never a reason to fail the calling command.
+ */
+async function notifyRunningDaemon(): Promise<void> {
+  try {
+    const dir = funnelStateDir();
+    const token = fs.readFileSync(path.join(dir, 'proxy-token'), 'utf-8').trim();
+    if (!token) return;
+    let bind = '127.0.0.1:11435';
+    try {
+      const raw = readProxyConfigRaw();
+      const match = raw.match(/^bind\s*=\s*"([^"]+)"\s*$/m);
+      if (match?.[1]) bind = match[1];
+    } catch {
+      /* use the documented default */
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1500);
+    try {
+      await fetch(`http://${bind}/internal/reload-config`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    /* no daemon running, or it's unreachable — not an error for this command */
+  }
+}
+
 const CLOUD_ROUTING_DISCLOSURE = [
   'Enabling cloud routing.',
   '',
@@ -109,7 +150,7 @@ const CLOUD_ROUTING_DISCLOSURE = [
   'Disable anytime: ruflo proxy config --local-only',
 ].join('\n');
 
-const configSub: Command = {
+export const configSub: Command = {
   name: 'config',
   description: 'Toggle cloud routing (ADR-304) — local backends only by default',
   options: [
@@ -139,6 +180,7 @@ const configSub: Command = {
 
     if (wantLocalOnly) {
       writeDataPlane('local');
+      await notifyRunningDaemon();
       revokeConsent('cloud-routing', 'proxy-config-local-only');
       output.printSuccess('Cloud routing disabled — reverted to local-only routing.');
       return { success: true, data: { plane: 'local' } };
@@ -155,6 +197,7 @@ const configSub: Command = {
       recordConsent('cloud-routing', true, 'proxy-config-cloud');
     }
     writeDataPlane('cloud');
+    await notifyRunningDaemon();
     output.printSuccess('Cloud routing enabled.');
     output.writeln('  Requests routed to local backends still never leave this machine.');
     output.writeln('  Disable anytime: ruflo proxy config --local-only');
@@ -176,7 +219,7 @@ const SPONSOR_DISCLOSURE = [
   '  ruflo proxy sponsor-disable',
 ].join('\n');
 
-const sponsorEnableSub: Command = {
+export const sponsorEnableSub: Command = {
   name: 'sponsor-enable',
   description: "Opt into Cognitum-sponsored downtime capacity (ADR-313)",
   options: [
@@ -195,6 +238,7 @@ const sponsorEnableSub: Command = {
     }
     recordConsent('sponsored-downtime', true, 'proxy-sponsor-enable');
     writeSponsoredConsentMirror(true);
+    await notifyRunningDaemon();
     recordFunnelEvent('sponsor_mode_enabled', 'statusline', getInstalledCliVersion());
     output.printSuccess('Sponsored downtime mode enabled.');
     output.writeln('The proxy will use it automatically while ruflo settings notices');
@@ -203,19 +247,20 @@ const sponsorEnableSub: Command = {
   },
 };
 
-const sponsorDisableSub: Command = {
+export const sponsorDisableSub: Command = {
   name: 'sponsor-disable',
   description: 'Revoke sponsored-downtime consent and stop using sponsored capacity',
   action: async (): Promise<CommandResult> => {
     revokeConsent('sponsored-downtime', 'proxy-sponsor-disable');
     writeSponsoredConsentMirror(false);
+    await notifyRunningDaemon();
     recordFunnelEvent('sponsor_mode_disabled', 'statusline', getInstalledCliVersion());
     output.printSuccess('Sponsored downtime mode disabled.');
     return { success: true };
   },
 };
 
-const sponsorStatusSub: Command = {
+export const sponsorStatusSub: Command = {
   name: 'sponsor-status',
   description: 'Show sponsored-downtime consent + rate-limit flag state',
   action: async (): Promise<CommandResult> => {
@@ -233,7 +278,7 @@ const sponsorStatusSub: Command = {
 };
 
 /** Convenience: clear the rate-limited flag once you're back to normal. */
-const sponsorClearSub: Command = {
+export const sponsorClearSub: Command = {
   name: 'sponsor-clear',
   description: 'Clear the rate-limited flag (your Claude limit has reset)',
   action: async (): Promise<CommandResult> => {
@@ -260,7 +305,7 @@ const POWER_SAVER_DISCLOSURE = [
   'Disable anytime: ruflo proxy power-saver-disable',
 ].join('\n');
 
-const powerSaverEnableSub: Command = {
+export const powerSaverEnableSub: Command = {
   name: 'power-saver-enable',
   description: 'Opt into power saver mode — route everyday requests through your own Cognitum account (ADR-314)',
   options: [
@@ -279,6 +324,7 @@ const powerSaverEnableSub: Command = {
     }
     recordConsent('power-saver', true, 'proxy-power-saver-enable');
     writePowerSaverConsentMirror(true);
+    await notifyRunningDaemon();
     recordFunnelEvent('power_saver_enabled', 'statusline', getInstalledCliVersion());
     output.printSuccess('Power saver mode enabled.');
     output.writeln('Flag it active with: ruflo settings notices quota-low');
@@ -287,19 +333,20 @@ const powerSaverEnableSub: Command = {
   },
 };
 
-const powerSaverDisableSub: Command = {
+export const powerSaverDisableSub: Command = {
   name: 'power-saver-disable',
   description: 'Revoke power-saver consent and stop routing through Cognitum for cost savings',
   action: async (): Promise<CommandResult> => {
     revokeConsent('power-saver', 'proxy-power-saver-disable');
     writePowerSaverConsentMirror(false);
+    await notifyRunningDaemon();
     recordFunnelEvent('power_saver_disabled', 'statusline', getInstalledCliVersion());
     output.printSuccess('Power saver mode disabled.');
     return { success: true };
   },
 };
 
-const powerSaverStatusSub: Command = {
+export const powerSaverStatusSub: Command = {
   name: 'power-saver-status',
   description: 'Show power-saver consent + quota-low flag state',
   action: async (): Promise<CommandResult> => {
@@ -317,7 +364,7 @@ const powerSaverStatusSub: Command = {
 };
 
 /** Convenience: clear the quota-low flag once you're back to normal. */
-const powerSaverClearSub: Command = {
+export const powerSaverClearSub: Command = {
   name: 'power-saver-clear',
   description: 'Clear the quota-low flag',
   action: async (): Promise<CommandResult> => {
@@ -347,7 +394,7 @@ const TRAINING_SHARE_DISCLOSURE = [
   'Disable anytime: ruflo proxy training-share-disable',
 ].join('\n');
 
-const trainingShareEnableSub: Command = {
+export const trainingShareEnableSub: Command = {
   name: 'training-share-enable',
   description: 'Opt into sharing sponsored-plane interaction content for meta-llm training (ADR-315)',
   options: [
@@ -366,6 +413,7 @@ const trainingShareEnableSub: Command = {
     }
     recordConsent('training-data-sharing', true, 'proxy-training-share-enable');
     writeTrainingShareConsentMirror(true);
+    await notifyRunningDaemon();
     recordFunnelEvent('training_share_enabled', 'statusline', getInstalledCliVersion());
     output.printSuccess('Training-data sharing enabled.');
     output.writeln('Only sponsored-plane requests carry the consent header. Disable anytime:');
@@ -374,19 +422,20 @@ const trainingShareEnableSub: Command = {
   },
 };
 
-const trainingShareDisableSub: Command = {
+export const trainingShareDisableSub: Command = {
   name: 'training-share-disable',
   description: 'Revoke training-data-sharing consent — stop sending the training consent header',
   action: async (): Promise<CommandResult> => {
     revokeConsent('training-data-sharing', 'proxy-training-share-disable');
     writeTrainingShareConsentMirror(false);
+    await notifyRunningDaemon();
     recordFunnelEvent('training_share_disabled', 'statusline', getInstalledCliVersion());
     output.printSuccess('Training-data sharing disabled.');
     return { success: true };
   },
 };
 
-const trainingShareStatusSub: Command = {
+export const trainingShareStatusSub: Command = {
   name: 'training-share-status',
   description: 'Show training-data-sharing consent state',
   action: async (): Promise<CommandResult> => {


### PR DESCRIPTION
## Summary
- The Rust proxy binary (`cognitum-one/meta-proxy`) loads `~/.ruflo/proxy-config.toml` once at boot into `AppState.config` and never re-reads it afterward (`src/main.rs`).
- `ruflo proxy sponsor-enable`/`sponsor-disable`, `power-saver-enable`/`power-saver-disable`, `training-share-enable`/`training-share-disable`, and `config --cloud`/`--local-only` all write that file directly — so an already-running daemon silently ignored every one of these commands until manually restarted. Discovered while validating the automatic Claude-usage-failover feature (ADR-321) end-to-end against a live daemon.
- Adds `notifyRunningDaemon()`, called after all 8 config-write call sites: `POST /internal/reload-config` (meta-proxy v0.4.1, [cognitum-one/meta-proxy#28](https://github.com/cognitum-one/meta-proxy/pull/28)) with the local proxy token. Best-effort — swallows every error, since "no daemon running yet" (e.g. granting consent before the proxy has ever started) is the common, expected case, never a reason to fail the calling command.

## Test plan
- [x] `npx tsc --noEmit` — zero errors in the touched files (pre-existing, unrelated cross-package build-ordering errors elsewhere in this fresh worktree, confirmed absent from `proxy.ts`/`proxy-reload.test.ts` specifically)
- [x] 9 new unit tests (`__tests__/proxy-reload.test.ts`) against a real local mock HTTP server: every write path notifies, `config` with no flags (status-only read) correctly does *not* notify, and the command never fails when no daemon is listening or the token file is missing
- [x] `__tests__/funnel.test.ts` (122 tests) — no regressions
- [x] **Live-verified against the real running v0.4.1 meta-proxy daemon**, not just mocks: baseline `/status` showed `sponsored_available: true`; ran the real (compiled) `sponsor-disable` against it with zero manual intervention; `/status` immediately flipped to `sponsored_available: false`; re-ran `sponsor-enable` to restore state, confirmed instant reflection again

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)