### PR TITLE
chore: update package-lock.json version to 3.32.21 (scheduled verification run)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.9",
+  "version": "3.32.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.9",
+      "version": "3.32.21",
       "license": "MIT",
       "dependencies": {
         "@claude-flow/cli-core": "3.7.0-alpha.5",


### PR DESCRIPTION
## Summary

- Updated `package-lock.json` version field from `3.32.9` → `3.32.21` — a side-effect of running `npm install` during the 2026-07-27T07:03Z scheduled verification run to resolve `@noble/ed25519` for the witness verification check.

## Verification run outcome

The scheduled 12-hour verification run completed. Key findings:

- **HIGH**: CI on `main` is broken — `RUFLO_MEMORY_SCAN_ON_WRITE` violates ADR-125/ADR-130 env-var-precedence in `commands/memory.ts:139`. Filed as issue #2794.
- **MEDIUM**: Witness verification exits with precondition code 2 (partial build; valid signature, `regressed=0`).
- All published packages (`v3.32.21`), federation breaker smoke, transport smoke, doctor, and npm dist-tags passed.

## Test plan

- [ ] Confirm `package-lock.json` change does not introduce any unintended dependency shifts
- [ ] Verify lock file is consistent with `package.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpwUiPq8xehnKwPb88LbyJ)_