### PR TITLE
fix(statusline): getPkgVersion() resolves main repo node_modules when CWD is a git worktree (#2742)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -647,6 +647,33 @@ function getPkgVersion() {
       path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
       path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
     ];
+    // #2742: git worktrees have no node_modules — the CWD-based probes above
+    // all miss and the version falls back to the baked-in default. A worktree's
+    // .git is a FILE pointing at the main repo's .git/worktrees/<name>; parse
+    // it with pure fs (no spawn — the statusline render path avoids spawns)
+    // and add the main repo's node_modules candidates to the probe list.
+    try {
+      let dir = CWD;
+      while (dir !== path.dirname(dir)) {
+        const dotGit = path.join(dir, '.git');
+        if (fs.existsSync(dotGit)) {
+          if (fs.statSync(dotGit).isFile()) {
+            const m = fs.readFileSync(dotGit, 'utf-8').match(/^gitdir:\s*(.+)$/m);
+            const wtGitDir = m && m[1].trim();
+            const idx = wtGitDir ? wtGitDir.lastIndexOf(path.sep + '.git' + path.sep + 'worktrees' + path.sep) : -1;
+            if (idx > 0) {
+              const mainRoot = wtGitDir.slice(0, idx);
+              pkgPaths.push(
+                path.join(mainRoot, 'node_modules', 'ruflo', 'package.json'),
+                path.join(mainRoot, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+              );
+            }
+          }
+          break;
+        }
+        dir = path.dirname(dir);
+      }
+    } catch { /* ignore */ }
     // #2221: global installs (npm i -g ruflo) live outside CWD/node_modules, so the
     // probes above all miss and the version falls back to the hard-coded default.
     // Derive the global node_modules dir from the running node binary (no npm spawn —

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -647,6 +647,33 @@ function getPkgVersion() {
       path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
       path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
     ];
+    // #2742: git worktrees have no node_modules — the CWD-based probes above
+    // all miss and the version falls back to the baked-in default. A worktree's
+    // .git is a FILE pointing at the main repo's .git/worktrees/<name>; parse
+    // it with pure fs (no spawn — the statusline render path avoids spawns)
+    // and add the main repo's node_modules candidates to the probe list.
+    try {
+      let dir = CWD;
+      while (dir !== path.dirname(dir)) {
+        const dotGit = path.join(dir, '.git');
+        if (fs.existsSync(dotGit)) {
+          if (fs.statSync(dotGit).isFile()) {
+            const m = fs.readFileSync(dotGit, 'utf-8').match(/^gitdir:\s*(.+)$/m);
+            const wtGitDir = m && m[1].trim();
+            const idx = wtGitDir ? wtGitDir.lastIndexOf(path.sep + '.git' + path.sep + 'worktrees' + path.sep) : -1;
+            if (idx > 0) {
+              const mainRoot = wtGitDir.slice(0, idx);
+              pkgPaths.push(
+                path.join(mainRoot, 'node_modules', 'ruflo', 'package.json'),
+                path.join(mainRoot, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+              );
+            }
+          }
+          break;
+        }
+        dir = path.dirname(dir);
+      }
+    } catch { /* ignore */ }
     // #2221: global installs (npm i -g ruflo) live outside CWD/node_modules, so the
     // probes above all miss and the version falls back to the hard-coded default.
     // Derive the global node_modules dir from the running node binary (no npm spawn —

--- a/v3/@claude-flow/cli/__tests__/issue-2742-worktree-pkg-version.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2742-worktree-pkg-version.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression coverage for issue #2742: getPkgVersion() misses the project
+ * install when CWD is a git worktree and falls back to the baked-in version.
+ *
+ * The fix adds a worktree probe between the CWD-based candidate paths and
+ * the global-install probe: when CWD/.git is a FILE (git worktree marker)
+ * containing `gitdir: /path/to/main/.git/worktrees/<name>`, the main repo's
+ * node_modules paths are appended to the candidate list.
+ *
+ * Pattern mirrors bug-cluster-2219-2226.test.ts (#2221's global probe) and
+ * issue-2682-statusline-identity.test.ts (functional script execution).
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { generateStatuslineScript } from '../src/init/statusline-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+const SCRIPT = generateStatuslineScript(DEFAULT_INIT_OPTIONS);
+
+describe('#2742 — getPkgVersion() resolves main repo node_modules when CWD is a git worktree', () => {
+  it('contains the worktree probe code (.git file + worktrees path parse)', () => {
+    expect(SCRIPT).toContain('.git');
+    expect(SCRIPT).toContain('worktrees');
+    expect(SCRIPT).toContain('gitdir:');
+  });
+
+  it('still keeps the existing CWD-based candidate probes (no regression)', () => {
+    expect(SCRIPT).toContain("'marketplaces', 'ruflo', 'package.json'");
+    expect(SCRIPT).toContain("'node_modules', 'ruflo', 'package.json'");
+    expect(SCRIPT).toContain("'node_modules', '@claude-flow', 'cli', 'package.json'");
+  });
+
+  it('still keeps the global npm install probes from #2221 (no regression)', () => {
+    expect(SCRIPT).toContain('process.execPath');
+    expect(SCRIPT).toContain("'lib', 'node_modules'");
+  });
+
+  it('finds the version from the main repo when CWD is a worktree (functional)', () => {
+    // Layout:
+    //   <tmp>/fake-main/node_modules/ruflo/package.json   (version 9.9.9)
+    //   <tmp>/wt/.git  →  file: "gitdir: <tmp>/fake-main/.git/worktrees/test-wt"
+    //   run the script with cwd=<tmp>/wt
+    const root = mkdtempSync(path.join(tmpdir(), 'ruflo-wt2742-'));
+    const mainRoot = path.join(root, 'fake-main');
+    const mainGitDir = path.join(mainRoot, '.git', 'worktrees', 'test-wt');
+    const mainModules = path.join(mainRoot, 'node_modules', 'ruflo');
+    const wtDir = path.join(root, 'wt');
+    const scriptPath = path.join(root, 'statusline.cjs');
+    try {
+      mkdirSync(mainModules, { recursive: true });
+      writeFileSync(
+        path.join(mainModules, 'package.json'),
+        JSON.stringify({ name: 'ruflo', version: '9.9.9' }),
+      );
+      mkdirSync(mainGitDir, { recursive: true });
+      mkdirSync(wtDir, { recursive: true });
+      // .git as a FILE pointing at the worktree gitdir under the main repo.
+      writeFileSync(path.join(wtDir, '.git'), `gitdir: ${mainGitDir}\n`);
+      writeFileSync(scriptPath, SCRIPT, 'utf8');
+
+      const output = execFileSync(process.execPath, [scriptPath], {
+        cwd: wtDir,
+        input: JSON.stringify({ model: { display_name: 'Test' } }),
+        encoding: 'utf8',
+        env: { PATH: '/nonexistent', HOME: root },
+        timeout: 15_000,
+      });
+      // The statusline header carries the resolved version. Look for 9.9.9
+      // anywhere in the output — it only appears if the worktree probe found
+      // the main repo's node_modules/ruflo/package.json.
+      expect(output).toContain('9.9.9');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT add worktree paths when .git is a directory (normal repo)', () => {
+    // In a normal repo, .git is a directory — the worktree probe must bail
+    // (the `isFile()` guard) and add nothing. We verify by asserting the
+    // baked-in default version still appears (no fake main-repo path leaked
+    // into the candidate list). We place a decoy package.json in a location
+    // that ONLY the worktree probe would find if the isFile() guard failed.
+    const root = mkdtempSync(path.join(tmpdir(), 'ruflo-normal2742-'));
+    const cwd = path.join(root, 'normal-repo');
+    const scriptPath = path.join(root, 'statusline.cjs');
+    try {
+      // A normal repo: .git is a directory. Put a decoy "main repo" with a
+      // sentinel version that would leak if the probe mis-parsed a directory.
+      const decoyMain = path.join(root, 'decoy-main');
+      const decoyModules = path.join(decoyMain, 'node_modules', 'ruflo');
+      mkdirSync(decoyModules, { recursive: true });
+      writeFileSync(
+        path.join(decoyModules, 'package.json'),
+        JSON.stringify({ name: 'ruflo', version: '0.0.0-SENTINEL' }),
+      );
+      // Construct a .git DIRECTORY (not a worktree). We also craft a
+      // .git/worktrees/foo path so that if the probe erroneously read .git
+      // as if it were a file, the lastIndexOf('/.git/worktrees/') match
+      // would still succeed and resolve decoyMain. The isFile() guard is
+      // the only thing preventing this.
+      const gitDir = path.join(cwd, '.git');
+      mkdirSync(gitDir, { recursive: true });
+      mkdirSync(path.join(gitDir, 'worktrees', 'foo'), { recursive: true });
+      mkdirSync(cwd, { recursive: true });
+      writeFileSync(scriptPath, SCRIPT, 'utf8');
+
+      const output = execFileSync(process.execPath, [scriptPath], {
+        cwd,
+        input: JSON.stringify({ model: { display_name: 'Test' } }),
+        encoding: 'utf8',
+        env: { PATH: '/nonexistent', HOME: root },
+        timeout: 15_000,
+      });
+      // The sentinel decoy version must NOT appear — the worktree probe
+      // must have bailed on .git being a directory.
+      expect(output).not.toContain('0.0.0-SENTINEL');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2742

When Claude Code runs inside a **git worktree** (common multi-agent pattern), the worktree has no `node_modules` of its own. `getPkgVersion()` in the generated statusline (`statusline.cjs`) probed `CWD/node_modules/...` — which all missed — causing the statusline to show a stale baked-in version instead of the actually-installed one.

## Fix

Added a worktree probe to `getPkgVersion()` that resolves the main repo `node_modules` when CWD is a linked worktree. In a worktree, `.git` is a plain **file** containing `gitdir: /path/to/main/.git/worktrees/<name>`. The probe:

1. Walks up from CWD to find the nearest `.git` entry
2. If `.git` is a **file** (worktree indicator), reads the `gitdir:` line
3. Extracts the main repo root via `lastIndexOf('/.git/worktrees/')`
4. Adds the main repo `node_modules/ruflo/package.json` and `node_modules/@claude-flow/cli/package.json` to the candidate paths

Pure `fs` operations — no process spawn (matches the template design constraint for the render path). Slots into the existing candidate list before the #2221 global-install probes, so the highest-version-wins selection applies unchanged.

## Changes

| File | Change |
|------|-------|
| `.claude/helpers/statusline.cjs` | +27 lines (worktree probe in `getPkgVersion()`) |
| `v3/@claude-flow/cli/.claude/helpers/statusline.cjs` | +27 lines (identical, drift-guard enforced) |
| `v3/@claude-flow/cli/__tests__/issue-2742-worktree-pkg-version.test.ts` | +125 lines (5 test cases) |

**Total:** 3 files, +179 lines, 0 deletions (additive only).

## Verification

Independent detached-HEAD worktree verification — all gates PASS:
- **Gate 1** (Diff review): Worktree probe correctly placed between CWD probes and #2221 global probes. Pure fs, additive, both copies identical.
- **Gate 2** (Syntax check): `node --check` exit 0 on both `.cjs` copies.
- **Gate 3** (Drift guard): `diff` of both copies = zero differences.
- **Gate 4** (Regression test): 5/5 new tests PASS.
- **Gate 5** (Existing tests): `statusline-cost-display` (13/13), `issue-2682-identity` (2/2), `issue-2694-cve-counter` (8/8) all PASS — zero regressions.
- **Gate 6** (Functional sanity): Logic traced — worktree `.git` file -> main repo root -> correct paths. Normal repo `.git` directory -> correctly skipped.

## Context

Same function/lineage as #2195 and #2221 — this closes the remaining resolution gap for worktree environments. Reporter (Markus-Buchholz) provided the code snippet; this PR adapts it to the existing code style.

Generated by ruflo-loop (z-ai/glm-5.2, cheap tier).
