### PR TITLE
fix(memory): keep post-task results searchable in persistent HNSW

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-hnsw-bridge-dual-write-2908.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-hnsw-bridge-dual-write-2908.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression coverage for #2908: a successful AgentDB bridge write must not
+ * suppress the persistent local HNSW update. `hooks_post-task --store-results`
+ * stores through the canonical memory path, and semantic routing reads the
+ * `.swarm/hnsw.index` + `.swarm/hnsw.metadata.json` pair. Both indexes must
+ * therefore be updated by the same write.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const state = vi.hoisted(() => ({
+  bridgeAddToHNSW: vi.fn(async () => true),
+}));
+
+vi.mock('../src/memory/memory-bridge.js', () => ({
+  bridgeAddToHNSW: state.bridgeAddToHNSW,
+}));
+
+let root: string;
+const originalRoot = process.env.CLAUDE_FLOW_MEMORY_PATH;
+const originalDisableBridge = process.env.CLAUDE_FLOW_DISABLE_BRIDGE;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'ruflo-memory-2908-'));
+  process.env.CLAUDE_FLOW_MEMORY_PATH = root;
+  delete process.env.CLAUDE_FLOW_DISABLE_BRIDGE;
+  state.bridgeAddToHNSW.mockClear();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.resetModules();
+  if (originalRoot === undefined) delete process.env.CLAUDE_FLOW_MEMORY_PATH;
+  else process.env.CLAUDE_FLOW_MEMORY_PATH = originalRoot;
+  if (originalDisableBridge === undefined) delete process.env.CLAUDE_FLOW_DISABLE_BRIDGE;
+  else process.env.CLAUDE_FLOW_DISABLE_BRIDGE = originalDisableBridge;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('persistent HNSW dual-write (#2908)', () => {
+  it('updates the local HNSW index even when the AgentDB bridge succeeds', async () => {
+    const memory = await import('../src/memory/memory-initializer.js');
+    const id = 'post-task-2908';
+    const embedding = [0.2, 0.4, 0.8];
+
+    const indexed = await memory.addToHNSWIndex(id, embedding, {
+      id,
+      key: 'routing-decision:task-2908',
+      namespace: 'patterns',
+      content: 'quenzibar regression marker',
+    });
+
+    expect(indexed).toBe(true);
+    expect(state.bridgeAddToHNSW).toHaveBeenCalledTimes(1);
+    expect(state.bridgeAddToHNSW).toHaveBeenCalledWith(
+      id,
+      embedding,
+      expect.objectContaining({
+        key: 'routing-decision:task-2908',
+        namespace: 'patterns',
+      }),
+    );
+
+    expect(memory.getHNSWStatus()).toMatchObject({
+      available: true,
+      initialized: true,
+      entryCount: 1,
+      dimensions: embedding.length,
+    });
+
+    const metadataPath = path.join(root, 'hnsw.metadata.json');
+    expect(existsSync(metadataPath)).toBe(true);
+    const metadata = new Map<string, { key: string; namespace: string }>(
+      JSON.parse(readFileSync(metadataPath, 'utf8')),
+    );
+    expect(metadata.get(id)).toMatchObject({
+      key: 'routing-decision:task-2908',
+      namespace: 'patterns',
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -799,15 +799,17 @@ export async function addToHNSWIndex(
   embedding: number[],
   entry: HNSWEntry
 ): Promise<boolean> {
-  // ADR-053: Try AgentDB v3 bridge first
+  // ADR-053: Keep the AgentDB bridge and the persistent local HNSW
+  // index in sync. They are separate retrieval surfaces: a successful
+  // bridge insert must not suppress `.swarm/hnsw.index` metadata.
   const bridge = await getBridge();
+  let bridgeIndexed = false;
   if (bridge) {
-    const bridgeResult = await bridge.bridgeAddToHNSW(id, embedding, entry);
-    if (bridgeResult === true) return true;
+    bridgeIndexed = await bridge.bridgeAddToHNSW(id, embedding, entry) === true;
   }
 
   const index = await getHNSWIndex({ dimensions: embedding.length });
-  if (!index) return false;
+  if (!index) return bridgeIndexed;
 
   try {
     const vector = new Float32Array(embedding);
@@ -821,7 +823,7 @@ export async function addToHNSWIndex(
     saveHNSWMetadata();
     return true;
   } catch {
-    return false;
+    return bridgeIndexed;
   }
 }
 


### PR DESCRIPTION
## Summary

`hooks post-task --store-results` reaches the canonical memory write path, but a successful AgentDB bridge insertion causes `addToHNSWIndex()` to return before updating the persistent local HNSW index and metadata.

As a result, the row is durable in AgentDB but remains invisible to the local persistent HNSW retrieval surface used by `memory search` and the semantic router.

## Root cause

`addToHNSWIndex()` treated a successful bridge write as completion even though AgentDB and the local `.swarm/hnsw.index` / `.swarm/hnsw.metadata.json` files are separate retrieval surfaces.

## Changes

- preserve the AgentDB bridge insertion;
- continue into the persistent local HNSW update after bridge success;
- return bridge success only as a fallback when the optional local HNSW backend is unavailable or its update fails;
- add a focused regression test verifying both the bridge call and persistent HNSW state/metadata.

## Validation

The identical two-file diff passed the fork's full standard suites before the branch was rebuilt into one clean commit:

- V3 tests and typecheck;
- CI/CD and verification pipelines;
- cross-agent integration tests;
- CodeQL;
- CVE audit gate.

The clean branch contains one commit and only the implementation plus regression test. Its newly generated checks currently require workflow approval after the history rewrite.

## Test scope and limitation

The regression test targets the isolated root cause in `addToHNSWIndex()`: after a successful mocked AgentDB bridge write, the real local HNSW implementation is initialized and its persistent metadata is updated.

It is not a full subprocess reproduction of the complete `ruflo hooks post-task ...` followed by `ruflo memory search ...` command sequence from #2908. Maintainers can still run that issue reproducer as an end-to-end acceptance check. The PR does not claim to repair already-missing historical index entries or add a reindex command.

Fixes #2908