### PR TITLE
fix: stop daemon autostart in non-Ruflo projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.37",
+  "version": "3.32.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.37",
+      "version": "3.32.38",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.37",
+  "version": "3.32.38",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.37",
+  "version": "3.32.38",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.37"
+    "@claude-flow/cli": "^3.32.38"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.32.37",
+    "version": "3.32.38",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "dae295fb9ae2626b89899c19a20cc911541af82b52d2eeb9b214d618b96e9a86",
@@ -8,6 +8,6 @@
       "statusline.cjs": "0457fe53f8cd2c56458ff178392536a5868efd1a573665fa43bc01d2d95ca677"
     }
   },
-  "signature": "4aXDfffQBBhj8kE+NJo5s/G4exfj/xdhqCwWIJxyGijINFL2GleKUam1oIYH9iyDeAZ1FKWrFAUzZ2WNEwMCDg==",
+  "signature": "TIaAcMVhpk+ezMRAJCOA7NQlvIznNqICVsJOiEDnW0Xqpxg1Zr3/RM2VlHaMqN7kaOiDf8sdus0R7b+mwFjUAg==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/__tests__/daemon-autostart.test.ts
+++ b/v3/@claude-flow/cli/__tests__/daemon-autostart.test.ts
@@ -5,11 +5,17 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { ensureDaemonRunning, isDaemonAlive } from '../src/services/daemon-autostart.js';
+import {
+  ensureDaemonRunning,
+  isDaemonAlive,
+  isRufloProject,
+} from '../src/services/daemon-autostart.js';
+import { applyChampion } from '../src/config/harness-feedback-applier.js';
 
 function project(): string {
   const cwd = mkdtempSync(join(tmpdir(), 'daemon-as-'));
   mkdirSync(join(cwd, '.claude-flow'), { recursive: true });
+  writeFileSync(join(cwd, '.claude-flow', 'config.yaml'), 'version: 3\n');
   return cwd;
 }
 
@@ -63,6 +69,39 @@ describe('ensureDaemonRunning', () => {
     expect(r).toEqual({ started: false, reason: 'not a ruflo project' });
     expect(spawned).toBe(0);
     expect(existsSync(join(cwd, '.claude-flow'))).toBe(false);
+  });
+
+  it('does not let startup-created policy state authorize daemon auto-start (#2852)', () => {
+    delete process.env.RUFLO_DAEMON_AUTOSTART;
+    const cwd = mkdtempSync(join(tmpdir(), 'claude-policy-only-'));
+    mkdirSync(join(cwd, '.claude'), { recursive: true });
+    writeFileSync(
+      join(cwd, '.claude', 'proven-config.json'),
+      JSON.stringify({ championId: `sha256:${'a'.repeat(64)}` }),
+    );
+
+    // This mirrors the startup ordering in CLI.run(): applying a shipped
+    // champion creates .claude-flow before daemon auto-start is evaluated.
+    expect(applyChampion(cwd).applied).toBe(true);
+    expect(existsSync(join(cwd, '.claude-flow'))).toBe(true);
+    expect(isRufloProject(cwd)).toBe(false);
+
+    let spawned = 0;
+    const result = ensureDaemonRunning(cwd, {
+      isAlive: () => false,
+      spawnFn: () => { spawned++; },
+    });
+    expect(result).toEqual({ started: false, reason: 'not a ruflo project' });
+    expect(spawned).toBe(0);
+  });
+
+  it('recognizes only explicit Ruflo markers, not generic state directories', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'ruflo-markers-'));
+    mkdirSync(join(cwd, '.claude-flow'), { recursive: true });
+    expect(isRufloProject(cwd)).toBe(false);
+
+    writeFileSync(join(cwd, '.claude-flow', 'config.json'), '{}');
+    expect(isRufloProject(cwd)).toBe(true);
   });
 
   it('respects a project-local claude-flow.config.json opt-out (survives env vars not propagating)', () => {

--- a/v3/@claude-flow/cli/catalog-manifest.json
+++ b/v3/@claude-flow/cli/catalog-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "generation": 4,
-  "generatedAt": "2026-07-29T19:34:39.000Z",
-  "gitSha": "d45a371d",
+  "generatedAt": "2026-07-29T19:49:43.000Z",
+  "gitSha": "bbfbb0a6",
   "catalog": {
     "agents": 164,
     "tools": 397,

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.37",
+  "version": "3.32.38",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/services/daemon-autostart.ts
+++ b/v3/@claude-flow/cli/src/services/daemon-autostart.ts
@@ -64,6 +64,46 @@ function autostartDisabled(projectRoot: string): boolean {
   return autostartDisabledByProjectConfig(projectRoot);
 }
 
+/**
+ * Return true only when the directory contains a durable Ruflo project marker.
+ *
+ * A bare `.claude/` is owned by Claude Code, and a bare `.claude-flow/` is not
+ * sufficient either: startup-time policy/champion migration can create it
+ * before this function runs. Treating that mutation as authorization caused a
+ * read-only command in any Claude project to spawn a detached daemon (#2852).
+ */
+export function isRufloProject(projectRoot: string): boolean {
+  const root = path.resolve(projectRoot);
+  const directMarkers = [
+    path.join(root, '.claude-flow', 'config.yaml'),
+    path.join(root, '.claude-flow', 'config.yml'),
+    path.join(root, '.claude-flow', 'config.json'),
+    path.join(root, 'claude-flow.config.json'),
+    path.join(root, '.swarm', 'memory.db'),
+  ];
+  if (directMarkers.some((marker) => fs.existsSync(marker))) return true;
+
+  try {
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(root, '.claude', 'settings.json'), 'utf-8'),
+    );
+    if (settings && typeof settings === 'object' && 'claudeFlow' in settings) {
+      return true;
+    }
+  } catch { /* absent/malformed/non-Ruflo settings */ }
+
+  try {
+    const mcp = JSON.parse(fs.readFileSync(path.join(root, '.mcp.json'), 'utf-8'));
+    const servers = mcp?.mcpServers;
+    if (servers && typeof servers === 'object'
+      && ('ruflo' in servers || 'claude-flow' in servers)) {
+      return true;
+    }
+  } catch { /* absent/malformed/non-Ruflo MCP config */ }
+
+  return false;
+}
+
 export interface EnsureResult { started: boolean; reason?: string }
 
 /** Spawn `daemon start` detached, reusing all its lock/TTL machinery. Injectable for tests. */
@@ -90,10 +130,7 @@ export function ensureDaemonRunning(
 ): EnsureResult {
   try {
     if (autostartDisabled(projectRoot)) return { started: false, reason: 'disabled (RUFLO_DAEMON_AUTOSTART=0 or project config)' };
-    // `.claude/` belongs to Claude Code and is present in many repositories
-    // that have never initialized Ruflo. Only Ruflo's own state directory is
-    // an authorization signal for spawning a detached background process.
-    if (!fs.existsSync(path.join(projectRoot, '.claude-flow'))) {
+    if (!isRufloProject(projectRoot)) {
       return { started: false, reason: 'not a ruflo project' };
     }
     const alive = (opts.isAlive ?? isDaemonAlive)(projectRoot);

--- a/v3/docs/releases/v3.32.38.md
+++ b/v3/docs/releases/v3.32.38.md
@@ -1,0 +1,46 @@
+# Ruflo v3.32.38: Daemons Start Only for Ruflo Projects
+
+Ruflo v3.32.38 fixes a background-process leak discovered during the
+post-release audit: a read-only command in a directory containing only a
+Claude Code `.claude/` folder could start a detached Ruflo daemon.
+
+The trigger was subtle. Signed-champion startup migration created a
+`.claude-flow/` state directory, and daemon auto-start then mistook that
+startup-created directory for prior user initialization. Repeated commands in
+unrelated Claude projects could therefore accumulate one daemon per directory.
+
+## Install or upgrade
+
+```bash
+npm install --global ruflo@3.32.38
+ruflo --version
+```
+
+## What changed
+
+Daemon auto-start now requires a durable Ruflo project marker:
+
+- a Ruflo runtime config under `.claude-flow/`;
+- a legacy `claude-flow.config.json`;
+- an initialized `.swarm/memory.db`;
+- a Ruflo-specific Claude settings section; or
+- a Ruflo/Claude Flow MCP server entry.
+
+A generic `.claude/` directory, an empty `.claude-flow/` directory, or policy
+state created during the current startup no longer authorizes a detached
+process. Explicit `ruflo daemon start` remains available everywhere, and
+initialized Ruflo projects retain automatic background workers.
+
+## Validation
+
+- The exact issue reproduction was run against 3.32.37 and produced a daemon.
+- The same reproduction against the patched build produced no process and no
+  daemon PID file, even though signed-champion and policy state were applied.
+- Daemon auto-start regression suite: 13/13.
+- CLI TypeScript build passes.
+- The stable release pipeline builds immutable archives, smoke-installs all
+  three public packages, publishes those same bytes, and verifies a fresh
+  registry installation.
+
+This release resolves
+[#2852](https://github.com/ruvnet/ruflo/issues/2852).


### PR DESCRIPTION
## Outcome

Fixes the confirmed daemon leak in #2852. A startup-created .claude-flow directory is no longer sufficient authorization for a detached process. Auto-start now requires a durable Ruflo marker that existed independently of the current startup migration.

## Root cause

The #2834 guard rejected a bare .claude directory, but signed-champion application ran first and created .claude-flow. The daemon guard then interpreted its own startup mutation as evidence that Ruflo had been initialized.

## Fix

- Require a Ruflo runtime config, legacy config, initialized Ruflo memory, Ruflo-specific Claude settings, or Ruflo MCP entry.
- Reject generic .claude and .claude-flow directories, including policy/champion state created during the same startup.
- Preserve explicit daemon start and auto-start in initialized projects.

## Validation

- Exact 3.32.37 repro: daemon spawned.
- Patched end-to-end repro: no daemon process and no daemon PID file.
- Daemon autostart suite: 13/13.
- CLI release contracts: 25/25.
- CLI build and helper signing verification pass.

Closes #2852