### PR TITLE
chore(release): prepare v3.32.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.30",
+  "version": "3.32.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.30",
+      "version": "3.32.31",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.30",
+  "version": "3.32.31",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.30",
+  "version": "3.32.31",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.30"
+    "@claude-flow/cli": "^3.32.31"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.30",
+  "version": "3.32.31",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/docs/releases/v3.32.31.md
+++ b/v3/docs/releases/v3.32.31.md
@@ -1,0 +1,98 @@
+# Ruflo v3.32.31: Governed Flywheel Candidates and Explicit Autopilot Scope
+
+Ruflo's self-improvement loop should explore useful candidates without
+relaxing its promotion guardrails, and Autopilot should never search a broader
+task surface than the operator requested. v3.32.31 fixes both contracts.
+
+The Flywheel safety envelope now describes the complete retrieval policy that
+the built-in proposer actually emits. Valid candidates can reach evaluation
+again, while every tunable value remains bounded and promotion remains subject
+to signed receipts, policy authorization, and the atomic transaction gate.
+
+Autopilot now treats explicitly configured task sources strictly. Misspelled,
+empty, or unsupported sources fail with a useful error instead of silently
+falling back to every default source. Recovery from absent or damaged legacy
+state remains backward compatible.
+
+## What this enables
+
+- Run the local Flywheel proposer without every full retrieval-policy snapshot
+  being rejected as outside its own safety envelope.
+- Tune `alpha`, `subjectWeight`, `mmrLambda`, `bodyWeight`, and
+  `typePenaltyFactor` inside explicit finite bounds.
+- Keep Darwin and local proposers subordinate to Ruflo's evaluation,
+  receipt-verification, and promotion transaction.
+- Configure Autopilot task discovery with an exact, auditable source set.
+- Detect configuration mistakes before Autopilot state is persisted or task
+  discovery begins.
+
+## Install or upgrade
+
+```bash
+npm install --global ruflo@3.32.31
+ruflo doctor
+```
+
+Or run without a global installation:
+
+```bash
+npx ruflo@3.32.31 --version
+```
+
+## Configure Autopilot task sources
+
+The supported sources are `team-tasks`, `swarm-tasks`, and `file-checklist`.
+
+```bash
+ruflo autopilot config \
+  --task-sources swarm-tasks,file-checklist
+```
+
+Unsupported input now exits unsuccessfully and leaves the stored configuration
+unchanged:
+
+```bash
+ruflo autopilot config --task-sources issues
+```
+
+## Evaluate Flywheel candidates
+
+Inspect the current transaction and ledger state:
+
+```bash
+ruflo metaharness flywheel status
+```
+
+Run one governed evaluation using the built-in proposer:
+
+```bash
+ruflo metaharness flywheel run --proposer local
+```
+
+Evaluation still does not grant promotion authority. Promotion requires an
+accepted receipt, trusted signing key, current baseline, matching ledger head,
+policy authorization, and explicit confirmation.
+
+## Compatibility and migration
+
+- Existing valid Autopilot state continues to load unchanged.
+- Missing or corrupt persisted task-source state still recovers to the legacy
+  defaults; only new explicit configuration is validated strictly.
+- The retrieval safety-envelope reference advances to v2. Old v1 receipts
+  should be re-evaluated under the new envelope rather than promoted as if the
+  governing bounds had not changed.
+- The release remains the standard three-package train:
+  `@claude-flow/cli`, `claude-flow`, and `ruflo`.
+
+## Validation contract
+
+Release acceptance requires:
+
+- full PR CI for both fixes;
+- combined Flywheel and Autopilot focused tests;
+- version-lockstep validation across all three public packages;
+- immutable tarball construction and bundled-runtime inspection;
+- fresh-install smoke tests for CLI, policy, daemon, Codex initialization, and
+  wrapper commands;
+- registry integrity verification;
+- aligned `latest`, `alpha`, and `v3alpha` npm tags.


### PR DESCRIPTION
## Summary

- release the Flywheel safety-envelope correction from #2836
- release strict explicit Autopilot task-source validation from #2838
- advance the three public packages in lockstep to 3.32.31
- add end-user install, usage, compatibility, and validation notes

## Validation

- `node scripts/audit-umbrella-version-lockstep.mjs`
- 6 focused Flywheel/Autopilot suites, 38 assertions
- full V3 recursive TypeScript build across 23 packages
- `git diff --check`
