### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-ruvnet-claude-flow)](https://mcpindex.ai/server/io-github-ruvnet-claude-flow)
+
 <div align="center">
 
 [![Ruflo Banner](ruflo/assets/ruflo-small.jpeg)](https://cognitum.one/agentic-engineering)


### PR DESCRIPTION
Hey, ran claude-flow's registered MCP server through mcpindex's screen (description-level check for injection/manipulation patterns). Came back clean, so added the badge to your README. Advisory only, not a security cert. Close this if it's not useful to you, no worries.