### PR TITLE
fix(browser): make browser-session npx shell-outs Windows-native via node <npx-cli.js> (#2770)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/browser-session-npx-2770.test.ts
+++ b/v3/@claude-flow/cli/__tests__/browser-session-npx-2770.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression test for #2770: on Windows every browser-session tool that
+ * shells out via bare `npx` fails with ENOENT — `execFile('npx', ...)`
+ * cannot launch the `npx.cmd` shim without a shell, and explicit
+ * `npx.cmd` is EINVAL under Node's CVE-2024-27980 hardening. `shell: true`
+ * is not an acceptable fix because `browser_session_record` forwards a
+ * caller-controlled URL (space-joined args under `shell: true` = command
+ * injection on the host).
+ *
+ * Contract pinned here:
+ *   (a) when Node's bundled npx-cli.js is resolvable relative to
+ *       process.execPath, npx invocations run as `node <npx-cli.js> <args>`
+ *       — a real executable on every platform, no shell, args stay
+ *       literal argv;
+ *   (b) when it is not resolvable, the original bare-`npx` spawn is
+ *       preserved (working POSIX default / exotic layouts);
+ *   (c) no shell-out in this module ever passes `shell: true`.
+ *
+ * We cannot spawn real processes in CI, so `node:child_process.execFile`
+ * is mocked (promisify-aware — the module always promisifies it) and the
+ * exported tool handlers are driven directly; assertions are on the binary
+ * handed to execFile. Module state (npx resolution is memoized) is reset
+ * between tests via vi.resetModules() + fresh dynamic import.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface CapturedCall {
+  cmd: string;
+  args: string[];
+  opts: Record<string, unknown>;
+}
+
+const execFileCalls: CapturedCall[] = [];
+
+// Behavior knobs the mocks read at call time (reset in beforeEach).
+let npxCliJsExists = true;
+let rejectCmds: string[] = [];
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { promisify } = await import('node:util');
+  const fake = () => {
+    throw new Error('callback-style execFile not expected — shell() promisifies');
+  };
+  (fake as unknown as Record<symbol, unknown>)[promisify.custom] = async (
+    cmd: string,
+    args: string[],
+    opts: Record<string, unknown>,
+  ) => {
+    execFileCalls.push({ cmd, args, opts });
+    const base = cmd.split(/[\\/]/).pop() ?? cmd;
+    if (rejectCmds.includes(base)) {
+      const err = new Error(`spawn ${cmd} ENOENT`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return { stdout: '{}', stderr: '' };
+  };
+  return { ...actual, execFile: fake as unknown as typeof actual.execFile };
+});
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: (p: unknown) =>
+      String(p).includes('npx-cli.js') ? npxCliJsExists : actual.existsSync(p as import('node:fs').PathLike),
+  };
+});
+
+type BrowserSessionTools = typeof import('../src/mcp-tools/browser-session-tools.js');
+
+async function loadTools(): Promise<BrowserSessionTools['browserSessionTools']> {
+  const mod: BrowserSessionTools = await import('../src/mcp-tools/browser-session-tools.js');
+  return mod.browserSessionTools;
+}
+
+function tool(tools: BrowserSessionTools['browserSessionTools'], name: string) {
+  const t = tools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool not found: ${name}`);
+  return t;
+}
+
+/** Calls that targeted npx in any form (bare or via node <npx-cli.js>). */
+function npxInvocations(): CapturedCall[] {
+  return execFileCalls.filter(
+    (c) => c.cmd === 'npx' || (c.args[0] ?? '').includes('npx-cli.js'),
+  );
+}
+
+beforeEach(() => {
+  execFileCalls.length = 0;
+  npxCliJsExists = true;
+  rejectCmds = [];
+  vi.resetModules();
+});
+
+describe('browser-session npx shell-outs (#2770)', () => {
+  describe('with Node\'s bundled npx-cli.js resolvable (the Windows fix)', () => {
+    it('browser_template_apply invokes node <npx-cli.js>, never bare npx', async () => {
+      const tools = await loadTools();
+      await tool(tools, 'browser_template_apply').handler({ name: 'checkout-flow' });
+
+      const npxCalls = npxInvocations();
+      expect(npxCalls.length).toBeGreaterThan(0);
+      for (const call of npxCalls) {
+        expect(call.cmd).toBe(process.execPath);
+        expect(call.args[0]).toMatch(/npx-cli\.js$/);
+      }
+      // Original npx argv is preserved verbatim after the cli script.
+      expect(npxCalls[0].args.slice(1)).toEqual([
+        '-y', '@claude-flow/cli@latest', 'memory', 'retrieve',
+        '--namespace', 'browser-templates',
+        '--key', 'checkout-flow',
+      ]);
+    });
+
+    it('browser_cookie_use invokes node <npx-cli.js>, never bare npx', async () => {
+      const tools = await loadTools();
+      await tool(tools, 'browser_cookie_use').handler({ host: 'example.com' });
+
+      const npxCalls = npxInvocations();
+      expect(npxCalls.length).toBeGreaterThan(0);
+      for (const call of npxCalls) {
+        expect(call.cmd).toBe(process.execPath);
+        expect(call.args[0]).toMatch(/npx-cli\.js$/);
+      }
+    });
+
+    it('browser_session_end never spawns bare npx (memory-store index + ruvector fallback)', async () => {
+      const tools = await loadTools();
+      await tool(tools, 'browser_session_end').handler({
+        session: 'sess-2770',
+        rvf_path: 'sess-2770.rvf',
+        verdict: 'pass',
+      });
+
+      const bare = execFileCalls.filter((c) => c.cmd === 'npx');
+      expect(bare).toEqual([]);
+      // The AgentDB index call site must still have fired, through node.
+      const idx = execFileCalls.find((c) => c.args.includes('store'));
+      expect(idx).toBeDefined();
+      expect(idx!.cmd).toBe(process.execPath);
+    });
+
+    it('browser_session_record npx fallback passes the user URL as one literal argv element', async () => {
+      // Force the direct agent-browser spawn to fail so the handler takes
+      // the npx fallback — the call site that forwards input.url (#2770's
+      // injection-risk site: this URL must never meet a shell).
+      rejectCmds = ['agent-browser'];
+      const hostileUrl = 'https://example.com/?q=a&b=`c`|d';
+
+      const tools = await loadTools();
+      await tool(tools, 'browser_session_record').handler({
+        url: hostileUrl,
+        task: 'regression 2770',
+        session: 'sess-2770-rec',
+        rvf_dir: 'tmp-2770',
+      });
+
+      const bare = execFileCalls.filter((c) => c.cmd === 'npx');
+      expect(bare).toEqual([]);
+      const fallback = execFileCalls.find((c) => c.args.includes('agent-browser') && c.args.includes('open'));
+      expect(fallback).toBeDefined();
+      expect(fallback!.cmd).toBe(process.execPath);
+      expect(fallback!.args[0]).toMatch(/npx-cli\.js$/);
+      // Literal argv — exactly one element equals the raw URL, unescaped/unsplit.
+      expect(fallback!.args.filter((a) => a === hostileUrl)).toHaveLength(1);
+    });
+
+    it('no shell-out in the module ever passes shell: true', async () => {
+      rejectCmds = ['agent-browser'];
+      const tools = await loadTools();
+      await tool(tools, 'browser_template_apply').handler({ name: 'tpl' });
+      await tool(tools, 'browser_cookie_use').handler({ host: 'example.com' });
+      await tool(tools, 'browser_session_end').handler({ session: 's1', rvf_path: 's1.rvf', verdict: 'fail' });
+      await tool(tools, 'browser_session_record').handler({ url: 'https://example.com', task: 't', session: 's2', rvf_dir: 'tmp-2770' });
+
+      expect(execFileCalls.length).toBeGreaterThan(0);
+      for (const call of execFileCalls) {
+        expect(call.opts?.shell).toBeUndefined();
+      }
+    });
+  });
+
+  describe('without a resolvable npx-cli.js (fallback contract)', () => {
+    it('browser_template_apply falls back to the original bare-npx spawn', async () => {
+      npxCliJsExists = false;
+      const tools = await loadTools();
+      await tool(tools, 'browser_template_apply').handler({ name: 'tpl' });
+
+      const npxCalls = npxInvocations();
+      expect(npxCalls.length).toBeGreaterThan(0);
+      for (const call of npxCalls) {
+        expect(call.cmd).toBe('npx');
+      }
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/browser-session-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/browser-session-tools.ts
@@ -109,7 +109,53 @@ function resolveLocalRuvectorCli(): Promise<string | null> {
 async function ruvector(args: string[], opts: { timeout?: number } = {}): Promise<ShellResult> {
   const cli = await resolveLocalRuvectorCli();
   if (cli) return shell(process.execPath, [cli, ...args], opts);
-  return shell('npx', ['-y', RUVECTOR_PIN, ...args], opts);
+  return npxShell(['-y', RUVECTOR_PIN, ...args], opts);
+}
+
+/**
+ * Resolve Node's bundled npx-cli.js (memoized). On Windows the bare `npx`
+ * command is an `npx.cmd` shim that execFile cannot launch without a shell
+ * (ENOENT — #2770), and explicit `npx.cmd` is EINVAL under Node's
+ * CVE-2024-27980 hardening. `shell: true` is not an option either: execFile
+ * space-joins array args under a shell, and browser_session_record forwards
+ * a caller-controlled URL — a command-injection surface. Spawning
+ * `node <npx-cli.js>` is a real executable on every platform: no shell, no
+ * PATHEXT/.cmd resolution, args stay literal argv.
+ */
+let npxCliJsPromise: Promise<string | null> | null = null;
+
+function resolveNpxCliJs(): Promise<string | null> {
+  if (npxCliJsPromise) return npxCliJsPromise;
+  npxCliJsPromise = (async () => {
+    try {
+      const path = await import('node:path');
+      const { existsSync } = await import('node:fs');
+      const execDir = path.dirname(process.execPath);
+      // Windows layout: <node dir>\node_modules\npm; POSIX: <prefix>/lib/node_modules/npm.
+      const candidates = [
+        path.join(execDir, 'node_modules', 'npm', 'bin', 'npx-cli.js'),
+        path.join(execDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npx-cli.js'),
+      ];
+      for (const candidate of candidates) {
+        if (existsSync(candidate)) return candidate;
+      }
+    } catch {
+      // fall through to the bare-npx fallback
+    }
+    return null;
+  })();
+  return npxCliJsPromise;
+}
+
+/**
+ * Run an npx command without ever involving a shell: `node <npx-cli.js>`
+ * when Node's bundled npm ships one (required on Windows — #2770), bare
+ * `npx` otherwise (working POSIX default / exotic install layouts).
+ */
+async function npxShell(args: string[], opts: { timeout?: number } = {}): Promise<ShellResult> {
+  const cliJs = await resolveNpxCliJs();
+  if (cliJs) return shell(process.execPath, [cliJs, ...args], opts);
+  return shell('npx', args, opts);
 }
 
 async function ensureSessionsDir(): Promise<string> {
@@ -207,7 +253,7 @@ export const browserSessionTools: MCPTool[] = [
       // 3. browser_open via agent-browser
       const bo = await shell('agent-browser', ['--session', sessionId, '--json', 'open', input.url as string], { timeout: 30000 });
       if (!bo.success) {
-        const npxBo = await shell('npx', ['--yes', 'agent-browser', '--session', sessionId, '--json', 'open', input.url as string], { timeout: 60000 });
+        const npxBo = await npxShell(['--yes', 'agent-browser', '--session', sessionId, '--json', 'open', input.url as string], { timeout: 60000 });
         if (!npxBo.success) {
           return fail('browser open failed', { detail: npxBo.error, stderr: npxBo.stderr, sessionId, rvfPath });
         }
@@ -280,7 +326,7 @@ export const browserSessionTools: MCPTool[] = [
         tags: input.tags ?? [],
         ended_at: new Date().toISOString(),
       });
-      const idx = await shell('npx', ['-y', '@claude-flow/cli@latest', 'memory', 'store',
+      const idx = await npxShell(['-y', '@claude-flow/cli@latest', 'memory', 'store',
         '--namespace', 'browser-sessions',
         '--key', input.session as string,
         '--value', indexValue], { timeout: 60000 });
@@ -370,7 +416,7 @@ export const browserSessionTools: MCPTool[] = [
     handler: async (input) => {
       const vN = validateText(input.name as string, 'name');
       if (!vN.valid) return fail(vN.error || 'invalid name');
-      const r = await shell('npx', ['-y', '@claude-flow/cli@latest', 'memory', 'retrieve',
+      const r = await npxShell(['-y', '@claude-flow/cli@latest', 'memory', 'retrieve',
         '--namespace', 'browser-templates',
         '--key', input.name as string], { timeout: 60000 });
       if (!r.success) return fail('template fetch failed', { detail: r.error, stderr: r.stderr });
@@ -400,7 +446,7 @@ export const browserSessionTools: MCPTool[] = [
     handler: async (input) => {
       const vH = validateText(input.host as string, 'host');
       if (!vH.valid) return fail(vH.error || 'invalid host');
-      const r = await shell('npx', ['-y', '@claude-flow/cli@latest', 'memory', 'retrieve',
+      const r = await npxShell(['-y', '@claude-flow/cli@latest', 'memory', 'retrieve',
         '--namespace', 'browser-cookies',
         '--key', input.host as string], { timeout: 60000 });
       if (!r.success) return fail('cookie lookup failed', { detail: r.error, stderr: r.stderr });


### PR DESCRIPTION
## Summary

Fixes #2770.

On Windows, every browser-session MCP tool that shells out via bare `npx` fails immediately with `ENOENT`, surfaced as `"command not found: npx"` — even with npx correctly installed and on PATH. All five call sites in `v3/@claude-flow/cli/src/mcp-tools/browser-session-tools.ts` are affected: the `ruvector()` npx fallback, `browser_session_record`'s agent-browser fallback, `browser_session_end`'s AgentDB index store, and the `browser_template_apply` / `browser_cookie_use` memory retrieves.

## Root cause

`shell()` uses promisified `execFile` with no shell:

```ts
const bo = await shell('npx', ['--yes', 'agent-browser', '--session', sessionId, '--json', 'open', input.url as string], { timeout: 30000 });
```

On Windows `npx` is an `npx.cmd` shim, and `.cmd`/`.bat` files cannot be launched by `execFile`/`spawn` without a shell. Explicit `npx.cmd` is no escape either — Node's CVE-2024-27980 hardening makes it `EINVAL`. Reproduced on Windows 11 / Node v24.18.0:

```
execFile('npx', ['--version'])      → ENOENT
execFile('npx.cmd', ['--version'])  → EINVAL
node <bundled npx-cli.js> --version → "11.16.0"
```

`shell: true` would "work" but is rejected deliberately: `execFile` space-joins array args under a shell, and `browser_session_record` forwards a **caller-controlled URL** — a crafted URL with shell metacharacters becomes command injection on the host (the concern #2770 itself flags).

## Fix

Resolve Node's own bundled `npm/bin/npx-cli.js` relative to `process.execPath` (both the Windows `<node dir>\node_modules\npm` and POSIX `<prefix>/lib/node_modules/npm` layouts, memoized) and spawn it via `node` — a real executable on every platform, no shell, args stay literal argv. All five bare-`npx` call sites now route through the new `npxShell()`; when `npx-cli.js` is not resolvable, the original bare-`npx` spawn is preserved unchanged. This generalizes the `resolveLocalRuvectorCli()` + `shell(process.execPath, [cli, ...args])` precedent already in the same file.

Also audited `browser-intent-tools.ts` per the issue's note: it has no `npx`/`execFile` shell-outs, so no change there.

## Verification

New regression suite `v3/@claude-flow/cli/__tests__/browser-session-npx-2770.test.ts` (mock-first; drives the exported tool handlers and asserts on the binary handed to `execFile`):

- with `npx-cli.js` resolvable: `browser_template_apply`, `browser_cookie_use`, `browser_session_end` and the `browser_session_record` fallback all invoke `node <npx-cli.js>`, never bare `npx`; original argv preserved verbatim; the caller-controlled URL stays one literal argv element
- fallback contract: without a resolvable `npx-cli.js`, bare `npx` is preserved
- security pin: no shell-out in the module ever passes `shell: true`

Failing before the fix (the contract assertions catch bare `npx`), passing after:

```
pre-fix:  Test Files  1 failed (1)   Tests  4 failed | 2 passed (6)
post-fix: Test Files  1 passed (1)   Tests  6 passed (6)
```

`pnpm --filter @claude-flow/cli run build` (tsc) passes. Full CLI-package vitest run compared against a pre-fix baseline on the same machine: the only differing results are the six new tests; an A/B run with the fix stashed shows the pre-existing Windows-environment failures (`__tests__/ruvector/*` WASM resolution, symlink-EPERM) are byte-identical with and without this change.

## Explicitly NOT done (scope decisions)

- No change to `browser-intent-tools.ts` (verified clean).
- The cold `npx --yes agent-browser` pull of an unpinned package that #2770 flags as a separate supply-chain concern is untouched — same behavior, now just launchable on Windows.
- No attempt to fix the unrelated pre-existing Windows test failures (ruvector WASM resolution, symlink EPERM under non-elevated shells).
