### PR TITLE
fix(flywheel): align ADR-322 safety envelope with the policy surface it guards

### DIFF
--- a/v3/@claude-flow/cli/__tests__/flywheel-envelope-proposer-contract.test.ts
+++ b/v3/@claude-flow/cli/__tests__/flywheel-envelope-proposer-contract.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ADR-322 regression: the REAL local proposer against the REAL production
+ * safety envelope.
+ *
+ * The shipped v1 envelope allowed `['alpha','topK','rerank','mmrLambda']` while
+ * `retrievalPolicyNeighbors` emits full `RetrievalConfig` snapshots keyed
+ * `alpha, subjectWeight, mmrLambda, bodyWeight, typePenaltyFactor`. Since
+ * `validateCandidate` rejects a candidate when ANY of its keys is outside the
+ * allowlist, every locally-proposed candidate was inadmissible and
+ * `runFlywheelWorker` always returned
+ * `{ran:false, reason:'proposer archive contained no admissible candidates'}`.
+ *
+ * The existing suites could not catch this: `flywheel-proposer.test.ts` builds a
+ * synthetic `allowedPolicyKeys: ['alpha']` envelope with synthetic alpha-only
+ * candidates, and `harness-flywheel.test.ts` calls `runFlywheelTick` directly,
+ * bypassing the proposer archive. Nothing bound the two real pieces together.
+ * These tests do exactly that.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_CONFIG, retrievalPolicyNeighbors, type RetrievalConfig } from '../src/services/harness-flywheel.js';
+import { proposeFlywheelCandidates } from '../src/services/flywheel-proposer.js';
+import { retrievalSafetyEnvelope } from '../src/services/harness-flywheel-runtime.js';
+
+const ZERO_RESOURCES = {
+  p95LatencyMicros: 0,
+  costMicrosPerTask: 0,
+  tokensPerTask: 0,
+  failureRate: 0,
+  evaluationCostMicros: 0,
+};
+
+const proposeReal = (baseline: RetrievalConfig) => proposeFlywheelCandidates({
+  mode: 'local',
+  baselinePolicy: baseline as unknown as Record<string, unknown>,
+  safetyEnvelope: retrievalSafetyEnvelope(),
+  seed: 1,
+  localProposer: () => retrievalPolicyNeighbors(baseline).map((policy) => ({
+    policy: policy as unknown as Record<string, unknown>,
+    resources: { ...ZERO_RESOURCES },
+  })),
+});
+
+describe('ADR-322 envelope <-> local proposer contract', () => {
+  it('should admit locally-proposed candidates when baseline is DEFAULT_CONFIG', async () => {
+    const archive = await proposeReal(DEFAULT_CONFIG);
+
+    expect(archive.candidates.length).toBeGreaterThan(0);
+    expect(archive.admissibleCandidates.length).toBeGreaterThan(0);
+  });
+
+  it('should yield a non-empty Pareto front, which runFlywheelWorker requires to proceed', async () => {
+    const archive = await proposeReal(DEFAULT_CONFIG);
+
+    expect(archive.paretoCandidates.length).toBeGreaterThan(0);
+  });
+
+  it('should allow exactly the keys the proposer emits', () => {
+    const envelope = retrievalSafetyEnvelope();
+    const emittedKeys = Object.keys(retrievalPolicyNeighbors(DEFAULT_CONFIG)[0]).sort();
+
+    expect([...envelope.allowedPolicyKeys].sort()).toEqual(emittedKeys);
+  });
+
+  it('should bound every allowed key, since an unbounded key is never range-checked', () => {
+    const envelope = retrievalSafetyEnvelope();
+
+    for (const key of envelope.allowedPolicyKeys) {
+      const bounds = envelope.numericBounds?.[key];
+      expect(bounds, `${key} has no numeric bounds`).toBeDefined();
+      expect(Number.isFinite(bounds?.min), `${key} min is not finite`).toBe(true);
+      expect(Number.isFinite(bounds?.max), `${key} max is not finite`).toBe(true);
+    }
+  });
+
+  it('should reject an out-of-range weight on a previously unbounded axis', async () => {
+    const archive = await proposeFlywheelCandidates({
+      mode: 'local',
+      baselinePolicy: DEFAULT_CONFIG as unknown as Record<string, unknown>,
+      safetyEnvelope: retrievalSafetyEnvelope(),
+      seed: 1,
+      localProposer: () => [{
+        policy: { ...DEFAULT_CONFIG, subjectWeight: 1e9 } as unknown as Record<string, unknown>,
+        resources: { ...ZERO_RESOURCES },
+      }],
+    });
+
+    expect(archive.admissibleCandidates).toHaveLength(0);
+    expect(archive.candidates[0].rejectionReasons).toContain('subjectWeight above maximum');
+  });
+});

--- a/v3/@claude-flow/cli/src/services/harness-flywheel-runtime.ts
+++ b/v3/@claude-flow/cli/src/services/harness-flywheel-runtime.ts
@@ -40,6 +40,52 @@ const ANCHOR: AnchorTask[] = [
 ].map(([q, labels], i) => ({ id: `q${String(i).padStart(2, '0')}`, input: { id: `q${String(i).padStart(2, '0')}`, q: q as string }, expected: labels as string[] }));
 
 /**
+ * The ADR-322 retrieval safety envelope.
+ *
+ * It MUST describe the policy surface the proposer actually emits —
+ * `RetrievalConfig`. The v1 envelope allowed `topK`/`rerank`, which are
+ * `neural_patterns` search-call arguments not representable in
+ * `RetrievalConfig`, while omitting the three weight axes that
+ * `retrievalPolicyNeighbors` does mutate. Because `validateCandidate` checks
+ * EVERY key of a candidate policy (candidates are full snapshots, not deltas),
+ * that drift made every locally-proposed candidate inadmissible and the local
+ * evaluation path unreachable — no receipt, therefore no promotion, ever.
+ *
+ * Every axis carries a finite bound: an allowed key WITHOUT bounds is an
+ * unbounded key, because `validateCandidate` applies bounds only when present.
+ * A Darwin proposer could otherwise submit arbitrary weights on the three axes.
+ *
+ * Exported so tests can bind the REAL envelope to the REAL proposer; the drift
+ * survived review precisely because no test wired those two together.
+ */
+export function retrievalSafetyEnvelope(ref?: string): SafetyEnvelope {
+  const allowedPolicyKeys = ['alpha', 'subjectWeight', 'mmrLambda', 'bodyWeight', 'typePenaltyFactor'];
+  const numericBounds = {
+    alpha: { min: 0.1, max: 0.9 },
+    subjectWeight: { min: 0.1, max: 10 },
+    mmrLambda: { min: 0.3, max: 0.9 },
+    bodyWeight: { min: 0.1, max: 10 },
+    typePenaltyFactor: { min: 0.1, max: 10 },
+  };
+  return {
+    ref: ref ?? sha256Ref(JSON.stringify({
+      schema: 'ruflo.retrieval-safety-envelope/v2',
+      allowedPolicyKeys,
+      numericBounds,
+    })),
+    allowedPolicyKeys,
+    numericBounds,
+    // Retrieval evaluations are local and report zero provider spend today;
+    // finite ceilings make any future resource evidence fail closed.
+    maxP95LatencyMicros: 5_000_000,
+    maxCostMicrosPerTask: 10_000,
+    maxTokensPerTask: 100_000,
+    maxFailureRate: 0.01,
+    maxEvaluationCostMicros: 1_000_000,
+  };
+}
+
+/**
  * Run one live flywheel tick against `projectRoot`. Opt-in + $0 default: with
  * RUFLO_HARNESS_LOOP unset it is a no-op. Best-effort; never throws.
  */
@@ -84,30 +130,7 @@ export async function runFlywheelWorker(
       ...DEFAULT_CONFIG,
       ...((applier.activeChampion(projectRoot)?.params as Partial<RetrievalConfig>) ?? {}),
     };
-    const safetyEnvelope: SafetyEnvelope = {
-      ref: opts.safetyEnvelopeRef ?? sha256Ref(JSON.stringify({
-        schema: 'ruflo.retrieval-safety-envelope/v1',
-        allowedPolicyKeys: ['alpha', 'topK', 'rerank', 'mmrLambda'],
-        numericBounds: {
-          alpha: { min: 0.1, max: 0.9 },
-          topK: { min: 5, max: 20 },
-          mmrLambda: { min: 0.3, max: 0.9 },
-        },
-      })),
-      allowedPolicyKeys: ['alpha', 'topK', 'rerank', 'mmrLambda'],
-      numericBounds: {
-        alpha: { min: 0.1, max: 0.9 },
-        topK: { min: 5, max: 20 },
-        mmrLambda: { min: 0.3, max: 0.9 },
-      },
-      // Retrieval evaluations are local and report zero provider spend today;
-      // finite ceilings make any future resource evidence fail closed.
-      maxP95LatencyMicros: 5_000_000,
-      maxCostMicrosPerTask: 10_000,
-      maxTokensPerTask: 100_000,
-      maxFailureRate: 0.01,
-      maxEvaluationCostMicros: 1_000_000,
-    };
+    const safetyEnvelope = retrievalSafetyEnvelope(opts.safetyEnvelopeRef);
     // CLI flag opts.proposer takes precedence over RUFLO_FLYWHEEL_PROPOSER.
     const proposerMode = opts.proposer
       ?? ((process.env.RUFLO_FLYWHEEL_PROPOSER as ProposerMode | undefined) ?? 'auto');


### PR DESCRIPTION
Fixes #2835 (defect 1).

## Summary

The ADR-322 retrieval safety envelope named a policy surface that does not exist, which made the local flywheel evaluation path unreachable. This aligns the envelope with `RetrievalConfig`, bounds every axis, and adds the contract test that was missing.

## The defect

`harness-flywheel-runtime.ts:97` allowed `['alpha','topK','rerank','mmrLambda']`. `retrievalPolicyNeighbors` emits `RetrievalConfig` snapshots keyed `alpha, subjectWeight, mmrLambda, bodyWeight, typePenaltyFactor`. `topK`/`rerank` are `neural_patterns` search-call arguments, not policy keys.

`validateCandidate` checks every key of a candidate policy, and candidates are full snapshots rather than deltas, so the three disallowed weights rode along on all of them:

```
candidates: 19   admissible: 0   pareto: 0
```

`runFlywheelWorker` requires a non-empty Pareto front, so every run ended at `"proposer archive contained no admissible candidates"`. No receipt, therefore no promotion.

## The fix

Envelope now names exactly the five real axes, each with a finite bound:

```ts
alpha:             { min: 0.1, max: 0.9 }
subjectWeight:     { min: 0.1, max: 10  }
mmrLambda:         { min: 0.3, max: 0.9 }
bodyWeight:        { min: 0.1, max: 10  }
typePenaltyFactor: { min: 0.1, max: 10  }
```

Bounds on all five, not just the two that had them, because `validateCandidate:105` range-checks a key only when bounds are present — an allowed-but-unbounded key is unbounded in practice. Measured:

```
bounds on 2 keys -> subjectWeight=1e9 ADMISSIBLE, bodyWeight=-5000 ADMISSIBLE, typePenaltyFactor=1e12 ADMISSIBLE
bounds on all 5  -> all rejected
```

The envelope is hoisted into an exported `retrievalSafetyEnvelope()` so tests can bind the real envelope to the real proposer.

## Why it shipped green

`flywheel-proposer.test.ts` uses a synthetic `allowedPolicyKeys: ['alpha']` envelope with synthetic alpha-only candidates. `harness-flywheel.test.ts` calls `runFlywheelTick` directly and bypasses the archive. Nothing joined the real proposer to the real envelope, so a fully green suite never exercised the shipped configuration.

`flywheel-envelope-proposer-contract.test.ts` closes that seam: real `retrievalPolicyNeighbors`, real `retrievalSafetyEnvelope()`, asserting the allowlist equals the emitted key set, that every allowed key is finitely bounded, and that an out-of-range weight on a previously unbounded axis is refused.

## Verification

- New test: **5/5 fail** against the v1 envelope, **5/5 pass** against v2. Confirmed by temporarily reverting the envelope and re-running.
- Full flywheel/harness suite: **16 files, 98 tests, green**.
- `tsc --noEmit`: 437 errors on this branch and **437 on pristine `origin/main`** — identical, pre-existing, none in the touched files.
- End-to-end against a real project with the fix applied to the installed build: the run advances past the proposer and reaches the next gate (`store too small to harvest a corpus`), confirming the admissibility blocker is what was stopping it.

## Compatibility

Envelope schema `v1 -> v2` changes `safetyEnvelopeRef`, and `flywheel-transaction.ts:351` rejects receipts whose ref differs from the pinned `activeSafetyEnvelopeRef`. Since the local path could never produce a promotable receipt, no local lineage can exist to migrate. A Darwin-produced lineage would need an explicit envelope migration.

## Not addressed here

Defects 2 and 3 in #2835 — the `auto`-proposer promotion dead-end and the non-finite-value throw out of `validateCandidate`. The first looks like a governance decision rather than a bug, so I left it for you rather than guessing at intent.

🤖 Generated with Ruflo & AQE
