### PR TITLE
fix(metaharness): pin @metaharness/darwin + pin-drift guard (ruflo analog of upstream #142/#149)

### DIFF
--- a/.github/workflows/metaharness-pin-drift.yml
+++ b/.github/workflows/metaharness-pin-drift.yml
@@ -1,0 +1,79 @@
+# metaharness-pin-drift — watch ruflo's metaharness dependency pins for drift.
+#
+# A pin correct at publish time silently rots when upstream ships a release the
+# pin's range excludes (agent-harness-generator#142 / #149). This workflow diffs
+# each declared range against npm `latest` on a schedule, opens/updates a
+# tracking issue when a pin falls behind, and fails PRs that introduce drift.
+name: metaharness-pin-drift
+
+on:
+  schedule:
+    - cron: '17 5 * * 1'   # Mondays 05:17 UTC (off-peak minute)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'v3/@claude-flow/cli/package.json'
+      - 'v3/@claude-flow/cli/src/services/distill-oracle.ts'
+      - 'scripts/check-metaharness-pins.mjs'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  pin-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check metaharness pin drift
+        id: check
+        run: |
+          node scripts/check-metaharness-pins.mjs --format json > /tmp/pins.json
+          echo "drift=0" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      # The script exits 1 on drift; surface that as an output flag without
+      # failing the whole job (so the scheduled path can still file the issue).
+      - name: Record drift flag
+        if: steps.check.outcome == 'failure'
+        run: echo "drift=1" >> "$GITHUB_OUTPUT"
+        id: flag
+
+      - name: Human-readable summary
+        if: always()
+        run: node scripts/check-metaharness-pins.mjs || true
+
+      # On a PR, drift is a hard failure — a PR must not merge a stale pin.
+      - name: Fail PR on drift
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-metaharness-pins.mjs
+
+      # On the schedule/dispatch path, open or update a tracking issue.
+      - name: Open or update tracking issue on drift
+        if: steps.flag.outputs.drift == '1' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="metaharness pin drift — a pinned dependency is behind npm latest"
+          BODY_FILE=/tmp/issue-body.md
+          {
+            echo "The metaharness pin-drift watcher found a pin whose range no longer"
+            echo "admits the current npm release. Bump the range in"
+            echo "\`v3/@claude-flow/cli/package.json\` (and \`MH_DARWIN_PIN\` in"
+            echo "\`distill-oracle.ts\` if darwin moved), then re-run the guard."
+            echo ""
+            echo '```json'
+            cat /tmp/pins.json
+            echo '```'
+          } > "$BODY_FILE"
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+          else
+            gh issue create --title "$TITLE" --label bug --body-file "$BODY_FILE"
+          fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.24",
+  "version": "3.32.25",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.24",
+  "version": "3.32.25",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/scripts/check-metaharness-pins.mjs
+++ b/scripts/check-metaharness-pins.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// check-metaharness-pins — pin-drift watcher for ruflo's metaharness deps.
+//
+// WHY: a version pin that was correct at publish time silently rots when the
+// upstream ships a new release the pin's range excludes. This is the failure
+// mode reported upstream in agent-harness-generator#142 (`@metaharness/darwin`
+// caret-locked to 0.2.x, three majors behind) and #149 (META_PROXY_VERSION
+// pinned, three releases behind, with no watcher). Ruflo pins three metaharness
+// packages; this script diffs each declared range against npm `latest` and
+// flags any pin whose range no longer admits the current release.
+//
+// Checked pins (single source of truth = v3/@claude-flow/cli/package.json):
+//   - metaharness            (dependencies)          — the umbrella / MCP subprocess CLI
+//   - @metaharness/router    (dependencies)          — neural-router.ts dynamic import
+//   - @metaharness/darwin    (optionalDependencies)  — Darwin evolve / GEPA subprocess
+// Plus a lock-step check: the MH_DARWIN_PIN constant in distill-oracle.ts (used
+// for the Tier-1 oracle's `npx @metaharness/darwin@<pin>` calls) must satisfy
+// the declared @metaharness/darwin range, so the two can't drift apart.
+//
+// USAGE
+//   node scripts/check-metaharness-pins.mjs                 # exits 1 if any pin is stale
+//   node scripts/check-metaharness-pins.mjs --format json   # CI/issue-body consumable
+//   node scripts/check-metaharness-pins.mjs --offline       # skip npm, only lock-step check
+//
+// EXIT CODES
+//   0  every pin's range admits npm latest (and the darwin constant is in range)
+//   1  at least one pin is behind (range excludes latest) OR constant out of range
+//   2  unexpected error (network flake surfaces as a warning, NOT a false drift)
+
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..');
+const CLI_PKG = join(REPO, 'v3', '@claude-flow', 'cli', 'package.json');
+const DISTILL = join(REPO, 'v3', '@claude-flow', 'cli', 'src', 'services', 'distill-oracle.ts');
+
+const ARGS = { format: 'table', offline: false };
+for (let i = 2; i < process.argv.length; i++) {
+  if (process.argv[i] === '--format') ARGS.format = process.argv[++i];
+  else if (process.argv[i] === '--offline') ARGS.offline = true;
+}
+
+/** Parse "1.2.3" → [1,2,3]; tolerant of pre-release/build suffixes. */
+function parseVer(v) {
+  const m = String(v).trim().replace(/^v/, '').match(/^(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/** Does `latest` satisfy `range`? Supports the caret/tilde/exact forms ruflo uses. */
+function satisfies(range, latest) {
+  const lv = parseVer(latest);
+  if (!lv) return null;
+  const op = range[0] === '^' || range[0] === '~' ? range[0] : '=';
+  const bv = parseVer(op === '=' ? range : range.slice(1));
+  if (!bv) return null;
+  const gte = cmp(lv, bv) >= 0;
+  if (!gte) return false;
+  if (op === '=') return cmp(lv, bv) === 0;
+  // Upper bound: caret locks the left-most non-zero component; tilde locks minor.
+  let hi;
+  if (op === '^') hi = bv[0] > 0 ? [bv[0] + 1, 0, 0] : bv[1] > 0 ? [0, bv[1] + 1, 0] : [0, 0, bv[2] + 1];
+  else hi = [bv[0], bv[1] + 1, 0]; // ~
+  return cmp(lv, hi) < 0;
+}
+function cmp(a, b) { for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i]; return 0; }
+
+function npmLatest(pkg) {
+  const out = execFileSync('npm', ['view', pkg, 'version'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+  return out.trim();
+}
+
+async function main() {
+  const pkg = JSON.parse(readFileSync(CLI_PKG, 'utf-8'));
+  const pins = [
+    { name: 'metaharness', range: pkg.dependencies?.metaharness, where: 'dependencies' },
+    { name: '@metaharness/router', range: pkg.dependencies?.['@metaharness/router'], where: 'dependencies' },
+    { name: '@metaharness/darwin', range: pkg.optionalDependencies?.['@metaharness/darwin'], where: 'optionalDependencies' },
+  ];
+
+  const rows = [];
+  for (const p of pins) {
+    if (!p.range) { rows.push({ ...p, status: 'undeclared', latest: null, note: 'pin not found in package.json' }); continue; }
+    if (ARGS.offline) { rows.push({ ...p, status: 'skipped', latest: null, note: 'offline mode' }); continue; }
+    let latest;
+    try { latest = npmLatest(p.name); }
+    catch { rows.push({ ...p, status: 'unknown', latest: null, note: 'npm view failed (network?) — not treated as drift' }); continue; }
+    const ok = satisfies(p.range, latest);
+    rows.push({ ...p, latest, status: ok === false ? 'STALE' : ok === true ? 'current' : 'unparseable' });
+  }
+
+  // Lock-step: MH_DARWIN_PIN constant must satisfy the declared darwin range.
+  let constRow = null;
+  try {
+    const m = readFileSync(DISTILL, 'utf-8').match(/MH_DARWIN_PIN\s*=\s*['"]([^'"]+)['"]/);
+    const declared = pkg.optionalDependencies?.['@metaharness/darwin'];
+    if (m && declared) {
+      const inRange = satisfies(declared, m[1]);
+      constRow = { name: 'MH_DARWIN_PIN (distill-oracle.ts)', pin: m[1], declared, status: inRange === false ? 'OUT-OF-RANGE' : 'in-range' };
+    }
+  } catch { /* non-fatal */ }
+
+  const stale = rows.filter((r) => r.status === 'STALE');
+  const constBad = constRow && constRow.status === 'OUT-OF-RANGE';
+  const drift = stale.length > 0 || constBad;
+  const payload = { generatedAt: new Date().toISOString(), drift, pins: rows, constCheck: constRow };
+
+  if (ARGS.format === 'json') {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.log('# check-metaharness-pins\n');
+    console.log('| Package | Declared | npm latest | Status |');
+    console.log('|---|---|---|---|');
+    for (const r of rows) console.log(`| ${r.name} | ${r.range ?? '—'} | ${r.latest ?? '—'} | ${r.status} |`);
+    if (constRow) console.log(`| ${constRow.name} | =${constRow.pin} (vs ${constRow.declared}) | — | ${constRow.status} |`);
+    console.log('');
+    if (drift) {
+      console.log('⚠ **Pin drift detected.** One or more metaharness pins no longer admit the current npm release.');
+      console.log('Bump the range in v3/@claude-flow/cli/package.json (and MH_DARWIN_PIN if darwin moved), then re-run.');
+    } else {
+      console.log('✓ All metaharness pins admit the current npm `latest`.');
+    }
+  }
+  process.exit(drift ? 1 : 0);
+}
+
+main().catch((e) => { console.error('check-metaharness-pins crashed:', e?.message || e); process.exit(2); });

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -115,6 +115,7 @@
   "optionalDependencies": {
     "@claude-flow/memory": "^3.0.0-alpha.21",
     "@claude-flow/security": "^3.0.0-alpha.12",
+    "@metaharness/darwin": "^0.8.0",
     "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "better-sqlite3": "^12.9.0",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.24",
+  "version": "3.32.25",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/mcp-tools/metaharness-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/metaharness-tools.ts
@@ -378,7 +378,7 @@ export const metaharnessTools: MCPTool[] = [
   },
   // ───────────────────────────────────────────────────────────────────────
   // ADR-153 — @metaharness/darwin integration (3 tools).
-  // Backed by the separate `@metaharness/darwin@~0.3.1` npm package, NOT
+  // Backed by the separate `@metaharness/darwin@~0.8.0` npm package, NOT
   // the umbrella `metaharness`. Plugin scripts shell out via _darwin.mjs.
   // Same {success, data, degraded, exitCode} contract.
   // ───────────────────────────────────────────────────────────────────────

--- a/v3/@claude-flow/cli/src/services/distill-oracle.ts
+++ b/v3/@claude-flow/cli/src/services/distill-oracle.ts
@@ -45,6 +45,15 @@ import {
   type ReflectResult,
 } from './fable-harness.js';
 
+// Pinned @metaharness/darwin version for the Tier-1 mechanical oracle's `npx`
+// invocations. Bare `npx --yes @metaharness/darwin` floats to whatever npm
+// `latest` is, so a breaking darwin release could silently change eval
+// behavior mid-run (the #142 pin-drift failure mode). Pin it, and let
+// scripts/check-metaharness-pins.mjs watch this constant for drift. Kept in
+// lock-step with the optionalDependencies pin in package.json and the plugin
+// darwin cache (darwin-cache-0.8.0).
+export const MH_DARWIN_PIN = '0.8.0';
+
 // ── Provenance ─────────────────────────────────────────────────────────────
 
 export type ResolvedProvenance = 'oracle:test-exec' | 'judge:fable' | 'proxy:structural';
@@ -359,7 +368,7 @@ export function buildOraclePlan(spec: TestSpec, remote: string | null): OraclePl
   const probeCommands = [
     `ssh -o BatchMode=yes -o ConnectTimeout=8 ${r} 'echo ok'`,
     `${sshLocal}'command -v docker >/dev/null 2>&1 && echo docker-present || echo docker-missing'`,
-    `${sshLocal}'command -v darwin >/dev/null 2>&1 || npx --yes @metaharness/darwin --version'`,
+    `${sshLocal}'command -v darwin >/dev/null 2>&1 || npx --yes @metaharness/darwin@${MH_DARWIN_PIN} --version'`,
   ];
 
   let kind: OracleKind;
@@ -371,7 +380,7 @@ export function buildOraclePlan(spec: TestSpec, remote: string | null): OraclePl
     const suite = spec.benchSuite ? `--suite ${shq(spec.benchSuite)}` : '';
     const kase = spec.benchCase ? `--case ${shq(spec.benchCase)}` : '';
     evalCommands.push(
-      `${sshLocal}'cd ${workdir} && npx --yes @metaharness/darwin bench run ${suite} ${kase} --json'`.replace(/\s+/g, ' ').trim(),
+      `${sshLocal}'cd ${workdir} && npx --yes @metaharness/darwin@${MH_DARWIN_PIN} bench run ${suite} ${kase} --json'`.replace(/\s+/g, ' ').trim(),
     );
     parseHint = 'resolved = darwin bench run reports the case scored PASS (exit 0, json.passed=true)';
   } else if (spec.evalCommand) {
@@ -386,7 +395,7 @@ export function buildOraclePlan(spec: TestSpec, remote: string | null): OraclePl
     const f2p = (spec.failToPass ?? []).map(shq).join(' ');
     const p2p = (spec.passToPass ?? []).map(shq).join(' ');
     evalCommands.push(
-      `${sshLocal}'cd ${workdir} && npx --yes @metaharness/darwin swebench-eval` +
+      `${sshLocal}'cd ${workdir} && npx --yes @metaharness/darwin@${MH_DARWIN_PIN} swebench-eval` +
         `${spec.repo ? ` --repo ${shq(spec.repo)}` : ''}` +
         `${spec.baseCommit ? ` --base ${shq(spec.baseCommit)}` : ''}` +
         `${f2p ? ` --fail-to-pass ${f2p}` : ''}` +

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/aidefence':
     dependencies:
@@ -66,7 +66,7 @@ importers:
     dependencies:
       '@claude-flow/cli':
         specifier: '>=3.5.0'
-        version: 3.32.17(@types/node@20.19.27)(zod@3.25.76)
+        version: link:../cli
       agent-browser:
         specifier: ^0.27.0
         version: 0.27.0
@@ -110,7 +110,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/cli':
     dependencies:
@@ -126,12 +126,18 @@ importers:
       '@claude-flow/shared':
         specifier: 3.0.0-alpha.7
         version: 3.0.0-alpha.7
+      '@metaharness/router':
+        specifier: ^0.3.2
+        version: 0.3.2
       '@noble/ed25519':
         specifier: 2.3.0
         version: 2.3.0
       '@ruvector/rabitq-wasm':
         specifier: 0.1.0
         version: 0.1.0
+      metaharness:
+        specifier: ^0.4.1
+        version: 0.4.1
       semver:
         specifier: 7.7.3
         version: 7.7.3
@@ -148,6 +154,9 @@ importers:
       '@claude-flow/security':
         specifier: ^3.0.0-alpha.12
         version: link:../security
+      '@metaharness/darwin':
+        specifier: ^0.8.0
+        version: 0.8.0
       agentdb:
         specifier: ^3.0.0-alpha.17
         version: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
@@ -174,7 +183,7 @@ importers:
     dependencies:
       '@claude-flow/cli':
         specifier: ^3.0.0
-        version: 3.32.17(@types/node@20.19.27)(zod@3.25.76)
+        version: link:../cli
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
@@ -211,7 +220,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/deployment':
     dependencies:
@@ -224,7 +233,7 @@ importers:
         version: 25.0.2(typescript@5.9.3)
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/embeddings':
     dependencies:
@@ -274,7 +283,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/hooks':
     dependencies:
@@ -309,7 +318,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/integration':
     dependencies:
@@ -354,7 +363,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/memory':
     dependencies:
@@ -403,7 +412,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugin-agent-federation':
     dependencies:
@@ -453,7 +462,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugins':
     dependencies:
@@ -481,7 +490,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/providers':
     dependencies:
@@ -506,7 +515,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/security':
     dependencies:
@@ -526,7 +535,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/shared':
     dependencies:
@@ -560,7 +569,7 @@ importers:
         version: 7.2.0
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
       ws:
         specifier: ^8.16.0
         version: 8.19.0
@@ -572,7 +581,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/testing':
     devDependencies:
@@ -590,7 +599,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
 packages:
 
@@ -745,55 +754,6 @@ packages:
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
     requiresBuild: true
 
-  /@claude-flow/cli-core@3.7.0-alpha.5:
-    resolution: {integrity: sha512-WbhpxGpxhRoVmjtizIdt2IGlcX0nPmGktXe3JDtII4MeVTgifHuBYpx4cX4EQiBqGCt4cxxM4nDOFQUUqAK9Aw==}
-    hasBin: true
-    dev: false
-
-  /@claude-flow/cli@3.32.17(@types/node@20.19.27)(zod@3.25.76):
-    resolution: {integrity: sha512-9ZUoXsJbrPifGz3Zk7ZL8g93s0Alnny2jagCiXtOvjKS3eM6mqro02W2072sVuuIJAc4yZKJB9AZosErmn/VIg==}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@claude-flow/cli-core': 3.7.0-alpha.5
-      '@claude-flow/mcp': 3.0.0-alpha.8
-      '@claude-flow/neural': 3.0.0-alpha.9(@types/node@20.19.27)(zod@3.25.76)
-      '@claude-flow/shared': 3.0.0-alpha.7
-      '@noble/ed25519': 2.3.0
-      '@ruvector/rabitq-wasm': 0.1.0
-      semver: 7.7.3
-      sql.js: 1.14.1
-      yaml: 2.9.0
-    optionalDependencies:
-      '@claude-flow/memory': 3.0.0-alpha.21(@types/node@20.19.27)(zod@3.25.76)
-      '@claude-flow/security': 3.0.0-alpha.12
-      agentdb: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
-      agentic-flow: 3.0.0-alpha.2
-      better-sqlite3: 12.9.0
-      ruvector: 0.2.27(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@modelcontextprotocol/sdk'
-      - '@ruvector/diskann'
-      - '@ruvector/pi-brain'
-      - '@ruvector/router'
-      - '@ruvector/ruvllm'
-      - '@types/node'
-      - '@valibot/to-json-schema'
-      - arktype
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - debug
-      - effect
-      - jose
-      - react-native-b4a
-      - supports-color
-      - sury
-      - utf-8-validate
-      - zod
-    dev: false
-
   /@claude-flow/mcp@3.0.0-alpha.8:
     resolution: {integrity: sha512-lP1t8GMWDl9RxnwMZrjMukZkyglhge7Znhj1PbUiUQ94kHcN+dAxUkA75HM1n7BONbIDcE/CS8qN2ril5KgzNg==}
     dependencies:
@@ -807,54 +767,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: false
-
-  /@claude-flow/memory@3.0.0-alpha.21(@types/node@20.19.27)(zod@3.25.76):
-    resolution: {integrity: sha512-5H5rJOh7nGuzmFazTvJWZIbeZvf+HJjonM98vWijzbL4kQvBDWj6zwhsxQ3wrwJSrs5ALgQQmhxQ7Mr+gagAFw==}
-    cpu: [x64, arm64]
-    os: [darwin, linux, win32]
-    dependencies:
-      agentdb: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
-      sql.js: 1.14.1
-    optionalDependencies:
-      better-sqlite3: 12.9.0
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@types/node'
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-      - zod
-    dev: false
-
-  /@claude-flow/neural@3.0.0-alpha.9(@types/node@20.19.27)(zod@3.25.76):
-    resolution: {integrity: sha512-u7mx6rQxHrpCyKVtP600QorSJrEhoqYEyGZgYVU1kGWwYitScJH3rzWzss95Dn+RazcCAk7yElEG/iSbhtxU6g==}
-    dependencies:
-      '@claude-flow/memory': 3.0.0-alpha.21(@types/node@20.19.27)(zod@3.25.76)
-      '@ruvector/sona': 0.1.5
-    optionalDependencies:
-      agentdb: 3.0.0-alpha.17(@types/node@20.19.27)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@types/node'
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-      - zod
-    dev: false
-
-  /@claude-flow/security@3.0.0-alpha.12:
-    resolution: {integrity: sha512-/b1V6zXOhFSs+Y8UztyPFHqkNjDKslwpAn9+KJFWHqZMwnnPnBnW0WQHoZAGx+5+rewI619pVT9gIANkyt3luQ==}
-    requiresBuild: true
-    dependencies:
-      '@noble/ed25519': 2.3.0
-      bcryptjs: 3.0.3
-      zod: 3.25.76
-    optionalDependencies:
-      '@napi-rs/keyring': 1.3.0
-    dev: false
-    optional: true
 
   /@claude-flow/shared@3.0.0-alpha.7:
     resolution: {integrity: sha512-5iehTHguBFjlyZqy+fRoKfZVL/nFeE93A94nUUKJvu8y7AmhfpVqtQAZbmKztwQGJ5rv7iBb3Kwl1MUo3K5QkA==}
@@ -1710,6 +1622,46 @@ packages:
 
   /@leichtgewicht/ip-codec@2.0.5:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
+    dev: false
+
+  /@metaharness/darwin@0.2.8:
+    resolution: {integrity: sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    dev: false
+
+  /@metaharness/darwin@0.8.0:
+    resolution: {integrity: sha512-Pgefr/es0Btofh7GxQrOAg/i43ZKcLUfeD9rndOAkpA8s3ZYohSmfLerJLNsGOOKc2eTvmmauljl8QEVmKC2dw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@metaharness/flywheel@0.1.7:
+    resolution: {integrity: sha512-am7dROkjyS1Zkms3TOcn2LVHjwMLQXPJ6Pu1aP55q40vWJLRONGdGvnrcBL/VhMFqjQrVB57lmSn2E+s5CSZwA==}
+    dev: false
+
+  /@metaharness/redblue@0.1.4:
+    resolution: {integrity: sha512-JaAk6bs3xA7Ks5RnAcZoxI3WfzpYL+Bk262SCI07w82BDOA7C6VxwGM63F7b86lRTKUVjTEnSqf7QZ3uyElT/g==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    dev: false
+
+  /@metaharness/router@0.3.2:
+    resolution: {integrity: sha512-LQElU6mUrWd3ffJ5bwoonEIgw7oFQZpwZaehffyl/Pg+iozpRjIBPEXdb4uTOBnKH+yPiTEWKc+h9AiZr9Os9w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@ruvector/tiny-dancer': ^0.1.21
+    peerDependenciesMeta:
+      '@ruvector/tiny-dancer':
+        optional: true
+    dev: false
+
+  /@metaharness/weight-eft@0.1.1:
+    resolution: {integrity: sha512-GSg0APPAbRK93OzrzlE+R8hfEK+I5+Zhmh0Z28RC9Mk5/MjhPo3shqINO7ye8VPGYHIO4rars9FwCWbe/V4cEQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
     dev: false
 
   /@modelcontextprotocol/sdk@1.25.1(hono@4.12.11)(zod@3.25.76):
@@ -6637,7 +6589,7 @@ packages:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
     dev: true
 
   /@vitest/expect@4.1.8:
@@ -6665,7 +6617,7 @@ packages:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 7.3.0(@types/node@20.19.27)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@20.19.27)(yaml@2.8.2)
     dev: true
 
   /@vitest/pretty-format@4.1.8:
@@ -9946,6 +9898,15 @@ packages:
       json-buffer: 3.0.1
     dev: true
 
+  /kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: false
+
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -10219,6 +10180,26 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  /metaharness@0.4.1:
+    resolution: {integrity: sha512-Kd+cd2VJcTHZwh5YTIIj/Qe/dmhRVpvT9Q1iSn+bbFkFWPcvArAIqJ114kpBLQi2Om3jxXX+oGA2QaAn9NUeaA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@metaharness/kernel': ^0.1.0
+    peerDependenciesMeta:
+      '@metaharness/kernel':
+        optional: true
+    dependencies:
+      '@metaharness/darwin': 0.2.8
+      '@metaharness/flywheel': 0.1.7
+      '@metaharness/redblue': 0.1.4
+      '@metaharness/weight-eft': 0.1.1
+      kolorist: 1.8.0
+      prompts: 2.4.2
+    optionalDependencies:
+      '@ruvector/ruvllm': 2.6.0
+    dev: false
 
   /micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -11234,6 +11215,14 @@ packages:
     dev: false
     optional: true
 
+  /prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+    dev: false
+
   /proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
     requiresBuild: true
@@ -12000,6 +11989,10 @@ packages:
     requiresBuild: true
     dependencies:
       is-arrayish: 0.3.4
+
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: false
 
   /skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -12867,7 +12860,6 @@ packages:
       yaml: 2.8.2
     optionalDependencies:
       fsevents: 2.3.3
-    dev: false
 
   /vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0):
     resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
@@ -12999,7 +12991,7 @@ packages:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.0(@types/node@20.19.27)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@20.19.27)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw
@@ -13210,6 +13202,7 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
     requiresBuild: true
+    optional: true
 
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}


### PR DESCRIPTION
## Summary

Upstream `agent-harness-generator` #142 (darwin caret-locked to 0.2.x, 3 majors behind) and #149 (`META_PROXY_VERSION` pinned with no watcher) are both **silent pin-drift** failures. Ruflo had the same latent gap on its own metaharness deps. This closes it ruflo-side; companion PRs fix the upstream repo.

## Real fix — a floating darwin pin

`distill-oracle.ts` invoked `npx --yes @metaharness/darwin` with **no version pin** at three call sites (the Tier-1 mechanical oracle), so it floated to whatever npm `latest` was — a breaking darwin release could change eval behavior mid-run. Now:
- Pinned via a single `MH_DARWIN_PIN = '0.8.0'` constant used by all three sites.
- Declared `@metaharness/darwin: ^0.8.0` in `optionalDependencies` (subprocess-invoked → kept optional per ADR-150/321) as the single source of truth.
- Fixed a stale `@metaharness/darwin@~0.3.1` doc comment.

## New guard — the #149 analog ruflo lacked

- **`scripts/check-metaharness-pins.mjs`** — diffs each declared range (`metaharness`, `@metaharness/router`, `@metaharness/darwin`) against npm `latest`, plus a lock-step check that `MH_DARWIN_PIN` satisfies the declared darwin range. Exit 1 on drift; network flakes surface as a warning, never a false positive.
- **`.github/workflows/metaharness-pin-drift.yml`** — runs the guard weekly + on PRs touching the pins; opens/updates a tracking issue when a pin falls behind, and hard-fails PRs that introduce drift.

## Validation

```
$ node scripts/check-metaharness-pins.mjs
| metaharness           | ^0.4.1 | 0.4.1 | current |
| @metaharness/router   | ^0.3.2 | 0.3.2 | current |
| @metaharness/darwin   | ^0.8.0 | 0.8.0 | current |
| MH_DARWIN_PIN         | =0.8.0 (vs ^0.8.0) | — | in-range |
✓ All metaharness pins admit the current npm latest.  (exit 0)
```

- Router API-surface compat: **9/9 passed**
- CLI builds clean; `pnpm install --frozen-lockfile` verified with the darwin optionalDep.

Refs: ruvnet/agent-harness-generator#142, #149; ADR-150, ADR-321.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)