### PR TITLE
fix(release): bump claude-flow umbrella 3.32.2→3.32.7 to match cli + ruflo (v3-ci.yml red on main)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.2",
+  "version": "3.32.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.2",
+      "version": "3.32.7",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.2",
+  "version": "3.32.7",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

v3-ci.yml's `umbrella-version-lockstep-audit` step is **RED on main** because the three umbrella packages that ship together drifted:

| Package | Path | Version |
|---|---|---|
| `@claude-flow/cli` | `v3/@claude-flow/cli/package.json` | 3.32.7 |
| `claude-flow` (umbrella) | root `package.json` | **3.32.2** ← behind |
| `ruflo` | `ruflo/package.json` | 3.32.7 |

The `audit-umbrella-version-lockstep.mjs` guard (added for #2151) enforces that all three ship at the same version per CLAUDE.md "Publishing Rules". It fails with:

```
✗ version drift across umbrella packages: 3.32.7 / 3.32.2.
    Bump all three to the same version per CLAUDE.md "Publishing Rules" before shipping:
      v3/@claude-flow/cli/package.json   ← 3.32.7
      package.json (claude-flow)         ← 3.32.2
      ruflo/package.json                 ← 3.32.7
```

Observed on v3-ci.yml run [29662162819](https://github.com/ruvnet/ruflo/actions/runs/29662162819) (59f5c7f, failed 2026-07-18T21:46:55Z).

## Fix

Bump root `package.json` + `package-lock.json` version `3.32.2` → `3.32.7` so all three umbrella packages are at the same version. No code change, no dep change — `ruflo`'s `@claude-flow/cli` dep range `^3.32.7` already covers 3.32.7.

## Diff

2 files, +3/-3:
- `package.json`: `"version": "3.32.2"` → `"3.32.7"`
- `package-lock.json`: `"version": "3.32.2"` → `"3.32.7"` (2 occurrences: top-level + root packages entry)

## Verification

Inline replication of `audit-umbrella-version-lockstep.mjs` logic (worktree at fdf2060):
```
=== umbrella-version-lockstep audit (inline) ===
  @claude-flow/cli     3.32.7
  claude-flow          3.32.7
  ruflo                3.32.7
  ok: all three at identical version 3.32.7
  ruflo dep "@claude-flow/cli": "^3.32.7" covers 3.32.7 ✓

ok: all three umbrella packages at identical version, ruflo dep covers cli
```

Both audit conditions pass: (1) all three versions identical, (2) ruflo's `^3.32.7` range includes cli's 3.32.7. CI will run the actual `node scripts/audit-umbrella-version-lockstep.mjs` gate.

## Notes

- `v3/@claude-flow/cli/.claude/helpers/.helpers-version` also contains `3.32.2` but is a **separate concern** (cryptographic helpers signing version, not the umbrella package version) — not touched.
- `verification/*/manifest.md.json` reference `fix/stable-issues-v3.32.2` as a historical branch name — not actionable.
- `pnpm-lock.yaml` does not embed the root package version — no change needed.

Closes: v3-ci.yml `umbrella-version-lockstep-audit` red on main
Ref: ruvnet/ruflo#2151