### PR TITLE
fix(memory): memory_search omitted namespace no longer collapses to empty 'default'

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-search-namespace-default-2646.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-search-namespace-default-2646.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression guard for issue #2646 — the MCP `memory_search` tool returned
+ * 0 results when the optional `namespace` parameter was omitted, even though
+ * `memory_stats` confirmed entries existed across multiple namespaces with
+ * 100% embedding coverage. Passing any concrete `namespace` returned the
+ * expected hits immediately.
+ *
+ * This is the THIRD occurrence of this exact bug shape (#1123, #1131 — both
+ * closed Feb/Mar). Root cause each time: the `memory_search` tool handler in
+ * `mcp-tools/memory-tools.ts` coerces an omitted `namespace` to the literal
+ * string `'default'`:
+ *
+ *   const namespace = (input.namespace as string) || 'default';
+ *
+ * But BOTH underlying search implementations — `searchEntries()` in
+ * `memory/memory-initializer.ts` and `bridgeSearchEntries()` in
+ * `memory/memory-bridge.ts` — already resolve an omitted/undefined namespace
+ * to the `'all'` sentinel (fan out across every namespace):
+ *
+ *   const effectiveNamespace = namespace || 'all';
+ *
+ * `'default'` is truthy, so passing it explicitly defeats that fallback and
+ * silently scopes the search to a namespace that is usually empty (the CLI
+ * `memory search` command already gets this right — see
+ * `commands/memory.ts`, which defaults to `'all'`, not `'default'`).
+ *
+ * Why prior fixes didn't catch the regression: #1123/#1131 fixed the
+ * *search-layer* default (`searchEntries`/`bridgeSearchEntries`) but nothing
+ * asserted what the `memory_search` MCP *tool handler* actually forwards to
+ * that layer, so a later refactor of `memory-tools.ts` could silently
+ * reintroduce `|| 'default'` at the tool boundary without breaking anything.
+ * This guard asserts the forwarded argument directly, at the tool boundary.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fs so `ensureInitialized()`'s legacy-migration check (`hasLegacyStore`)
+// is a deterministic no-op regardless of the real cwd.
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  readFileSync: vi.fn(() => '{}'),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+// Spy on the search layer so we can assert exactly what `memory_search`
+// forwards to it, and simulate the real-world repro: a populated
+// "projetos" namespace alongside an empty "default" one.
+// `vi.hoisted()` is required here: `vi.mock()` factories are hoisted above
+// all other module-level code (including `const` declarations), so a plain
+// `const searchEntries = vi.fn(...)` referenced inside the factory below
+// would throw a temporal-dead-zone error at mock-evaluation time.
+const { searchEntries } = vi.hoisted(() => {
+  const fn = vi.fn(async (opts: { namespace?: string }) => {
+    // Faithful to the real implementations' `namespace || 'all'` semantics —
+    // an omitted/undefined namespace (or the explicit 'all' sentinel) must
+    // search across every namespace; anything else scopes to that namespace.
+    const effectiveNamespace = opts.namespace || 'all';
+
+    const allEntries = [
+      { id: 'a1', key: 'note/alpha', content: 'ruflo memory probe', score: 0.9, namespace: 'projetos' },
+      { id: 'a2', key: 'note/beta', content: 'ruflo memory probe', score: 0.8, namespace: 'patterns' },
+    ];
+
+    if (effectiveNamespace === 'all') {
+      return { success: true, results: allEntries, searchTime: 1 };
+    }
+    // The 'default' namespace (and any other namespace with no data) is empty
+    // — exactly the failure mode from the issue's memory_stats repro.
+    const scoped = allEntries.filter((e) => e.namespace === effectiveNamespace);
+    return { success: true, results: scoped, searchTime: 1 };
+  });
+  return { searchEntries: fn };
+});
+
+vi.mock('../src/memory/memory-initializer.js', () => ({
+  generateEmbedding: vi.fn(async () => ({ embedding: new Array(384).fill(0.1), dimensions: 384, model: 'mock' })),
+  storeEntry: vi.fn(async () => ({ success: true, id: 'mock-id' })),
+  searchEntries,
+  listEntries: vi.fn(async () => ({ success: true, entries: [], total: 0 })),
+  getEntry: vi.fn(async () => null),
+  deleteEntry: vi.fn(async () => ({ success: true })),
+  getStats: vi.fn(async () => ({ totalEntries: 0 })),
+  initializeDatabase: vi.fn(async () => ({ success: true })),
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true })),
+  checkMemoryInitialization: vi.fn(async () => ({ initialized: true, version: '3.0.0' })),
+  migrateFromLegacy: vi.fn(async () => ({ success: true, migrated: 0 })),
+}));
+
+import { memoryTools } from '../src/mcp-tools/memory-tools.js';
+
+const tool = memoryTools.find((t) => t.name === 'memory_search');
+
+describe('memory_search namespace default (#2646, 3rd occurrence of #1123/#1131)', () => {
+  beforeEach(() => {
+    searchEntries.mockClear();
+  });
+
+  it('exists', () => {
+    expect(tool).toBeDefined();
+  });
+
+  it('schema no longer documents a literal "default" namespace default (the misleading doc from the issue)', () => {
+    const props = (tool!.inputSchema as { properties: Record<string, { description?: string }> }).properties;
+    const desc = props.namespace?.description ?? '';
+    expect(desc).not.toContain('default: "default"');
+  });
+
+  it('omitting namespace forwards namespace=undefined to the search layer, not the literal string "default"', async () => {
+    await tool!.handler({ query: 'test query' });
+    expect(searchEntries).toHaveBeenCalled();
+    const callArgs = searchEntries.mock.calls[0][0] as { namespace?: string };
+    // This is the exact assertion that would have failed against the
+    // regressed code (`namespace = input.namespace || 'default'`).
+    expect(callArgs.namespace).not.toBe('default');
+    expect(callArgs.namespace).toBeUndefined();
+  });
+
+  it('reproduces the issue #2646 repro end-to-end: omitting namespace returns hits from ALL namespaces', async () => {
+    const r = await tool!.handler({ query: 'ruflo memory probe' }) as { results: unknown[]; total: number };
+    // Pre-fix this was `{ results: [], total: 0 }` even though entries existed
+    // in "projetos"/"patterns" — exactly the memory_stats-vs-memory_search
+    // mismatch reported in the issue.
+    expect(r.total).toBe(2);
+    expect(r.results.map((e) => (e as { key: string }).key)).toEqual(
+      expect.arrayContaining(['note/alpha', 'note/beta']),
+    );
+  });
+
+  it('an explicit namespace is still forwarded unchanged (back-compat with the issue\'s working case)', async () => {
+    await tool!.handler({ query: 'test', namespace: 'projetos' });
+    const callArgs = searchEntries.mock.calls[0][0] as { namespace?: string };
+    expect(callArgs.namespace).toBe('projetos');
+
+    const r = await tool!.handler({ query: 'test', namespace: 'projetos' }) as { results: unknown[]; total: number };
+    expect(r.total).toBe(1);
+    expect((r.results[0] as { key: string }).key).toBe('note/alpha');
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -443,7 +443,7 @@ export const memoryTools: MCPTool[] = [
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Search query (semantic similarity)' },
-        namespace: { type: 'string', description: 'Namespace to search (default: "default")' },
+        namespace: { type: 'string', description: 'Namespace to search (default: all namespaces — omit to search across every namespace)' },
         limit: { type: 'number', description: 'Maximum results (default: 10)' },
         threshold: { type: 'number', description: 'Minimum similarity threshold 0-1 (default: 0.3)' },
         smart: { type: 'boolean', description: 'Enable SmartRetrieval pipeline — query expansion, RRF fusion, recency boost, MMR diversity (default: false)' },
@@ -455,11 +455,19 @@ export const memoryTools: MCPTool[] = [
       const { searchEntries } = await getMemoryFunctions();
 
       const query = input.query as string;
-      const namespace = (input.namespace as string) || 'default';
+      // #2646 (3rd occurrence of #1123/#1131 shape): do NOT coerce an omitted
+      // namespace to the literal string 'default' here. Both searchEntries()
+      // and bridgeSearchEntries() already resolve an omitted/undefined
+      // namespace to 'all' (fan out across every namespace) — but 'default'
+      // is truthy, so passing it defeats that fallback and silently scopes
+      // the search to a namespace that is usually empty. Leave namespace
+      // undefined when not provided so the underlying `|| 'all'` fallback
+      // in the search layer actually fires.
+      const namespace = input.namespace as string | undefined;
       const limit = (input.limit as number) ?? 10;
       const threshold = (input.threshold as number) ?? 0.3;
 
-      validateMemoryInput(undefined, undefined, query);
+      validateMemoryInput(undefined, undefined, query, namespace);
 
       const startTime = performance.now();
 


### PR DESCRIPTION
## Summary

Fixes #2646 — the third occurrence of the #1123/#1131 bug shape: the MCP `memory_search` tool returned `{ results: [], total: 0 }` when the optional `namespace` parameter was omitted, even though `memory_stats` confirmed entries existed across multiple namespaces with 100% embedding coverage. Passing any concrete `namespace` returned the expected hits immediately.

## Root cause

The `memory_search` tool handler in `v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts` coerced an omitted `namespace` to the literal string `'default'`:

```ts
const namespace = (input.namespace as string) || 'default';
```

But **both** underlying search implementations already resolve an omitted/undefined namespace to the `'all'` sentinel (fan out across every namespace):

- `searchEntries()` in `v3/@claude-flow/cli/src/memory/memory-initializer.ts`: `const effectiveNamespace = namespace || 'all';`
- `bridgeSearchEntries()` in `v3/@claude-flow/cli/src/memory/memory-bridge.ts`: `const effectiveNamespace = namespace || 'all';`

`'default'` is truthy, so passing it explicitly defeated that fallback and silently scoped the search to a namespace that is usually empty — exactly matching the issue's repro (`memory_stats` showing entries in `patterns`/`projetos`/etc. while `memory_search` with no namespace returned 0).

Confirming evidence this is tool-handler-only: the CLI's `memory search` command (`v3/@claude-flow/cli/src/commands/memory.ts`) already gets this right — `const namespace = ctx.flags.namespace as string || 'all';`. The lower-level search-layer fix from #1123/#1131 never regressed; a later refactor of the MCP tool handler alone reintroduced the hardcoded `'default'` at the tool boundary, which is exactly why the prior fixes didn't catch this: nothing asserted what the tool handler forwards to the search layer.

## Fix

- Leave `namespace` `undefined` when the caller omits it, instead of coercing to `'default'`, so the search layer's own `namespace || 'all'` fallback actually fires.
- Also pass the (optional) namespace through `validateMemoryInput` for the existing path-traversal/shell-metacharacter check, matching how other tool handlers already validate it.
- Corrected the `inputSchema` description, which previously (and misleadingly, per the issue) documented the empty-default behavior as intended (`'Namespace to search (default: "default")'`).

## Test

Added `v3/@claude-flow/cli/__tests__/memory-search-namespace-default-2646.test.ts`, which mocks the search layer (faithfully reproducing its real `namespace || 'all'` semantics) to:
1. Assert the tool forwards `namespace: undefined` (not the literal string `'default'`) when omitted.
2. Reproduce the issue's exact repro end-to-end: omitting `namespace` returns hits from every namespace instead of `{ results: [], total: 0 }`.
3. Confirm an explicit `namespace` is still forwarded unchanged (back-compat with the issue's already-working case).

There was no existing test guarding this exact tool-handler behavior (the existing `memory-search-unified-2246.test.ts` only covers the separate `memory_search_unified` tool), which is why the regression slipped through twice before.

### Verification

```
✓ __tests__/memory-search-namespace-default-2646.test.ts (5 tests)
  ✓ exists
  ✓ schema no longer documents a literal "default" namespace default (the misleading doc from the issue)
  ✓ omitting namespace forwards namespace=undefined to the search layer, not the literal string "default"
  ✓ reproduces the issue #2646 repro end-to-end: omitting namespace returns hits from ALL namespaces
  ✓ an explicit namespace is still forwarded unchanged (back-compat with the issue's working case)

Test Files  1 passed (1)
     Tests  5 passed (5)
```

Also manually reverted the fix locally and reran the same test file to confirm it fails against the pre-fix handler (3/5 tests fail, reproducing `total: 0` exactly), then restored the fix — confirming the test is an effective regression guard. Also ran `memory-search-unified-2246.test.ts` alongside it (14 tests total, all passing) to confirm no interaction with the sibling tool's namespace fan-out logic.

## Scope

Only touches the `memory_search` MCP tool handler (`memory-tools.ts`) and adds one new test file. Does not touch `memory_search_unified`, the CLI `memory search`/`store`/`retrieve`/`delete` commands (which already default correctly or intentionally require an exact namespace), or any other issue in the tracker.