### PR TITLE
fix(cli): pre-edit/post-bash/notify hook subcommands were silent no-ops

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hook-handler-subcommand-parity.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hook-handler-subcommand-parity.test.ts
@@ -1,0 +1,73 @@
+/**
+ * settings-generator.ts wires PreToolUse (Write|Edit|MultiEdit) to invoke
+ * `hook-handler.cjs pre-edit`, with the stated intent "validate commands and
+ * edits before execution". But the generated hook-handler.cjs (helpers-generator.ts)
+ * never defined a `pre-edit` case in its handlers table.
+ *
+ * Effect on every fresh `ruflo init`: the dispatcher's fallback for a present-but-
+ * unrecognized command is `console.log('[OK] Hook: ' + command)`, then it force-exits 0.
+ * So every Write/Edit/MultiEdit tool call fired a hook that logged success and validated
+ * nothing -- a silent no-op masquerading as a passing check, for every agent-driven file
+ * edit under a default install.
+ *
+ * This test pins the general invariant so it can't regress silently again: every
+ * hook-handler.cjs subcommand that settings-generator.ts wires into settings.json must
+ * have a matching case in the handlers table generateHookHandler() actually emits.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateSettings } from '../src/init/settings-generator.js';
+import { generateHookHandler } from '../src/init/helpers-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+type HookEntry = { type: string; command: string; timeout?: number };
+type Matcher = { matcher?: string; hooks: HookEntry[] };
+type Settings = { hooks?: Record<string, Matcher[]> };
+
+function extractHookHandlerSubcommands(settings: Settings): string[] {
+  const found: string[] = [];
+  for (const matchers of Object.values(settings.hooks ?? {})) {
+    for (const matcher of matchers) {
+      for (const hook of matcher.hooks) {
+        if (!hook.command.includes('hook-handler.cjs')) continue;
+        // Both the POSIX and cmd.exe branches of hookCmd() append the
+        // subcommand as the final space-separated token before the
+        // trailing quote/paren that closes the command string.
+        const match = hook.command.match(/hook-handler\.cjs\S*\s+([a-z-]+)["')]*\s*$/i);
+        if (match) found.push(match[1]);
+      }
+    }
+  }
+  return [...new Set(found)];
+}
+
+describe('hook-handler.cjs subcommand parity (pre-edit no-op regression)', () => {
+  it('every hook-handler.cjs subcommand referenced by generateSettings() has a matching handler in generateHookHandler()', () => {
+    const settings = generateSettings(DEFAULT_INIT_OPTIONS) as Settings;
+    const referenced = extractHookHandlerSubcommands(settings);
+
+    // Sanity check the extraction itself actually found the wiring we're testing --
+    // if this ever comes back empty, the regex or the generator shape changed and the
+    // test below would pass vacuously.
+    expect(referenced).toEqual(expect.arrayContaining(['pre-bash', 'pre-edit', 'post-edit']));
+
+    const generatedSource = generateHookHandler();
+    for (const subcommand of referenced) {
+      expect(generatedSource, `missing handler case for '${subcommand}' referenced by settings.json hooks`).toContain(
+        `'${subcommand}':`
+      );
+    }
+  });
+
+  it("generateHookHandler()'s 'pre-edit' handler does not silently fall through to the unrecognized-command branch", () => {
+    const source = generateHookHandler();
+    expect(source).toContain("'pre-edit':");
+    // The old bug: 'pre-edit' had no case, so `handlers['pre-edit']` was undefined and
+    // execution fell into the `else if (command)` branch that just logs '[OK] Hook: ' + command.
+    // Assert the handler table itself defines the case, not just that the string appears
+    // somewhere incidentally (e.g. in a comment or the usage string).
+    const handlersTableMatch = source.match(/const handlers = \{([\s\S]*?)\n\};/);
+    expect(handlersTableMatch).not.toBeNull();
+    expect(handlersTableMatch![1]).toContain("'pre-edit':");
+  });
+});

--- a/v3/@claude-flow/cli/src/init/helpers-generator.ts
+++ b/v3/@claude-flow/cli/src/init/helpers-generator.ts
@@ -641,6 +641,26 @@ export function generateHookHandler(): string {
     "    console.log('[OK] Command validated');",
     '  },',
     '',
+    // Was previously unhandled: settings-generator.ts wires PreToolUse
+    // (Write|Edit|MultiEdit) to `hook-handler.cjs pre-edit`, but no 'pre-edit'
+    // case existed here. handlers['pre-edit'] was undefined, so main() fell into
+    // the unrecognized-but-present-command branch (`console.log('[OK] Hook: ' +
+    // command)`) and exited 0 -- every file edit passed a hook that reported
+    // success and validated nothing. This is a minimal, same-tier counterpart to
+    // pre-bash (path-based, not content-based); real edit-content validation is
+    // deliberately left to a follow-up.
+    "  'pre-edit': () => {",
+    "    var file = String(hookInput.file_path || toolInputObj.file_path || process.env.TOOL_INPUT_file_path || args[0] || '').toLowerCase();",
+    "    var protectedPaths = ['/etc/passwd', '/etc/shadow', '.ssh/authorized_keys', '.ssh/id_rsa', '.git/config', 'c:\\\\windows\\\\system32'];",
+    '    for (var j = 0; j < protectedPaths.length; j++) {',
+    '      if (file.indexOf(protectedPaths[j]) !== -1) {',
+    "        console.error('[BLOCKED] Edit to protected path detected: ' + protectedPaths[j]);",
+    '        process.exit(1);',
+    '      }',
+    '    }',
+    "    console.log('[OK] Edit validated');",
+    '  },',
+    '',
     "  'post-edit': () => {",
     '    if (session && session.metric) {',
     "      try { session.metric('edits'); } catch (e) { /* no active session */ }",
@@ -652,6 +672,16 @@ export function generateHookHandler(): string {
     '      } catch (e) { /* non-fatal */ }',
     '    }',
     "    console.log(toolFailed ? '[LEARN] Edit FAILURE recorded' : '[OK] Edit recorded');",
+    '  },',
+    '',
+    // Same class of bug as 'pre-edit' above: settings-generator.ts wires PostToolUse
+    // (matcher 'Bash') to `hook-handler.cjs post-bash`, but no 'post-bash' case existed.
+    // Mirrors 'post-edit' -- record-only, no blocking (the tool already ran by PostToolUse).
+    "  'post-bash': () => {",
+    '    if (session && session.metric) {',
+    "      try { session.metric('commands'); } catch (e) { /* no active session */ }",
+    '    }',
+    "    console.log(toolFailed ? '[LEARN] Command FAILURE recorded' : '[OK] Command recorded');",
     '  },',
     '',
     "  'session-restore': () => {",
@@ -737,6 +767,12 @@ export function generateHookHandler(): string {
     "    console.log('[OK] Status check');",
     '  },',
     '',
+    // Same class of bug: settings-generator.ts wires the Notification event to
+    // `hook-handler.cjs notify`, but no 'notify' case existed.
+    "  'notify': () => {",
+    "    console.log('[OK] Notification received');",
+    '  },',
+    '',
     "  'stats': () => {",
     '    if (intelligence && intelligence.stats) {',
     "      intelligence.stats(args.includes('--json'));",
@@ -755,7 +791,7 @@ export function generateHookHandler(): string {
     '} else if (command) {',
     "  console.log('[OK] Hook: ' + command);",
     '} else {',
-    "  console.log('Usage: hook-handler.cjs <route|pre-bash|post-edit|session-restore|session-end|pre-task|post-task|compact-manual|compact-auto|status|stats>');",
+    "  console.log('Usage: hook-handler.cjs <route|pre-bash|pre-edit|post-edit|post-bash|notify|session-restore|session-end|pre-task|post-task|compact-manual|compact-auto|status|stats>');",
     '}',
     '} // end main',
     '',


### PR DESCRIPTION
## What

`settings-generator.ts` wires three hooks into the generated `settings.json` by subcommand name — `pre-edit` (PreToolUse, `Write|Edit|MultiEdit`), `post-bash` (PostToolUse, `Bash`), and `notify` (Notification) — but the generated `hook-handler.cjs` (`helpers-generator.ts`) never defined a matching case for any of the three.

`main()`'s fallback for a command that's present but not in the `handlers` table is:

```js
} else if (command) {
  console.log('[OK] Hook: ' + command);
}
```

...then the process force-exits 0 regardless. So on a fresh `ruflo init`, all three hooks fired, logged `[OK]`, and did nothing. The one with real impact: PreToolUse's stated intent is "validate commands and edits before execution" (see the comment above `generateHooksConfig`'s `PreToolUse` block) — but every single Write/Edit/MultiEdit tool call was passing through a hook that validated nothing at all.

## Fix

- `pre-edit`: minimal path-based protected-path check, deliberately the same tier of check `pre-bash` already does for commands (hardcoded list, not full content validation). Real edit-content validation (secrets, destructive patterns) felt like a bigger, more opinionated change than a first fix should be — happy to follow up with that separately if useful.
- `post-bash`: record-only, mirrors the existing `post-edit` handler's shape.
- `notify`: mirrors the existing minimal `status` handler.
- Updated the usage string to list all three.

## Test

Added `__tests__/hook-handler-subcommand-parity.test.ts`. It doesn't just pin the three cases above — it mechanically extracts every `hook-handler.cjs <subcommand>` reference from `generateSettings()`'s actual output and asserts `generateHookHandler()` defines a matching case for each. That's how `post-bash` and `notify` turned up — I only went looking for `pre-edit`, and the general check caught two more instances of the same bug. Neither generator file had any prior test coverage.

`npx vitest run __tests__/hook-handler-subcommand-parity.test.ts` — 2/2 passing.

Also ran `npx tsc --noEmit`-equivalent via `npm run build` in this workspace to confirm no new type errors from the edit — the build does fail in this environment, but every error is in unrelated files (`@claude-flow/cli-core`, `@claude-flow/neural`, `@claude-flow/memory` unresolved — sibling workspace packages not built in a fresh `pnpm install`), none in `helpers-generator.ts`. Did not run the full monorepo test suite (it has substantial pre-existing failures in this environment — WASM/native modules not built, Docker unavailable, etc. — unrelated to this change); ran the targeted test only.
