### PR TITLE
chore(release): harden memory migration for v3.32.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.33",
+  "version": "3.32.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.33",
+      "version": "3.32.34",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.33",
+  "version": "3.32.34",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.33",
+  "version": "3.32.34",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.33"
+    "@claude-flow/cli": "^3.32.34"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.32.33",
+    "version": "3.32.34",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "50ea92a72651bdc95634f7588d56a5870963168eef5226f66ed14af3b47c8d9a",
@@ -8,6 +8,6 @@
       "statusline.cjs": "d2a0eac56d1267d8dbed2d70b09feb592299469196ec4b215909f2b052144882"
     }
   },
-  "signature": "cdCqQZfkjY3y+45Yuk0kKw2yV3CApVm21lmQcxZhYrxgAhhh2o6nAWbFnmNUJIMD/LBPmDjiy4zT9kjoRMMOCA==",
+  "signature": "i0qilACTabRlI6VORA0QyP0r4EuvJsrvtkucxia3TStgq/la250iesyKjlcHbLV/6fshZiGtPMLq1nmXLf+ZAw==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/__tests__/memory-bridge-provenance-migration.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-bridge-provenance-migration.test.ts
@@ -17,7 +17,7 @@
  * the real failure. Observed live: an MCP server dropped every memory_store
  * for hours while better-sqlite3 was healthy the whole time.
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import initSqlJs from 'sql.js';
 import { ensureBridgeSchema } from '../src/memory/memory-bridge.js';
 
@@ -90,5 +90,16 @@ describe('bridge schema migration (ADR-323 provenance_type)', () => {
     db.run(LEGACY_TABLE);
 
     expect(ensureBridgeSchema(db)).toBe(true);
+  });
+
+  it('should fail closed when ALTER fails for a reason other than an existing column', () => {
+    const exec = vi.fn((sql: string) => {
+      if (sql.startsWith('ALTER TABLE')) {
+        throw new Error('SQLITE_READONLY: attempt to write a readonly database');
+      }
+    });
+
+    expect(ensureBridgeSchema({ exec })).toBe(false);
+    expect(exec).toHaveBeenCalledTimes(2);
   });
 });

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.33",
+  "version": "3.32.34",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -625,9 +625,15 @@ export function ensureBridgeSchema(db: { exec: (sql: string) => unknown }): bool
     // WAL-sidecar error naming an unrelated cause. Silent, total write loss.
     try {
       db.exec(`ALTER TABLE memory_entries ADD COLUMN provenance_type TEXT DEFAULT 'unknown'`);
-    } catch {
-      // Already present (the common case). SQLite has no ADD COLUMN IF NOT
-      // EXISTS, so attempt-and-ignore is the idiom.
+    } catch (err) {
+      // Already present is the common case. SQLite has no ADD COLUMN IF NOT
+      // EXISTS, so attempt-and-ignore only that exact condition. Treating a
+      // read-only, locked, or corrupt database as migrated would cache a
+      // schema that bridgeStoreEntry() still cannot use.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/duplicate column name:\s*provenance_type/i.test(msg)) {
+        throw err;
+      }
     }
     db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_ns ON memory_entries(namespace)`);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_key ON memory_entries(key)`);
@@ -913,6 +919,11 @@ export async function bridgeStoreEntry(options: {
       ttl ? now + (ttl * 1000) : null
     );
 
+    // A completed native write proves the bridge is currently healthy. Do not
+    // retain a diagnostic from an earlier transient failure and append it to a
+    // later, unrelated sql.js fallback refusal.
+    bridgeFailureReason = null;
+
     // #2775: strict insert against an ACTIVE existing row → changes === 0
     // (the ON CONFLICT WHERE clause above suppressed the update). Surface
     // this as a typed data-level error rather than a bridge failure —
@@ -983,11 +994,6 @@ export async function bridgeStoreEntry(options: {
     // never triggers the #2735 whole-image guard with a misleading
     // "active native WAL connection" error.
     const msg = err instanceof Error ? err.message : String(err);
-    // Returning null below demotes the caller to the sql.js whole-image path,
-    // whose WAL-sidecar guard then reports a cause that has nothing to do with
-    // what actually went wrong here. Record the real error so it can be
-    // surfaced alongside that guard's message.
-    bridgeFailureReason = msg;
     if (/UNIQUE constraint failed/i.test(msg)) {
       return {
         success: false,
@@ -995,6 +1001,11 @@ export async function bridgeStoreEntry(options: {
         error: `key "${options.key}" already exists in namespace "${options.namespace ?? 'default'}" — pass upsert=true (--upsert on the CLI) to update it`,
       };
     }
+    // Returning null below demotes the caller to the sql.js whole-image path,
+    // whose WAL-sidecar guard then reports a cause that has nothing to do with
+    // what actually went wrong here. Record the real error so it can be
+    // surfaced alongside that guard's message.
+    bridgeFailureReason = msg;
     return null;
   }
 }

--- a/v3/docs/releases/v3.32.34.md
+++ b/v3/docs/releases/v3.32.34.md
@@ -1,0 +1,59 @@
+# Ruflo v3.32.34: Reliable Memory Writes on Existing Installations
+
+v3.32.34 repairs a migration gap that could prevent `memory store` and MCP
+`memory_store` writes on databases created before ADR-323.
+
+The native AgentDB bridge now adds the required `provenance_type` column to
+existing `memory_entries` tables before writing. If that migration cannot run
+because the database is read-only, locked, or damaged, Ruflo fails closed and
+reports the native bridge error instead of presenting an unrelated WAL fallback
+message.
+
+The bridge failure latch is also recoverable: shutdown resets it, successful
+native writes clear stale diagnostics, and degradation notices remain visible.
+
+## Install or upgrade
+
+```bash
+npm install --global ruflo@3.32.34
+ruflo doctor
+```
+
+Existing databases are migrated automatically on the first native bridge
+access. No manual SQL is required.
+
+## Verify memory round-trip
+
+```bash
+ruflo memory store \
+  --key release-3.32.34-check \
+  --value "memory bridge migration works" \
+  --namespace verification
+
+ruflo memory retrieve \
+  --key release-3.32.34-check \
+  --namespace verification
+```
+
+For MCP clients, the equivalent `memory_store` and `memory_retrieve` tools use
+the same repaired path.
+
+## What changed
+
+- Migrates `provenance_type` on pre-ADR-323 AgentDB files.
+- Retries schema setup when the database was not writable.
+- Preserves the actual native bridge error for diagnostics.
+- Clears obsolete bridge errors after a successful native write.
+- Resets a failed initialization latch during bridge shutdown.
+- Keeps native-driver fallback notices visible.
+- Adds regression coverage for legacy databases, idempotent migration,
+  fail-closed migration, and failure-latch recovery.
+
+## Compatibility
+
+The migration is additive and idempotent. New databases already contain the
+column; existing databases receive it once; installations without the optional
+native bridge continue to use the existing sql.js path.
+
+This release resolves [#2843](https://github.com/ruvnet/ruflo/issues/2843) via
+[#2844](https://github.com/ruvnet/ruflo/pull/2844).


### PR DESCRIPTION
## Summary

- publish the #2844 legacy AgentDB migration as v3.32.34
- fail closed when `ALTER TABLE` fails for anything except the expected duplicate-column condition
- clear stale bridge diagnostics after a successful native write
- keep the three public package versions and signed helper manifest in lockstep
- add end-user upgrade and verification notes

## Validation

- 42/42 focused memory, provenance, WAL guard, durability, and upsert tests
- 23/23 V3 workspace packages build
- real `better-sqlite3` legacy database migration, write/read round-trip, and idempotent rerun
- signed helper manifest verified for 3.32.34
- `npm pack --dry-run` succeeds for `@claude-flow/cli`, `claude-flow`, and `ruflo`

Closes #2843
