### PR TITLE
docs: NPM_TOKEN publish path restored (granular access token)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -984,32 +984,49 @@ memory_search_unified({ query: "authentication security", limit: 5 })
 - Use the existing authenticated `ruvnet` npm session. Do not replace it with a
   token from another GCP project.
 
-**`npm publish` auth — CONFIRMED procedure (2026-07-30, v3.32.39 release):**
-The `ruvnet` account's 2FA method is a **WebAuthn security key**, not a TOTP
-authenticator app — there is no numeric code to pass via `--otp=<code>`. The
-`NPM_TOKEN` automation-token secret in GCP Secret Manager (`ruv-dev` project) does
-**NOT** have publish rights to `@claude-flow/cli` — confirmed twice with a real
-publish attempt: authenticates fine for reads (200 on `whoami`/`GET`) but gets a
-real `404 Not Found` on the publish `PUT` (npm returns 404, not 403, for scope/
-permission problems on scoped packages). Don't waste time on that path again unless
-the human explicitly says they've re-scoped it.
+**`npm publish` auth — FIXED (2026-07-30):** use the `NPM_TOKEN` secret in GCP
+Secret Manager (`ruv-dev` project, version 3+) directly, via a throwaway
+`.npmrc` with `NPM_CONFIG_USERCONFIG` — same pattern as the helpers-signing-key
+handling. This is a granular access token ("ruflo publishjing", expires
+2026-10-28) with `package: write` + `bypass_2fa: true`, scoped broadly enough
+to cover `@claude-flow/cli`, `claude-flow`, and `ruflo`. Confirmed end-to-end
+against the real registry (not just a permissions probe): `npm publish` for
+`@claude-flow/cli` succeeded via this token with zero OTP/WebAuthn prompt, and
+`npm dist-tag add` against both a scoped (`@claude-flow/cli`) and unscoped
+(`claude-flow`) package also went through with no prompt.
 
-What actually works, and must be driven by the human (an agent cannot approve a
-WebAuthn prompt):
-1. Human goes to npmjs.com → account 2FA settings → turns OFF "Require two-factor
-   authentication for write actions" (this narrows the setting to auth-only, not a
-   full 2FA disable).
-2. Human runs `npm login` in their own real terminal — this opens a browser tab to
-   re-authenticate and refreshes the session under the new setting.
-3. Agent can then run `npm publish` (with the signing-key env vars below) directly
-   via Bash — this worked with NO further prompt for the `@claude-flow/cli`,
-   `claude-flow`, and `ruflo` publishes in the 3.32.39 release.
-4. **`npm dist-tag add` still requires a fresh WebAuthn approval PER CALL**,
-   regardless of the write-2FA setting above — each of the 6 calls (alpha +
-   v3alpha × 3 packages) printed its own `https://www.npmjs.com/auth/cli/<uuid>`
-   URL and blocked until the human approved it in a browser. This cannot be
-   scripted or batched — tell the human up front it's 6 individual approvals, not
-   1, so "it keeps asking me" doesn't read as broken.
+**Why the earlier `NPM_TOKEN` version failed:** versions 1/2 of that secret
+were older classic automation tokens, and npm has been restricting tokens that
+bypass 2FA for writes account-wide (the login flow prints this notice —
+`gh.io/npm-gat-bypass2fa-deprecation`). Version 3 is a **granular access
+token** created explicitly for this purpose, which is npm's supported
+replacement path (its own 2FA-bypass flag still works for a granular token,
+unlike the deprecated classic automation tokens). If this token's `bypass_2fa`
+flag or scope ever gets narrowed/expired (check expiry above), the fallback
+is the WebAuthn dance below — but try this path first every time.
+
+```bash
+gcloud secrets versions access latest --secret=NPM_TOKEN --project=ruv-dev > /tmp/.npmrc-publish-raw
+printf '//registry.npmjs.org/:_authToken=%s\n' "$(cat /tmp/.npmrc-publish-raw)" > /tmp/.npmrc-publish
+rm -f /tmp/.npmrc-publish-raw
+NPM_CONFIG_USERCONFIG=/tmp/.npmrc-publish npm publish   # from the package dir, with signing-key env vars for @claude-flow/cli
+NPM_CONFIG_USERCONFIG=/tmp/.npmrc-publish npm dist-tag add <pkg>@<version> alpha
+NPM_CONFIG_USERCONFIG=/tmp/.npmrc-publish npm dist-tag add <pkg>@<version> v3alpha
+shred -u /tmp/.npmrc-publish 2>/dev/null || rm -f /tmp/.npmrc-publish   # ALWAYS clean up, same discipline as the signing key
+```
+
+**Fallback — WebAuthn procedure, if the token above is dead:** the `ruvnet`
+account's 2FA method is a WebAuthn security key, not TOTP (no numeric
+`--otp=<code>` exists). This must be driven by the human (an agent cannot
+approve a WebAuthn browser prompt):
+1. Human goes to npmjs.com → account 2FA settings → turns OFF "Require
+   two-factor authentication for write actions" (narrows to auth-only, not a
+   full 2FA disable), then runs `npm login` in their own terminal to refresh
+   the session under the new setting.
+2. Agent can then run `npm publish` directly via Bash with no further prompt.
+3. **`npm dist-tag add` still requires a fresh WebAuthn approval PER CALL**
+   regardless of the write-2FA setting — 6 individual browser approvals for a
+   3-package release (alpha + v3alpha × 3), not 1. Tell the human up front.
 - After every dist-tag call (or if unsure), verify with
   `npm view <pkg> dist-tags --json` — don't trust the CLI's own stdout alone, since
   a WebAuthn prompt that's still pending in the browser produces no terminal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -984,14 +984,17 @@ memory_search_unified({ query: "authentication security", limit: 5 })
 - Use the existing authenticated `ruvnet` npm session. Do not replace it with a
   token from another GCP project.
 
-**`npm publish` auth — FIXED (2026-07-30):** use the `NPM_TOKEN` secret in GCP
-Secret Manager (`ruv-dev` project, version 3+) directly, via a throwaway
-`.npmrc` with `NPM_CONFIG_USERCONFIG` — same pattern as the helpers-signing-key
-handling. This is a granular access token ("ruflo publishjing", expires
-2026-10-28) with `package: write` + `bypass_2fa: true`, scoped broadly enough
-to cover `@claude-flow/cli`, `claude-flow`, and `ruflo`. Confirmed end-to-end
-against the real registry (not just a permissions probe): `npm publish` for
-`@claude-flow/cli` succeeded via this token with zero OTP/WebAuthn prompt, and
+**`npm publish` auth — FIXED (2026-07-30):** use the `NPM_TOKEN` secret directly,
+via a throwaway `.npmrc` with `NPM_CONFIG_USERCONFIG` — same pattern as the
+helpers-signing-key handling. It is mirrored in two GCP projects — `ruv-dev`
+(version 3+) and `cognitum-20260110` (version 7+) — so either project's copy
+is current; use whichever `gcloud` session is already authenticated. This is a
+granular access token ("ruflo publishjing", expires 2026-10-28) with
+`package: write` + `bypass_2fa: true`, scoped broadly enough to cover
+`@claude-flow/cli`, `claude-flow`, and `ruflo` (plus the `cognitum`/
+`cognitum-one` orgs). Confirmed end-to-end against the real registry (not just
+a permissions probe): `npm publish` for `@claude-flow/cli` succeeded via this
+token with zero OTP/WebAuthn prompt, and
 `npm dist-tag add` against both a scoped (`@claude-flow/cli`) and unscoped
 (`claude-flow`) package also went through with no prompt.
 


### PR DESCRIPTION
Rotated NPM_TOKEN (GCP ruv-dev, version 3) to a granular access token with confirmed publish rights — no more OTP/WebAuthn friction for routine releases. Documents why the old token stopped working (npm's account-wide restriction on classic 2FA-bypass tokens) and demotes the WebAuthn dance to a fallback. Docs-only.