### PR TITLE
fix(plugins): require ADR-323 provenance on direct V3 memory writes

### DIFF
--- a/.github/workflows/plugin-memory-provenance.yml
+++ b/.github/workflows/plugin-memory-provenance.yml
@@ -1,0 +1,86 @@
+name: Plugin memory provenance
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'v3/plugins/**/src/**'
+      - 'v3/plugins/agentic-qe/__tests__/memory-provenance.test.ts'
+      - 'v3/plugins/prime-radiant/__tests__/memory-provenance.test.ts'
+      - 'v3/plugins/agentic-qe/package.json'
+      - 'v3/plugins/prime-radiant/package.json'
+      - 'v3/scripts/audit-plugin-memory-provenance.mjs'
+      - 'v3/scripts/__tests__/audit-plugin-memory-provenance.test.mjs'
+      - 'v3/package.json'
+      - 'v3/pnpm-lock.yaml'
+      - '.github/workflows/plugin-memory-provenance.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'v3/plugins/**/src/**'
+      - 'v3/plugins/agentic-qe/__tests__/memory-provenance.test.ts'
+      - 'v3/plugins/prime-radiant/__tests__/memory-provenance.test.ts'
+      - 'v3/plugins/agentic-qe/package.json'
+      - 'v3/plugins/prime-radiant/package.json'
+      - 'v3/scripts/audit-plugin-memory-provenance.mjs'
+      - 'v3/scripts/__tests__/audit-plugin-memory-provenance.test.mjs'
+      - 'v3/package.json'
+      - 'v3/pnpm-lock.yaml'
+      - '.github/workflows/plugin-memory-provenance.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  provenance-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: v3/pnpm-lock.yaml
+
+      - name: Install V3 dependencies
+        working-directory: v3
+        run: pnpm install --frozen-lockfile
+
+      - name: Test provenance audit
+        working-directory: v3
+        run: node --test scripts/__tests__/audit-plugin-memory-provenance.test.mjs
+
+      - name: Audit plugin memory writes
+        working-directory: v3
+        run: node scripts/audit-plugin-memory-provenance.mjs
+
+      - name: Install Agentic-QE dependencies
+        working-directory: v3/plugins/agentic-qe
+        run: npm install --ignore-scripts --no-audit --no-fund --no-package-lock
+
+      - name: Test Agentic-QE provenance
+        working-directory: v3/plugins/agentic-qe
+        run: npm exec vitest -- run __tests__/memory-provenance.test.ts
+
+      - name: Type-check Agentic-QE
+        working-directory: v3/plugins/agentic-qe
+        run: npm run type-check
+
+      - name: Install Prime Radiant dependencies
+        working-directory: v3/plugins/prime-radiant
+        run: npm install --ignore-scripts --no-audit --no-fund --no-package-lock
+
+      - name: Test Prime Radiant provenance
+        working-directory: v3/plugins/prime-radiant
+        run: npm exec vitest -- run __tests__/memory-provenance.test.ts
+
+      - name: Type-check Prime Radiant
+        working-directory: v3/plugins/prime-radiant
+        run: npm run typecheck

--- a/v3/plugins/agentic-qe/__tests__/memory-provenance.test.ts
+++ b/v3/plugins/agentic-qe/__tests__/memory-provenance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { QEMemoryBridge } from '../src/bridges/QEMemoryBridge.js';
+
+function createHarness() {
+  const store = vi.fn(async () => 'stored-id');
+  const memory = {
+    createNamespace: vi.fn(async () => undefined),
+    store,
+    search: vi.fn(async () => []),
+    query: vi.fn(async () => []),
+    delete: vi.fn(async () => true),
+    clearNamespace: vi.fn(async () => 0),
+    getStats: vi.fn(async () => ({
+      totalEntries: 0,
+      entriesByNamespace: {},
+      memoryUsage: 0,
+    })),
+  };
+  const embeddings = {
+    embed: vi.fn(async () => ({ embedding: new Float32Array([0.1, 0.2, 0.3]) })),
+  };
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const bridge = new QEMemoryBridge(memory as any, embeddings as any, logger as any);
+  return { bridge, store };
+}
+
+describe('QEMemoryBridge provenance', () => {
+  it('classifies every official QE memory write with canonical provenance', async () => {
+    const { bridge, store } = createHarness();
+    await bridge.initialize();
+
+    await bridge.storeTestPattern({
+      id: 'pattern-1',
+      type: 'unit',
+      description: 'A deterministic unit-test pattern',
+      code: 'expect(value).toBe(true)',
+      language: 'typescript',
+      framework: 'vitest',
+      effectiveness: 0.95,
+      usageCount: 1,
+      tags: ['unit'],
+    } as any);
+
+    await bridge.storeCoverageGap({
+      id: 'gap-1',
+      file: 'src/example.ts',
+      type: 'branch',
+      location: { startLine: 12, endLine: 18 },
+      reason: 'Uncovered failure branch',
+      riskScore: 0.8,
+      priority: 'high',
+    } as any);
+
+    await bridge.storeTrajectory({
+      id: 'trajectory-1',
+      taskType: 'unit-test',
+      agentId: 'qe-agent',
+      success: true,
+      reward: 1,
+      verdict: 'pass',
+      steps: [{ action: 'run focused tests' }],
+      durationMs: 25,
+    } as any);
+
+    expect(store).toHaveBeenCalledTimes(3);
+    expect(store.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      provenance_type: 'agent_output',
+    }));
+    expect(store.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      provenance_type: 'tool_result',
+    }));
+    expect(store.mock.calls[2]?.[0]).toEqual(expect.objectContaining({
+      provenance_type: 'system_observation',
+    }));
+  });
+});

--- a/v3/plugins/agentic-qe/src/bridges/QEMemoryBridge.ts
+++ b/v3/plugins/agentic-qe/src/bridges/QEMemoryBridge.ts
@@ -41,9 +41,17 @@ interface NamespaceConfig {
   schema?: Record<string, { type: string; index?: boolean }>;
 }
 
+type MemoryProvenanceType =
+  | 'user_claim'
+  | 'agent_output'
+  | 'system_observation'
+  | 'tool_result'
+  | 'unknown';
+
 interface StoreEntry {
   namespace: string;
   content: string;
+  provenance_type: MemoryProvenanceType;
   embedding?: Float32Array;
   metadata?: Record<string, unknown>;
   type?: string;
@@ -214,6 +222,7 @@ export class QEMemoryBridge implements IQEMemoryBridge {
           usageCount: pattern.usageCount,
           tags: pattern.tags,
         },
+        provenance_type: 'agent_output',
         type: 'semantic',
       });
 
@@ -293,6 +302,7 @@ export class QEMemoryBridge implements IQEMemoryBridge {
           startLine: gap.location.startLine,
           endLine: gap.location.endLine,
         },
+        provenance_type: 'tool_result',
         type: 'episodic',
         ttl: QE_NAMESPACES.coverageData.ttl,
       });
@@ -402,6 +412,7 @@ export class QEMemoryBridge implements IQEMemoryBridge {
           stepCount: trajectory.steps.length,
           durationMs: trajectory.durationMs,
         },
+        provenance_type: 'system_observation',
         type: 'procedural',
       });
 

--- a/v3/plugins/prime-radiant/__tests__/memory-provenance.test.ts
+++ b/v3/plugins/prime-radiant/__tests__/memory-provenance.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PrimeRadiantPlugin } from '../src/plugin.js';
+
+function createContext() {
+  const store = vi.fn(async () => undefined);
+  const services = new Map<string, unknown>([
+    ['memory', {
+      store,
+      registerPreStoreHook: vi.fn(),
+    }],
+    ['hiveMind', {
+      getAgentStates: vi.fn(async () => [
+        {
+          id: 'agent-a',
+          communicationsWith: { 'agent-b': 3 },
+          totalCommunications: 3,
+        },
+        {
+          id: 'agent-b',
+          communicationsWith: { 'agent-a': 2 },
+          totalCommunications: 2,
+        },
+      ]),
+    }],
+  ]);
+
+  const context = {
+    get<T>(key: string): T {
+      return services.get(key) as T;
+    },
+    set(key: string, value: unknown): void {
+      services.set(key, value);
+    },
+    has(key: string): boolean {
+      return services.has(key);
+    },
+  };
+
+  return { context, store };
+}
+
+describe('Prime Radiant memory provenance', () => {
+  it('stores computed swarm stability as a system observation', async () => {
+    const plugin = new PrimeRadiantPlugin();
+    const { context, store } = createContext();
+    const initialized = await plugin.initialize(context);
+    expect(initialized.success).toBe(true);
+
+    const hook = plugin.getHooks().find(({ name }) => name === 'pr/post-swarm-task');
+    expect(hook).toBeDefined();
+    await hook!.handler(context, {
+      isSwarmTask: true,
+      taskId: 'task-123',
+    });
+
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(store).toHaveBeenCalledWith(expect.objectContaining({
+      namespace: 'pr/stability-metrics',
+      key: 'task-task-123',
+      provenance_type: 'system_observation',
+    }));
+  });
+});

--- a/v3/plugins/prime-radiant/src/plugin.ts
+++ b/v3/plugins/prime-radiant/src/plugin.ts
@@ -1200,11 +1200,17 @@ export class PrimeRadiantPlugin implements IPlugin {
         // Store metrics
         if (context.has('memory')) {
           const memory = context.get<{
-            store: (entry: { namespace: string; key: string; content: string }) => Promise<void>;
+            store: (entry: {
+              namespace: string;
+              key: string;
+              content: string;
+              provenance_type: 'system_observation';
+            }) => Promise<void>;
           }>('memory');
           await memory.store({
             namespace: 'pr/stability-metrics',
             key: `task-${task.taskId}`,
+            provenance_type: 'system_observation',
             content: JSON.stringify({
               taskId: task.taskId,
               stable: spectral.stable,

--- a/v3/scripts/__tests__/audit-plugin-memory-provenance.test.mjs
+++ b/v3/scripts/__tests__/audit-plugin-memory-provenance.test.mjs
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  auditPluginMemoryProvenance,
+  auditSource,
+} from '../audit-plugin-memory-provenance.mjs';
+
+test('accepts a top-level canonical provenance property', () => {
+  const findings = auditSource(`
+    await this.memory.store({
+      content: JSON.stringify(pattern),
+      provenance_type: 'agent_output',
+      metadata: { nested: true },
+    });
+  `, 'plugin.ts');
+  assert.deepEqual(findings, []);
+});
+
+test('accepts shorthand and quoted top-level provenance properties', () => {
+  assert.deepEqual(auditSource(`
+    const provenance_type = 'tool_result';
+    memory.store({ content: 'a', provenance_type });
+    services.memory.store({ content: 'b', 'provenance_type': 'system_observation' });
+  `, 'plugin.ts'), []);
+});
+
+test('nested metadata provenance does not satisfy the write contract', () => {
+  const findings = auditSource(`
+    this.memory.store({
+      content: 'value',
+      metadata: { provenance_type: 'agent_output' },
+    });
+  `, 'plugin.ts');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].code, 'MISSING_PROVENANCE_TYPE');
+  assert.equal(findings[0].line, 2);
+});
+
+test('methods and accessors cannot spoof a provenance value', () => {
+  const findings = auditSource(`
+    memory.store({ content: 'a', provenance_type() { return 'tool_result'; } });
+    memory.store({ content: 'b', get provenance_type() { return 'agent_output'; } });
+  `, 'plugin.ts');
+  assert.deepEqual(findings.map((finding) => finding.code), [
+    'MISSING_PROVENANCE_TYPE',
+    'MISSING_PROVENANCE_TYPE',
+  ]);
+});
+
+test('strings and comments cannot spoof provenance', () => {
+  const findings = auditSource(`
+    memory.store({
+      content: 'provenance_type: tool_result',
+      // provenance_type: 'agent_output'
+      metadata: {},
+    });
+  `, 'plugin.ts');
+  assert.equal(findings[0]?.code, 'MISSING_PROVENANCE_TYPE');
+});
+
+test('detects nested and optional memory receivers', () => {
+  const findings = auditSource(`
+    context.services.memory.store({ content: 'a' });
+    this.memory?.store({ content: 'b' });
+  `, 'plugin.ts');
+  assert.deepEqual(findings.map((finding) => finding.code), [
+    'MISSING_PROVENANCE_TYPE',
+    'MISSING_PROVENANCE_TYPE',
+  ]);
+});
+
+test('rejects non-literal store entries because provenance cannot be inspected', () => {
+  const findings = auditSource(`
+    const entry = { content: 'value', provenance_type: 'tool_result' };
+    memory.store(entry);
+  `, 'plugin.ts');
+  assert.equal(findings[0]?.code, 'NON_LITERAL_STORE_ENTRY');
+});
+
+test('ignores unrelated store calls and memory reads', () => {
+  assert.deepEqual(auditSource(`
+    cache.store({ content: 'value' });
+    someMemory.store({ content: 'value' });
+    memory.search({ query: 'value' });
+  `, 'plugin.ts'), []);
+});
+
+test('reports malformed source instead of silently skipping it', () => {
+  const findings = auditSource('memory.store({ content: ;', 'broken.ts');
+  assert.equal(findings[0]?.code, 'SOURCE_PARSE_ERROR');
+});
+
+test('repository audit scans plugin source and excludes tests', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ruflo-plugin-provenance-'));
+  try {
+    const src = path.join(root, 'example', 'src');
+    const tests = path.join(src, '__tests__');
+    mkdirSync(tests, { recursive: true });
+
+    writeFileSync(path.join(src, 'good.ts'), `
+      memory.store({ content: 'ok', provenance_type: 'tool_result' });
+    `);
+    writeFileSync(path.join(src, 'bad.ts'), `
+      this.memory.store({ content: 'missing' });
+    `);
+    writeFileSync(path.join(tests, 'fixture.test.ts'), `
+      this.memory.store({ content: 'test fixture without provenance' });
+    `);
+
+    const result = auditPluginMemoryProvenance(root);
+    assert.equal(result.findings.length, 1);
+    assert.equal(result.findings[0].code, 'MISSING_PROVENANCE_TYPE');
+    assert.match(result.findings[0].file, /bad\.ts$/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/v3/scripts/audit-plugin-memory-provenance.mjs
+++ b/v3/scripts/audit-plugin-memory-provenance.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Enforce ADR-323 provenance on direct memory writes in plugin source.
+ *
+ * The audit parses JavaScript and TypeScript with the TypeScript compiler API.
+ * It fails when a call whose receiver ends in `memory.store` does not pass an
+ * object literal with a top-level `provenance_type` property.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const V3_ROOT = path.dirname(SCRIPT_DIR);
+const DEFAULT_PLUGIN_ROOT = path.join(V3_ROOT, 'plugins');
+const SOURCE_SUFFIXES = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const MAX_SOURCE_BYTES = 2 * 1024 * 1024;
+
+function walk(directory, output = []) {
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return output;
+  }
+
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') continue;
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) walk(target, output);
+    else if (entry.isFile() && SOURCE_SUFFIXES.has(path.extname(entry.name))) output.push(target);
+  }
+  return output;
+}
+
+function scriptKindFor(file) {
+  switch (path.extname(file).toLowerCase()) {
+    case '.tsx': return ts.ScriptKind.TSX;
+    case '.jsx': return ts.ScriptKind.JSX;
+    case '.js':
+    case '.mjs':
+    case '.cjs': return ts.ScriptKind.JS;
+    default: return ts.ScriptKind.TS;
+  }
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    ts.isParenthesizedExpression(current)
+    || ts.isAsExpression(current)
+    || ts.isTypeAssertionExpression(current)
+    || ts.isNonNullExpression(current)
+    || (typeof ts.isSatisfiesExpression === 'function' && ts.isSatisfiesExpression(current))
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function staticName(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  if (ts.isComputedPropertyName(name)) {
+    const expression = unwrapExpression(name.expression);
+    if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+      return expression.text;
+    }
+  }
+  return null;
+}
+
+function elementName(expression) {
+  const argument = expression.argumentExpression && unwrapExpression(expression.argumentExpression);
+  if (argument && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))) {
+    return argument.text;
+  }
+  return null;
+}
+
+function propertyAccessParts(expression) {
+  const current = unwrapExpression(expression);
+  if (ts.isPropertyAccessExpression(current)) {
+    return { receiver: current.expression, name: current.name.text };
+  }
+  if (ts.isElementAccessExpression(current)) {
+    return { receiver: current.expression, name: elementName(current) };
+  }
+  return null;
+}
+
+function isMemoryReceiver(expression) {
+  const current = unwrapExpression(expression);
+  if (ts.isIdentifier(current)) return current.text === 'memory';
+  const access = propertyAccessParts(current);
+  return access?.name === 'memory';
+}
+
+function isMemoryStoreCall(node) {
+  if (!ts.isCallExpression(node)) return false;
+  const access = propertyAccessParts(node.expression);
+  return access?.name === 'store' && isMemoryReceiver(access.receiver);
+}
+
+function hasTopLevelProvenance(objectLiteral) {
+  return objectLiteral.properties.some((property) => {
+    if (ts.isPropertyAssignment(property) || ts.isShorthandPropertyAssignment(property)) {
+      return staticName(property.name) === 'provenance_type';
+    }
+    return false;
+  });
+}
+
+function lineOf(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+function diagnosticText(diagnostic) {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+}
+
+export function auditSource(source, file = '<memory>') {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(file),
+  );
+
+  const parseErrors = sourceFile.parseDiagnostics.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (parseErrors.length > 0) {
+    return parseErrors.map((diagnostic) => ({
+      file,
+      line: diagnostic.start === undefined
+        ? 1
+        : sourceFile.getLineAndCharacterOfPosition(diagnostic.start).line + 1,
+      code: 'SOURCE_PARSE_ERROR',
+      detail: diagnosticText(diagnostic),
+    }));
+  }
+
+  const findings = [];
+  const visit = (node) => {
+    if (isMemoryStoreCall(node)) {
+      const firstArgument = node.arguments[0] && unwrapExpression(node.arguments[0]);
+      if (!firstArgument || !ts.isObjectLiteralExpression(firstArgument)) {
+        findings.push({
+          file,
+          line: lineOf(sourceFile, node),
+          code: 'NON_LITERAL_STORE_ENTRY',
+          detail: 'Plugin memory.store calls must use an inspectable object literal',
+        });
+      } else if (!hasTopLevelProvenance(firstArgument)) {
+        findings.push({
+          file,
+          line: lineOf(sourceFile, node),
+          code: 'MISSING_PROVENANCE_TYPE',
+          detail: 'Plugin memory.store object must declare top-level provenance_type',
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return findings;
+}
+
+export function auditPluginMemoryProvenance(pluginRoot = DEFAULT_PLUGIN_ROOT) {
+  const findings = [];
+  const files = walk(pluginRoot).filter((file) => {
+    const normalized = file.split(path.sep).join('/');
+    return normalized.includes('/src/')
+      && !normalized.includes('/__tests__/')
+      && !/\.(?:test|spec)\.[^.]+$/.test(normalized);
+  });
+
+  for (const file of files) {
+    const displayFile = path.relative(V3_ROOT, file);
+    try {
+      const stats = statSync(file);
+      if (!stats.isFile()) continue;
+      if (stats.size > MAX_SOURCE_BYTES) {
+        findings.push({
+          file: displayFile,
+          line: 1,
+          code: 'SOURCE_SIZE_LIMIT',
+          detail: `Source file exceeds ${MAX_SOURCE_BYTES} bytes`,
+        });
+        continue;
+      }
+      findings.push(...auditSource(readFileSync(file, 'utf8'), displayFile));
+    } catch (error) {
+      findings.push({
+        file: displayFile,
+        line: 1,
+        code: 'READ_ERROR',
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { filesScanned: files.length, findings };
+}
+
+function main() {
+  const json = process.argv.includes('--format=json') || process.argv.includes('--json');
+  const result = auditPluginMemoryProvenance();
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.findings.length === 0) {
+    console.log(`Plugin memory provenance audit passed (${result.filesScanned} source files scanned)`);
+  } else {
+    console.error(`Plugin memory provenance audit failed (${result.findings.length} finding(s))`);
+    for (const finding of result.findings) {
+      console.error(`- ${finding.file}:${finding.line} ${finding.code}: ${finding.detail}`);
+    }
+  }
+
+  process.exitCode = result.findings.length === 0 ? 0 : 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## Summary

ADR-323 added typed provenance to Ruflo's canonical memory storage and retrieval paths, but direct `memory.store(...)` calls inside V3 plugin source can still omit `provenance_type` and silently fall back to `unknown`.

This change classifies the current direct V3 plugin writes and adds a repository guard so new calls matching that same direct-call shape cannot omit an explicit provenance role.

## Changes

- require `provenance_type` in the Agentic-QE bridge-local store contract;
- classify Agentic-QE test patterns as `agent_output`;
- classify coverage gaps as `tool_result`;
- classify learning trajectories as `system_observation`;
- classify Prime Radiant swarm-stability metrics as `system_observation`;
- add focused runtime regressions for both plugins;
- add a TypeScript-AST audit for direct `memory.store(...)` calls under `v3/plugins/**/src/**`;
- run the audit, plugin regressions, and plugin typechecks in dedicated CI.

## Audit behavior

The audit requires an inspectable object literal with a top-level `provenance_type` property. It intentionally fails closed on non-literal entries and does not accept lookalikes placed in:

- nested metadata;
- strings or comments;
- methods or accessors named `provenance_type`.

It also reports malformed or oversized source instead of silently skipping it.

## Validation

The dedicated `Plugin memory provenance` workflow passes on the clean one-commit branch:

- AST audit tests;
- repository-wide audit over the defined V3 plugin source boundary;
- Agentic-QE provenance regression;
- Agentic-QE typecheck;
- Prime Radiant provenance regression;
- Prime Radiant typecheck.

CodeQL also passes on the same commit. The remaining standard fork workflows were still running or queued when this Draft was opened.

## Exact scope and limitations

This PR covers direct calls whose receiver resolves syntactically to `memory.store(...)` inside `v3/plugins/**/src/**`. It does not claim to detect every possible alias, wrapper, destructured method, dynamically computed call, root-level plugin tree, or independently embedded memory implementation.

It does **not** claim that every plugin bridge is active in the production runtime, nor does it change the memory schema, persistence backend, or retrieval semantics introduced by ADR-323.

Follow-up to #2820 / ADR-323.