### PR TITLE
fix(security): harden plugin manifest JSON parsing

### DIFF
--- a/.github/workflows/all-plugins-smoke.yml
+++ b/.github/workflows/all-plugins-smoke.yml
@@ -18,12 +18,18 @@ on:
       - 'plugins/**'
       - 'scripts/smoke-all-plugins.mjs'
       - 'scripts/audit-plugin-mcp-prefix.mjs'
+      - 'scripts/audit-plugin-manifest.mjs'
+      - 'scripts/lib/parse-untrusted-json.mjs'
+      - 'scripts/__tests__/parse-untrusted-json.test.mjs'
       - '.github/workflows/all-plugins-smoke.yml'
   pull_request:
     paths:
       - 'plugins/**'
       - 'scripts/smoke-all-plugins.mjs'
       - 'scripts/audit-plugin-mcp-prefix.mjs'
+      - 'scripts/audit-plugin-manifest.mjs'
+      - 'scripts/lib/parse-untrusted-json.mjs'
+      - 'scripts/__tests__/parse-untrusted-json.test.mjs'
       - '.github/workflows/all-plugins-smoke.yml'
   workflow_dispatch:
 
@@ -66,15 +72,14 @@ jobs:
         # violations that escape per-plugin coverage (new plugin without
         # smoke, new skill without smoke-list update, etc.).
 
+      - name: Test bounded plugin manifest parser
+        run: node --test scripts/__tests__/parse-untrusted-json.test.mjs
+
       - name: Fleet-wide plugin.json manifest audit (iter 88)
         run: node scripts/audit-plugin-manifest.mjs
-        # Scans every plugins/*/.claude-plugin/plugin.json for: valid JSON,
-        # required fields (name/version/description/keywords[]) present
-        # and non-empty, version matches semver X.Y.Z, name matches
-        # enclosing directory. Each plugin's smoke step 1 pins its own
-        # expected version literal; this catches structural violations
-        # (non-semver, name drift, missing fields) that the per-plugin
-        # grep can't see.
+        # Scans every plugins/*/.claude-plugin/plugin.json for bounded,
+        # structurally safe JSON plus the existing semantic manifest checks:
+        # required fields, semver, directory-name agreement, and keywords[].
 
       - name: Fleet-wide plugin MCP namespace audit
         run: node scripts/audit-plugin-mcp-prefix.mjs

--- a/scripts/__tests__/parse-untrusted-json.test.mjs
+++ b/scripts/__tests__/parse-untrusted-json.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  parseUntrustedJsonFile,
+  validateUntrustedJson,
+  UntrustedJsonError,
+} from '../lib/parse-untrusted-json.mjs';
+
+function withTempJson(source, callback) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'ruflo-untrusted-json-'));
+  const file = path.join(directory, 'manifest.json');
+  writeFileSync(file, source, 'utf8');
+  try {
+    return callback(file, directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function assertCode(expectedCode, operation) {
+  assert.throws(operation, (error) => {
+    assert.ok(error instanceof UntrustedJsonError);
+    assert.equal(error.code, expectedCode);
+    return true;
+  });
+}
+
+test('accepts a bounded plain-object manifest', () => {
+  withTempJson(
+    JSON.stringify({
+      name: 'example-plugin',
+      version: '1.0.0',
+      skills: [{ name: 'audit' }],
+    }),
+    (file) => {
+      const parsed = parseUntrustedJsonFile(file);
+      assert.equal(parsed.name, 'example-plugin');
+      assert.equal(parsed.skills[0].name, 'audit');
+    },
+  );
+});
+
+test('rejects a non-object JSON root', () => {
+  withTempJson('[{"name":"plugin"}]', (file) => {
+    assertCode('ROOT_NOT_OBJECT', () => parseUntrustedJsonFile(file));
+  });
+});
+
+test('rejects __proto__ at any nesting level', () => {
+  withTempJson('{"name":"plugin","nested":{"__proto__":{"polluted":true}}}', (file) => {
+    assertCode('PROTOTYPE_POLLUTION_KEY', () => parseUntrustedJsonFile(file));
+  });
+});
+
+test('rejects constructor.prototype key paths', () => {
+  withTempJson('{"name":"plugin","constructor":{"prototype":{"polluted":true}}}', (file) => {
+    assertCode('PROTOTYPE_POLLUTION_KEY', () => parseUntrustedJsonFile(file));
+  });
+});
+
+test('allows legitimate standalone constructor and prototype metadata', () => {
+  const parsed = validateUntrustedJson(JSON.parse(
+    '{"constructor":"plugin-factory","prototype":{"name":"reference-shape"}}',
+  ));
+  assert.equal(parsed.constructor, 'plugin-factory');
+  assert.equal(parsed.prototype.name, 'reference-shape');
+});
+
+test('rejects files above the configured byte limit before parsing', () => {
+  withTempJson('{"name":"plugin","padding":"0123456789"}', (file) => {
+    assertCode('FILE_SIZE_LIMIT', () => parseUntrustedJsonFile(file, { maxBytes: 10 }));
+  });
+});
+
+test('rejects invalid JSON', () => {
+  withTempJson('{"name":', (file) => {
+    assertCode('INVALID_JSON', () => parseUntrustedJsonFile(file));
+  });
+});
+
+test('rejects non-file paths', () => {
+  withTempJson('{"name":"plugin"}', (_file, directory) => {
+    assertCode('NOT_A_FILE', () => parseUntrustedJsonFile(directory));
+  });
+});
+
+test('rejects excessive nesting', () => {
+  const deeplyNested = { value: true };
+  let current = deeplyNested;
+  for (let depth = 0; depth < 6; depth += 1) {
+    current.child = {};
+    current = current.child;
+  }
+
+  assertCode('DEPTH_LIMIT', () => validateUntrustedJson(deeplyNested, { maxDepth: 4 }));
+});
+
+test('rejects oversized collections', () => {
+  assertCode('ARRAY_LIMIT', () => validateUntrustedJson({ values: [1, 2, 3] }, { maxArrayLength: 2 }));
+  assertCode('OBJECT_KEY_LIMIT', () => validateUntrustedJson({ a: 1, b: 2 }, { maxObjectKeys: 1 }));
+});
+
+test('rejects node and string limit violations', () => {
+  assertCode('NODE_LIMIT', () => validateUntrustedJson({ a: 1, b: 2 }, { maxNodes: 2 }));
+  assertCode('STRING_LIMIT', () => validateUntrustedJson({ value: 'abcd' }, { maxStringLength: 3 }));
+});

--- a/scripts/audit-plugin-manifest.mjs
+++ b/scripts/audit-plugin-manifest.mjs
@@ -11,6 +11,7 @@
 //     but not that it has a value).
 //   - A new plugin authored without ANY plugin.json (no smoke means no
 //     coverage at all).
+//   - Oversized, deeply nested, or prototype-polluting JSON structures.
 //
 // USAGE
 //   node scripts/audit-plugin-manifest.mjs                 # all plugins
@@ -18,24 +19,31 @@
 //   node scripts/audit-plugin-manifest.mjs --only ruflo-cost-tracker
 //
 // CHECKS per plugins/<name>/.claude-plugin/plugin.json
-//   1. File exists and parses as JSON.
-//   2. Required fields present and non-empty: name / version / description.
-//   3. version matches semver (N.N.N optionally with +/- suffix).
-//   4. name matches the enclosing directory name (drift after rename).
-//   5. keywords is an array (may be empty, but must be present).
+//   1. File exists, is size-bounded, and parses as JSON.
+//   2. Root is a plain object with bounded depth and collection sizes.
+//   3. Reserved prototype-pollution keys are rejected at every depth.
+//   4. Required fields present and non-empty: name / version / description.
+//   5. version matches semver (N.N.N optionally with +/- suffix).
+//   6. name matches the enclosing directory name (drift after rename).
+//   7. keywords is an array (may be empty, but must be present).
 //
 // EXIT CODES
 //   0  all manifests clean
 //   1  at least one violation
 //   2  scan error (no plugins dir)
 
-import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  parseUntrustedJsonFile,
+  UntrustedJsonError,
+} from './lib/parse-untrusted-json.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = dirname(SCRIPTS_DIR);
 const PLUGINS_DIR = join(REPO_ROOT, 'plugins');
+const MAX_MANIFEST_BYTES = 1_048_576;
 
 const ARGS = (() => {
   const a = { format: 'table', only: null };
@@ -75,18 +83,32 @@ function discoverManifests() {
   return out.sort((a, b) => a.plugin.localeCompare(b.plugin));
 }
 
+function jsonViolationCheck(error) {
+  if (!(error instanceof UntrustedJsonError)) return 'safe JSON structure';
+  if (error.code === 'READ_ERROR' || error.code === 'NOT_A_FILE') return 'readable';
+  if (error.code === 'INVALID_JSON') return 'valid JSON';
+  if (error.code === 'FILE_SIZE_LIMIT') return 'file size limit';
+  return 'safe JSON structure';
+}
+
 function auditManifest(entry) {
   const violations = [];
-  let raw;
-  try { raw = readFileSync(entry.path, 'utf-8'); }
-  catch (e) {
-    violations.push({ check: 'readable', detail: e.message });
-    return violations;
-  }
   let json;
-  try { json = JSON.parse(raw); }
-  catch (e) {
-    violations.push({ check: 'valid JSON', detail: e.message.slice(0, 120) });
+  try {
+    json = parseUntrustedJsonFile(entry.path, {
+      maxBytes: MAX_MANIFEST_BYTES,
+      maxDepth: 16,
+      maxNodes: 50_000,
+      maxArrayLength: 10_000,
+      maxObjectKeys: 5_000,
+      maxStringLength: 256_000,
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    violations.push({
+      check: jsonViolationCheck(error),
+      detail: detail.slice(0, 160),
+    });
     return violations;
   }
 
@@ -154,7 +176,9 @@ function main() {
     console.log('');
     if (findings.length === 0) {
       console.log('✓ Every plugin.json:');
-      console.log('  - parses as JSON');
+      console.log('  - is bounded and parses as JSON');
+      console.log('  - has a plain-object root and safe nested keys');
+      console.log('  - stays within depth and collection limits');
       console.log('  - has name / version / description / keywords[]');
       console.log('  - name matches the enclosing directory');
       console.log('  - version matches semver X.Y.Z[±suffix]');

--- a/scripts/lib/parse-untrusted-json.mjs
+++ b/scripts/lib/parse-untrusted-json.mjs
@@ -1,0 +1,165 @@
+import { lstatSync, readFileSync } from 'node:fs';
+
+export class UntrustedJsonError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'UntrustedJsonError';
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new UntrustedJsonError(code, message);
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isPrototypePollutionPath(key, child) {
+  if (key === '__proto__') return true;
+  return key === 'constructor' && isPlainObject(child) && hasOwn(child, 'prototype');
+}
+
+/**
+ * Validate a parsed JSON value before application code consumes it.
+ *
+ * The limits are intentionally conservative for plugin manifests. They bound
+ * traversal cost and reject object-key paths commonly used for prototype
+ * pollution while preserving legitimate standalone `constructor` and
+ * `prototype` metadata fields.
+ */
+export function validateUntrustedJson(value, options = {}) {
+  const {
+    requireRootObject = true,
+    maxDepth = 16,
+    maxNodes = 50_000,
+    maxArrayLength = 10_000,
+    maxObjectKeys = 5_000,
+    maxStringLength = 256_000,
+  } = options;
+
+  if (requireRootObject && !isPlainObject(value)) {
+    fail('ROOT_NOT_OBJECT', 'JSON root must be a plain object');
+  }
+
+  let visitedNodes = 0;
+  const stack = [{ value, depth: 0, path: '$' }];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    visitedNodes += 1;
+
+    if (visitedNodes > maxNodes) {
+      fail('NODE_LIMIT', `JSON exceeds the maximum node count of ${maxNodes}`);
+    }
+    if (current.depth > maxDepth) {
+      fail('DEPTH_LIMIT', `JSON exceeds the maximum depth of ${maxDepth} at ${current.path}`);
+    }
+
+    if (typeof current.value === 'string') {
+      if (current.value.length > maxStringLength) {
+        fail(
+          'STRING_LIMIT',
+          `JSON string exceeds the maximum length of ${maxStringLength} at ${current.path}`,
+        );
+      }
+      continue;
+    }
+
+    if (current.value === null || typeof current.value !== 'object') continue;
+
+    if (Array.isArray(current.value)) {
+      if (current.value.length > maxArrayLength) {
+        fail(
+          'ARRAY_LIMIT',
+          `JSON array exceeds the maximum length of ${maxArrayLength} at ${current.path}`,
+        );
+      }
+      for (let index = current.value.length - 1; index >= 0; index -= 1) {
+        stack.push({
+          value: current.value[index],
+          depth: current.depth + 1,
+          path: `${current.path}[${index}]`,
+        });
+      }
+      continue;
+    }
+
+    if (!isPlainObject(current.value)) {
+      fail('NON_PLAIN_OBJECT', `JSON contains a non-plain object at ${current.path}`);
+    }
+
+    const entries = Object.entries(current.value);
+    if (entries.length > maxObjectKeys) {
+      fail(
+        'OBJECT_KEY_LIMIT',
+        `JSON object exceeds the maximum key count of ${maxObjectKeys} at ${current.path}`,
+      );
+    }
+
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const [key, child] = entries[index];
+      if (isPrototypePollutionPath(key, child)) {
+        fail(
+          'PROTOTYPE_POLLUTION_KEY',
+          `Unsafe JSON key path is not allowed at ${current.path}.${key}`,
+        );
+      }
+      stack.push({
+        value: child,
+        depth: current.depth + 1,
+        path: `${current.path}.${key}`,
+      });
+    }
+  }
+
+  return value;
+}
+
+/**
+ * Read and validate a JSON file from an untrusted source.
+ */
+export function parseUntrustedJsonFile(filePath, options = {}) {
+  const { maxBytes = 1_048_576, ...validationOptions } = options;
+
+  let stats;
+  try {
+    stats = lstatSync(filePath);
+  } catch (error) {
+    fail('READ_ERROR', `Unable to stat JSON file: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!stats.isFile()) {
+    fail('NOT_A_FILE', 'JSON path must reference a regular file');
+  }
+  if (stats.size > maxBytes) {
+    fail('FILE_SIZE_LIMIT', `JSON file exceeds the maximum size of ${maxBytes} bytes`);
+  }
+
+  let source;
+  try {
+    source = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    fail('READ_ERROR', `Unable to read JSON file: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (Buffer.byteLength(source, 'utf8') > maxBytes) {
+    fail('FILE_SIZE_LIMIT', `JSON file exceeds the maximum size of ${maxBytes} bytes`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(source);
+  } catch (error) {
+    fail('INVALID_JSON', `Invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return validateUntrustedJson(parsed, validationOptions);
+}


### PR DESCRIPTION
## Summary

Harden the fleet-wide plugin manifest audit against malformed or adversarial `plugin.json` files without changing the existing semantic manifest policy.

## Problem

`scripts/audit-plugin-manifest.mjs` previously read and parsed each manifest directly with `JSON.parse()`. The audit did not bound file size or parsed structure, reject non-regular files, or guard against prototype-pollution key paths before consuming manifest data.

The existing `all-plugins-smoke` workflow also did not trigger when the manifest audit itself changed and did not run focused parser tests.

## Changes

- add a reusable bounded JSON-file parser;
- require a plain-object root;
- reject `__proto__` and `constructor.prototype` pollution paths;
- preserve legitimate standalone `constructor` and `prototype` metadata;
- reject non-regular files, including symbolic links;
- bound file bytes, traversal depth, node count, array length, object keys, and string length;
- re-check actual UTF-8 byte length after reading;
- integrate the parser into `audit-plugin-manifest.mjs`;
- add 11 dependency-free `node:test` regressions;
- update `all-plugins-smoke` path filters so parser and audit changes trigger the workflow;
- run parser tests before the real fleet-wide manifest audit.

## Validation

The rebuilt branch contains one commit and passes:

- `node --test scripts/__tests__/parse-untrusted-json.test.mjs` — 11/11;
- the full `all-plugins-smoke` workflow;
- all current plugin smoke contracts;
- the real fleet-wide plugin manifest audit;
- CodeQL;
- CVE Audit Gate;
- `no-metaharness-smoke`.

The remaining standard fork workflows were still running or queued when this Draft was opened.

## Exact scope and limitations

This change hardens the CI-side manifest audit only. It does not modify plugin discovery, runtime loading, manifest schema, or the existing required-field and semver checks.

The parser bounds resource use and rejects dangerous JSON structures in a normal checked-out CI workspace. It is not a filesystem sandbox and does not claim to defend against a concurrent hostile process replacing a file between the metadata check and the read.