### PR TITLE
ci: publish the three-package stable train

### DIFF
--- a/.github/workflows/stable-npm-release.yml
+++ b/.github/workflows/stable-npm-release.yml
@@ -7,18 +7,6 @@ on:
         description: Existing v-prefixed Git tag to publish
         required: true
         type: string
-      security_version:
-        description: Policy runtime version bundled by this release
-        required: true
-        type: string
-      codex_version:
-        description: Codex adapter version bundled by this release
-        required: true
-        type: string
-      federation_version:
-        description: Agent federation plugin version bundled by this release
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -40,18 +28,6 @@ jobs:
         run: |
           if [[ "${{ inputs.tag }}" != v* ]]; then
             echo "::error::tag must start with v"
-            exit 1
-          fi
-          if [[ ! "${{ inputs.security_version }}" =~ ^3\.0\.0-alpha\.[0-9]+$ ]]; then
-            echo "::error::security_version must be a 3.0.0 alpha"
-            exit 1
-          fi
-          if [[ ! "${{ inputs.codex_version }}" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::codex_version must be a stable 3.x version"
-            exit 1
-          fi
-          if [[ ! "${{ inputs.federation_version }}" =~ ^1\.0\.0-alpha\.[0-9]+$ ]]; then
-            echo "::error::federation_version must be a 1.0.0 alpha"
             exit 1
           fi
 
@@ -89,33 +65,9 @@ jobs:
               throw new Error(`${pkg.name}: expected ${expected}, got ${pkg.version}`);
             }
           }
-          const security = require('./v3/@claude-flow/security/package.json');
-          if (security.version !== process.env.SECURITY_VERSION) {
-            throw new Error(
-              `${security.name}: expected ${process.env.SECURITY_VERSION}, got ${security.version}`,
-            );
-          }
-          const cli = packages[2];
-          if (cli.optionalDependencies['@claude-flow/security']
-              !== `^${process.env.SECURITY_VERSION}`) {
-            throw new Error('CLI security dependency is not in release lockstep');
-          }
-          const codex = require('./v3/@claude-flow/codex/package.json');
-          if (codex.version !== process.env.CODEX_VERSION) {
-            throw new Error(`${codex.name}: expected ${process.env.CODEX_VERSION}, got ${codex.version}`);
-          }
-          const federation = require('./v3/@claude-flow/plugin-agent-federation/package.json');
-          if (federation.version !== process.env.FEDERATION_VERSION) {
-            throw new Error(
-              `${federation.name}: expected ${process.env.FEDERATION_VERSION}, got ${federation.version}`,
-            );
-          }
           NODE
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          SECURITY_VERSION: ${{ inputs.security_version }}
-          CODEX_VERSION: ${{ inputs.codex_version }}
-          FEDERATION_VERSION: ${{ inputs.federation_version }}
 
       - name: Install and build publishable packages
         working-directory: v3
@@ -173,55 +125,13 @@ jobs:
 
           pack_dir="$(mktemp -d)"
           trap 'rm -rf "$pack_dir"' EXIT
-          npm pack --ignore-scripts --pack-destination "$pack_dir" ./v3/@claude-flow/security
-          npm pack --ignore-scripts --pack-destination "$pack_dir" ./v3/@claude-flow/codex
-          npm pack --ignore-scripts --pack-destination "$pack_dir" ./v3/@claude-flow/plugin-agent-federation
           npm pack --ignore-scripts --pack-destination "$pack_dir" ./v3/@claude-flow/cli
           npm pack --ignore-scripts --pack-destination "$pack_dir" .
           npm pack --ignore-scripts --pack-destination "$pack_dir" ./ruflo
-          test "$(find "$pack_dir" -maxdepth 1 -name '*.tgz' | wc -l)" -eq 6
+          test "$(find "$pack_dir" -maxdepth 1 -name '*.tgz' | wc -l)" -eq 3
           while IFS= read -r archive; do
             tar -tzf "$archive" >/dev/null
           done < <(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print)
-
-      - name: Publish policy runtime
-        working-directory: v3/@claude-flow/security
-        shell: bash
-        run: |
-          if npm view "@claude-flow/security@${SECURITY_VERSION}" version >/dev/null 2>&1; then
-            echo "@claude-flow/security@${SECURITY_VERSION} already published"
-          else
-            npm publish --ignore-scripts --access public --tag v3alpha
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          SECURITY_VERSION: ${{ inputs.security_version }}
-
-      - name: Publish Codex adapter
-        working-directory: v3/@claude-flow/codex
-        shell: bash
-        run: |
-          if npm view "@claude-flow/codex@${CODEX_VERSION}" version >/dev/null 2>&1; then
-            echo "@claude-flow/codex@${CODEX_VERSION} already published"
-          else
-            npm publish --ignore-scripts --access public --tag latest
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CODEX_VERSION: ${{ inputs.codex_version }}
-
-      - name: Publish agent federation plugin
-        working-directory: v3/@claude-flow/plugin-agent-federation
-        shell: bash
-        run: |
-          if npm view "@claude-flow/plugin-agent-federation@${FEDERATION_VERSION}" version >/dev/null 2>&1; then
-            echo "@claude-flow/plugin-agent-federation@${FEDERATION_VERSION} already published"
-          else
-            npm publish --ignore-scripts --access public --tag v3alpha
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          FEDERATION_VERSION: ${{ inputs.federation_version }}
 
       - name: Publish CLI
         working-directory: v3/@claude-flow/cli
@@ -268,14 +178,8 @@ jobs:
         shell: bash
         run: |
           version="${RELEASE_TAG#v}"
-          test "$(npm view "@claude-flow/security@${SECURITY_VERSION}" version)" = "${SECURITY_VERSION}"
-          test "$(npm view "@claude-flow/codex@${CODEX_VERSION}" version)" = "${CODEX_VERSION}"
-          test "$(npm view "@claude-flow/plugin-agent-federation@${FEDERATION_VERSION}" version)" = "${FEDERATION_VERSION}"
           test "$(npm view "@claude-flow/cli@${version}" version)" = "${version}"
           test "$(npm view "claude-flow@${version}" version)" = "${version}"
           test "$(npm view "ruflo@${version}" version)" = "${version}"
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          SECURITY_VERSION: ${{ inputs.security_version }}
-          CODEX_VERSION: ${{ inputs.codex_version }}
-          FEDERATION_VERSION: ${{ inputs.federation_version }}


### PR DESCRIPTION
## What changed

- defines the stable Ruflo npm train as exactly `@claude-flow/cli`, `claude-flow`, and `ruflo`
- removes internal package versions from workflow inputs and release validation
- stops packing, publishing, and registry-verifying internal `@claude-flow/*` implementation packages
- retains the full build/test/export gates so bundled internal capabilities are still validated
- keeps immutable-tag checkout, signed-helper verification, idempotent publish checks, and exact registry verification for the three public packages

## Why

The prior workflow treated internal packages as independently publishable release artifacts. It failed before reaching the actual user-facing train and turned an internal-package access response into a false release blocker. Normal Ruflo releases bundle those internals into the CLI distribution and publish only the three public entry points.

## User impact

Stable release automation now matches the known-good manual release contract and cannot partially fail on unrelated internal package coordinates.

## Validation

- workflow YAML parses successfully
- `git diff --check`
- structural assertions verify one `tag` input, exactly three publish steps, three `NPM_TOKEN` bindings, three archive packs, and no internal-package publish steps
- v3.32.29 manual publication is being verified against this contract