### PR TITLE
chore(release): Ruflo v3.32.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.34",
+  "version": "3.32.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.34",
+      "version": "3.32.35",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.34",
+  "version": "3.32.35",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.34",
+  "version": "3.32.35",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.34"
+    "@claude-flow/cli": "^3.32.35"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.32.34",
+    "version": "3.32.35",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "50ea92a72651bdc95634f7588d56a5870963168eef5226f66ed14af3b47c8d9a",
@@ -8,6 +8,6 @@
       "statusline.cjs": "d2a0eac56d1267d8dbed2d70b09feb592299469196ec4b215909f2b052144882"
     }
   },
-  "signature": "i0qilACTabRlI6VORA0QyP0r4EuvJsrvtkucxia3TStgq/la250iesyKjlcHbLV/6fshZiGtPMLq1nmXLf+ZAw==",
+  "signature": "7hAABpKaZablL78ug8UW506P+ppwYlDb2qws0D4BbCeugfGQTdDEOYsndbZMc4+Wzbx10oQbnubqh8jHZnHvBQ==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/catalog-manifest.json
+++ b/v3/@claude-flow/cli/catalog-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "generation": 3,
-  "generatedAt": "2026-07-29T05:10:56.000Z",
-  "gitSha": "da257a20",
+  "generation": 4,
+  "generatedAt": "2026-07-29T17:53:37.877Z",
+  "gitSha": "9cf769cc",
   "catalog": {
     "agents": 164,
-    "tools": 395,
+    "tools": 397,
     "skills": 34
   },
   "benchmark": null

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.34",
+  "version": "3.32.35",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/docs/releases/v3.32.35.md
+++ b/v3/docs/releases/v3.32.35.md
@@ -1,0 +1,116 @@
+# Ruflo v3.32.35: Adaptive Swarms and Safer Learning Loops
+
+Ruflo v3.32.35 gives long-running agent teams a controlled way to learn which
+workers should receive future tasks. The new `pheromone-adaptive` topology
+combines outcome, latency, and consensus signals while preserving protected
+roles, a minimum active quorum, and existing permissions. It begins in dry-run
+mode so teams can inspect its decisions before enabling scheduling changes.
+
+This release also makes the surrounding learning loop more trustworthy:
+project flywheels must evaluate against a project-local, hash-pinned benchmark;
+learned routing updates inside a live MCP process; AgentDB deletes and upserts
+remove stale vectors; and daemon auto-start is limited to actual Ruflo
+projects.
+
+## Install or upgrade
+
+```bash
+npm install --global ruflo@3.32.35
+ruflo doctor
+```
+
+Existing installations remain compatible. The default topology is still
+`hierarchical`, old swarm state remains readable, historical flywheel receipts
+remain verifiable, and the new adaptive scheduler is opt-in.
+
+## Try adaptive swarm scheduling
+
+Start in the default calibration mode:
+
+```bash
+ruflo swarm init \
+  --topology pheromone-adaptive \
+  --max-agents 8
+
+ruflo swarm pheromone
+ruflo agent metrics --format json
+```
+
+When the observations look right, explicitly enable scheduling enforcement:
+
+```bash
+ruflo swarm init \
+  --topology pheromone-adaptive \
+  --max-agents 8 \
+  --apsc-live
+```
+
+Live mode changes Ruflo dispatch eligibility only. It does not terminate
+agents, revoke access, discard context, or widen permissions.
+
+## Use a project-local flywheel anchor
+
+Create `.claude/eval/flywheel-anchor.manifest.json`:
+
+```json
+{
+  "schemaVersion": "ruflo.flywheel-anchor-manifest/v1",
+  "path": "my-project-anchor.json",
+  "sha256": "sha256:<canonical-task-hash>"
+}
+```
+
+The referenced anchor contains at least four labelled tasks. Ruflo binds its
+canonical hash into new evaluation receipts. A non-Ruflo repository without a
+project anchor now fails closed instead of silently optimizing against Ruflo's
+built-in development benchmark.
+
+## What changed
+
+- Adds the opt-in `pheromone-adaptive` swarm topology with role-aware EMA
+  scoring, dry-run calibration, protected roles, quorum floors, bounded
+  exploration, atomic cross-process updates, CLI inspection, and MCP tools.
+- Connects `hooks post-task` outcomes to adaptive scheduling and exposes each
+  agent's score, sample count, role, and eligibility through `agent metrics`.
+- Adds hash-pinned, project-local flywheel evaluation anchors and receipt
+  binding while retaining historical receipt verification.
+- Makes learned routing use supported, discriminative evidence and immediately
+  invalidates a warm router after labelled outcomes.
+- Makes AgentDB logical-key upserts, deletes, and cleanup reconcile every stale
+  vector and report accurate lifecycle metrics.
+- Limits daemon auto-start to projects containing `.claude-flow/`, reports the
+  first start, and applies a 30-minute abandoned-daemon idle timeout.
+
+## Measured benchmark
+
+On the declared synthetic benchmark (12 agents, 20,000 updates), adaptive
+scheduling produced:
+
+- 33.3% active-agent reduction;
+- +0.2617 admitted mean score;
+- 0.0066 ms update p95 in the release validation run;
+- preserved quorum and protected-role invariants.
+
+These are Ruflo benchmark results for that workload, not a universal production
+performance claim.
+
+## Validation
+
+- TypeScript builds passed for `@claude-flow/shared`, `@claude-flow/swarm`, and
+  `@claude-flow/cli`.
+- The changed-surface suite passed 93 tests across nine files.
+- Twenty concurrent outcome writers persisted all twenty rounds with no
+  residual lock.
+- Built CLI smoke tests covered initialization, automatic post-task learning,
+  status, manual updates, and JSON metrics.
+- CI/CD, V3 CI/CD, CodeQL, cross-agent integration, CVE audit, and verification
+  workflows passed on the merged commit.
+
+This release ships [#2848](https://github.com/ruvnet/ruflo/pull/2848) and
+resolves
+[#2815](https://github.com/ruvnet/ruflo/issues/2815),
+[#2819](https://github.com/ruvnet/ruflo/issues/2819),
+[#2832](https://github.com/ruvnet/ruflo/issues/2832),
+[#2834](https://github.com/ruvnet/ruflo/issues/2834),
+[#2839](https://github.com/ruvnet/ruflo/issues/2839), and
+[#2840](https://github.com/ruvnet/ruflo/issues/2840).


### PR DESCRIPTION
# Ruflo v3.32.35: Adaptive Swarms and Safer Learning Loops

Ruflo v3.32.35 gives long-running agent teams a controlled way to learn which
workers should receive future tasks. The new `pheromone-adaptive` topology
combines outcome, latency, and consensus signals while preserving protected
roles, a minimum active quorum, and existing permissions. It begins in dry-run
mode so teams can inspect its decisions before enabling scheduling changes.

This release also makes the surrounding learning loop more trustworthy:
project flywheels must evaluate against a project-local, hash-pinned benchmark;
learned routing updates inside a live MCP process; AgentDB deletes and upserts
remove stale vectors; and daemon auto-start is limited to actual Ruflo
projects.

## Install or upgrade

```bash
npm install --global ruflo@3.32.35
ruflo doctor
```

Existing installations remain compatible. The default topology is still
`hierarchical`, old swarm state remains readable, historical flywheel receipts
remain verifiable, and the new adaptive scheduler is opt-in.

## Try adaptive swarm scheduling

Start in the default calibration mode:

```bash
ruflo swarm init \
  --topology pheromone-adaptive \
  --max-agents 8

ruflo swarm pheromone
ruflo agent metrics --format json
```

When the observations look right, explicitly enable scheduling enforcement:

```bash
ruflo swarm init \
  --topology pheromone-adaptive \
  --max-agents 8 \
  --apsc-live
```

Live mode changes Ruflo dispatch eligibility only. It does not terminate
agents, revoke access, discard context, or widen permissions.

## Use a project-local flywheel anchor

Create `.claude/eval/flywheel-anchor.manifest.json`:

```json
{
  "schemaVersion": "ruflo.flywheel-anchor-manifest/v1",
  "path": "my-project-anchor.json",
  "sha256": "sha256:<canonical-task-hash>"
}
```

The referenced anchor contains at least four labelled tasks. Ruflo binds its
canonical hash into new evaluation receipts. A non-Ruflo repository without a
project anchor now fails closed instead of silently optimizing against Ruflo's
built-in development benchmark.

## What changed

- Adds the opt-in `pheromone-adaptive` swarm topology with role-aware EMA
  scoring, dry-run calibration, protected roles, quorum floors, bounded
  exploration, atomic cross-process updates, CLI inspection, and MCP tools.
- Connects `hooks post-task` outcomes to adaptive scheduling and exposes each
  agent's score, sample count, role, and eligibility through `agent metrics`.
- Adds hash-pinned, project-local flywheel evaluation anchors and receipt
  binding while retaining historical receipt verification.
- Makes learned routing use supported, discriminative evidence and immediately
  invalidates a warm router after labelled outcomes.
- Makes AgentDB logical-key upserts, deletes, and cleanup reconcile every stale
  vector and report accurate lifecycle metrics.
- Limits daemon auto-start to projects containing `.claude-flow/`, reports the
  first start, and applies a 30-minute abandoned-daemon idle timeout.

## Measured benchmark

On the declared synthetic benchmark (12 agents, 20,000 updates), adaptive
scheduling produced:

- 33.3% active-agent reduction;
- +0.2617 admitted mean score;
- 0.0066 ms update p95 in the release validation run;
- preserved quorum and protected-role invariants.

These are Ruflo benchmark results for that workload, not a universal production
performance claim.

## Validation

- TypeScript builds passed for `@claude-flow/shared`, `@claude-flow/swarm`, and
  `@claude-flow/cli`.
- The changed-surface suite passed 93 tests across nine files.
- Twenty concurrent outcome writers persisted all twenty rounds with no
  residual lock.
- Built CLI smoke tests covered initialization, automatic post-task learning,
  status, manual updates, and JSON metrics.
- CI/CD, V3 CI/CD, CodeQL, cross-agent integration, CVE audit, and verification
  workflows passed on the merged commit.

This release ships [#2848](https://github.com/ruvnet/ruflo/pull/2848) and
resolves
[#2815](https://github.com/ruvnet/ruflo/issues/2815),
[#2819](https://github.com/ruvnet/ruflo/issues/2819),
[#2832](https://github.com/ruvnet/ruflo/issues/2832),
[#2834](https://github.com/ruvnet/ruflo/issues/2834),
[#2839](https://github.com/ruvnet/ruflo/issues/2839), and
[#2840](https://github.com/ruvnet/ruflo/issues/2840).
