### PR TITLE
fix(statusline): real model name from stdin + worktree version resolution

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -633,12 +633,55 @@ function compareVersions(a, b) {
   return 0;
 }
 
+// #2742: when CWD is a linked git worktree, it has no node_modules of its
+// own (worktrees don't get their own `npm install`), so every CWD-relative
+// probe in getPkgVersion() misses and the version silently falls back to
+// the baked-in default — even though the main repo's install a few
+// directories away is perfectly resolvable. A linked worktree's `.git` is
+// a plain FILE (not a directory) containing `gitdir: <main>/.git/worktrees/
+// <name>`; walk up from CWD to find it, parse the pointer, and strip the
+// trailing `.git/worktrees/<name>` segment to recover the main repo root.
+// Pure fs — no `git rev-parse` spawn (statusline renders are latency-
+// sensitive; this doc comment's neighbors are explicit about avoiding
+// spawns in the render path).
+function resolveWorktreeMainRoot() {
+  try {
+    let dir = CWD;
+    for (;;) {
+      const dotGit = path.join(dir, '.git');
+      if (fs.existsSync(dotGit)) {
+        if (fs.statSync(dotGit).isFile()) {
+          const contents = fs.readFileSync(dotGit, 'utf-8');
+          const m = contents.match(/^gitdir:\s*(.+)$/m);
+          const wtGitDir = m && m[1].trim();
+          if (wtGitDir) {
+            // Git writes this pointer with forward slashes even on Windows
+            // (a git-for-windows convention for its own internal files) —
+            // path.sep (backslash on win32) never matches, so normalize
+            // before searching rather than building an OS-specific marker.
+            const normalized = wtGitDir.replace(/\\/g, '/');
+            const marker = '/.git/worktrees/';
+            const idx = normalized.lastIndexOf(marker);
+            if (idx > 0) return normalized.slice(0, idx);
+          }
+        }
+        return null; // a real (non-worktree) .git dir — nothing to resolve
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) return null; // reached filesystem root
+      dir = parent;
+    }
+  } catch {
+    return null;
+  }
+}
+
 function getPkgVersion() {
   // Baked in at generation time from the real running CLI's own resolved
   // version (see generateStatuslineScript()'s doc comment) — correct even
   // when this renders via a pure npx invocation with no local install for
   // the candidate scan below to find.
-  let ver = "3.28.0";
+  let ver = "3.32.8";
   try {
     const home = os.homedir();
     const pkgPaths = [
@@ -647,6 +690,17 @@ function getPkgVersion() {
       path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
       path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
     ];
+    // #2742: CWD is a linked git worktree with no node_modules of its own —
+    // probe the main repo's install too, so a worktree session shows the
+    // same version a main-repo session would.
+    const worktreeMainRoot = resolveWorktreeMainRoot();
+    if (worktreeMainRoot) {
+      pkgPaths.push(
+        path.join(worktreeMainRoot, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+        path.join(worktreeMainRoot, 'node_modules', 'ruflo', 'package.json'),
+        path.join(worktreeMainRoot, 'v3', '@claude-flow', 'cli', 'package.json'),
+      );
+    }
     // #2221: global installs (npm i -g ruflo) live outside CWD/node_modules, so the
     // probes above all miss and the version falls back to the hard-coded default.
     // Derive the global node_modules dir from the running node binary (no npm spawn —

--- a/scripts/regen-statusline-artifact.mjs
+++ b/scripts/regen-statusline-artifact.mjs
@@ -7,13 +7,16 @@
  * that these stay in lockstep.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 const generatorPath = resolve(repoRoot, 'v3/@claude-flow/cli/dist/src/init/statusline-generator.js');
-const { generateStatuslineScript } = await import(generatorPath);
+// A raw absolute path (e.g. Windows `C:\...`) isn't a valid ESM specifier —
+// dynamic import() requires a real URL scheme. pathToFileURL() is the
+// documented cross-platform fix (works unchanged on POSIX too).
+const { generateStatuslineScript } = await import(pathToFileURL(generatorPath).href);
 
 const script = generateStatuslineScript({
   statusline: { enabled: true, style: 'compact' },

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -633,12 +633,55 @@ function compareVersions(a, b) {
   return 0;
 }
 
+// #2742: when CWD is a linked git worktree, it has no node_modules of its
+// own (worktrees don't get their own `npm install`), so every CWD-relative
+// probe in getPkgVersion() misses and the version silently falls back to
+// the baked-in default — even though the main repo's install a few
+// directories away is perfectly resolvable. A linked worktree's `.git` is
+// a plain FILE (not a directory) containing `gitdir: <main>/.git/worktrees/
+// <name>`; walk up from CWD to find it, parse the pointer, and strip the
+// trailing `.git/worktrees/<name>` segment to recover the main repo root.
+// Pure fs — no `git rev-parse` spawn (statusline renders are latency-
+// sensitive; this doc comment's neighbors are explicit about avoiding
+// spawns in the render path).
+function resolveWorktreeMainRoot() {
+  try {
+    let dir = CWD;
+    for (;;) {
+      const dotGit = path.join(dir, '.git');
+      if (fs.existsSync(dotGit)) {
+        if (fs.statSync(dotGit).isFile()) {
+          const contents = fs.readFileSync(dotGit, 'utf-8');
+          const m = contents.match(/^gitdir:\s*(.+)$/m);
+          const wtGitDir = m && m[1].trim();
+          if (wtGitDir) {
+            // Git writes this pointer with forward slashes even on Windows
+            // (a git-for-windows convention for its own internal files) —
+            // path.sep (backslash on win32) never matches, so normalize
+            // before searching rather than building an OS-specific marker.
+            const normalized = wtGitDir.replace(/\\/g, '/');
+            const marker = '/.git/worktrees/';
+            const idx = normalized.lastIndexOf(marker);
+            if (idx > 0) return normalized.slice(0, idx);
+          }
+        }
+        return null; // a real (non-worktree) .git dir — nothing to resolve
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) return null; // reached filesystem root
+      dir = parent;
+    }
+  } catch {
+    return null;
+  }
+}
+
 function getPkgVersion() {
   // Baked in at generation time from the real running CLI's own resolved
   // version (see generateStatuslineScript()'s doc comment) — correct even
   // when this renders via a pure npx invocation with no local install for
   // the candidate scan below to find.
-  let ver = "3.28.0";
+  let ver = "3.32.8";
   try {
     const home = os.homedir();
     const pkgPaths = [
@@ -647,6 +690,17 @@ function getPkgVersion() {
       path.join(CWD, 'node_modules', 'ruflo', 'package.json'),
       path.join(CWD, 'v3', '@claude-flow', 'cli', 'package.json'),
     ];
+    // #2742: CWD is a linked git worktree with no node_modules of its own —
+    // probe the main repo's install too, so a worktree session shows the
+    // same version a main-repo session would.
+    const worktreeMainRoot = resolveWorktreeMainRoot();
+    if (worktreeMainRoot) {
+      pkgPaths.push(
+        path.join(worktreeMainRoot, 'node_modules', '@claude-flow', 'cli', 'package.json'),
+        path.join(worktreeMainRoot, 'node_modules', 'ruflo', 'package.json'),
+        path.join(worktreeMainRoot, 'v3', '@claude-flow', 'cli', 'package.json'),
+      );
+    }
     // #2221: global installs (npm i -g ruflo) live outside CWD/node_modules, so the
     // probes above all miss and the version falls back to the hard-coded default.
     // Derive the global node_modules dir from the running node binary (no npm spawn —

--- a/v3/@claude-flow/cli/__tests__/issue-2733-statusline-model-name.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2733-statusline-model-name.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression coverage for issue #2733: `hooks statusline`'s model-name
+ * resolution was fully hardcoded (`const modelName = 'Opus 4.6 (1M context)'`)
+ * and ignored the actual active model Claude Code passes on stdin entirely.
+ *
+ * The CLI is spawned as a real subprocess (not imported) because the
+ * hardcoded value lived inside a large nested function in the command's
+ * `action`, not a unit-testable export — the same reasoning documented in
+ * memory-search-recall-2558.test.ts for using a real process here. Skipped
+ * when the CLI hasn't been built (`bin/cli.js` absent) — standard flow is
+ * `npm run build && npm test`.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(HERE, '..', 'bin', 'cli.js');
+const CLI_BUILT = fs.existsSync(CLI);
+
+function runStatusline(stdin: string): { user: { modelName: string } } {
+  const raw = execFileSync('node', [CLI, 'hooks', 'statusline', '--json'], {
+    input: stdin,
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+  // The CLI may print unrelated warnings (e.g. helper-integrity notices) to
+  // stdout ahead of the JSON payload in some environments; the JSON object
+  // itself is always the last well-formed `{...}` block in the output.
+  const start = raw.indexOf('{');
+  const parsed = JSON.parse(raw.slice(start));
+  return parsed;
+}
+
+describe.skipIf(!CLI_BUILT)('hooks statusline model name — issue #2733', () => {
+  it('reports the real active model from Claude Code stdin JSON', () => {
+    const result = runStatusline(JSON.stringify({ model: { display_name: 'Sonnet 4.6 (1M context)' } }));
+    expect(result.user.modelName).toBe('Sonnet 4.6 (1M context)');
+    expect(result.user.modelName).not.toBe('Opus 4.6 (1M context)');
+  });
+
+  it('never renders the old hardcoded model string regardless of stdin', () => {
+    const result = runStatusline(JSON.stringify({ model: { display_name: 'Haiku 4.5' } }));
+    expect(result.user.modelName).toBe('Haiku 4.5');
+  });
+
+  it('falls back to a generic label (not a fixed fake model name) when stdin has no model field', () => {
+    const result = runStatusline(JSON.stringify({}));
+    expect(result.user.modelName).not.toBe('Opus 4.6 (1M context)');
+    expect(result.user.modelName).toBe('Claude Code');
+  });
+
+  it('falls back gracefully on malformed stdin', () => {
+    const result = runStatusline('not json');
+    expect(result.user.modelName).not.toBe('Opus 4.6 (1M context)');
+    expect(result.user.modelName).toBe('Claude Code');
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/issue-2742-statusline-worktree-version.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2742-statusline-worktree-version.test.ts
@@ -1,0 +1,89 @@
+/** Regression coverage for issue #2742: getPkgVersion() in the generated
+ * statusline.cjs missed the project install when CWD is a linked git
+ * worktree (no node_modules of its own), silently falling back to the
+ * baked-in default version instead of resolving the main repo's install a
+ * few directories away.
+ *
+ * Follows the same generate-script-then-execute-as-a-real-subprocess
+ * pattern as issue-2682-statusline-identity.test.ts. */
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { generateStatuslineScript } from '../src/init/statusline-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+const SCRIPT = generateStatuslineScript(DEFAULT_INIT_OPTIONS);
+const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('statusline worktree version resolution — issue #2742', () => {
+  it('resolves the main repo package.json version from a linked-worktree CWD with no local node_modules', () => {
+    const parent = mkdtempSync(path.join(tmpdir(), 'ruflo-worktree-'));
+    const mainRoot = path.join(parent, 'main-repo');
+    const worktreeRoot = path.join(parent, 'main-repo-worktree');
+    const script = path.join(parent, 'statusline.cjs');
+
+    // Simulate a real repo with an installed @claude-flow/cli at a known
+    // version, plus a linked worktree that has no node_modules of its own —
+    // exactly the topology `git worktree add` produces.
+    mkdirSync(path.join(mainRoot, 'v3', '@claude-flow', 'cli'), { recursive: true });
+    writeFileSync(
+      path.join(mainRoot, 'v3', '@claude-flow', 'cli', 'package.json'),
+      JSON.stringify({ name: '@claude-flow/cli', version: '9.9.9-worktree-test' }),
+    );
+    mkdirSync(path.join(mainRoot, '.git', 'worktrees', 'main-repo-worktree'), { recursive: true });
+    mkdirSync(worktreeRoot, { recursive: true });
+    // A linked worktree's `.git` is a plain FILE pointing at the main
+    // repo's `.git/worktrees/<name>` — git writes this with forward
+    // slashes even on Windows, which is exactly what tripped up a naive
+    // path.sep-based parser during development of this fix.
+    writeFileSync(
+      path.join(worktreeRoot, '.git'),
+      `gitdir: ${mainRoot.replace(/\\/g, '/')}/.git/worktrees/main-repo-worktree\n`,
+    );
+
+    try {
+      writeFileSync(script, SCRIPT, 'utf8');
+      const output = execFileSync(process.execPath, [script], {
+        cwd: worktreeRoot,
+        input: JSON.stringify({ model: { display_name: 'Codex' } }),
+        encoding: 'utf8',
+        // Deny every OTHER version-resolution candidate (global installs,
+        // marketplace checkout, npm prefix) by pointing HOME somewhere with
+        // none of those, and PATH nowhere — isolates the assertion to the
+        // worktree-crawl candidate specifically, not just "some candidate
+        // happened to resolve".
+        env: { PATH: '/nonexistent', HOME: parent },
+        timeout: 15_000,
+      });
+      expect(stripAnsi(output)).toContain('9.9.9-worktree-test');
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('does not misidentify a real (non-worktree) .git directory as a worktree', () => {
+    const parent = mkdtempSync(path.join(tmpdir(), 'ruflo-nonworktree-'));
+    const cwd = path.join(parent, 'plain-repo');
+    const script = path.join(parent, 'statusline.cjs');
+    mkdirSync(path.join(cwd, '.git'), { recursive: true }); // a real repo: .git is a DIRECTORY
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(script, SCRIPT, 'utf8');
+    try {
+      // Should render without throwing — a real .git dir must short-circuit
+      // resolveWorktreeMainRoot() cleanly (return null), not be misread as
+      // worktree-pointer content.
+      const output = execFileSync(process.execPath, [script], {
+        cwd,
+        input: JSON.stringify({ model: { display_name: 'Codex' } }),
+        encoding: 'utf8',
+        env: { PATH: '/nonexistent', HOME: parent },
+        timeout: 15_000,
+      });
+      expect(output.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -4205,12 +4205,49 @@ const statuslineCommand: Command = {
       return { memoryMB, contextPct, intelligencePct, subAgents };
     }
 
+    // #2733: Claude Code pipes session JSON (incl. the real active model) on
+    // stdin to statusline commands. Read it synchronously the same way
+    // .claude/helpers/statusline.cjs's getModelFromStdin() does, so this CLI
+    // subcommand is correct standalone — not just when the generated helper
+    // happens to override its output. Read once, memoized per invocation
+    // (mirrors statusline.cjs's _stdinData cache).
+    let _stdinData: unknown;
+    let _stdinRead = false;
+    function getStdinData(): { model?: { display_name?: string } } | null {
+      if (_stdinRead) return _stdinData as { model?: { display_name?: string } } | null;
+      _stdinRead = true;
+      try {
+        if (process.stdin.isTTY) { _stdinData = null; return null; }
+        const chunks: Buffer[] = [];
+        const buf = Buffer.alloc(4096);
+        let bytesRead: number;
+        try {
+          while ((bytesRead = fs.readSync(0, buf, 0, buf.length, null)) > 0) {
+            chunks.push(Buffer.from(buf.subarray(0, bytesRead)));
+          }
+        } catch { /* EOF or read error */ }
+        const raw = Buffer.concat(chunks).toString('utf-8').trim();
+        _stdinData = (raw && raw.startsWith('{')) ? JSON.parse(raw) : null;
+      } catch {
+        _stdinData = null;
+      }
+      return _stdinData as { model?: { display_name?: string } } | null;
+    }
+    function getModelFromStdin(): string | null {
+      const data = getStdinData();
+      return (data && data.model && typeof data.model.display_name === 'string') ? data.model.display_name : null;
+    }
+
     // Get user info
     function getUserInfo() {
       const identityMode = (process.env.RUFLO_STATUSLINE_IDENTITY || 'project').toLowerCase();
       let name = path.basename(process.cwd()) || 'project';
       let gitBranch = '';
-      const modelName = 'Opus 4.6 (1M context)';
+      // Real active model from Claude Code's stdin payload when available;
+      // this string is only a last-resort label for direct/manual CLI
+      // invocation with no stdin (e.g. a bare terminal run) — never shown
+      // when Claude Code itself is the caller.
+      const modelName = getModelFromStdin() || 'Claude Code';
       const isWindows = process.platform === 'win32';
 
       try {

--- a/v3/@claude-flow/cli/src/funnel/message-transport.ts
+++ b/v3/@claude-flow/cli/src/funnel/message-transport.ts
@@ -5,16 +5,23 @@
  *
  * Design discipline:
  *   1. **Never blocks the render.** The statusline reads only the local
- *      cache. This module refreshes the cache in the background; a fresh
- *      install shows the in-code fallback pool until the first refresh
- *      lands (usually seconds after CLI startup).
+ *      cache. This module refreshes the cache in the background; per
+ *      ADR-311 "zero local promo content" there is NO in-code fallback
+ *      pool — a genuinely fresh install (empty cache) shows nothing on
+ *      the promo/disclosure row until the first background refresh lands
+ *      (see hook-handler.cjs's SessionStart-triggered detached
+ *      `hooks refresh-funnel`, usually within seconds of CLI startup, but
+ *      contingent on network reachability to the messages endpoint). This
+ *      comment previously (incorrectly) described an in-code fallback
+ *      pool; there has never been one since ADR-311 — see disclosure.ts's
+ *      own "fail-closed" doc comment for the authoritative statement.
  *   2. **Content pipeline stays authoritative.** Every message the server
  *      returns is validated by `isValidMessage()` from `messages.ts` —
  *      same schema, same host allowlist, same control-char strip, same
  *      80-column cap. A tampered or accidentally-broken remote feed can
  *      pollute nothing.
  *   3. **Fail silent.** Any network/parse/validation failure leaves the
- *      previously-cached (or in-code) pool intact.
+ *      previously-cached pool intact (empty, if nothing has landed yet).
  *   4. **Bounded cache size.** ≤ 128 KiB and ≤ 200 messages — matches
  *      ADR-309's bounded-local-queue discipline.
  *   5. **Kill switch.** `RUFLO_FUNNEL_MESSAGES=0` (or `RUFLO_FUNNEL=0`)


### PR DESCRIPTION
## Summary

Fixes #2733, #2742.

### #2733 — hooks statusline hardcoded modelName

`hooks.ts`'s `getUserInfo()` hardcoded `const modelName = 'Opus 4.6 (1M context)'`, ignoring the actual active model Claude Code passes on stdin entirely.

This is **cosmetically masked** in the default render path — the generated `.claude/helpers/statusline.cjs` already parses stdin correctly (`getModelFromStdin()`) and overrides the CLI's output — which is why real-world statuslines correctly show the actual model. But it's a real bug for direct/manual `hooks statusline` CLI use, or any stdin-parse failure in the wrapper (the fallback would then silently be a fixed, increasingly-stale fake model name instead of a generic label).

**Fix:** mirror `statusline.cjs`'s own stdin-reading approach inside `hooks.ts`, so the CLI subcommand is correct standalone, not just when the generated helper happens to override it. Falls back to `"Claude Code"` (not a fake model name) when stdin has no model field.

### #2742 — statusline getPkgVersion() misses git worktrees

`getPkgVersion()` only probed CWD-relative paths (`CWD/node_modules/...`, `CWD/v3/@claude-flow/cli/...`). A linked git worktree has no `node_modules` of its own (worktrees don't get their own `npm install`), so every probe missed and the version silently fell back to the baked-in default from whenever the helper was last generated — a very common pattern for multi-agent worktree setups.

**Fix:** a pure-fs worktree-root resolver, per the issue's own proposed approach — a linked worktree's `.git` is a plain FILE containing `gitdir: <main>/.git/worktrees/<name>`; walk up from CWD, parse the pointer, strip the trailing segment to recover the main repo root, and probe its `node_modules`/`v3` paths too. No `git rev-parse` spawn (statusline renders are latency-sensitive).

**Caught and fixed a real bug in this same resolver during testing** (not present in the issue's proposed snippet, discovered via an actual `git worktree add` repro): git writes the `gitdir:` pointer with **forward slashes even on native Windows**, so a `path.sep`-based (backslash) marker search silently never matched. Normalized to forward slashes before searching.

## Also in this PR

- `v3/@claude-flow/cli/.claude/helpers/statusline.cjs` is the source of truth per the #2679 redesign (`generateStatuslineScript()` reads it and substitutes two tokens). Regenerated the propagated root-level copy via `scripts/regen-statusline-artifact.mjs`, which also needed a small cross-platform fix — dynamic `import()` of a raw Windows path isn't a valid ESM specifier, wrapped with `pathToFileURL()`.
- Corrected a stale/misleading comment in `message-transport.ts` claiming a fresh install "shows the in-code fallback pool until the first refresh lands" — there has never been an in-code fallback pool since ADR-311 ("zero local promo content"); a fresh install's promo row is genuinely empty until the first background refresh lands. Found while investigating a "promo doesn't show on new installs" report; the underlying fail-closed design and SessionStart-triggered refresh mechanism were confirmed working as intended (this machine's own `~/.ruflo` state shows a healthy, recently-rotated promo history) — only the comment was wrong, not the behavior.
- **Left alone** (flagged, not fixed): `v3/@claude-flow/mcp/.claude/helpers/statusline.cjs` — a separate, unreferenced ~500-line legacy implementation predating the #2195 delegation rewrite, no source references anywhere in its own package.

## Verification

- 21/21 new + existing statusline tests pass (`issue-2733-statusline-model-name.test.ts`, `issue-2742-statusline-worktree-version.test.ts`, `issue-2682-statusline-identity.test.ts`, `statusline-cost-display.test.ts` drift-guard)
- 122/122 funnel tests pass, 10/10 hooks tests pass
- Clean `tsc --noEmit`
- Manually confirmed both fixes end-to-end: real stdin model name renders correctly; a real `git worktree add` scenario resolves the main repo's version instead of falling back to the baked default

🤖 Generated with [Claude Code](https://claude.ai/code)