### PR TITLE
ADR-380 correction: real @agntcy/slim-bindings package + 2 upstream bugs filed

### DIFF
--- a/plugins/ruflo-agntcy/docs/adrs/ADR-380-agntcy-outshift-runtime-integration.md
+++ b/plugins/ruflo-agntcy/docs/adrs/ADR-380-agntcy-outshift-runtime-integration.md
@@ -115,6 +115,50 @@ Shared with companion ADR-240: generate a MetaHarness agent, publish its signed 
 - Does the existing `claims_*` AuthScope machinery get subsumed by CASA envelopes over time, or do they stay parallel (claims = internal agent-to-agent authorization, CASA = user-intent-to-network authorization)? Worth its own follow-up ADR once §3 ships and the overlap (or lack of one) is concretely observable.
 - Where does the Rust `ruflo agntcy` crate live — a new top-level package, or folded into the existing federation-peer-rust surface given the CI plumbing already exists there?
 
+## Update (2026-07-31) — corrected: real AGNTCY packages exist
+
+This ADR's original text (and the code it shipped with, PR #2879) stated
+that no AGNTCY/SLIM/Outshift npm package existed anywhere under any
+plausible name. **That was wrong**, and is corrected here rather than
+silently edited out of the history above, per this repo's own norms around
+honest documentation.
+
+The original check only tried *guessed, scoped* names (`@agntcy/slim`,
+`@agntcy/dir`) and got 404s. The real packages are unscoped or differently
+suffixed:
+
+- **`@agntcy/slim-bindings`** (npm, v1.4.1 stable / v2.0.0-alpha.4) — real
+  SLIM Node.js bindings, documented for exactly the plain-Node use case §2
+  needs. Now correctly named in `runtime.ts`'s `AGNTCY_PACKAGE_NAME` and
+  declared in `optionalDependencies`.
+- **`agntcy-dir`** (npm, v1.5.0) — real Directory JS/TS SDK, used by the
+  companion ADR-240 §2.2 for real, live-tested push/publish/lookup against
+  a real Directory server (Go apiserver + zot + postgres, run locally from
+  `agntcy/dir`'s own `install/docker/docker-compose.yml`).
+
+**SLIM specifically is still not live-connectable today** — not because no
+package exists, but because of a real, verified, upstream packaging bug: a
+transitive dependency (`uniffi-bindgen-react-native`) ships raw,
+uncompiled TypeScript as its package.json `main` with no build output,
+which only works inside a bundler (Metro) and fails to load under plain
+Node `require`/`import`
+(`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, reproduced directly).
+Filed upstream: [agntcy/slim#1916](https://github.com/agntcy/slim/issues/1916)
+(downstream impact — their own README's plain-Node example is currently
+broken by this) and
+[jhugman/uniffi-bindgen-react-native#422](https://github.com/jhugman/uniffi-bindgen-react-native/issues/422)
+(root cause). `detectAgntcyRuntime()`'s existing graceful-degradation
+design (§1) already handles this correctly with zero code changes needed —
+its catch-all branch surfaces the real error and falls back to local
+transport, verified against the exact real failure mode.
+
+Root cause investigated (in `agntcy/oasf-sdk`, hoping to find something
+patchable) before concluding a PR wasn't possible for the Directory-side
+class-name validation bug either — that validation logic turned out to be
+a remote hosted service (`schema.oasf.outshift.com`), not local source in
+any AGNTCY repo. Filed as
+[agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943) instead.
+
 ## References
 
 - Cisco AGNTCY overview — https://outshift.cisco.com/the-internet-of-agents/agntcy

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -120,6 +120,7 @@
     "zod": "^3.22.0"
   },
   "optionalDependencies": {
+    "@agntcy/slim-bindings": "^1.4.1",
     "@napi-rs/keyring": "1.3.0",
     "@claude-flow/memory": "^3.0.0-alpha.21",
     "agentdb": "^3.0.0-alpha.17",

--- a/v3/@claude-flow/cli/src/commands/agntcy/runtime.ts
+++ b/v3/@claude-flow/cli/src/commands/agntcy/runtime.ts
@@ -5,21 +5,31 @@
  * `agent publish`, `swarm join <namespace>`) that talk to Cisco Outshift's
  * AGNTCY ecosystem (SLIM transport, Directory publish, group membership).
  *
- * As of this scaffold (2026-07-30), NO `@claude-flow/agntcy` package (or
- * any SLIM SDK under any other guessed npm/crates.io name) exists — a
- * repo-wide check and a registry check both came back clean/404. This
- * module therefore NEVER performs a real network call to AGNTCY
- * infrastructure. It only answers one question, deterministically and
- * without throwing: "has the operator pointed ruflo at a SLIM endpoint,
- * and if so, is the optional runtime package actually installed?"
+ * CORRECTED (2026-07-31): the original scaffold guessed at a package name
+ * (`@claude-flow/agntcy`) and concluded no real SLIM SDK existed anywhere.
+ * That check only tried guessed names — the real package is
+ * `@agntcy/slim-bindings` (npm, real, published, documented for plain
+ * Node.js use). It currently **fails to load** in plain Node, but for a
+ * different, more specific reason: a transitive dependency
+ * (`uniffi-bindgen-react-native`) ships raw, uncompiled TypeScript as its
+ * package.json `main`, which only works inside a bundler (Metro, for its
+ * React Native use case) — not plain `require`/`import`. Filed upstream:
+ * agntcy/slim#1916 and jhugman/uniffi-bindgen-react-native#422 (root cause).
+ *
+ * This module's existing graceful-degradation design already handles this
+ * correctly without any change to its logic: `detectAgntcyRuntime()`'s
+ * catch-all branch (anything other than MODULE_NOT_FOUND) reports the real
+ * underlying error and falls back to local transport — which is exactly
+ * what happens today when the dynamic import hits the packaging bug above.
+ * Once that upstream issue is fixed, this same code path starts succeeding
+ * with zero changes needed here.
  *
  * Per ADR-150's precedent (which ADR-380 §1 explicitly follows, not
  * ADR-321's hard-dependency exception):
  *   - removable:            deleting this whole directory changes nothing
  *                            about the rest of the CLI working.
- *   - optional-only:        `@claude-flow/agntcy` MUST live in
- *                            optionalDependencies once it is published,
- *                            never `dependencies`.
+ *   - optional-only:        `@agntcy/slim-bindings` MUST live in
+ *                            optionalDependencies, never `dependencies`.
  *   - graceful degradation: every caller of `detectAgntcyRuntime()` falls
  *                            back to the local transport / existing
  *                            authorization model on `configured: false`.
@@ -31,13 +41,14 @@
 export const AGNTCY_ENDPOINT_ENV = 'RUFLO_AGNTCY_SLIM_ENDPOINT';
 
 /**
- * Guessed package name for the future optional runtime. Verified 404 on
- * npm as of this scaffold — see the ADR-380 companion research. Kept as a
+ * The real SLIM Node.js bindings package (npm, published, real). Kept as a
  * named constant (not a string literal scattered through the module) so a
- * single edit repoints every dynamic-import call site once the real
- * package ships.
+ * single edit repoints every dynamic-import call site if that ever changes.
+ * Currently fails to load due to an upstream packaging bug — see this
+ * file's header comment — which `detectAgntcyRuntime()`'s catch-all branch
+ * already handles gracefully.
  */
-export const AGNTCY_PACKAGE_NAME = '@claude-flow/agntcy';
+export const AGNTCY_PACKAGE_NAME = '@agntcy/slim-bindings';
 
 /** Pointer to the ADR every "not configured" message should send users to. */
 export const AGNTCY_ADR_PATH = 'v3/docs/adr/ADR-380-agntcy-outshift-runtime-integration.md';
@@ -63,9 +74,11 @@ export interface AgntcyRuntimeStatus {
  *   1. An env var presence check for {@link AGNTCY_ENDPOINT_ENV}. Absent →
  *      not configured, no further work.
  *   2. A dynamic `import()` of {@link AGNTCY_PACKAGE_NAME}, wrapped in
- *      try/catch. Today this import always fails with a module-resolution
- *      error (the package doesn't exist yet) — that failure is treated as
- *      the expected "not installed" signal, not a bug.
+ *      try/catch. The package is real and installable, but today the
+ *      import fails at load time due to an upstream packaging bug in one
+ *      of its transitive dependencies (see this file's header comment) —
+ *      that failure surfaces through the generic catch branch below with
+ *      the real error message, not the MODULE_NOT_FOUND branch.
  *
  * @param env Injectable for tests; defaults to `process.env`.
  */

--- a/v3/docs/adr/ADR-380-agntcy-outshift-runtime-integration.md
+++ b/v3/docs/adr/ADR-380-agntcy-outshift-runtime-integration.md
@@ -115,6 +115,50 @@ Shared with companion ADR-240: generate a MetaHarness agent, publish its signed 
 - Does the existing `claims_*` AuthScope machinery get subsumed by CASA envelopes over time, or do they stay parallel (claims = internal agent-to-agent authorization, CASA = user-intent-to-network authorization)? Worth its own follow-up ADR once §3 ships and the overlap (or lack of one) is concretely observable.
 - Where does the Rust `ruflo agntcy` crate live — a new top-level package, or folded into the existing federation-peer-rust surface given the CI plumbing already exists there?
 
+## Update (2026-07-31) — corrected: real AGNTCY packages exist
+
+This ADR's original text (and the code it shipped with, PR #2879) stated
+that no AGNTCY/SLIM/Outshift npm package existed anywhere under any
+plausible name. **That was wrong**, and is corrected here rather than
+silently edited out of the history above, per this repo's own norms around
+honest documentation.
+
+The original check only tried *guessed, scoped* names (`@agntcy/slim`,
+`@agntcy/dir`) and got 404s. The real packages are unscoped or differently
+suffixed:
+
+- **`@agntcy/slim-bindings`** (npm, v1.4.1 stable / v2.0.0-alpha.4) — real
+  SLIM Node.js bindings, documented for exactly the plain-Node use case §2
+  needs. Now correctly named in `runtime.ts`'s `AGNTCY_PACKAGE_NAME` and
+  declared in `optionalDependencies`.
+- **`agntcy-dir`** (npm, v1.5.0) — real Directory JS/TS SDK, used by the
+  companion ADR-240 §2.2 for real, live-tested push/publish/lookup against
+  a real Directory server (Go apiserver + zot + postgres, run locally from
+  `agntcy/dir`'s own `install/docker/docker-compose.yml`).
+
+**SLIM specifically is still not live-connectable today** — not because no
+package exists, but because of a real, verified, upstream packaging bug: a
+transitive dependency (`uniffi-bindgen-react-native`) ships raw,
+uncompiled TypeScript as its package.json `main` with no build output,
+which only works inside a bundler (Metro) and fails to load under plain
+Node `require`/`import`
+(`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, reproduced directly).
+Filed upstream: [agntcy/slim#1916](https://github.com/agntcy/slim/issues/1916)
+(downstream impact — their own README's plain-Node example is currently
+broken by this) and
+[jhugman/uniffi-bindgen-react-native#422](https://github.com/jhugman/uniffi-bindgen-react-native/issues/422)
+(root cause). `detectAgntcyRuntime()`'s existing graceful-degradation
+design (§1) already handles this correctly with zero code changes needed —
+its catch-all branch surfaces the real error and falls back to local
+transport, verified against the exact real failure mode.
+
+Root cause investigated (in `agntcy/oasf-sdk`, hoping to find something
+patchable) before concluding a PR wasn't possible for the Directory-side
+class-name validation bug either — that validation logic turned out to be
+a remote hosted service (`schema.oasf.outshift.com`), not local source in
+any AGNTCY repo. Filed as
+[agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943) instead.
+
 ## References
 
 - Cisco AGNTCY overview — https://outshift.cisco.com/the-internet-of-agents/agntcy

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/aidefence':
     dependencies:
@@ -110,7 +110,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/cli':
     dependencies:
@@ -190,6 +190,9 @@ importers:
         specifier: ^3.22.0
         version: 3.25.76
     optionalDependencies:
+      '@agntcy/slim-bindings':
+        specifier: ^1.4.1
+        version: 1.4.1
       '@claude-flow/memory':
         specifier: ^3.0.0-alpha.21
         version: link:../memory
@@ -259,7 +262,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/deployment':
     dependencies:
@@ -272,7 +275,7 @@ importers:
         version: 25.0.2(typescript@5.9.3)
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/embeddings':
     dependencies:
@@ -322,7 +325,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/hooks':
     dependencies:
@@ -357,7 +360,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/integration':
     dependencies:
@@ -402,7 +405,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/memory':
     dependencies:
@@ -454,7 +457,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugin-agent-federation':
     dependencies:
@@ -504,7 +507,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/plugins':
     dependencies:
@@ -532,7 +535,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/providers':
     dependencies:
@@ -557,7 +560,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/security':
     dependencies:
@@ -577,7 +580,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/shared':
     dependencies:
@@ -611,7 +614,7 @@ importers:
         version: 7.2.0
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
       ws:
         specifier: ^8.16.0
         version: 8.19.0
@@ -623,7 +626,7 @@ importers:
     devDependencies:
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
   '@claude-flow/testing':
     devDependencies:
@@ -641,7 +644,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: '>=4.1.0'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
 
 packages:
 
@@ -664,6 +667,100 @@ packages:
 
   /@actions/io@2.0.0:
     resolution: {integrity: sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==}
+
+  /@agntcy/slim-bindings-darwin-arm64@1.4.1:
+    resolution: {integrity: sha512-K9IbX/nnsfJFXEQICukO0XfCFj/0UqY2DhL9nnjFbfO9Zq+hKzreWMzLLzHvffFrONwPFgijg6cM4L7ImAvssw==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    dependencies:
+      ffi-rs: 1.3.4
+      ref-napi: 3.0.3
+      uniffi-bindgen-react-native: 0.29.3-1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@agntcy/slim-bindings-darwin-x64@1.4.1:
+    resolution: {integrity: sha512-pOPKDmfUfXpKH04nnCh+cPfDu4Hyp4wgH0L1NxZkrArswPgqUzRVeawz80NUCkEgv3o88QCcVOpHr+APU1xFzg==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    dependencies:
+      ffi-rs: 1.3.4
+      ref-napi: 3.0.3
+      uniffi-bindgen-react-native: 0.29.3-1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@agntcy/slim-bindings-linux-arm64-gnu@1.4.1:
+    resolution: {integrity: sha512-5EcZogyHtY+w5gART3jYutYEdSwDca1iSgdI5F5fmrLWaojhGltgJtM3CHmctDeigSVH+IUY0d6ZjqabuK2UlQ==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    dependencies:
+      ffi-rs: 1.3.4
+      ref-napi: 3.0.3
+      uniffi-bindgen-react-native: 0.29.3-1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@agntcy/slim-bindings-linux-x64-gnu@1.4.1:
+    resolution: {integrity: sha512-XFQLlbK32mt5hH5EMM0DqlWBuKv6o+OMbVbD8u1/qE07YEEvgRiDkunHlGoKn2HdggQdMSEEZjH/QsitBBuCqA==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    dependencies:
+      ffi-rs: 1.3.4
+      ref-napi: 3.0.3
+      uniffi-bindgen-react-native: 0.29.3-1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@agntcy/slim-bindings-win32-arm64-msvc@1.4.1:
+    resolution: {integrity: sha512-adDCdLpX/OkJV3zQbDraKaPCedOCgO6ZLZjDZ9bLPh6DUlDmz6PcqA8HkbGc5TEFfo4XFEExyGPo0SgtUn/+/A==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    dependencies:
+      ffi-rs: 1.3.4
+      ref-napi: 3.0.3
+      uniffi-bindgen-react-native: 0.29.3-1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@agntcy/slim-bindings-win32-x64-msvc@1.4.1:
+    resolution: {integrity: sha512-Pkj4BhVyfXh13uDkGF9iU3aBJ2XB/T3RAk9EW9fHUk5uvkpd14VD7oYKQBQtb7SIEKGohC2UX3/jZ8yj+ujlpA==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    dependencies:
+      ffi-rs: 1.3.4
+      ref-napi: 3.0.3
+      uniffi-bindgen-react-native: 0.29.3-1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
+
+  /@agntcy/slim-bindings@1.4.1:
+    resolution: {integrity: sha512-xyBp0/I2Qb0/G0Xe7GaexjdTvLBpbN9qCWNutoYH66BEF5+dlZ+aZgspjuVJxjkC1iOnDvQag8yaax8betr8Lg==}
+    engines: {node: '>=18.0.0'}
+    requiresBuild: true
+    optionalDependencies:
+      '@agntcy/slim-bindings-darwin-arm64': 1.4.1
+      '@agntcy/slim-bindings-darwin-x64': 1.4.1
+      '@agntcy/slim-bindings-linux-arm64-gnu': 1.4.1
+      '@agntcy/slim-bindings-linux-x64-gnu': 1.4.1
+      '@agntcy/slim-bindings-win32-arm64-msvc': 1.4.1
+      '@agntcy/slim-bindings-win32-x64-msvc': 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
 
   /@ai-sdk/google@3.0.43(zod@3.25.76):
     resolution: {integrity: sha512-NGCgP5g8HBxrNdxvF8Dhww+UKfqAkZAmyYBvbu9YLoBkzAmGKDBGhVptN/oXPB5Vm0jggMdoLycZ8JReQM8Zqg==}
@@ -6616,7 +6713,7 @@ packages:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0)
     dev: true
 
   /@vitest/expect@4.1.8:
@@ -6644,7 +6741,7 @@ packages:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 7.3.0(@types/node@20.19.27)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@20.19.27)(yaml@2.8.2)
     dev: true
 
   /@vitest/pretty-format@4.1.8:
@@ -6707,6 +6804,105 @@ packages:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  /@yuuang/ffi-rs-android-arm64@1.3.4:
+    resolution: {integrity: sha512-2ywkkOk1j1lbcYyaH9KeyR7i2Qtq4gDfnkmhF5vlRGnwve1j5RWH2ZlF3990raEx6OLophke/JXfUGQL9Dy0ig==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-darwin-arm64@1.3.4:
+    resolution: {integrity: sha512-FEogaqNfk9yI9szLebGW9JR/OAwMZ+vkeHVhpcZBvRWTce5IA7mfZorY2KhzP+SEjz4F5q5+fFr6GzHzm/gxvQ==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-darwin-x64@1.3.4:
+    resolution: {integrity: sha512-JuEPUOsE7qz6o4kSKgX+KymzSFUvyafpGykVbvm9+11Gx/fQy1lzrYkg2VdI70ctM3mjWARGpcaVZlCyPZVRvg==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-linux-arm-gnueabihf@1.3.4:
+    resolution: {integrity: sha512-9Alv4r8uZ/kZN6PKqIUoqrtWcpOD/iq3R/w31dEM2aQ8XaftZVD5oANO8IP9lFROb8QmJwDpyW1mfG1GQ0WJjA==}
+    engines: {node: '>= 12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-linux-arm64-gnu@1.3.4:
+    resolution: {integrity: sha512-iconeq2sjAgPn9RyLhfnjawaepeaj8o9EdSI4fg3y92dr0Tbjkr2KjNREgloLN1Jw5BGPt89/sJsDqBWLZP8Rg==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-linux-arm64-musl@1.3.4:
+    resolution: {integrity: sha512-ptjhnk2M0QTWaKq59wCR4mZ6LeRFOEXmsybp/SOHn5OZ8XYZLnv5FqSGHLPeJp2WvwzhS8SNjn/A2XmHfF3vow==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-linux-x64-gnu@1.3.4:
+    resolution: {integrity: sha512-TM0nfjruTuipNbksyV3iKvMKFeIHNI15tpPuqOzndcVi1Ms1I4tEAyi0gYTFjXUtcjSwBdjhztmIYphStRLVug==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-linux-x64-musl@1.3.4:
+    resolution: {integrity: sha512-aKPSWXoEutWw8et4dhp4tq3x7FOg3C2mBT4gJr/cJxE/vcGxFKCsg3HjKNi3D1BwSZqh0bGuniZCFrde2DpkkA==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-win32-arm64-msvc@1.3.4:
+    resolution: {integrity: sha512-hJndCj9xEosRw9Xn02IwzfXy8tgXvspJT5Qhpld9xXDFZyY0wYKxxO2VZhJNiIuX9vuEUgqeVvfCp5EeTpom1Q==}
+    engines: {node: '>= 12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-win32-ia32-msvc@1.3.4:
+    resolution: {integrity: sha512-tXowkiiq3mdnK8CtgSWKQ1dRLJvF0d1pd4qomIl8Pv1To1SWATZ20lag3sXv19+utdrwInWvCi4NjHDmN92Y1A==}
+    engines: {node: '>= 12'}
+    cpu: [x64, ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@yuuang/ffi-rs-win32-x64-msvc@1.3.4:
+    resolution: {integrity: sha512-Kxr2Z2EU2Lutl7hBYrs90/s0lQ6OWavscVu62Bx4gckg+DdxZaQuxHRktdL5ITH7tdUewj3OqkcUNZXCvGCe0Q==}
+    engines: {node: '>= 12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -8834,6 +9030,24 @@ packages:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  /ffi-rs@1.3.4:
+    resolution: {integrity: sha512-rUX011WXszmHHmu/HO5CZQCscU+poR4tPrrTO+M1ePbq2QIptpklpr/Fujc8GBuILNXBdxVRsn+Kfp3uihsHFw==}
+    requiresBuild: true
+    optionalDependencies:
+      '@yuuang/ffi-rs-android-arm64': 1.3.4
+      '@yuuang/ffi-rs-darwin-arm64': 1.3.4
+      '@yuuang/ffi-rs-darwin-x64': 1.3.4
+      '@yuuang/ffi-rs-linux-arm-gnueabihf': 1.3.4
+      '@yuuang/ffi-rs-linux-arm64-gnu': 1.3.4
+      '@yuuang/ffi-rs-linux-arm64-musl': 1.3.4
+      '@yuuang/ffi-rs-linux-x64-gnu': 1.3.4
+      '@yuuang/ffi-rs-linux-x64-musl': 1.3.4
+      '@yuuang/ffi-rs-win32-arm64-msvc': 1.3.4
+      '@yuuang/ffi-rs-win32-ia32-msvc': 1.3.4
+      '@yuuang/ffi-rs-win32-x64-msvc': 1.3.4
+    dev: false
+    optional: true
+
   /figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
@@ -9157,6 +9371,12 @@ packages:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  /get-symbol-from-current-process-h@1.0.2:
+    resolution: {integrity: sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
@@ -10486,6 +10706,12 @@ packages:
     dependencies:
       semver: 7.7.3
 
+  /node-addon-api@3.2.1:
+    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
@@ -11432,6 +11658,20 @@ packages:
     dependencies:
       esprima: 4.0.1
     dev: false
+
+  /ref-napi@3.0.3:
+    resolution: {integrity: sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==}
+    engines: {node: '>= 10.0'}
+    requiresBuild: true
+    dependencies:
+      debug: 4.4.3
+      get-symbol-from-current-process-h: 1.0.2
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
 
   /registry-auth-token@5.1.0:
     resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
@@ -12694,6 +12934,13 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  /uniffi-bindgen-react-native@0.29.3-1:
+    resolution: {integrity: sha512-o6gXZsAh55yuvhwF2WSFdIHV4phyfWcCmg4DuyfJWJ7CvUz1UcIz2S4u9SmXAz1jsuqvu6Xc9hexrRBB0a5osg==}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
     requiresBuild: true
@@ -12879,7 +13126,6 @@ packages:
       yaml: 2.8.2
     optionalDependencies:
       fsevents: 2.3.3
-    dev: false
 
   /vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.1.9)(vite@7.3.0):
     resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
@@ -13011,7 +13257,7 @@ packages:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.0(@types/node@20.19.27)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@20.19.27)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Follow-up to #2879 (merged). That PR's original ADR-380 text claimed no AGNTCY/SLIM package existed anywhere on npm — that was wrong, the check only tried guessed scoped names. Corrects the record and the code.

- **`runtime.ts`**: `AGNTCY_PACKAGE_NAME` corrected from the placeholder `@claude-flow/agntcy` to the real, published `@agntcy/slim-bindings` (v1.4.1). Added to `optionalDependencies`.
- **Verified live**: the real package currently fails to load in plain Node — but for a specific, root-caused reason (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, not `MODULE_NOT_FOUND`), which `detectAgntcyRuntime()`'s existing catch-all already handles correctly with zero logic changes. Reproduced this exact failure mode directly against a real install in isolation before writing any of this.
- **2 upstream issues filed** with the root cause: [agntcy/slim#1916](https://github.com/agntcy/slim/issues/1916) and [jhugman/uniffi-bindgen-react-native#422](https://github.com/jhugman/uniffi-bindgen-react-native/issues/422) (a transitive dependency ships raw TypeScript as its `package.json` main with no build output — works in a bundler, not plain Node).
- **ADR-380 updated in place** (still `Proposed`, this repo's convention allows direct amendment) documenting the correction rather than silently rewriting history.

Companion metaharness PR also got the equivalent real correction for the Directory side (`agntcy-dir`, now live-integration-tested against a real local server, plus a separate upstream bug found and filed: [agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943)).

## Test plan

- [x] `npx vitest run __tests__/agntcy` — 18/18 passing, unchanged behavior (graceful degradation still works, now for the *correct* reason)
- [x] `npx tsc --noEmit` — clean (the only pre-existing errors are unrelated stale `@claude-flow/security` build artifacts, confirmed by grep)
- [x] Reproduced the real upstream failure mode directly (isolated install, not through this repo) to confirm the catch-all branch handles it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)