### PR TITLE
fix(hooks): statusline reads model name from stdin JSON instead of hardcoding 'Opus 4.6 (1M context)' (#2733)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/issue-2733-statusline-model-stdin.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2733-statusline-model-stdin.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for issue #2733: `hooks statusline` hardcoded modelName to
+ * 'Opus 4.6 (1M context)' regardless of stdin/actual model. After the fix,
+ * readStatuslineModelFromStdin() reads `model.display_name` from the JSON
+ * payload Claude Code pipes via stdin, falling back to 'Claude Code'.
+ *
+ * @see https://github.com/ruvnet/ruflo/issues/2733
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockReadSync, mockIsTTY } = vi.hoisted(() => ({
+  mockReadSync: vi.fn(),
+  mockIsTTY: { value: false },
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readSync: mockReadSync };
+});
+
+Object.defineProperty(process.stdin, 'isTTY', {
+  get: () => mockIsTTY.value,
+  configurable: true,
+});
+
+const { readStatuslineModelFromStdin, _resetStdinModelCache } =
+  await import('../src/commands/hooks.js');
+
+/** Helper: make readSync return the given string payload then EOF on next call. */
+function feedStdin(payload: string): void {
+  const payloadBuf = Buffer.from(payload);
+  mockReadSync.mockImplementationOnce((_fd: number, buf: Buffer) => {
+    payloadBuf.copy(buf, 0, 0, payloadBuf.length);
+    return payloadBuf.length;
+  });
+  mockReadSync.mockImplementationOnce(() => 0); // EOF
+}
+
+describe('readStatuslineModelFromStdin — issue #2733', () => {
+  beforeEach(() => {
+    _resetStdinModelCache();
+    mockReadSync.mockReset();
+    mockIsTTY.value = false;
+  });
+
+  it('returns the model display_name from stdin JSON payload', () => {
+    feedStdin(JSON.stringify({ model: { display_name: 'Sonnet 4.5' } }));
+    expect(readStatuslineModelFromStdin()).toBe('Sonnet 4.5');
+  });
+
+  it('returns null when stdin is a TTY (manual terminal, no piped data)', () => {
+    mockIsTTY.value = true;
+    expect(readStatuslineModelFromStdin()).toBeNull();
+  });
+
+  it('returns null when stdin has no model.display_name field', () => {
+    feedStdin(JSON.stringify({ other_field: 'value' }));
+    expect(readStatuslineModelFromStdin()).toBeNull();
+  });
+
+  it('returns null when stdin is not valid JSON', () => {
+    feedStdin('not json at all');
+    expect(readStatuslineModelFromStdin()).toBeNull();
+  });
+
+  it('returns null when stdin is empty (EOF immediately)', () => {
+    mockReadSync.mockImplementationOnce(() => 0);
+    expect(readStatuslineModelFromStdin()).toBeNull();
+  });
+
+  it('caches the result — second call does not read stdin again', () => {
+    feedStdin(JSON.stringify({ model: { display_name: 'Haiku 3.5' } }));
+    expect(readStatuslineModelFromStdin()).toBe('Haiku 3.5');
+    // Second call should return cached value without new readSync calls
+    const callCountAfterFirst = mockReadSync.mock.calls.length;
+    expect(readStatuslineModelFromStdin()).toBe('Haiku 3.5');
+    expect(mockReadSync.mock.calls.length).toBe(callCountAfterFirst);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -8,7 +8,7 @@ import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { storeCommand } from './transfer-store.js';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   getSecurityStatus as sharedGetSecurityStatus,
@@ -25,6 +25,38 @@ import {
 function safeNum(value: unknown, fallback = 0): number {
   const n = typeof value === 'number' ? value : Number(value);
   return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * #2733: Read the active model's display name from the JSON payload Claude
+ * Code pipes to statusline commands via stdin. Returns null when stdin is a
+ * TTY (manual terminal use) or the payload has no model.display_name. Matches
+ * the pattern in init/statusline-generator.ts getModelFromStdin(). Exported
+ * for unit testing.
+ */
+let _stdinModelCache: string | null | undefined;
+export function readStatuslineModelFromStdin(): string | null {
+  if (_stdinModelCache !== undefined) return _stdinModelCache;
+  try {
+    if (process.stdin.isTTY) { _stdinModelCache = null; return null; }
+    const chunks: Buffer[] = [];
+    const buf = Buffer.alloc(4096);
+    let bytesRead: number;
+    while ((bytesRead = readSync(0, buf, 0, buf.length, null)) > 0) {
+      chunks.push(buf.subarray(0, bytesRead));
+    }
+    const raw = Buffer.concat(chunks).toString('utf-8').trim();
+    const data = raw && raw.startsWith('{') ? JSON.parse(raw) : null;
+    _stdinModelCache = (data && data.model && data.model.display_name) || null;
+  } catch {
+    _stdinModelCache = null;
+  }
+  return _stdinModelCache;
+}
+
+/** Reset the stdin model cache (test-only — never call in production). */
+export function _resetStdinModelCache(): void {
+  _stdinModelCache = undefined;
 }
 
 // ============================================================================
@@ -4210,7 +4242,7 @@ const statuslineCommand: Command = {
       const identityMode = (process.env.RUFLO_STATUSLINE_IDENTITY || 'project').toLowerCase();
       let name = path.basename(process.cwd()) || 'project';
       let gitBranch = '';
-      const modelName = 'Opus 4.6 (1M context)';
+      const modelName = readStatuslineModelFromStdin() || 'Claude Code';
       const isWindows = process.platform === 'win32';
 
       try {


### PR DESCRIPTION
## Summary

Fixes #2733 — `hooks statusline` hardcoded `modelName` to `'Opus 4.6 (1M context)'` regardless of stdin/actual model.

The `getUserInfo()` function in the `hooks statusline` command (`v3/@claude-flow/cli/src/commands/hooks.ts`) set `const modelName = 'Opus 4.6 (1M context)';` unconditionally, ignoring the JSON payload Claude Code pipes via stdin to statusline commands. This meant every statusline rendered "Opus 4.6 (1M context)" regardless of the actual active model (Sonnet, Haiku, etc.).

## Fix

Added `readStatuslineModelFromStdin()` — a module-level exported function that reads the `model.display_name` field from the JSON payload Claude Code sends on stdin (matching the existing pattern in `init/statusline-generator.ts:getModelFromStdin()`). Falls back to `'Claude Code'` when stdin is a TTY (manual terminal use) or has no model field.

**Before:**
```ts
const modelName = 'Opus 4.6 (1M context)';
```

**After:**
```ts
const modelName = readStatuslineModelFromStdin() || 'Claude Code';
```

## Changes

| File | Change |
|------|--------|
| `v3/@claude-flow/cli/src/commands/hooks.ts` | +34/-2: added `readSync` import, `readStatuslineModelFromStdin()` function (exported, cached), replaced hardcoded string |
| `v3/@claude-flow/cli/__tests__/issue-2733-statusline-model-stdin.test.ts` | +79: new regression test (6 cases: stdin model name, TTY fallback, no model field, invalid JSON, empty stdin, caching) |

## Verification

Independent worktree at `03b6232`, CI-faithful sequence:

| Gate | Command | Result |
|------|---------|--------|
| 1 | `pnpm install --frozen-lockfile` | ✅ exit 0 |
| 2 | vitest TypeScript transform | ✅ imports resolve |
| 3 | `vitest run issue-2733-statusline-model-stdin.test.ts` | ✅ 6/6 pass |
| 4 | `vitest run issue-2682-statusline-identity.test.ts issue-2694-cve-counter.test.ts statusline-cost-display.test.ts` | ✅ 23/23 pass (zero regressions) |

Diff: 2 files, +113/-2.

Fixes #2733