### PR TITLE
chore(release): prepare v3.32.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.31",
+  "version": "3.32.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.31",
+      "version": "3.32.32",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.31",
+  "version": "3.32.32",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.31",
+  "version": "3.32.32",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.31"
+    "@claude-flow/cli": "^3.32.32"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.32.30",
+    "version": "3.32.32",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "50ea92a72651bdc95634f7588d56a5870963168eef5226f66ed14af3b47c8d9a",
@@ -8,6 +8,6 @@
       "statusline.cjs": "d2a0eac56d1267d8dbed2d70b09feb592299469196ec4b215909f2b052144882"
     }
   },
-  "signature": "6wQg/DXPVzG1hEnZzI0RcEi/6wfUnXyFYZ09Ho7jVHz84sbuX1flCWZA3qq5c8BvUtZ9/oCs9GOpEnMykGk4CA==",
+  "signature": "04DvDI9kCGvy1HIskgegJsTnGUTgnDBMGTb/c+ef/hy3XgM4WvpHb6xePaWraB6YQ4F41+4BZRi4ZeBWBrVbBA==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.31",
+  "version": "3.32.32",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/docs/releases/v3.32.32.md
+++ b/v3/docs/releases/v3.32.32.md
@@ -1,0 +1,87 @@
+# Ruflo v3.32.32: Governed Flywheel Candidates and Explicit Autopilot Scope
+
+Ruflo's self-improvement loop should explore useful candidates without
+relaxing its promotion guardrails, and Autopilot should never search a broader
+task surface than the operator requested. v3.32.32 fixes both contracts.
+
+The Flywheel safety envelope now describes the complete retrieval policy that
+the built-in proposer actually emits. Valid candidates can reach evaluation
+again, while every tunable value remains bounded and promotion remains subject
+to signed receipts, policy authorization, and the atomic transaction gate.
+
+Autopilot now treats explicitly configured task sources strictly. Misspelled,
+empty, or unsupported sources fail with a useful error instead of silently
+falling back to every default source. Recovery from absent or damaged legacy
+state remains backward compatible.
+
+## Install or upgrade
+
+```bash
+npm install --global ruflo@3.32.32
+ruflo doctor
+```
+
+Or run without a global installation:
+
+```bash
+npx ruflo@3.32.32 --version
+```
+
+## Configure an exact Autopilot scope
+
+The supported sources are `team-tasks`, `swarm-tasks`, and `file-checklist`.
+
+```bash
+ruflo autopilot config \
+  --task-sources swarm-tasks,file-checklist
+```
+
+Unsupported input now exits unsuccessfully and leaves the stored configuration
+unchanged:
+
+```bash
+ruflo autopilot config --task-sources issues
+```
+
+## Evaluate governed Flywheel candidates
+
+```bash
+ruflo metaharness flywheel status
+ruflo metaharness flywheel run --proposer local
+```
+
+The local proposer can now produce admissible full-policy candidates over
+`alpha`, `subjectWeight`, `mmrLambda`, `bodyWeight`, and
+`typePenaltyFactor`. Evaluation still cannot authorize promotion. Promotion
+requires an accepted receipt, trusted signing key, current baseline, matching
+ledger head, policy authorization, and explicit confirmation.
+
+## Compatibility
+
+- Existing valid Autopilot state continues to load unchanged.
+- Missing or corrupt persisted task-source state still recovers to the legacy
+  defaults; only new explicit configuration is validated strictly.
+- The retrieval safety-envelope reference advances to v2. Old v1 receipts
+  should be re-evaluated under the new envelope.
+- The release remains the standard three-package train:
+  `@claude-flow/cli`, `claude-flow`, and `ruflo`.
+
+## Release note
+
+`v3.32.31` was reserved by an immutable Git tag, but its release pipeline
+stopped at helper-manifest verification before any npm publication. v3.32.32
+contains the same reviewed fixes with the correctly versioned and signed helper
+manifest.
+
+## Validation contract
+
+Release acceptance requires:
+
+- full CI for the Flywheel and Autopilot fixes;
+- combined focused tests;
+- version-lockstep validation across all three public packages;
+- signed helper-manifest verification;
+- immutable tarball construction and bundled-runtime inspection;
+- fresh-install CLI, policy, daemon, Codex initialization, and wrapper smokes;
+- registry integrity verification and aligned `latest`, `alpha`, and
+  `v3alpha` tags.


### PR DESCRIPTION
## Summary

- advance the stable three-package train to 3.32.32
- carry the merged Flywheel and Autopilot fixes from #2836 and #2838
- regenerate the Ed25519 helper manifest for the release version
- document that the immutable v3.32.31 pipeline stopped before npm publication

## Validation

- version-lockstep audit passed
- signed helper manifest verified at 3.32.32
- 6 focused suites / 38 assertions passed
- recursive TypeScript build passed across 23 packages
- `git diff --check` passed
