### PR TITLE
chore(release): 3.33.0 — ADR-377 AgentDB Retrieval Security Layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.32.38",
+  "version": "3.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.32.38",
+      "version": "3.33.0",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.32.38",
+  "version": "3.33.0",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.32.38",
+  "version": "3.33.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "package:rvf": "bash src/scripts/package-rvf.sh"
   },
   "dependencies": {
-    "@claude-flow/cli": "^3.32.38"
+    "@claude-flow/cli": "^3.33.0"
   },
   "optionalDependencies": {},
   "overrides": {

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.32.38",
+  "version": "3.33.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- Version bump 3.32.41 → 3.33.0 (minor — new public API surface: `AgentDbRetrievalGuard`, `MemoryPoisonForensics`, `McpCallerIdentity`, all backward-compatible and off by default).
- Includes #2874 (ADR-377 implementation) on top of the already-released 3.32.41 base.
- `scripts/audit-umbrella-version-lockstep.mjs` passes — all three umbrella packages at 3.33.0, `ruflo`'s `@claude-flow/cli` dep bumped to `^3.33.0`.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds (no lockfile drift)
- [x] Built in dependency order: cli-core, neural, then shared/security/codex/plugin-agent-federation/swarm/cli via `prepare-root-publish.mjs` — all clean
- [x] ADR-377 test suites re-run against this exact build: memory (9), hooks (11), security (11) — 31/31 passing
- [ ] CI

🤖 Generated with [Claude Code](https://claude.ai/code)