### PR TITLE
feat(status): machine-readable health checks via --health-check --format json

### DIFF
--- a/v3/@claude-flow/cli/__tests__/status-health-check-json.test.ts
+++ b/v3/@claude-flow/cli/__tests__/status-health-check-json.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for `status --health-check --format json`.
+ *
+ * performHealthCheck() has always computed a structured result —
+ * `{ checks, summary }` is returned in CommandResult.data — but the JSON
+ * format flag was only honored by the plain `status` path four lines above
+ * the health-check dispatch, so `status --health-check --format json`
+ * printed decorated human text. CI wants to parse health checks; this
+ * pins the machine-readable contract:
+ *   (a) `--health-check --format json` emits exactly one printJson payload
+ *       shaped { checks, summary } with no decorated text around it;
+ *   (b) exit-code semantics are unchanged (exit 1 when any check fails)
+ *       and the JSON is still emitted on failure — a red health check must
+ *       remain parseable in CI;
+ *   (c) text mode is untouched (no printJson without the format flag).
+ *
+ * Mock-first per house style: mcp-client and output are mocked; the
+ * command action is driven directly (same harness as commands.test.ts;
+ * note getSystemStatus calls the underscore tool names swarm_status /
+ * mcp_status / memory_stats / task_summary).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { statusCommand } from '../src/commands/status.js';
+import type { CommandContext } from '../src/types.js';
+import * as fs from 'fs';
+import { output } from '../src/output.js';
+import { callMCPTool } from '../src/mcp-client.js';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn()
+}));
+
+vi.mock('../src/mcp-client.js', () => ({
+  MCPClientError: class MCPClientError extends Error {},
+  callMCPTool: vi.fn()
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    writeln: vi.fn(),
+    printInfo: vi.fn(),
+    printSuccess: vi.fn(),
+    printError: vi.fn(),
+    printWarning: vi.fn(),
+    printTable: vi.fn(),
+    printJson: vi.fn(),
+    printList: vi.fn(),
+    printBox: vi.fn(),
+    createSpinner: vi.fn(() => ({
+      start: vi.fn(),
+      succeed: vi.fn(),
+      fail: vi.fn(),
+      stop: vi.fn()
+    })),
+    highlight: (str: string) => str,
+    bold: (str: string) => str,
+    dim: (str: string) => str,
+    success: (str: string) => str,
+    error: (str: string) => str,
+    warning: (str: string) => str,
+    info: (str: string) => str,
+    progressBar: () => '[=====>    ]',
+    setColorEnabled: vi.fn()
+  }
+}));
+
+/** Healthy-system responses for the tools getSystemStatus actually calls. */
+function mockHealthySystem(): void {
+  vi.mocked(callMCPTool).mockImplementation(async (toolName: string) => {
+    if (toolName === 'swarm_status') {
+      return {
+        swarmId: 'swarm-json-1',
+        topology: 'hierarchical-mesh',
+        agents: { total: 5, active: 3, idle: 2, terminated: 0 },
+        health: 'healthy',
+        uptime: 3600000
+      };
+    }
+    if (toolName === 'mcp_status') {
+      return { running: true, port: 3000, transport: 'stdio' };
+    }
+    if (toolName === 'memory_stats') {
+      return {
+        entries: 100,
+        size: 1024000,
+        backend: 'hybrid',
+        performance: { avgSearchTime: 0.5, cacheHitRate: 0.85 }
+      };
+    }
+    if (toolName === 'task_summary') {
+      return { total: 10, pending: 3, running: 2, completed: 5, failed: 0 };
+    }
+    throw new Error(`unexpected tool: ${toolName}`);
+  });
+}
+
+describe('status --health-check --format json', () => {
+  let ctx: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    ctx = {
+      args: [],
+      flags: { 'health-check': true, format: 'json', _: [] },
+      cwd: '/test/project',
+      interactive: false
+    };
+  });
+
+  it('emits one machine-readable { checks, summary } payload and no decorated text', async () => {
+    mockHealthySystem();
+
+    const result = await statusCommand.action!(ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode ?? 0).toBe(0);
+
+    expect(output.printJson).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(output.printJson).mock.calls[0][0] as {
+      checks: Array<{ name: string; status: string; message: string }>;
+      summary: { passed: number; warned: number; failed: number };
+    };
+    expect(Array.isArray(payload.checks)).toBe(true);
+    expect(payload.checks.length).toBeGreaterThan(0);
+    for (const check of payload.checks) {
+      expect(['pass', 'warn', 'fail']).toContain(check.status);
+      expect(typeof check.name).toBe('string');
+      expect(typeof check.message).toBe('string');
+    }
+    // Summary counts must reconcile with the checks array.
+    expect(payload.summary).toEqual({
+      passed: payload.checks.filter(c => c.status === 'pass').length,
+      warned: payload.checks.filter(c => c.status === 'warn').length,
+      failed: payload.checks.filter(c => c.status === 'fail').length
+    });
+    expect(payload.summary.failed).toBe(0);
+
+    // JSON mode must not interleave decorated text on stdout.
+    expect(output.writeln).not.toHaveBeenCalled();
+    expect(output.printSuccess).not.toHaveBeenCalled();
+    expect(output.printError).not.toHaveBeenCalled();
+
+    // data keeps the same shape callers already rely on.
+    expect(result.data).toEqual(payload);
+  });
+
+  it('still emits JSON and exits 1 when a check fails (parseable red result for CI)', async () => {
+    // swarm_status throwing = system not running -> "System Running" fails.
+    vi.mocked(callMCPTool).mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await statusCommand.action!(ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+
+    expect(output.printJson).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(output.printJson).mock.calls[0][0] as {
+      checks: Array<{ name: string; status: string }>;
+      summary: { passed: number; warned: number; failed: number };
+    };
+    expect(payload.summary.failed).toBeGreaterThan(0);
+    expect(payload.checks.some(c => c.status === 'fail')).toBe(true);
+    expect(output.writeln).not.toHaveBeenCalled();
+  });
+
+  it('leaves text mode untouched when --format json is absent', async () => {
+    mockHealthySystem();
+    ctx.flags = { 'health-check': true, _: [] };
+
+    const result = await statusCommand.action!(ctx);
+
+    expect(result.success).toBe(true);
+    expect(output.printJson).not.toHaveBeenCalled();
+    // The decorated report still renders.
+    expect(output.writeln).toHaveBeenCalled();
+    expect(output.printSuccess).toHaveBeenCalled();
+    expect(result.data).toHaveProperty('checks');
+    expect(result.data).toHaveProperty('summary');
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/status.ts
+++ b/v3/@claude-flow/cli/src/commands/status.ts
@@ -370,7 +370,7 @@ const statusAction = async (ctx: CommandContext): Promise<CommandResult> => {
 
   // Health check mode
   if (healthCheck) {
-    return performHealthCheck(status);
+    return performHealthCheck(status, ctx.flags.format === 'json');
   }
 
   // JSON output
@@ -392,12 +392,9 @@ const statusAction = async (ctx: CommandContext): Promise<CommandResult> => {
 
 // Perform health checks
 async function performHealthCheck(
-  status: Awaited<ReturnType<typeof getSystemStatus>>
+  status: Awaited<ReturnType<typeof getSystemStatus>>,
+  asJson = false
 ): Promise<CommandResult> {
-  output.writeln();
-  output.writeln(output.bold('Health Check'));
-  output.writeln();
-
   const checks: Array<{ name: string; status: 'pass' | 'fail' | 'warn'; message: string }> = [];
 
   // Check if system is running
@@ -451,6 +448,28 @@ async function performHealthCheck(
     });
   }
 
+  const passed = checks.filter(c => c.status === 'pass').length;
+  const warned = checks.filter(c => c.status === 'warn').length;
+  const failed = checks.filter(c => c.status === 'fail').length;
+  const result: CommandResult = {
+    success: failed === 0,
+    exitCode: failed > 0 ? 1 : 0,
+    data: { checks, summary: { passed, warned, failed } }
+  };
+
+  // Machine-readable mode (`--health-check --format json`): emit the same
+  // { checks, summary } object the command already returns in data, with no
+  // decorated text around it, so CI can parse the result — including red
+  // ones (exit-code semantics are unchanged).
+  if (asJson) {
+    output.printJson(result.data as Record<string, unknown>);
+    return result;
+  }
+
+  output.writeln();
+  output.writeln(output.bold('Health Check'));
+  output.writeln();
+
   // Display results
   for (const check of checks) {
     const icon = check.status === 'pass' ? output.success('[PASS]') :
@@ -461,21 +480,13 @@ async function performHealthCheck(
 
   output.writeln();
 
-  const passed = checks.filter(c => c.status === 'pass').length;
-  const warned = checks.filter(c => c.status === 'warn').length;
-  const failed = checks.filter(c => c.status === 'fail').length;
-
   if (failed === 0) {
     output.printSuccess(`All checks passed (${passed} passed, ${warned} warnings)`);
   } else {
     output.printError(`Health check failed (${passed} passed, ${warned} warnings, ${failed} failed)`);
   }
 
-  return {
-    success: failed === 0,
-    exitCode: failed > 0 ? 1 : 0,
-    data: { checks, summary: { passed, warned, failed } }
-  };
+  return result;
 }
 
 // Watch mode - continuous status updates
@@ -748,6 +759,7 @@ export const statusCommand: Command = {
     { command: 'claude-flow status --watch', description: 'Watch mode with live updates' },
     { command: 'claude-flow status --watch -i 5', description: 'Watch mode updating every 5 seconds' },
     { command: 'claude-flow status --health-check', description: 'Run health checks' },
+    { command: 'claude-flow status --health-check --format json', description: 'Machine-readable health checks (CI)' },
     { command: 'claude-flow status --json', description: 'Output status as JSON' },
     { command: 'claude-flow status agents', description: 'Show detailed agent status' },
     { command: 'claude-flow status tasks', description: 'Show detailed task status' },


### PR DESCRIPTION
## Summary

`ruflo status --health-check --format json` now emits machine-readable output. Health checks are exactly the status surface CI pipelines want to parse, and all the data plumbing already existed — `performHealthCheck()` returns `{ checks, summary }` in `CommandResult.data` — it just was never printed as JSON: the health-check dispatch sits four lines above the `format === 'json'` branch in `statusAction`, so the flag was silently ignored and decorated human text came out instead.

## What it does

```
$ ruflo status --health-check --format json
{
  "checks": [
    { "name": "System Running", "status": "pass", "message": "System is running" },
    { "name": "Swarm Health",   "status": "pass", "message": "Swarm is healthy" },
    ...
  ],
  "summary": { "passed": 5, "warned": 1, "failed": 0 }
}
```

- Emits the exact `{ checks, summary }` object the command already returns in `data`, via `output.printJson`, with no decorated text around it — mirroring the four sibling `printJson` branches already in `status.ts` (status, agents, tasks, memory).
- Exit-code semantics unchanged: any failed check still exits 1, and the JSON is still emitted on failure so a red health check stays parseable in CI.
- Text mode is byte-identical to before.
- One new `examples` entry documents the flag combination.

## Verification

New suite `v3/@claude-flow/cli/__tests__/status-health-check-json.test.ts` (mock-first, same harness as `commands.test.ts`; note it mocks the underscore tool names `swarm_status`/`mcp_status`/`memory_stats`/`task_summary` that `getSystemStatus` actually calls):

- one `printJson` payload shaped `{ checks, summary }`, summary counts reconciled against the checks array, no `writeln`/`printSuccess`/`printError` interleaved
- edge case: when a check fails (system not running), exit code is 1 **and** valid JSON is still emitted
- guard: without `--format json`, text mode renders exactly as before and `printJson` is never called

Failing before the change, passing after:

```
pre-change:  Tests  2 failed | 1 passed (3)   (printJson never called)
post-change: Tests  3 passed (3)
```

`pnpm --filter @claude-flow/cli run build` (tsc) passes. Sibling suites (`p1-commands.test.ts`, `commands.test.ts`) show no new failures — the three pre-existing `Config Commands` failures on the test machine reproduce identically with this change stashed.

## Explicitly NOT done (scope decisions)

- No global `--json` ⇢ `--format json` normalization: ~11 commands check `flags.json`, ~25 check `flags.format`, and unifying them (including the documented-but-broken `status --json` example) is a separate, parser-level change. This PR stays consistent with `statusAction`'s existing `format === 'json'` gate.
- No JSON mode for `doctor` (larger surface, interleaved side effects) — same pattern could follow if this lands.
- `status --watch` JSON streaming is intentionally out of scope.
