### PR TITLE
fix(ruflo-adr): adr-create step 4 uses correct agentdb params (#2651)

### DIFF
--- a/plugins/ruflo-adr/skills/adr-create/SKILL.md
+++ b/plugins/ruflo-adr/skills/adr-create/SKILL.md
@@ -51,10 +51,12 @@ When a significant architectural decision needs to be recorded -- new technology
    ```
 
 4. **Store in AgentDB** -- Call `mcp__plugin_ruflo-core_ruflo__agentdb_hierarchical-store` with:
-   - path: `adr/ADR-NNN`
+   - key: `ADR-NNN`  <!-- no slash; AgentDB key charset is alphanumeric, _, -, ., : -->
    - value: `{ "id": "ADR-NNN", "title": "<title>", "status": "proposed", "date": "<today>", "file": "docs/adr/ADR-NNN-<slug>.md" }`
+   - tier: `semantic`
 
-5. **Find related ADRs** -- Call `mcp__plugin_ruflo-core_ruflo__memory_search` with the title as query in namespace `adr-patterns` to find related decisions. If matches found, add them to the Links section and create causal edges with relation `depends-on`.
+5. **Find related ADRs** -- Call `mcp__plugin_ruflo-core_ruflo__memory_search` with the title as query in namespace `adr-patterns` to find related decisions. If matches found, add them to the Links section and create causal edges with relation `depends-on`:
+   - `mcp__plugin_ruflo-core_ruflo__agentdb_causal-edge` with `sourceId: "ADR-NNN"` (no slash), `targetId: "ADR-MMM"` (no slash), `relation: "depends-on"`
 
 6. **Store pattern** -- Call `mcp__plugin_ruflo-core_ruflo__memory_store` in namespace `adr-patterns` with key `ADR-NNN` and the title + context as value for future semantic search.
 


### PR DESCRIPTION
## Fix #2651

`ruflo-adr`'s `adr-create` skill step 4 was unrunnable — it documented a non-existent `path` param and a key (`adr/ADR-NNN`) with a slash that violates the AgentDB key charset (allowed: alphanumeric, `_`, `-`, `.`, `:`).

### Changes (1 file, +4/-2)

**Step 4** — `plugins/ruflo-adr/skills/adr-create/SKILL.md`:
- `path: adr/ADR-NNN` → `key: ADR-NNN` (correct param name, no slash)
- Added `tier: semantic`

**Step 5**:
- Added explicit causal edge call format: `agentdb_causal-edge` with `sourceId: "ADR-NNN"` (no slash), `targetId: "ADR-MMM"` (no slash), `relation: "depends-on"`

### Verification
Independent detached-HEAD worktree (`/tmp/ruflo-verify-T23` at `ca7100318`):
- Gate 1: Diff review — 1 file, only steps 4+5 touched ✅
- Gate 2: No other files changed (1 file, +4/-2) ✅
- Gate 3: File integrity — valid markdown, all 7 steps intact ✅
- Gate 4: Correctness — `key` (not `path`), no slash, `tier: semantic`, step 5 IDs correct ✅

Loop does NOT merge. Awaiting human review.