### PR TITLE
fix(autopilot): reject invalid task sources

### DIFF
--- a/v3/@claude-flow/cli/__tests__/autopilot-task-sources.test.ts
+++ b/v3/@claude-flow/cli/__tests__/autopilot-task-sources.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  validateConfiguredTaskSources,
+  validateTaskSources,
+} from '../src/autopilot-state.js';
+
+describe('autopilot task-source validation', () => {
+  it('keeps recovery defaults for absent persisted state', () => {
+    expect(validateTaskSources(undefined)).toEqual([
+      'team-tasks',
+      'swarm-tasks',
+      'file-checklist',
+    ]);
+  });
+
+  it('rejects an unsupported explicit source instead of enabling defaults', () => {
+    expect(validateConfiguredTaskSources(['issues'])).toEqual({
+      valid: false,
+      invalidSources: ['issues'],
+      reason: 'Unsupported task source(s): issues',
+    });
+  });
+
+  it('rejects a mixed configuration instead of silently dropping invalid entries', () => {
+    expect(validateConfiguredTaskSources(['swarm-tasks', 'issues'])).toEqual({
+      valid: false,
+      invalidSources: ['issues'],
+      reason: 'Unsupported task source(s): issues',
+    });
+  });
+
+  it('normalizes and deduplicates valid explicit sources', () => {
+    expect(validateConfiguredTaskSources([' swarm-tasks ', 'file-checklist', 'swarm-tasks'])).toEqual({
+      valid: true,
+      sources: ['swarm-tasks', 'file-checklist'],
+    });
+  });
+
+  it('rejects an empty explicit source list', () => {
+    expect(validateConfiguredTaskSources([])).toMatchObject({
+      valid: false,
+      reason: 'At least one task source is required',
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/autopilot-state.ts
+++ b/v3/@claude-flow/cli/src/autopilot-state.ts
@@ -116,6 +116,29 @@ export function validateTaskSources(sources: unknown): string[] {
   return valid.length > 0 ? valid : defaults;
 }
 
+export type TaskSourceValidation =
+  | { valid: true; sources: string[] }
+  | { valid: false; invalidSources: string[]; reason: string };
+
+/** Strictly validate user-supplied task sources without enabling defaults. */
+export function validateConfiguredTaskSources(sources: unknown): TaskSourceValidation {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return { valid: false, invalidSources: [], reason: 'At least one task source is required' };
+  }
+
+  const normalized = sources.map(source => typeof source === 'string' ? source.trim() : String(source));
+  const invalidSources = normalized.filter(source => !VALID_TASK_SOURCES.has(source));
+  if (invalidSources.length > 0) {
+    return {
+      valid: false,
+      invalidSources,
+      reason: `Unsupported task source(s): ${invalidSources.join(', ')}`,
+    };
+  }
+
+  return { valid: true, sources: [...new Set(normalized)] };
+}
+
 // ── State Management ──────────────────────────────────────────
 
 export function getDefaultState(): AutopilotState {

--- a/v3/@claude-flow/cli/src/commands/autopilot.ts
+++ b/v3/@claude-flow/cli/src/commands/autopilot.ts
@@ -10,7 +10,7 @@ import { output } from '../output.js';
 import {
   loadState, saveState, appendLog, loadLog, discoverTasks,
   getProgress, calculateReward, tryLoadLearning, validateNumber,
-  validateTaskSources, LOG_FILE,
+  validateConfiguredTaskSources, VALID_TASK_SOURCES, LOG_FILE,
 } from '../autopilot-state.js';
 import { getCheckpointGate, CheckpointGate } from '../services/checkpoint-gate.js';
 
@@ -209,7 +209,7 @@ const configCommand: Command = {
   options: [
     { name: 'max-iterations', type: 'string', description: 'Max re-engagement iterations (1-1000)' },
     { name: 'timeout', type: 'string', description: 'Timeout in minutes (1-1440)' },
-    { name: 'task-sources', type: 'string', description: 'Comma-separated task sources' },
+    { name: 'task-sources', type: 'string', description: `Comma-separated task sources: ${[...VALID_TASK_SOURCES].join(', ')}` },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const state = loadState();
@@ -219,7 +219,14 @@ const configCommand: Command = {
 
     if (maxIter) state.maxIterations = validateNumber(maxIter, 1, 1000, state.maxIterations);
     if (timeout) state.timeoutMinutes = validateNumber(timeout, 1, 1440, state.timeoutMinutes);
-    if (sources) state.taskSources = validateTaskSources(sources.split(',').map(s => s.trim()).filter(Boolean));
+    if (sources !== undefined) {
+      const validation = validateConfiguredTaskSources(sources.split(',').map(s => s.trim()).filter(Boolean));
+      if (!validation.valid) {
+        output.printError(`${validation.reason}. Valid sources: ${[...VALID_TASK_SOURCES].join(', ')}`);
+        return { success: false, exitCode: 1 };
+      }
+      state.taskSources = validation.sources;
+    }
 
     saveState(state);
     appendLog({ ts: Date.now(), event: 'config-updated', maxIterations: state.maxIterations, timeoutMinutes: state.timeoutMinutes, taskSources: state.taskSources });

--- a/v3/@claude-flow/cli/src/mcp-tools/autopilot-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/autopilot-tools.ts
@@ -13,7 +13,7 @@ import { validateText } from './validate-input.js';
 import {
   loadState, saveState, appendLog, loadLog, discoverTasks,
   isTerminal, tryLoadLearning,
-  validateNumber, validateTaskSources,
+  validateNumber, validateConfiguredTaskSources,
   VALID_TASK_SOURCES,
 } from '../autopilot-state.js';
 
@@ -84,7 +84,12 @@ const autopilotConfig: MCPTool = {
     properties: {
       maxIterations: { type: 'number', description: 'Max re-engagement iterations (1-1000)' },
       timeoutMinutes: { type: 'number', description: 'Timeout in minutes (1-1440)' },
-      taskSources: { type: 'array', items: { type: 'string' }, description: `Task sources: ${[...VALID_TASK_SOURCES].join(', ')}` },
+      taskSources: {
+        type: 'array',
+        minItems: 1,
+        items: { type: 'string', enum: [...VALID_TASK_SOURCES] },
+        description: `Task sources: ${[...VALID_TASK_SOURCES].join(', ')}`,
+      },
     },
   },
   handler: async (params: Record<string, unknown>) => {
@@ -96,7 +101,17 @@ const autopilotConfig: MCPTool = {
       state.timeoutMinutes = validateNumber(params.timeoutMinutes, 1, 1440, state.timeoutMinutes);
     }
     if (params.taskSources !== undefined) {
-      state.taskSources = validateTaskSources(params.taskSources);
+      const validation = validateConfiguredTaskSources(params.taskSources);
+      if (!validation.valid) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            error: validation.reason,
+            validSources: [...VALID_TASK_SOURCES],
+          }) }],
+          isError: true,
+        };
+      }
+      state.taskSources = validation.sources;
     }
     saveState(state);
     return ok({ maxIterations: state.maxIterations, timeoutMinutes: state.timeoutMinutes, taskSources: state.taskSources });


### PR DESCRIPTION
## Summary

- reject unsupported or empty task-source lists at explicit CLI and MCP configuration boundaries
- preserve default recovery behavior for absent/corrupt persisted state
- enumerate valid values in CLI help and constrain the MCP input schema
- deduplicate normalized valid sources
- add focused regression coverage

Fixes #2837.

## Why

Before this change, an explicit unsupported value such as:

```sh
ruflo autopilot config --task-sources issues
```

was accepted and silently replaced by every default source. One of those defaults, `team-tasks`, intentionally scans the global `~/.claude/tasks` tree. The fail-open fallback could therefore make a workspace discover unrelated team tasks even though its autopilot state file remained workspace-local.

Persisted-state recovery and explicit configuration need different semantics: recovery may use defaults, but invalid user input should fail without saving broader defaults.

## Verification

- `npx vitest run __tests__/autopilot-task-sources.test.ts` — 5 tests passed
- `git diff --check` — passed
- `npx tsc --noEmit --pretty false` — blocked by existing repository baseline errors, including unresolved `@claude-flow/security` workspace outputs, unbuilt swarm declaration outputs, and pre-existing `unknown` exception typing in `src/auth/client.ts`; no error referenced a changed file
- ESLint is not a usable TypeScript gate in this checkout because the current root configuration parses TypeScript as legacy JavaScript (`import` is reported as reserved)

## Scope

This PR does not add `issues` as a new discovery source and does not change the intentional global scope of Claude team tasks. It only prevents invalid explicit configuration from silently enabling those sources.
