### PR TITLE
fix(routing): don't let a static pattern preempt the outcome store (#2886)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-route-static-preemption-2886.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-route-static-preemption-2886.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression guard for #2886 — a static TASK_PATTERNS match must not
+ * short-circuit the outcome store.
+ *
+ * `hooks_route` picks the first semantic match clearing `score > 0.4`. Static
+ * patterns need only that bar; learned patterns additionally need
+ * `support >= 2 && reliability >= 0.75` (#2864). The bug was not that gate —
+ * it was that a winning STATIC match skipped `suggestAgentsForTask()`
+ * entirely, and that function holds a second learned stage: nearest-neighbour
+ * over `.claude-flow/routing-outcomes.json`, gated at >= 2 overlapping
+ * keywords. So a static pattern matching on a char-hash similarity score beat
+ * an outcome match with 14 shared keywords.
+ *
+ * Measured on a 76-outcome replay before the fix: static was the least
+ * accurate decision path (38%), below keyword-fallback (52%) and learned
+ * (70%), while winning routes outright.
+ *
+ * The fix is deliberately narrow: only REAL evidence (`source:
+ * 'outcome-overlap'`) outranks a static pattern. A `KEYWORD_PATTERNS`
+ * substring hit still loses to a static semantic match — both are hardcoded
+ * guesses, and preferring one over the other has no evidence behind it.
+ *
+ * These tests write a real `routing-outcomes.json` into a temp cwd, because
+ * that file is what `suggestAgentsForTask()`'s second stage reads.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const { hooksRoute } = await import('../src/mcp-tools/hooks-tools.js');
+
+let origCwd: string;
+let workdir: string;
+
+/** Write outcomes whose keywords overlap `task` by >= 2, all for one agent. */
+function seedOutcomes(outcomes: Array<{ task: string; agent: string; keywords: string[] }>) {
+  mkdirSync(join(workdir, '.claude-flow'), { recursive: true });
+  writeFileSync(
+    join(workdir, '.claude-flow', 'routing-outcomes.json'),
+    JSON.stringify({
+      outcomes: outcomes.map(o => ({
+        ...o,
+        success: true,
+        quality: 0.9,
+        timestamp: new Date(0).toISOString(),
+      })),
+    }),
+  );
+}
+
+beforeEach(() => {
+  origCwd = process.cwd();
+  workdir = mkdtempSync(join(tmpdir(), 'ruflo-2886-'));
+  process.chdir(workdir);
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  try { rmSync(workdir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('#2886 — static patterns must not preempt the outcome store', () => {
+  it('prefers an outcome-overlap match over a static pattern, and says so', async () => {
+    // "refactor" is a static TASK_PATTERNS keyword routing to architect/coder/reviewer.
+    // The outcome store says tasks phrased like this were done by `tester`.
+    const task = 'refactor the agency agent pack sync and reinstall the bundled plugins';
+    seedOutcomes([
+      { task: 'agency agent pack sync reinstall bundled plugins', agent: 'tester',
+        keywords: ['agency', 'agent', 'pack', 'sync', 'reinstall', 'bundled', 'plugins'] },
+      { task: 'agency agent pack bundled plugins refresh', agent: 'tester',
+        keywords: ['agency', 'agent', 'pack', 'bundled', 'plugins', 'refresh'] },
+    ]);
+
+    const res: any = await hooksRoute.handler({ task });
+
+    expect(res.matchedPattern).toBe('outcome-overlap');
+    expect(res.primaryAgent.type).toBe('tester');
+    // The outranked static pattern is named, so the decision is auditable
+    // rather than silently different (issue ask #2).
+    expect(res.routing.backend).toMatch(/preferred over static/);
+  });
+
+  it('leaves learned matches alone — they already carry support/reliability (#2864)', async () => {
+    // Six outcomes for one agent build a `learned-coder` pattern that clears
+    // support >= 2 and reliability >= 0.75. A learned win must NOT be
+    // rerouted through the outcome-overlap branch.
+    const kws = ['quantum', 'flux', 'capacitor', 'calibration', 'harness'];
+    seedOutcomes(
+      Array.from({ length: 6 }, (_, i) => ({
+        task: `quantum flux capacitor calibration harness ${i}`,
+        agent: 'coder',
+        keywords: kws,
+      })),
+    );
+
+    const res: any = await hooksRoute.handler({
+      task: 'quantum flux capacitor calibration harness rebuild',
+    });
+
+    // Either a learned pattern wins outright, or nothing clears the score bar
+    // and it falls back — but it must never be silently downgraded to static.
+    expect(res.matchedPattern).not.toMatch(/^(refactor|feature|testing|security)-task$/);
+  });
+
+  it('does NOT let a bare KEYWORD_PATTERNS substring hit outrank a static match', async () => {
+    // No outcomes at all -> suggestAgentsForTask can only return source
+    // 'keyword' or 'default', neither of which should displace a static
+    // semantic match. This pins the narrowness of the fix.
+    seedOutcomes([]);
+
+    const res: any = await hooksRoute.handler({
+      task: 'refactor the deployment pipeline test coverage',
+    });
+
+    expect(res.matchedPattern).not.toBe('outcome-overlap');
+  });
+
+  it('still falls back to keyword matching when nothing clears the score bar', async () => {
+    seedOutcomes([]);
+    const res: any = await hooksRoute.handler({ task: 'zzzz' });
+    expect(['keyword-fallback', 'outcome-overlap']).toContain(res.matchedPattern);
+    expect(typeof res.primaryAgent.type).toBe('string');
+    expect(res.primaryAgent.type.length).toBeGreaterThan(0);
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/hooks-route-static-preemption-2886.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-route-static-preemption-2886.test.ts
@@ -25,12 +25,15 @@
  *
  *     It is frozen at IMPORT time. A `process.chdir()` in `beforeEach` runs
  *     after the top-level `await import(...)`, so the seeded fixture is never
- *     read and the outcome stage can never fire. Note the sibling
- *     `hooks-post-task-...-2786.test.ts` uses exactly that top-level-import
- *     shape and is correct — because `hooks_post-task` resolves the SAME path
- *     again at CALL time (hooks-tools.ts, in the handler). Read and write
- *     disagree about when `.` is resolved; only the read side is import-frozen.
- *     So: chdir FIRST, then `vi.resetModules()`, then import.
+ *     read and the outcome stage can never fire. Both the read (:226) and the
+ *     write (:240) use that same frozen const, so they agree with each other —
+ *     the only consequence is that a test cannot redirect either after import.
+ *     Note the sibling `hooks-post-task-...-2786.test.ts` uses exactly that
+ *     top-level-import shape and IS correct, but for a reason that does not
+ *     transfer: it asserts on `.claude-flow/memory/store.json`, built from a
+ *     relative const and resolved inside the handler (`MEMORY_DIR` :493,
+ *     `resolve(MEMORY_DIR)` :1636), so chdir does redirect that one.
+ *     So here: chdir FIRST, then `vi.resetModules()`, then import.
  *
  *  2. `suggestAgentsForTask()` checks `KEYWORD_PATTERNS` substrings BEFORE the
  *     outcome stage and returns immediately on a hit. `refactor`, `test`,

--- a/v3/@claude-flow/cli/__tests__/hooks-route-static-preemption-2886.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-route-static-preemption-2886.test.ts
@@ -8,33 +8,47 @@
  * it was that a winning STATIC match skipped `suggestAgentsForTask()`
  * entirely, and that function holds a second learned stage: nearest-neighbour
  * over `.claude-flow/routing-outcomes.json`, gated at >= 2 overlapping
- * keywords. So a static pattern matching on a char-hash similarity score beat
- * an outcome match with 14 shared keywords.
- *
- * Measured on a 76-outcome replay before the fix: static was the least
- * accurate decision path (38%), below keyword-fallback (52%) and learned
- * (70%), while winning routes outright.
+ * keywords.
  *
  * The fix is deliberately narrow: only REAL evidence (`source:
  * 'outcome-overlap'`) outranks a static pattern. A `KEYWORD_PATTERNS`
- * substring hit still loses to a static semantic match — both are hardcoded
- * guesses, and preferring one over the other has no evidence behind it.
+ * substring hit still loses — both are hardcoded guesses, and preferring one
+ * over the other has no evidence behind it.
  *
- * These tests write a real `routing-outcomes.json` into a temp cwd, because
- * that file is what `suggestAgentsForTask()`'s second stage reads.
+ * ⚠️ TWO TRAPS, both of which silently made an earlier draft of this file
+ * vacuous. They are why the module is imported INSIDE each case rather than
+ * at the top, and why the task strings look the way they do.
+ *
+ *  1. `ROUTING_OUTCOMES_PATH` (hooks-tools.ts) is a MODULE-LEVEL const:
+ *
+ *         const ROUTING_OUTCOMES_PATH = join(resolve('.'), '.claude-flow/...')
+ *
+ *     It is frozen at IMPORT time. A `process.chdir()` in `beforeEach` runs
+ *     after the top-level `await import(...)`, so the seeded fixture is never
+ *     read and the outcome stage can never fire. Note the sibling
+ *     `hooks-post-task-...-2786.test.ts` uses exactly that top-level-import
+ *     shape and is correct — because `hooks_post-task` resolves the SAME path
+ *     again at CALL time (hooks-tools.ts, in the handler). Read and write
+ *     disagree about when `.` is resolved; only the read side is import-frozen.
+ *     So: chdir FIRST, then `vi.resetModules()`, then import.
+ *
+ *  2. `suggestAgentsForTask()` checks `KEYWORD_PATTERNS` substrings BEFORE the
+ *     outcome stage and returns immediately on a hit. `refactor`, `test`,
+ *     `fix`, `api`, `security`, `memory`, `deploy` … are all in that table, so
+ *     a task containing one can never reach the branch under test. Cases that
+ *     must reach it use keyword-free task strings; the case that pins the
+ *     narrowness deliberately uses a keyword-bearing one.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-const { hooksRoute } = await import('../src/mcp-tools/hooks-tools.js');
-
 let origCwd: string;
 let workdir: string;
 
-/** Write outcomes whose keywords overlap `task` by >= 2, all for one agent. */
+/** Write outcomes into the temp cwd. Must be called BEFORE `load()`. */
 function seedOutcomes(outcomes: Array<{ task: string; agent: string; keywords: string[] }>) {
   mkdirSync(join(workdir, '.claude-flow'), { recursive: true });
   writeFileSync(
@@ -50,6 +64,12 @@ function seedOutcomes(outcomes: Array<{ task: string; agent: string; keywords: s
   );
 }
 
+/** Import hooks-tools AFTER the cwd is set — see trap 1 in the header. */
+async function load() {
+  vi.resetModules();
+  return await import('../src/mcp-tools/hooks-tools.js');
+}
+
 beforeEach(() => {
   origCwd = process.cwd();
   workdir = mkdtempSync(join(tmpdir(), 'ruflo-2886-'));
@@ -63,9 +83,10 @@ afterEach(() => {
 
 describe('#2886 — static patterns must not preempt the outcome store', () => {
   it('prefers an outcome-overlap match over a static pattern, and says so', async () => {
-    // "refactor" is a static TASK_PATTERNS keyword routing to architect/coder/reviewer.
-    // The outcome store says tasks phrased like this were done by `tester`.
-    const task = 'refactor the agency agent pack sync and reinstall the bundled plugins';
+    // Deliberately free of every KEYWORD_PATTERNS substring (trap 2), so the
+    // outcome stage is actually reachable. The store says tasks phrased like
+    // this were done by `tester`; a static pattern would say otherwise.
+    const task = 'agency agent pack sync reinstall the bundled plugins';
     seedOutcomes([
       { task: 'agency agent pack sync reinstall bundled plugins', agent: 'tester',
         keywords: ['agency', 'agent', 'pack', 'sync', 'reinstall', 'bundled', 'plugins'] },
@@ -73,17 +94,18 @@ describe('#2886 — static patterns must not preempt the outcome store', () => {
         keywords: ['agency', 'agent', 'pack', 'bundled', 'plugins', 'refresh'] },
     ]);
 
-    const res: any = await hooksRoute.handler({ task });
+    const { hooksRoute } = await load();
+    const res: any = await (hooksRoute as any).handler({ task });
 
     expect(res.matchedPattern).toBe('outcome-overlap');
     expect(res.primaryAgent.type).toBe('tester');
     // The outranked static pattern is named, so the decision is auditable
     // rather than silently different (issue ask #2).
-    expect(res.routing.backend).toMatch(/preferred over static/);
+    expect(res.routing.backend).toMatch(/preferred over static \S+/);
   });
 
   it('leaves learned matches alone — they already carry support/reliability (#2864)', async () => {
-    // Six outcomes for one agent build a `learned-coder` pattern that clears
+    // Six outcomes for one agent build a `learned-coder` pattern clearing
     // support >= 2 and reliability >= 0.75. A learned win must NOT be
     // rerouted through the outcome-overlap branch.
     const kws = ['quantum', 'flux', 'capacitor', 'calibration', 'harness'];
@@ -95,31 +117,47 @@ describe('#2886 — static patterns must not preempt the outcome store', () => {
       })),
     );
 
-    const res: any = await hooksRoute.handler({
-      task: 'quantum flux capacitor calibration harness rebuild',
+    const { hooksRoute } = await load();
+    // ⚠️ The task string is load-bearing and was chosen by measurement, not
+    // taste. Semantic scoring is a char-hash, so which pattern tops the list
+    // is sensitive to words that carry no meaning here: the same store and the
+    // same five keywords give `learned-coder` for '... harness run' but a
+    // static `security-task` for '... harness rebuild'. Only the former puts a
+    // LEARNED match on top, which is the precondition this case needs. It is
+    // also free of every KEYWORD_PATTERNS substring, so the outcome branch is
+    // genuinely reachable — otherwise the case would pass for the wrong reason.
+    const res: any = await (hooksRoute as any).handler({
+      task: 'quantum flux capacitor calibration harness run',
     });
 
-    // Either a learned pattern wins outright, or nothing clears the score bar
-    // and it falls back — but it must never be silently downgraded to static.
-    expect(res.matchedPattern).not.toMatch(/^(refactor|feature|testing|security)-task$/);
+    // A learned pattern must win outright, and must not be rerouted through
+    // the outcome-overlap branch. Removing the `semanticIsLearned` guard in
+    // hooksRoute turns this into 'outcome-overlap' — the #2864 regression.
+    expect(res.matchedPattern).toMatch(/^learned-/);
+    expect(res.primaryAgent.type).toBe('coder');
   });
 
   it('does NOT let a bare KEYWORD_PATTERNS substring hit outrank a static match', async () => {
-    // No outcomes at all -> suggestAgentsForTask can only return source
-    // 'keyword' or 'default', neither of which should displace a static
-    // semantic match. This pins the narrowness of the fix.
+    // An EMPTY but reachable outcome store: suggestAgentsForTask can only
+    // return source 'keyword' (the task contains `refactor` and `test`) or
+    // 'default'. Neither may displace a static semantic match. This pins the
+    // narrowness — the aggressive variant would turn this into
+    // 'outcome-overlap' or a keyword agent set.
     seedOutcomes([]);
 
-    const res: any = await hooksRoute.handler({
+    const { hooksRoute } = await load();
+    const res: any = await (hooksRoute as any).handler({
       task: 'refactor the deployment pipeline test coverage',
     });
 
     expect(res.matchedPattern).not.toBe('outcome-overlap');
+    expect(res.matchedPattern).toMatch(/-task$/);
   });
 
   it('still falls back to keyword matching when nothing clears the score bar', async () => {
     seedOutcomes([]);
-    const res: any = await hooksRoute.handler({ task: 'zzzz' });
+    const { hooksRoute } = await load();
+    const res: any = await (hooksRoute as any).handler({ task: 'zzzz' });
     expect(['keyword-fallback', 'outcome-overlap']).toContain(res.matchedPattern);
     expect(typeof res.primaryAgent.type).toBe('string');
     expect(res.primaryAgent.type.length).toBeGreaterThan(0);

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -686,13 +686,27 @@ function suggestAgentsForFile(filePath: string): string[] {
   return AGENT_PATTERNS[ext] || ['coder', 'architect'];
 }
 
-function suggestAgentsForTask(task: string): { agents: string[]; confidence: number } {
+type AgentSuggestion = {
+  agents: string[];
+  confidence: number;
+  /**
+   * How the suggestion was reached. Callers need this to tell a substring hit
+   * on the hardcoded KEYWORD_PATTERNS table apart from a nearest-neighbour
+   * match against real recorded outcomes — the latter is evidence, the former
+   * is a guess (#2886).
+   */
+  source: 'keyword' | 'outcome-overlap' | 'default';
+  /** Number of overlapping keywords, when source === 'outcome-overlap'. */
+  overlap?: number;
+};
+
+function suggestAgentsForTask(task: string): AgentSuggestion {
   const taskLower = task.toLowerCase();
 
   // Check static keyword patterns first
   for (const [pattern, result] of Object.entries(KEYWORD_PATTERNS)) {
     if (taskLower.includes(pattern)) {
-      return result;
+      return { ...result, source: 'keyword' };
     }
   }
 
@@ -714,12 +728,17 @@ function suggestAgentsForTask(task: string): { agents: string[]; confidence: num
 
     // Require at least 2 keyword overlap to prevent false positives
     if (bestAgent && bestOverlap >= 2) {
-      return { agents: [bestAgent], confidence: Math.min(0.6 + bestOverlap * 0.05, 0.85) };
+      return {
+        agents: [bestAgent],
+        confidence: Math.min(0.6 + bestOverlap * 0.05, 0.85),
+        source: 'outcome-overlap',
+        overlap: bestOverlap,
+      };
     }
   }
 
   // Default fallback
-  return { agents: ['coder', 'researcher', 'tester'], confidence: 0.7 };
+  return { agents: ['coder', 'researcher', 'tester'], confidence: 0.7, source: 'default' };
 }
 
 function assessCommandRisk(command: string): { risk: string; level: number; warnings: string[] } {
@@ -1144,7 +1163,36 @@ export const hooksRoute: MCPTool = {
       return Number(match.metadata.support ?? 0) >= 2
         && Number(match.metadata.reliability ?? 0) >= 0.75;
     });
-    if (eligibleSemantic) {
+    // #2886: a STATIC pattern clears only the score bar — it carries no
+    // support/reliability evidence — yet winning `.find()` order lets it
+    // short-circuit suggestAgentsForTask() entirely. That function holds a
+    // second learned stage: nearest-neighbour over routing-outcomes.json,
+    // gated at >= 2 overlapping keywords. So a static pattern matching on a
+    // char-hash similarity score beats an outcome match with 14 shared
+    // keywords. Measured on a 76-outcome replay: static is the least accurate
+    // decision path (38%) while keyword-fallback reaches 52% and learned 70%.
+    //
+    // Fix: when the best eligible match is static, consult the outcome store
+    // first and prefer it when it has real support. Learned matches are
+    // untouched — they already carry support/reliability, so they keep
+    // precedence exactly as #2864 intended.
+    const semanticIsLearned = eligibleSemantic
+      ? (eligibleSemantic.intent.startsWith('learned-')
+         || eligibleSemantic.metadata.source === 'learned')
+      : false;
+    const overlapSuggestion = (eligibleSemantic && !semanticIsLearned)
+      ? suggestAgentsForTask(task)
+      : null;
+
+    if (overlapSuggestion && overlapSuggestion.source === 'outcome-overlap') {
+      agents = overlapSuggestion.agents;
+      confidence = overlapSuggestion.confidence;
+      matchedPattern = 'outcome-overlap';
+      routingMethod = 'keyword';
+      // Surface WHICH static pattern was outranked, so the decision is
+      // auditable instead of silently different.
+      backendInfo = `outcome overlap (${overlapSuggestion.overlap} keywords) preferred over static ${eligibleSemantic!.intent}`;
+    } else if (eligibleSemantic) {
       const topMatch = eligibleSemantic;
       agents = (topMatch.metadata.agents as string[]) || ['coder', 'researcher'];
       confidence = topMatch.score;


### PR DESCRIPTION
Fixes #2886.

## The bug

`hooks_route` takes the first semantic match clearing `score > 0.4`. Static
`TASK_PATTERNS` clear only that bar — they carry no support/reliability evidence —
yet winning `.find()` order lets a static match short-circuit
`suggestAgentsForTask()` **entirely**.

That function holds a second learned stage nobody documents: nearest-neighbour over
`.claude-flow/routing-outcomes.json`, gated at >= 2 overlapping keywords. So a
static pattern matching on a char-hash similarity score beats an outcome match with
**14 shared keywords**.

Measured on a 76-outcome memorization replay, static is the least accurate decision
path while winning routes outright:

| decided by | accuracy | n |
|---|---|---|
| `keyword-fallback` | 52% | 58 |
| `learned-*` | 70% | 10 |
| **static** | **38%** | **8** |

## The fix

When the best eligible match is static, consult the outcome store first and prefer
it **only when it returns real evidence** (`source: 'outcome-overlap'`).

Learned matches are untouched — they already carry support/reliability, so #2864's
ordering is preserved exactly.

`suggestAgentsForTask()` now reports how it decided (`keyword` | `outcome-overlap` |
`default`) plus the overlap count. Additive: the other two call sites destructure
`agents`/`confidence` and are unaffected.

`backendInfo` names which static pattern was outranked, so the change is auditable
rather than silently different — issue ask #2.

**Deliberately narrow.** A bare `KEYWORD_PATTERNS` substring hit still loses to a
static semantic match. Both are hardcoded guesses, and preferring one over the other
has no evidence behind it; only recorded outcomes do.

## Measured effect — and a correction to the issue

Verified end to end by applying this change to an installed 3.34.0 build and
re-running the replay, then restoring (checksum-verified):

```
without fix   40/76 = 53%
with fix      41/76 = 54%
```

One route flips, and I can name it:

```
"verified learned-researcher pattern is loaded and ranked by ..."
want tester
before   feature-task     -> architect   WRONG
after    outcome-overlap  -> tester      CORRECT
```

**This corrects the "+3 routes" estimate in the issue body.** That simulation
assumed all nine static-decided tasks would reach `suggestAgentsForTask()`. Most hit
a `KEYWORD_PATTERNS` substring first (`test`), return `source: 'keyword'`, and
correctly stay static under this fix. The real gain on my set is +1.

I have left the more aggressive variant out: letting *any* `suggestAgentsForTask()`
result outrank a static match would additionally fix a `security-task -> tester`
misroute in my data, but it makes a hardcoded substring table beat a hardcoded
semantic table on no evidence, and looks much easier to regress against other
people's pattern sets. Happy to add it if you disagree.

## Tests

`__tests__/hooks-route-static-preemption-2886.test.ts`, following the
`hooks-post-task-routing-dual-write-2786.test.ts` convention — real
`routing-outcomes.json` in a temp cwd, since that file is what the second stage
reads. Four cases:

1. outcome-overlap outranks a static pattern, and `backendInfo` says which
2. learned matches are not rerouted (guards #2864)
3. a bare `KEYWORD_PATTERNS` hit does **not** displace a static match (pins the
   narrowness)
4. keyword-fallback still works when nothing clears the score bar

⚠️ **I could not run the suite locally.** `@claude-flow/cli` is not in the root
`workspaces` array and depends on `@claude-flow/codex@3.0.3`, which is not published
to npm, so `npm install` fails with `notarget` and `pnpm` resolution needs the full
monorepo toolchain I do not have set up. The assertions were instead checked field
by field against `hooksRoute`'s actual return shape in source — that caught two
wrong paths in my first draft (`res.routing.matchedPattern` and `res.agents`, which
are really `res.matchedPattern` and `res.primaryAgent.type`). **Please treat CI as
the gate on the test file**; the behavioural claim above was verified separately
against a real installed build.

Environment: ruflo 3.34.0, macOS/arm64, node v22.23.0, 76 labelled outcomes.
