### PR TITLE
chore(release): bump to 3.32.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.26",
+  "version": "3.32.27",
   "description": "Ruflo - Enterprise AI agent orchestration for Claude Code. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "dist/index.js",
   "type": "module",

--- a/plugins/ruflo-core/scripts/test-hooks.mjs
+++ b/plugins/ruflo-core/scripts/test-hooks.mjs
@@ -91,7 +91,10 @@ const run = (name, cmd, stdin, assertions) => {
       RUFLO_HOOK_SKIP_NPX: '1',
       RUFLO_HOOK_DEBUG_STDOUT: '1',
     },
-    timeout: 15_000,
+    // A clean CI runner may spend more than 15 seconds starting the CLI and
+    // policy/memory backends for its first Edit hook. Keep a finite timeout,
+    // but allow that measured cold-start path to complete.
+    timeout: 30_000,
   });
   const combined = (r.stdout ?? '') + (r.stderr ?? '');
   const errors = [];

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.26",
+  "version": "3.32.27",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/scripts/audit-env-var-precedence.mjs
+++ b/scripts/audit-env-var-precedence.mjs
@@ -156,6 +156,14 @@ const KNOWN_ESCAPE_HATCHES = new Set([
   // env is the documented operator fallback.
   'CLAUDE_FLOW_MEMORY_SEARCH_NAMESPACES',
 
+  // ── Orchestrator-injected worker identity label (not an auth credential) ───
+  // ADR-324 propagates this value to policy receipts so concurrent workers can
+  // be distinguished. It is intentionally env-only: exposing a CLI flag would
+  // imply that an agent may select its security principal. Human approval
+  // issuance still requires an authenticated identity adapter and never trusts
+  // this label as issuer proof.
+  'CLAUDE_FLOW_PRINCIPAL_ID',
+
   // ── OS / runtime standard env ────────────────────────────────────────────────
   'HOME',
   'USERPROFILE',

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest": {
-    "version": "3.32.9",
+    "version": "3.32.27",
     "files": {
-      "auto-memory-hook.mjs": "e3e1033b24704992ddef6b31c7fa9dd7fcd9e1af7935dd77ef73402b916b31e6",
-      "hook-handler.cjs": "f87ec28684bfc5fd0a54c46bd2a53a3fb037defe71d0ea4b8a5cb88a2cd87a3f",
-      "intelligence.cjs": "5a55d979cb7ba5c8c4f27f3b2e6d686fbb1045d180023b803da672a37e05b915",
-      "statusline.cjs": "10f74a1aa9af217d0623c0a9839d82825b0eed31a4707a7531a85c6116869a6c"
+      "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
+      "hook-handler.cjs": "50ea92a72651bdc95634f7588d56a5870963168eef5226f66ed14af3b47c8d9a",
+      "intelligence.cjs": "bd1f8e4b034944aee1df0391dc47ac2e8cc4b3aa542c65407a59d49620bbf76b",
+      "statusline.cjs": "d2a0eac56d1267d8dbed2d70b09feb592299469196ec4b215909f2b052144882"
     }
   },
-  "signature": "E590NNJFlbDXn0+xPDQqtCOX2KXTXY/DeEBidDqT7oRttLqpS0EBEBU5+WnU0tWutho7uVcUDW2548Job9pRAw==",
+  "signature": "qZMPL+08pJ9yRIibW5x19MugUnGsMn9jKvQOqf9IEVRDj5ULiimXyFoJe+qYI9d3siDV8OYtlfYaqFqfao1gCg==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/catalog-manifest.json
+++ b/v3/@claude-flow/cli/catalog-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "generation": 1,
-  "generatedAt": "2026-07-20T23:20:52.239Z",
-  "gitSha": "745dfbe3",
+  "generation": 2,
+  "generatedAt": "2026-07-29T02:16:56.448Z",
+  "gitSha": "61a915a6",
   "catalog": {
     "agents": 164,
-    "tools": 387,
+    "tools": 394,
     "skills": 34
   },
   "benchmark": null

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -113,7 +113,7 @@
   },
   "optionalDependencies": {
     "@claude-flow/memory": "^3.0.0-alpha.21",
-    "@claude-flow/security": "^3.0.0-alpha.12",
+    "@claude-flow/security": "^3.0.0-alpha.13",
     "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "better-sqlite3": "^12.9.0",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.26",
+  "version": "3.32.27",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/security/package.json
+++ b/v3/@claude-flow/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/security",
-  "version": "3.0.0-alpha.12",
+  "version": "3.0.0-alpha.13",
   "type": "module",
   "description": "Security module - CVE fixes, input validation, path security",
   "main": "dist/index.js",

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -158,7 +158,7 @@ importers:
         specifier: ^3.0.0-alpha.21
         version: link:../memory
       '@claude-flow/security':
-        specifier: ^3.0.0-alpha.12
+        specifier: ^3.0.0-alpha.13
         version: link:../security
       agentdb:
         specifier: ^3.0.0-alpha.17


### PR DESCRIPTION
## Summary

- bump `claude-flow`, `ruflo`, and `@claude-flow/cli` in lockstep to 3.32.27
- publish the new policy-engine runtime as `@claude-flow/security@3.0.0-alpha.13`
- update the CLI optional dependency so clean npm installs receive the policy runtime
- prepare the stable ADR-323/ADR-324 end-user release

## Validation

- policy security suite: 14/14 passed
- `@claude-flow/security` TypeScript build and OAuth export verification passed
- frozen workspace install passed
- dependency-overlap audit passed
- exact umbrella-package version identity verified
- full implementation CI is tracked on #2822

## Release order

1. `@claude-flow/security@3.0.0-alpha.13`
2. `@claude-flow/cli@3.32.27`
3. `claude-flow@3.32.27`
4. `ruflo@3.32.27`
5. `v3.32.27` GitHub release and end-user quick-start gist