### PR TITLE
chore(release): bump @claude-flow/cli, claude-flow, ruflo to 3.32.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.2",
+  "version": "3.32.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.2",
+      "version": "3.32.8",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.2",
+  "version": "3.32.8",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.7",
+  "version": "3.32.8",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package-lock.json
+++ b/v3/@claude-flow/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.4",
+  "version": "3.32.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@claude-flow/cli",
-      "version": "3.32.4",
+      "version": "3.32.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.7",
+  "version": "3.32.8",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
Bumps all three packages to `3.32.8`, restoring version lockstep (`claude-flow` umbrella had drifted to 3.32.2 while `@claude-flow/cli`/`ruflo` were at 3.32.7 — a pre-existing violation caught by the `Plugin package install-safety` CI job, ref #2151).

This release bundles two already-merged fixes:
- pnpm-lock.yaml drift fix (#2719/#2717, merged 59f5c7f9d)
- MCP memory_search namespace-default fix (#2646, merged 030c8e5c1)

## Verification
- All three `package.json` versions confirmed at `3.32.8`
- `ruflo`'s dependency range `^3.32.7` on `@claude-flow/cli` still covers `3.32.8`

🤖 Generated with [Claude Code](https://claude.ai/code)