### PR TITLE
fix(agntcy): pin @agntcy/slim-bindings to the confirmed-working alpha

### DIFF
--- a/plugins/ruflo-agntcy/README.md
+++ b/plugins/ruflo-agntcy/README.md
@@ -13,9 +13,11 @@ This plugin follows the **ADR-150 precedent**, not the ADR-321 hard-dependency e
 - Every code path that touches AGNTCY infrastructure MUST catch `MODULE_NOT_FOUND` / connection-refused and fall back to today's local transport and existing tool-authorization model.
 - This MUST pass a "works without AGNTCY installed" smoke test, mirrored on ADR-150's CI-gated architectural-constraint pattern.
 
-## No upstream packages exist yet
+## Upstream package status — corrected, and now live
 
-As of this plugin's scaffolding date, **no AGNTCY/SLIM/Outshift npm or crates.io package exists under any plausible name** — verified 404 across every guessed identifier. Nothing in this plugin `require`s or `import`s such a package. Any network-touching piece (Directory publish, SLIM connect, CASA policy fetch) is implemented as a **clearly-logged, clearly-erroring stub** behind a feature flag / config check, never faked as if it succeeded. The stub's error message points back at this plugin's governing ADRs (ADR-380, and companion metaharness ADR-240) so a caller understands *why* it failed, not just *that* it failed.
+**This section originally claimed no AGNTCY/SLIM/Outshift npm package existed under any plausible name.** That was wrong — the original check only tried guessed, scoped names and got 404s. The real SLIM package is `@agntcy/slim-bindings`, and as of 2026-07-31 it is genuinely live-connectable (pinned to the confirmed-working `2.0.0-alpha.5`; see [ADR-380's own "Update" sections](docs/adrs/ADR-380-agntcy-outshift-runtime-integration.md#update-2026-07-31--corrected-real-agntcy-packages-exist) for the full history, including two real upstream bugs found, filed, and resolved along the way). `detectAgntcyRuntime()` needed zero code changes for this — its existing graceful-degradation design already handled both "package resolves" and "package missing" correctly; only the pinned dependency version changed.
+
+The remaining honest gaps: AGNTCY Identity has no JS/TS SDK (genuinely Go-only, verified), and this plugin's CASA policy compiler is a real, tested implementation but enforcement still lives in the runtime layer per ADR-380 §3, never in this compiler. Nothing here fakes a success it hasn't earned.
 
 ## What's Included (per ADR-380)
 

--- a/plugins/ruflo-agntcy/docs/adrs/ADR-380-agntcy-outshift-runtime-integration.md
+++ b/plugins/ruflo-agntcy/docs/adrs/ADR-380-agntcy-outshift-runtime-integration.md
@@ -159,6 +159,35 @@ a remote hosted service (`schema.oasf.outshift.com`), not local source in
 any AGNTCY repo. Filed as
 [agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943) instead.
 
+## Update (2026-07-31, part 2) — both filed bugs resolved; SLIM is now live
+
+**agntcy/dir#1943 was our bug, not upstream's.** Maintainer @akijakya
+identified the real cause: the record pushed to the Directory declared
+`schema_version: '0.8.0'` while the skill ids/names being sent were derived
+from OASF **1.1.0**'s taxonomy — the server validates a skill against the
+taxonomy for the record's *own declared* version, so every 1.1.0-derived
+id/name was checked against 0.8.0 and correctly rejected. `id=60101`
+"worked" only by coincidence (0.8.0 has an unrelated skill, "indexing", at
+that same numeric slot). Fixing `schema_version` to `'1.1.0'` in the
+companion metaharness package resolved it completely — verified live, all
+9 previously-"broken" ids now push, and `id`+`name` sent together also
+works. Closed the issue with the resolution.
+
+**agntcy/slim#1916 is now live-connectable.** The SLIM maintainers
+confirmed they've moved off `uniffi-bindgen-react-native` onto
+`@ubjs/core`/`@ubjs/node` (compiled output) in the `alpha` dist-tag
+(`2.0.0-alpha.4+`), not yet promoted to `latest`. Verified live: a real
+server bring-up + client connect + graceful shutdown against
+`@agntcy/slim-bindings@2.0.0-alpha.5` succeeds under plain Node with zero
+errors. `package.json` now pins that exact version (deliberately, not a
+caret range — this is a pre-release channel) until the fix is promoted to
+`latest`. `detectAgntcyRuntime()` needed **zero code changes** — its
+existing graceful-degradation design already handled both directions
+correctly; only the pinned dependency version and its own doc comments
+changed. Real, end-to-end verified: `detectAgntcyRuntime()` now returns
+`configured: true` when `RUFLO_AGNTCY_SLIM_ENDPOINT` is set, not just in
+theory.
+
 ## References
 
 - Cisco AGNTCY overview — https://outshift.cisco.com/the-internet-of-agents/agntcy

--- a/v3/@claude-flow/cli/__tests__/agntcy/agntcy-commands.test.ts
+++ b/v3/@claude-flow/cli/__tests__/agntcy/agntcy-commands.test.ts
@@ -74,8 +74,27 @@ describe('agntcy command scaffold (ADR-380) — not-configured fallback', () => 
       expect(status.endpoint).toBeUndefined();
     });
 
-    it('reports not configured (package unpublished) when the endpoint is set', async () => {
+    it('reports configured when the endpoint is set and the optional package resolves', async () => {
+      // @agntcy/slim-bindings is pinned to the confirmed-working alpha
+      // (2.0.0-alpha.5, see package.json + runtime.ts's header comment for
+      // why — agntcy/slim#1916) and is a real optionalDependency here, so
+      // this genuinely exercises the "package installed and importable"
+      // path rather than asserting the old "not installed" fallback.
       const status = await detectAgntcyRuntime({ [AGNTCY_ENDPOINT_ENV]: 'https://slim.example.com' });
+      expect(status.configured).toBe(true);
+      expect(status.endpoint).toBe('https://slim.example.com');
+      expect(status.reason).toMatch(/resolved/);
+    });
+
+    it('still degrades gracefully if the optional package genuinely is not installed', async () => {
+      // Regression guard for the "works without AGNTCY installed" contract
+      // this file's header describes — simulate a MODULE_NOT_FOUND by
+      // probing a package name guaranteed not to exist, exercising the
+      // same catch branch a real "not installed" environment would hit.
+      const status = await detectAgntcyRuntime(
+        { [AGNTCY_ENDPOINT_ENV]: 'https://slim.example.com' },
+        '@agntcy/this-package-does-not-exist-in-any-registry',
+      );
       expect(status.configured).toBe(false);
       expect(status.endpoint).toBe('https://slim.example.com');
       expect(status.reason).toMatch(/not installed|error probing/);

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -120,7 +120,7 @@
     "zod": "^3.22.0"
   },
   "optionalDependencies": {
-    "@agntcy/slim-bindings": "^1.4.1",
+    "@agntcy/slim-bindings": "2.0.0-alpha.5",
     "@napi-rs/keyring": "1.3.0",
     "@claude-flow/memory": "^3.0.0-alpha.21",
     "agentdb": "^3.0.0-alpha.17",

--- a/v3/@claude-flow/cli/src/commands/agntcy/runtime.ts
+++ b/v3/@claude-flow/cli/src/commands/agntcy/runtime.ts
@@ -9,20 +9,31 @@
  * (`@claude-flow/agntcy`) and concluded no real SLIM SDK existed anywhere.
  * That check only tried guessed names — the real package is
  * `@agntcy/slim-bindings` (npm, real, published, documented for plain
- * Node.js use). It currently **fails to load** in plain Node, but for a
- * different, more specific reason: a transitive dependency
- * (`uniffi-bindgen-react-native`) ships raw, uncompiled TypeScript as its
- * package.json `main`, which only works inside a bundler (Metro, for its
- * React Native use case) — not plain `require`/`import`. Filed upstream:
+ * Node.js use).
+ *
+ * `@agntcy/slim-bindings@1.4.1` (npm `latest`) fails to load in plain Node —
+ * a transitive dependency (`uniffi-bindgen-react-native`) ships raw,
+ * uncompiled TypeScript as its package.json `main`, which only works inside
+ * a bundler (Metro, for its React Native use case). Filed upstream:
  * agntcy/slim#1916 and jhugman/uniffi-bindgen-react-native#422 (root cause).
  *
- * This module's existing graceful-degradation design already handles this
+ * UPDATE (2026-07-31, later): the SLIM maintainers confirmed they've moved
+ * off `uniffi-bindgen-react-native` onto `@ubjs/core`/`@ubjs/node` (compiled
+ * output, not raw TS) in the `alpha` dist-tag (`2.0.0-alpha.4+`), not yet
+ * promoted to `latest`. Verified live: a real server-bring-up + client-
+ * connect + graceful-shutdown smoke test against `@agntcy/slim-bindings@
+ * 2.0.0-alpha.5` succeeds under plain Node with zero errors. `package.json`
+ * now pins that exact alpha version (not a caret range — this is a
+ * pre-release channel, pin deliberately rather than floating) until the fix
+ * is promoted to `latest`, tracked by the same issue.
+ *
+ * This module's existing graceful-degradation design already handled this
  * correctly without any change to its logic: `detectAgntcyRuntime()`'s
  * catch-all branch (anything other than MODULE_NOT_FOUND) reports the real
- * underlying error and falls back to local transport — which is exactly
- * what happens today when the dynamic import hits the packaging bug above.
- * Once that upstream issue is fixed, this same code path starts succeeding
- * with zero changes needed here.
+ * underlying error and falls back to local transport when the import fails.
+ * Now that the pinned version actually loads, the happy path
+ * (`configured: true`) is real and verified, not aspirational — no change
+ * to this function was needed either way.
  *
  * Per ADR-150's precedent (which ADR-380 §1 explicitly follows, not
  * ADR-321's hard-dependency exception):
@@ -73,17 +84,19 @@ export interface AgntcyRuntimeStatus {
  * in order:
  *   1. An env var presence check for {@link AGNTCY_ENDPOINT_ENV}. Absent →
  *      not configured, no further work.
- *   2. A dynamic `import()` of {@link AGNTCY_PACKAGE_NAME}, wrapped in
- *      try/catch. The package is real and installable, but today the
- *      import fails at load time due to an upstream packaging bug in one
- *      of its transitive dependencies (see this file's header comment) —
- *      that failure surfaces through the generic catch branch below with
- *      the real error message, not the MODULE_NOT_FOUND branch.
+ *   2. A dynamic `import()` of {@link AGNTCY_PACKAGE_NAME} (or `packageName`
+ *      if overridden), wrapped in try/catch. Verified live: the pinned
+ *      `2.0.0-alpha.5` resolves cleanly — `configured: true` is a real,
+ *      exercised path today, not just a theoretical one.
  *
  * @param env Injectable for tests; defaults to `process.env`.
+ * @param packageName Injectable for tests (to simulate "package not
+ *   installed" without needing to actually uninstall the real optional
+ *   dependency); defaults to {@link AGNTCY_PACKAGE_NAME}.
  */
 export async function detectAgntcyRuntime(
   env: NodeJS.ProcessEnv = process.env,
+  packageName: string = AGNTCY_PACKAGE_NAME,
 ): Promise<AgntcyRuntimeStatus> {
   const endpoint = env[AGNTCY_ENDPOINT_ENV];
   if (!endpoint) {
@@ -96,14 +109,14 @@ export async function detectAgntcyRuntime(
     // `await import('pg')`). Never a static `import` — a static import
     // would make @claude-flow/cli fail to build/run when the package is
     // absent, which is the one thing ADR-150/ADR-380 forbid.
-    await import(AGNTCY_PACKAGE_NAME);
-    return { configured: true, reason: `${AGNTCY_PACKAGE_NAME} resolved`, endpoint };
+    await import(packageName);
+    return { configured: true, reason: `${packageName} resolved`, endpoint };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException | undefined)?.code;
     if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
       return {
         configured: false,
-        reason: `${AGNTCY_ENDPOINT_ENV} is set but the optional "${AGNTCY_PACKAGE_NAME}" runtime package is not installed`,
+        reason: `${AGNTCY_ENDPOINT_ENV} is set but the optional "${packageName}" runtime package is not installed`,
         endpoint,
       };
     }
@@ -112,7 +125,7 @@ export async function detectAgntcyRuntime(
     // than propagate, but keep the real reason for diagnostics.
     return {
       configured: false,
-      reason: `error probing "${AGNTCY_PACKAGE_NAME}": ${error instanceof Error ? error.message : String(error)}`,
+      reason: `error probing "${packageName}": ${error instanceof Error ? error.message : String(error)}`,
       endpoint,
     };
   }

--- a/v3/docs/adr/ADR-380-agntcy-outshift-runtime-integration.md
+++ b/v3/docs/adr/ADR-380-agntcy-outshift-runtime-integration.md
@@ -159,6 +159,35 @@ a remote hosted service (`schema.oasf.outshift.com`), not local source in
 any AGNTCY repo. Filed as
 [agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943) instead.
 
+## Update (2026-07-31, part 2) — both filed bugs resolved; SLIM is now live
+
+**agntcy/dir#1943 was our bug, not upstream's.** Maintainer @akijakya
+identified the real cause: the record pushed to the Directory declared
+`schema_version: '0.8.0'` while the skill ids/names being sent were derived
+from OASF **1.1.0**'s taxonomy — the server validates a skill against the
+taxonomy for the record's *own declared* version, so every 1.1.0-derived
+id/name was checked against 0.8.0 and correctly rejected. `id=60101`
+"worked" only by coincidence (0.8.0 has an unrelated skill, "indexing", at
+that same numeric slot). Fixing `schema_version` to `'1.1.0'` in the
+companion metaharness package resolved it completely — verified live, all
+9 previously-"broken" ids now push, and `id`+`name` sent together also
+works. Closed the issue with the resolution.
+
+**agntcy/slim#1916 is now live-connectable.** The SLIM maintainers
+confirmed they've moved off `uniffi-bindgen-react-native` onto
+`@ubjs/core`/`@ubjs/node` (compiled output) in the `alpha` dist-tag
+(`2.0.0-alpha.4+`), not yet promoted to `latest`. Verified live: a real
+server bring-up + client connect + graceful shutdown against
+`@agntcy/slim-bindings@2.0.0-alpha.5` succeeds under plain Node with zero
+errors. `package.json` now pins that exact version (deliberately, not a
+caret range — this is a pre-release channel) until the fix is promoted to
+`latest`. `detectAgntcyRuntime()` needed **zero code changes** — its
+existing graceful-degradation design already handled both directions
+correctly; only the pinned dependency version and its own doc comments
+changed. Real, end-to-end verified: `detectAgntcyRuntime()` now returns
+`configured: true` when `RUFLO_AGNTCY_SLIM_ENDPOINT` is set, not just in
+theory.
+
 ## References
 
 - Cisco AGNTCY overview — https://outshift.cisco.com/the-internet-of-agents/agntcy

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         version: 3.25.76
     optionalDependencies:
       '@agntcy/slim-bindings':
-        specifier: ^1.4.1
-        version: 1.4.1
+        specifier: 2.0.0-alpha.5
+        version: 2.0.0-alpha.5
       '@claude-flow/memory':
         specifier: ^3.0.0-alpha.21
         version: link:../memory
@@ -668,97 +668,80 @@ packages:
   /@actions/io@2.0.0:
     resolution: {integrity: sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==}
 
-  /@agntcy/slim-bindings-darwin-arm64@1.4.1:
-    resolution: {integrity: sha512-K9IbX/nnsfJFXEQICukO0XfCFj/0UqY2DhL9nnjFbfO9Zq+hKzreWMzLLzHvffFrONwPFgijg6cM4L7ImAvssw==}
+  /@agntcy/slim-bindings-darwin-arm64@2.0.0-alpha.5:
+    resolution: {integrity: sha512-M5DP+SPVn+ReAAK6GxHosxciNMCWZv1vxZziPcxWMt+HIOt4/9w7vlbJPe1dfmdEHegE9iNGQ+AOSKOfQS5rhQ==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      ffi-rs: 1.3.4
-      ref-napi: 3.0.3
-      uniffi-bindgen-react-native: 0.29.3-1
-    transitivePeerDependencies:
-      - supports-color
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     dev: false
     optional: true
 
-  /@agntcy/slim-bindings-darwin-x64@1.4.1:
-    resolution: {integrity: sha512-pOPKDmfUfXpKH04nnCh+cPfDu4Hyp4wgH0L1NxZkrArswPgqUzRVeawz80NUCkEgv3o88QCcVOpHr+APU1xFzg==}
+  /@agntcy/slim-bindings-darwin-x64@2.0.0-alpha.5:
+    resolution: {integrity: sha512-xWbywk8ZNABApjKiUe8E6umkGXYTNQBKAO1ZFPQfOP1OrSf3oupJTv/pkzsRifh+/dOFaojpZFvcZJfeM1L/jA==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      ffi-rs: 1.3.4
-      ref-napi: 3.0.3
-      uniffi-bindgen-react-native: 0.29.3-1
-    transitivePeerDependencies:
-      - supports-color
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     dev: false
     optional: true
 
-  /@agntcy/slim-bindings-linux-arm64-gnu@1.4.1:
-    resolution: {integrity: sha512-5EcZogyHtY+w5gART3jYutYEdSwDca1iSgdI5F5fmrLWaojhGltgJtM3CHmctDeigSVH+IUY0d6ZjqabuK2UlQ==}
+  /@agntcy/slim-bindings-linux-arm64-gnu@2.0.0-alpha.5:
+    resolution: {integrity: sha512-+3YZRrVNYpY4eD4Wn9aza6rsiGwB/hz/ojxyCPgeK9/4QFYVvUMnVq4H4sN+k5ckJP7lrR6ncfEqp7BJyOwKQA==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      ffi-rs: 1.3.4
-      ref-napi: 3.0.3
-      uniffi-bindgen-react-native: 0.29.3-1
-    transitivePeerDependencies:
-      - supports-color
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     dev: false
     optional: true
 
-  /@agntcy/slim-bindings-linux-x64-gnu@1.4.1:
-    resolution: {integrity: sha512-XFQLlbK32mt5hH5EMM0DqlWBuKv6o+OMbVbD8u1/qE07YEEvgRiDkunHlGoKn2HdggQdMSEEZjH/QsitBBuCqA==}
+  /@agntcy/slim-bindings-linux-x64-gnu@2.0.0-alpha.5:
+    resolution: {integrity: sha512-BYGtMWtJJTd+z6eioFvbGbg/oq0DwjhHRJtTYvNpHQ6CFhja3PhuxcUPrW53xKVLTD3saeZq8MVOGq2tuF+PRQ==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      ffi-rs: 1.3.4
-      ref-napi: 3.0.3
-      uniffi-bindgen-react-native: 0.29.3-1
-    transitivePeerDependencies:
-      - supports-color
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     dev: false
     optional: true
 
-  /@agntcy/slim-bindings-win32-arm64-msvc@1.4.1:
-    resolution: {integrity: sha512-adDCdLpX/OkJV3zQbDraKaPCedOCgO6ZLZjDZ9bLPh6DUlDmz6PcqA8HkbGc5TEFfo4XFEExyGPo0SgtUn/+/A==}
+  /@agntcy/slim-bindings-win32-arm64-msvc@2.0.0-alpha.5:
+    resolution: {integrity: sha512-dO6/JdvE2ANVujXMTSxSMqb94YN9+ox7HbNaSzQt8shERB/5XFgWKYDCrwEJC26ux8FzQcvaq8mnlePGueDq7g==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      ffi-rs: 1.3.4
-      ref-napi: 3.0.3
-      uniffi-bindgen-react-native: 0.29.3-1
-    transitivePeerDependencies:
-      - supports-color
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     dev: false
     optional: true
 
-  /@agntcy/slim-bindings-win32-x64-msvc@1.4.1:
-    resolution: {integrity: sha512-Pkj4BhVyfXh13uDkGF9iU3aBJ2XB/T3RAk9EW9fHUk5uvkpd14VD7oYKQBQtb7SIEKGohC2UX3/jZ8yj+ujlpA==}
+  /@agntcy/slim-bindings-win32-x64-msvc@2.0.0-alpha.5:
+    resolution: {integrity: sha512-w0mKFPKKkhwfQzaC/p1Ke3ogNL4AyxC9jt0LY0LsBHNIJaPPBvAbLMLVslZBgn2ghrMRS/nxdacdQrAcFQQzXg==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
     dependencies:
-      ffi-rs: 1.3.4
-      ref-napi: 3.0.3
-      uniffi-bindgen-react-native: 0.29.3-1
-    transitivePeerDependencies:
-      - supports-color
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     dev: false
     optional: true
 
-  /@agntcy/slim-bindings@1.4.1:
-    resolution: {integrity: sha512-xyBp0/I2Qb0/G0Xe7GaexjdTvLBpbN9qCWNutoYH66BEF5+dlZ+aZgspjuVJxjkC1iOnDvQag8yaax8betr8Lg==}
+  /@agntcy/slim-bindings@2.0.0-alpha.5:
+    resolution: {integrity: sha512-QBpln5ubYbJ7nMY2SUWJJfUsl5qmezqWNwcatdjuaZaK2dDIj2RHAvgNKNmuf8Exg+kuI/88SFrAZMNxLJolNQ==}
     engines: {node: '>=18.0.0'}
     requiresBuild: true
+    dependencies:
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
     optionalDependencies:
-      '@agntcy/slim-bindings-darwin-arm64': 1.4.1
-      '@agntcy/slim-bindings-darwin-x64': 1.4.1
-      '@agntcy/slim-bindings-linux-arm64-gnu': 1.4.1
-      '@agntcy/slim-bindings-linux-x64-gnu': 1.4.1
-      '@agntcy/slim-bindings-win32-arm64-msvc': 1.4.1
-      '@agntcy/slim-bindings-win32-x64-msvc': 1.4.1
-    transitivePeerDependencies:
-      - supports-color
+      '@agntcy/slim-bindings-darwin-arm64': 2.0.0-alpha.5
+      '@agntcy/slim-bindings-darwin-x64': 2.0.0-alpha.5
+      '@agntcy/slim-bindings-linux-arm64-gnu': 2.0.0-alpha.5
+      '@agntcy/slim-bindings-linux-x64-gnu': 2.0.0-alpha.5
+      '@agntcy/slim-bindings-win32-arm64-msvc': 2.0.0-alpha.5
+      '@agntcy/slim-bindings-win32-x64-msvc': 2.0.0-alpha.5
     dev: false
     optional: true
 
@@ -6677,6 +6660,91 @@ packages:
     dependencies:
       '@types/node': 20.19.27
 
+  /@ubjs/core@0.31.0-3:
+    resolution: {integrity: sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-darwin-arm64@0.31.0-3:
+    resolution: {integrity: sha512-GGQVPLkVo4Gc8qVLW4IGvS8bjl8eHXyeP4a97ntGmsAdXwE5gsS29o8xUEFROjhwHKD+9sgVeblCSWVG3CpHsw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-darwin-x64@0.31.0-3:
+    resolution: {integrity: sha512-2sc47u4XFYOsbmP5EW+Gx8m/yGrYnfFDFQm6+kz7goSWTNg84eEiz3COs9HKJDVuNJ5Khv5XipTO8CFadMLXCw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-linux-arm64-gnu@0.31.0-3:
+    resolution: {integrity: sha512-YStVXhYz/5jvlWf/p4fhiVT72unYAbGugifFC9QmO/+hnroQDAQ5t8SARbsc15G4olMcamdIB+GETiUB7gmaYg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-linux-arm64-musl@0.31.0-3:
+    resolution: {integrity: sha512-Izp4nvfy/LmibzFowAztkoDOksCR2fb2zl6fh1ojR1HEsg0rAGruxtI8d3fn8DI0lBXwqmn6SF///oD4mFNJPQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-linux-x64-gnu@0.31.0-3:
+    resolution: {integrity: sha512-Xdm21blyg5U/kW6s7OMvgrr8coGTkUlt26DVR9x8gKISif+E3YwdEskbFScWqystAiJnfjw7xHEc8UMu0Qlz7Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-linux-x64-musl@0.31.0-3:
+    resolution: {integrity: sha512-fFQ9BWS6i2LUH9SJgD9oEiKXXo/say59vHy7usFe1t7C2xvwvP34f5SuxXmWP9R8fHyA0aC4kIZ+TTwyHSv1Kw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-win32-arm64-msvc@0.31.0-3:
+    resolution: {integrity: sha512-ID6rSz1NmPsWTNBBNAw4OnJ5Dj8pcbtNJtdPB3OxcGigLBd/e0x7buhSI7os6Mo5iYtEdCynBRQHFJwub5XSPg==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node-win32-x64-msvc@0.31.0-3:
+    resolution: {integrity: sha512-wevs+Y+szwcCUT8IJFbB4/1nfxyRv/51l8oG7FGUPWD1xLPyuHfJBG27C+PDeC7KRzes/2n6aLo4DGZbr/LYTw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@ubjs/node@0.31.0-3:
+    resolution: {integrity: sha512-qNMpi2LICNwxGXZyRF8fSDBSpbezyZbEsydrbiMPJOmtOWr4tmZIEl7jkWGHVGShoBvHfFo4eHp5B4UVP928Cg==}
+    requiresBuild: true
+    optionalDependencies:
+      '@ubjs/node-darwin-arm64': 0.31.0-3
+      '@ubjs/node-darwin-x64': 0.31.0-3
+      '@ubjs/node-linux-arm64-gnu': 0.31.0-3
+      '@ubjs/node-linux-arm64-musl': 0.31.0-3
+      '@ubjs/node-linux-x64-gnu': 0.31.0-3
+      '@ubjs/node-linux-x64-musl': 0.31.0-3
+      '@ubjs/node-win32-arm64-msvc': 0.31.0-3
+      '@ubjs/node-win32-x64-msvc': 0.31.0-3
+    dev: false
+    optional: true
+
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     dev: true
@@ -6804,105 +6872,6 @@ packages:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  /@yuuang/ffi-rs-android-arm64@1.3.4:
-    resolution: {integrity: sha512-2ywkkOk1j1lbcYyaH9KeyR7i2Qtq4gDfnkmhF5vlRGnwve1j5RWH2ZlF3990raEx6OLophke/JXfUGQL9Dy0ig==}
-    engines: {node: '>= 12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-darwin-arm64@1.3.4:
-    resolution: {integrity: sha512-FEogaqNfk9yI9szLebGW9JR/OAwMZ+vkeHVhpcZBvRWTce5IA7mfZorY2KhzP+SEjz4F5q5+fFr6GzHzm/gxvQ==}
-    engines: {node: '>= 12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-darwin-x64@1.3.4:
-    resolution: {integrity: sha512-JuEPUOsE7qz6o4kSKgX+KymzSFUvyafpGykVbvm9+11Gx/fQy1lzrYkg2VdI70ctM3mjWARGpcaVZlCyPZVRvg==}
-    engines: {node: '>= 12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-linux-arm-gnueabihf@1.3.4:
-    resolution: {integrity: sha512-9Alv4r8uZ/kZN6PKqIUoqrtWcpOD/iq3R/w31dEM2aQ8XaftZVD5oANO8IP9lFROb8QmJwDpyW1mfG1GQ0WJjA==}
-    engines: {node: '>= 12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-linux-arm64-gnu@1.3.4:
-    resolution: {integrity: sha512-iconeq2sjAgPn9RyLhfnjawaepeaj8o9EdSI4fg3y92dr0Tbjkr2KjNREgloLN1Jw5BGPt89/sJsDqBWLZP8Rg==}
-    engines: {node: '>= 12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-linux-arm64-musl@1.3.4:
-    resolution: {integrity: sha512-ptjhnk2M0QTWaKq59wCR4mZ6LeRFOEXmsybp/SOHn5OZ8XYZLnv5FqSGHLPeJp2WvwzhS8SNjn/A2XmHfF3vow==}
-    engines: {node: '>= 12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-linux-x64-gnu@1.3.4:
-    resolution: {integrity: sha512-TM0nfjruTuipNbksyV3iKvMKFeIHNI15tpPuqOzndcVi1Ms1I4tEAyi0gYTFjXUtcjSwBdjhztmIYphStRLVug==}
-    engines: {node: '>= 12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-linux-x64-musl@1.3.4:
-    resolution: {integrity: sha512-aKPSWXoEutWw8et4dhp4tq3x7FOg3C2mBT4gJr/cJxE/vcGxFKCsg3HjKNi3D1BwSZqh0bGuniZCFrde2DpkkA==}
-    engines: {node: '>= 12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-win32-arm64-msvc@1.3.4:
-    resolution: {integrity: sha512-hJndCj9xEosRw9Xn02IwzfXy8tgXvspJT5Qhpld9xXDFZyY0wYKxxO2VZhJNiIuX9vuEUgqeVvfCp5EeTpom1Q==}
-    engines: {node: '>= 12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-win32-ia32-msvc@1.3.4:
-    resolution: {integrity: sha512-tXowkiiq3mdnK8CtgSWKQ1dRLJvF0d1pd4qomIl8Pv1To1SWATZ20lag3sXv19+utdrwInWvCi4NjHDmN92Y1A==}
-    engines: {node: '>= 12'}
-    cpu: [x64, ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@yuuang/ffi-rs-win32-x64-msvc@1.3.4:
-    resolution: {integrity: sha512-Kxr2Z2EU2Lutl7hBYrs90/s0lQ6OWavscVu62Bx4gckg+DdxZaQuxHRktdL5ITH7tdUewj3OqkcUNZXCvGCe0Q==}
-    engines: {node: '>= 12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -9030,24 +8999,6 @@ packages:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  /ffi-rs@1.3.4:
-    resolution: {integrity: sha512-rUX011WXszmHHmu/HO5CZQCscU+poR4tPrrTO+M1ePbq2QIptpklpr/Fujc8GBuILNXBdxVRsn+Kfp3uihsHFw==}
-    requiresBuild: true
-    optionalDependencies:
-      '@yuuang/ffi-rs-android-arm64': 1.3.4
-      '@yuuang/ffi-rs-darwin-arm64': 1.3.4
-      '@yuuang/ffi-rs-darwin-x64': 1.3.4
-      '@yuuang/ffi-rs-linux-arm-gnueabihf': 1.3.4
-      '@yuuang/ffi-rs-linux-arm64-gnu': 1.3.4
-      '@yuuang/ffi-rs-linux-arm64-musl': 1.3.4
-      '@yuuang/ffi-rs-linux-x64-gnu': 1.3.4
-      '@yuuang/ffi-rs-linux-x64-musl': 1.3.4
-      '@yuuang/ffi-rs-win32-arm64-msvc': 1.3.4
-      '@yuuang/ffi-rs-win32-ia32-msvc': 1.3.4
-      '@yuuang/ffi-rs-win32-x64-msvc': 1.3.4
-    dev: false
-    optional: true
-
   /figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
@@ -9371,12 +9322,6 @@ packages:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  /get-symbol-from-current-process-h@1.0.2:
-    resolution: {integrity: sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
@@ -10706,12 +10651,6 @@ packages:
     dependencies:
       semver: 7.7.3
 
-  /node-addon-api@3.2.1:
-    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
@@ -11658,20 +11597,6 @@ packages:
     dependencies:
       esprima: 4.0.1
     dev: false
-
-  /ref-napi@3.0.3:
-    resolution: {integrity: sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==}
-    engines: {node: '>= 10.0'}
-    requiresBuild: true
-    dependencies:
-      debug: 4.4.3
-      get-symbol-from-current-process-h: 1.0.2
-      node-addon-api: 3.2.1
-      node-gyp-build: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-    optional: true
 
   /registry-auth-token@5.1.0:
     resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
@@ -12933,13 +12858,6 @@ packages:
   /unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
-
-  /uniffi-bindgen-react-native@0.29.3-1:
-    resolution: {integrity: sha512-o6gXZsAh55yuvhwF2WSFdIHV4phyfWcCmg4DuyfJWJ7CvUz1UcIz2S4u9SmXAz1jsuqvu6Xc9hexrRBB0a5osg==}
-    hasBin: true
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}


### PR DESCRIPTION
## Summary

The SLIM maintainers confirmed on [agntcy/slim#1916](https://github.com/agntcy/slim/issues/1916) that they've moved off `uniffi-bindgen-react-native` onto `@ubjs/core`/`@ubjs/node` (compiled output, not raw TypeScript) in the `alpha` dist-tag (`2.0.0-alpha.4+`), not yet promoted to `latest`.

Verified live: a real server bring-up + client connect + graceful shutdown against `@agntcy/slim-bindings@2.0.0-alpha.5` succeeds under plain Node with zero errors. Verified `detectAgntcyRuntime()` itself (not a mock) now returns `configured: true` when `RUFLO_AGNTCY_SLIM_ENDPOINT` is set — exactly as its existing graceful-degradation design predicted it would once the upstream bug was fixed. **Zero logic changes needed to that function.**

Pinned to the exact alpha version (not a caret range — deliberate for a pre-release channel) rather than `latest`, until the fix is promoted upstream. Added `detectAgntcyRuntime()`'s optional `packageName` parameter so the "package genuinely not installed" fallback path stays covered by a real regression test now that the real package resolves.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile regenerated, scoped to this one dependency)
- [x] 19/19 `agntcy-commands.test.ts` tests pass, including the updated "reports configured" test and a new regression test for the "package genuinely missing" path
- [x] Real, non-mocked verification: `detectAgntcyRuntime()` called directly from within `@claude-flow/cli`'s actual package returns `{configured: true, reason: "@agntcy/slim-bindings resolved", ...}`
- [x] Real SLIM smoke test (server bring-up, client connect, graceful shutdown) against `2.0.0-alpha.5` in an isolated probe project

🤖 Generated with [Claude Code](https://claude.com/claude-code)