### PR TITLE
fix(memory): sanitize Windows drive-letter colon and spaces in resolveAutoMemoryDir

### DIFF
--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -110,6 +110,22 @@ describe('resolveAutoMemoryDir', () => {
     const b = resolveAutoMemoryDir('/workspaces/my-project');
     expect(a).toBe(b);
   });
+
+  it('should sanitize Windows drive-letter colons and spaces to dashes', () => {
+    // On Windows, a raw workingDir like `D:\Pycharm Projects\affiliate_autopilot`
+    // must map to `D--Pycharm-Projects-affiliate-autopilot` (colon, path
+    // separator, whitespace, and underscore all become `-`). A regex that only
+    // matched `/` and `_` left the drive-letter colon and the space in
+    // "Pycharm Projects" untouched, producing an invalid directory segment
+    // (e.g. "D:-Pycharm Projects-affiliate-autopilot") that made the
+    // subsequent mkdir throw ENOENT — silently breaking both curateIndex()
+    // and importFromAutoMemory() on Windows (imports stayed at 0 forever
+    // since memoryDir never existed).
+    const result = resolveAutoMemoryDir('D:\\Pycharm Projects\\affiliate_autopilot');
+    expect(result).toContain('D--Pycharm-Projects-affiliate-autopilot');
+    expect(result).not.toContain('D:-');
+    expect(result).not.toContain(' ');
+  });
 });
 
 describe('findGitRoot', () => {

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -762,11 +762,17 @@ export function resolveAutoMemoryDir(workingDir: string): string {
   const gitRoot = findGitRoot(workingDir);
   const basePath = gitRoot || workingDir;
 
-  // Claude Code normalizes to forward slashes then replaces both `/` and `_`
-  // with dashes (e.g. /workspaces/RX_ERP -> -workspaces-RX-ERP). The leading
-  // dash IS preserved.
+  // Claude Code normalizes to forward slashes then replaces `/`, `:`,
+  // whitespace, and `_` with dashes (e.g. /workspaces/RX_ERP -> -workspaces-RX-ERP;
+  // on Windows, D:\Pycharm Projects\foo -> D--Pycharm-Projects-foo). The leading
+  // dash IS preserved. The previous regex only matched `/` and `_`, leaving the
+  // drive-letter colon and spaces in a Windows path untouched, which produced an
+  // invalid directory segment (e.g. "D:-Pycharm Projects-foo") and made
+  // ensureMemoryDir()'s mkdir fail with ENOENT — silently breaking both
+  // curateIndex() (caught, non-fatal) and importFromAutoMemory() (memoryDir
+  // never existed, so imports silently stayed at 0 forever).
   const normalized = basePath.split(path.sep).join('/');
-  const projectKey = normalized.replace(/[\/_]/g, '-');
+  const projectKey = normalized.replace(/[:\/\s_]/g, '-');
 
   return path.join(
     process.env.HOME || process.env.USERPROFILE || '~',


### PR DESCRIPTION
## Summary
- `resolveAutoMemoryDir()`'s project-key regex only replaced `/` and `_` with `-`, leaving a Windows path's drive-letter colon and any spaces untouched.
- For a working dir like `D:\Pycharm Projects\my-app`, this produced the invalid directory segment `D:-Pycharm Projects-my-app` instead of the correct `D--Pycharm-Projects-my-app`, which made the subsequent `ensureMemoryDir()` `mkdir` throw `ENOENT`.
- This silently broke two things on Windows:
  - `curateIndex()` (called from `AutoMemoryBridge.syncToAutoMemory()`) caught the `ENOENT` non-fatally, so `sync` "succeeded" but never actually curated `MEMORY.md`.
  - `importFromAutoMemory()` checked `existsSync(memoryDir)` before reading, so imports silently returned 0 entries forever — no error surfaced, since the wrong directory simply never existed.
- Fixes both by widening the sanitization regex to also match `:` and whitespace, matching Claude Code's actual project-key convention (confirmed against real `~/.claude/projects/<key>/` directory names on Windows).

## Test plan
- [x] Added a regression test (`should sanitize Windows drive-letter colons and spaces to dashes`) in `auto-memory-bridge.test.ts` covering the exact Windows drive-letter + space case.
- [x] Syntax-checked both changed files with `node --experimental-strip-types --check`.
- [x] Verified against a real Windows project: before the fix, `auto-memory-hook.mjs sync` logged a caught `ENOENT` and `import` always reported "Imported 0 entries" despite real memory topic files existing; after the fix, `sync` completes cleanly and `import` correctly picks up all existing entries.
- [ ] Could not run the full `vitest` suite for this package locally (would require a full monorepo install); the change is a single-line regex widening with no other logic touched, so risk of regression elsewhere is low, but flagging for maintainer awareness.