### PR TITLE
fix(autopilot): enforce normalized CLI task sources

### DIFF
--- a/.github/workflows/stable-npm-release.yml
+++ b/.github/workflows/stable-npm-release.yml
@@ -254,6 +254,27 @@ jobs:
             timeout 30s node ../node_modules/@claude-flow/cli/bin/cli.js daemon start
             timeout 30s node ../node_modules/@claude-flow/cli/bin/cli.js daemon status
             timeout 30s node ../node_modules/@claude-flow/cli/bin/cli.js daemon stop
+            cd ..
+            mkdir autopilot-scope
+            cd autopilot-scope
+            if node ../node_modules/@claude-flow/cli/bin/cli.js \
+              autopilot config --task-sources issues; then
+              echo "::error::invalid explicit Autopilot source was accepted"
+              exit 1
+            fi
+            test ! -f .claude-flow/data/autopilot-state.json
+            node ../node_modules/@claude-flow/cli/bin/cli.js autopilot config \
+              --task-sources swarm-tasks,file-checklist \
+              --max-iterations 77
+            node - <<'NODE'
+          const state = require('./.claude-flow/data/autopilot-state.json');
+          if (JSON.stringify(state.taskSources) !== JSON.stringify(['swarm-tasks', 'file-checklist'])) {
+            throw new Error(`unexpected Autopilot task sources: ${JSON.stringify(state.taskSources)}`);
+          }
+          if (state.maxIterations !== 77) {
+            throw new Error(`unexpected Autopilot maxIterations: ${state.maxIterations}`);
+          }
+          NODE
           )
 
           root_install="$(mktemp -d)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.32",
+  "version": "3.32.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.32",
+      "version": "3.32.33",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.32",
+  "version": "3.32.33",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.32",
+  "version": "3.32.33",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.32"
+    "@claude-flow/cli": "^3.32.33"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.32.32",
+    "version": "3.32.33",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "50ea92a72651bdc95634f7588d56a5870963168eef5226f66ed14af3b47c8d9a",
@@ -8,6 +8,6 @@
       "statusline.cjs": "d2a0eac56d1267d8dbed2d70b09feb592299469196ec4b215909f2b052144882"
     }
   },
-  "signature": "04DvDI9kCGvy1HIskgegJsTnGUTgnDBMGTb/c+ef/hy3XgM4WvpHb6xePaWraB6YQ4F41+4BZRi4ZeBWBrVbBA==",
+  "signature": "cdCqQZfkjY3y+45Yuk0kKw2yV3CApVm21lmQcxZhYrxgAhhh2o6nAWbFnmNUJIMD/LBPmDjiy4zT9kjoRMMOCA==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/__tests__/autopilot-task-sources.test.ts
+++ b/v3/@claude-flow/cli/__tests__/autopilot-task-sources.test.ts
@@ -1,8 +1,14 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  STATE_FILE,
   validateConfiguredTaskSources,
   validateTaskSources,
 } from '../src/autopilot-state.js';
+import { autopilotCommand } from '../src/commands/autopilot.js';
+import { CommandParser } from '../src/parser.js';
 
 describe('autopilot task-source validation', () => {
   it('keeps recovery defaults for absent persisted state', () => {
@@ -41,5 +47,69 @@ describe('autopilot task-source validation', () => {
       valid: false,
       reason: 'At least one task source is required',
     });
+  });
+
+  it('rejects the parser-normalized CLI flag without persisting fallback defaults', async () => {
+    const parser = new CommandParser();
+    parser.registerCommand(autopilotCommand);
+    const parsed = parser.parse(['autopilot', 'config', '--task-sources', 'issues']);
+    expect(parsed.flags.taskSources).toBe('issues');
+
+    const config = autopilotCommand.subcommands?.find(command => command.name === 'config');
+    expect(config?.action).toBeDefined();
+
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ruflo-autopilot-invalid-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(projectRoot);
+      const result = await config!.action!({
+        args: parsed.positional,
+        flags: parsed.flags,
+        cwd: projectRoot,
+        interactive: false,
+      });
+      expect(result).toMatchObject({ success: false, exitCode: 1 });
+      expect(existsSync(STATE_FILE)).toBe(false);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('persists valid parser-normalized sources and max-iterations', async () => {
+    const parser = new CommandParser();
+    parser.registerCommand(autopilotCommand);
+    const parsed = parser.parse([
+      'autopilot',
+      'config',
+      '--task-sources',
+      'swarm-tasks,file-checklist',
+      '--max-iterations',
+      '77',
+    ]);
+    expect(parsed.flags).toMatchObject({
+      taskSources: 'swarm-tasks,file-checklist',
+      maxIterations: 77,
+    });
+
+    const config = autopilotCommand.subcommands?.find(command => command.name === 'config');
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ruflo-autopilot-valid-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(projectRoot);
+      const result = await config!.action!({
+        args: parsed.positional,
+        flags: parsed.flags,
+        cwd: projectRoot,
+        interactive: false,
+      });
+      expect(result).toMatchObject({ success: true });
+      const state = JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+      expect(state.taskSources).toEqual(['swarm-tasks', 'file-checklist']);
+      expect(state.maxIterations).toBe(77);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.32",
+  "version": "3.32.33",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/commands/autopilot.ts
+++ b/v3/@claude-flow/cli/src/commands/autopilot.ts
@@ -213,9 +213,11 @@ const configCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const state = loadState();
-    const maxIter = ctx.flags?.['max-iterations'] as string | undefined;
+    // CommandParser canonicalizes kebab-case flags to camelCase.
+    // Retain kebab-case reads for direct/legacy action callers.
+    const maxIter = (ctx.flags?.maxIterations ?? ctx.flags?.['max-iterations']) as string | number | undefined;
     const timeout = ctx.flags?.timeout as string | undefined;
-    const sources = ctx.flags?.['task-sources'] as string | undefined;
+    const sources = (ctx.flags?.taskSources ?? ctx.flags?.['task-sources']) as string | undefined;
 
     if (maxIter) state.maxIterations = validateNumber(maxIter, 1, 1000, state.maxIterations);
     if (timeout) state.timeoutMinutes = validateNumber(timeout, 1, 1440, state.timeoutMinutes);

--- a/v3/docs/releases/v3.32.33.md
+++ b/v3/docs/releases/v3.32.33.md
@@ -1,0 +1,56 @@
+# Ruflo v3.32.33: Autopilot Scope Enforcement at the Real CLI Boundary
+
+v3.32.33 completes the Flywheel and Autopilot reliability release by enforcing
+explicit task-source validation through the same normalized flags users pass
+to the CLI.
+
+The V3 parser converts kebab-case options such as `--task-sources` and
+`--max-iterations` to `taskSources` and `maxIterations`. The initial validation
+implementation correctly rejected unsupported values at the service and MCP
+layers but read the legacy kebab-case keys in the CLI action. As a result, the
+real command ignored the supplied value and persisted the default source set.
+
+This release reads the parser's canonical camelCase keys while retaining the
+legacy keys for direct action callers. A parser-to-command integration test and
+an immutable-tarball release smoke now prove that unsupported task sources fail
+without creating state.
+
+## Install or upgrade
+
+```bash
+npm install --global ruflo@3.32.33
+ruflo doctor
+```
+
+## Configure an exact Autopilot scope
+
+```bash
+ruflo autopilot config \
+  --task-sources swarm-tasks,file-checklist \
+  --max-iterations 77
+```
+
+Unsupported sources fail and leave the stored configuration unchanged:
+
+```bash
+ruflo autopilot config --task-sources issues
+```
+
+## Flywheel fix included
+
+The release also includes the v2 retrieval safety envelope from #2836. The
+built-in proposer can evaluate bounded full-policy candidates without gaining
+promotion authority.
+
+```bash
+ruflo metaharness flywheel status
+ruflo metaharness flywheel run --proposer local
+```
+
+## Release lineage
+
+- `v3.32.31` stopped before npm publication because its helper manifest was
+  signed for the prior version.
+- `v3.32.32` corrected the signed manifest and was published, but independent
+  post-registry validation found the CLI flag-normalization mismatch.
+- `v3.32.33` is the validated release and receives the stable npm tags.


### PR DESCRIPTION
## Summary

- read parser-normalized `taskSources` and `maxIterations` flags in Autopilot config
- preserve legacy kebab-case action keys for backward compatibility
- add parser-to-command tests for rejection-without-persistence and valid persistence
- add the real CLI boundary check to the immutable pre-publish tarball smoke
- release the corrected stable train as 3.32.33

## Validation

- 6 focused suites / 40 assertions passed
- real built CLI rejects `--task-sources issues` with exit code 1 and no state file
- real built CLI persists the exact valid source set and max iteration value
- recursive TypeScript build passed across 23 packages
- signed helper manifest verified at 3.32.33
- version lockstep, workflow YAML parse, and diff check passed
