### PR TITLE
fix(proxy): bump pinned meta-proxy release 0.4.0 -> 0.7.3

### DIFF
--- a/v3/@claude-flow/cli/__tests__/proxy-console-guidance.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-console-guidance.test.ts
@@ -59,7 +59,13 @@ describe('bare proxy console guidance', () => {
 
   it('gives installation guidance before the proxy exists', async () => {
     const { proxyConsoleGuidance, DEFAULT_PROXY_RELEASE } = await import('../src/commands/proxy-lifecycle.js');
-    const lines = proxyConsoleGuidance({ installed: false, running: false, pid: null, stalePidFile: false }).join('\n');
+    const lines = proxyConsoleGuidance({
+      installed: false,
+      running: false,
+      pid: null,
+      stalePidFile: false,
+      version: null,
+    }).join('\n');
 
     expect(lines).toContain('npx ruflo@latest proxy install --yes');
     // Assert against the constant, not a literal — a hardcoded version here
@@ -67,5 +73,90 @@ describe('bare proxy console guidance', () => {
     // version drifted from the installed one in the first place.
     expect(lines).toContain(`Meta-Proxy v${DEFAULT_PROXY_RELEASE}`);
     expect(lines).not.toContain('auth login');
+  });
+});
+
+/**
+ * A pin bump is only worth making if it reaches people who already installed
+ * the old one. Their entry point is this guidance, so the drift signal is
+ * asserted here rather than left to manual inspection.
+ */
+describe('pin-drift guidance for an existing install', () => {
+  const installedAt = (version: string | null) => ({
+    installed: true,
+    running: false,
+    pid: null,
+    stalePidFile: false,
+    version,
+  });
+
+  it('names the installed release, the pin, and the command that closes the gap', async () => {
+    const { proxyUpdateGuidance, DEFAULT_PROXY_RELEASE } = await import('../src/commands/proxy-lifecycle.js');
+
+    const lines = proxyUpdateGuidance(installedAt('0.4.0')).join('\n');
+
+    expect(lines).toContain('installed v0.4.0');
+    expect(lines).toContain(`current pin v${DEFAULT_PROXY_RELEASE}`);
+    expect(lines).toContain('npx ruflo@latest proxy update');
+  });
+
+  it('stays silent when the installed release already matches the pin', async () => {
+    const { proxyUpdateGuidance, DEFAULT_PROXY_RELEASE } = await import('../src/commands/proxy-lifecycle.js');
+
+    expect(proxyUpdateGuidance(installedAt(DEFAULT_PROXY_RELEASE))).toEqual([]);
+  });
+
+  /** Unknown is not "current" — claiming either way from no evidence is the bug. */
+  it('stays silent when the installed release is unknown', async () => {
+    const { proxyUpdateGuidance } = await import('../src/commands/proxy-lifecycle.js');
+
+    expect(proxyUpdateGuidance(installedAt(null))).toEqual([]);
+  });
+
+  it('stays silent when nothing is installed', async () => {
+    const { proxyUpdateGuidance } = await import('../src/commands/proxy-lifecycle.js');
+
+    expect(proxyUpdateGuidance({ ...installedAt('0.4.0'), installed: false })).toEqual([]);
+  });
+
+  it('surfaces the drift through the console guidance a running proxy shows', async () => {
+    const { proxyConsoleGuidance } = await import('../src/commands/proxy-lifecycle.js');
+
+    const lines = proxyConsoleGuidance({ ...installedAt('0.4.0'), running: true, pid: 4242 }).join('\n');
+
+    expect(lines).toContain('Meta Proxy is ready.');
+    expect(lines).toContain('An update is available');
+  });
+});
+
+describe('getProxyStatus version reporting', () => {
+  it('reads the installed release from the install manifest', async () => {
+    const { proxyBinaryPath, proxyInstallManifestPath } = await import('../src/proxy/paths.js');
+    fs.mkdirSync(path.dirname(proxyBinaryPath()), { recursive: true });
+    fs.writeFileSync(proxyBinaryPath(), 'test binary marker');
+    fs.mkdirSync(path.dirname(proxyInstallManifestPath()), { recursive: true });
+    fs.writeFileSync(proxyInstallManifestPath(), JSON.stringify({ version: '0.4.0', sha256: 'abc' }));
+
+    const { getProxyStatus } = await import('../src/proxy/lifecycle.js');
+
+    expect(getProxyStatus()).toMatchObject({ installed: true, version: '0.4.0' });
+  });
+
+  it('reports an unreadable manifest as unknown rather than throwing', async () => {
+    const { proxyBinaryPath, proxyInstallManifestPath } = await import('../src/proxy/paths.js');
+    fs.mkdirSync(path.dirname(proxyBinaryPath()), { recursive: true });
+    fs.writeFileSync(proxyBinaryPath(), 'test binary marker');
+    fs.mkdirSync(path.dirname(proxyInstallManifestPath()), { recursive: true });
+    fs.writeFileSync(proxyInstallManifestPath(), 'not json{');
+
+    const { getProxyStatus } = await import('../src/proxy/lifecycle.js');
+
+    expect(getProxyStatus()).toMatchObject({ installed: true, version: null });
+  });
+
+  it('reports no version when nothing is installed', async () => {
+    const { getProxyStatus } = await import('../src/proxy/lifecycle.js');
+
+    expect(getProxyStatus()).toMatchObject({ installed: false, version: null });
   });
 });

--- a/v3/@claude-flow/cli/__tests__/proxy-console-guidance.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-console-guidance.test.ts
@@ -58,11 +58,14 @@ describe('bare proxy console guidance', () => {
   });
 
   it('gives installation guidance before the proxy exists', async () => {
-    const { proxyConsoleGuidance } = await import('../src/commands/proxy-lifecycle.js');
+    const { proxyConsoleGuidance, DEFAULT_PROXY_RELEASE } = await import('../src/commands/proxy-lifecycle.js');
     const lines = proxyConsoleGuidance({ installed: false, running: false, pid: null, stalePidFile: false }).join('\n');
 
     expect(lines).toContain('npx ruflo@latest proxy install --yes');
-    expect(lines).toContain('Meta-Proxy v0.4.0');
+    // Assert against the constant, not a literal — a hardcoded version here
+    // would have to be edited on every pin bump, which is how the advertised
+    // version drifted from the installed one in the first place.
+    expect(lines).toContain(`Meta-Proxy v${DEFAULT_PROXY_RELEASE}`);
     expect(lines).not.toContain('auth login');
   });
 });

--- a/v3/@claude-flow/cli/__tests__/proxy-install-command.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-install-command.test.ts
@@ -1,7 +1,11 @@
 /**
- * `proxy install` defaults to the reviewed, signed Meta-Proxy v0.4.0
- * release. `--release` remains an explicit override; the default must still
- * pass through the normal consent gate and signature-verifying installer.
+ * `proxy install` defaults to the reviewed, signed Meta-Proxy release pinned
+ * by `DEFAULT_PROXY_RELEASE`. `--release` remains an explicit override; the
+ * default must still pass through the normal consent gate and
+ * signature-verifying installer.
+ *
+ * These assertions read the pin from the module rather than hardcoding a
+ * version, so a bump cannot leave the tests asserting a stale release.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -48,15 +52,21 @@ describe('proxy install - pinned release default', () => {
     expect(hasConsent('proxy-install')).toBe(false);
   });
 
-  it('uses v0.4.0 when confirmed without a release override', async () => {
-    const installProxy = vi.fn().mockResolvedValue({ version: '0.4.0', binaryPath: '/tmp/meta-proxy', sha256: 'abc' });
+  it('uses the pinned release when confirmed without a release override', async () => {
+    const installProxy = vi.fn();
+    // Register the mock BEFORE importing proxy-lifecycle.js — that module
+    // imports the installer at load time, so importing it first binds the
+    // real one and the test performs an actual download.
     vi.doMock('../src/proxy/install.js', () => ({ installProxy, uninstallProxy: vi.fn() }));
+
+    const { DEFAULT_PROXY_RELEASE } = await import('../src/commands/proxy-lifecycle.js');
+    installProxy.mockResolvedValue({ version: DEFAULT_PROXY_RELEASE, binaryPath: '/tmp/meta-proxy', sha256: 'abc' });
 
     const installSub = await getInstallSub();
     const result = await installSub.action!(ctxWithFlags({ yes: true }));
 
     expect(result?.success).toBe(true);
-    expect(installProxy).toHaveBeenCalledWith(expect.objectContaining({ version: '0.4.0' }));
+    expect(installProxy).toHaveBeenCalledWith(expect.objectContaining({ version: DEFAULT_PROXY_RELEASE }));
   });
 
   it('honors an explicit release override', async () => {

--- a/v3/@claude-flow/cli/__tests__/proxy-lifecycle.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-lifecycle.test.ts
@@ -30,7 +30,13 @@ afterEach(() => {
 describe('getProxyStatus', () => {
   it('reports not-installed and not-running on a fresh state dir', async () => {
     const { getProxyStatus } = await import('../src/proxy/lifecycle.js');
-    expect(getProxyStatus()).toEqual({ installed: false, running: false, pid: null, stalePidFile: false });
+    expect(getProxyStatus()).toEqual({
+      installed: false,
+      running: false,
+      pid: null,
+      stalePidFile: false,
+      version: null,
+    });
   });
 
   it('reports installed once a binary file exists at the expected path', async () => {

--- a/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
@@ -24,8 +24,14 @@ import {
 import { proxyTokenPath } from '../proxy/paths.js';
 import { removeInjectedToken, startTokenRefreshPump } from '../proxy/token-bridge.js';
 
-/** Pinned and reviewed; later upgrades remain explicit commands. */
-export const DEFAULT_PROXY_RELEASE = '0.4.0';
+/**
+ * Pinned and reviewed; later upgrades remain explicit commands.
+ *
+ * Keep this the single source of truth — interpolate it rather than writing
+ * the version into user-facing strings, or the pin silently drifts out of
+ * sync with the text that advertises it.
+ */
+export const DEFAULT_PROXY_RELEASE = '0.7.3';
 
 const PROXY_COMMAND = 'npx ruflo@latest proxy';
 const AUTH_COMMAND = 'npx ruflo@latest auth';

--- a/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy-lifecycle.ts
@@ -41,6 +41,25 @@ const AUTH_COMMAND = 'npx ruflo@latest auth';
  * Keep this independent of the command framework so the state-specific
  * guidance has a small, direct regression-test surface.
  */
+/**
+ * Lines shown when the binary on disk is an older release than the current
+ * pin — empty otherwise, including when the version is unknown (`null`),
+ * where the honest move is to say nothing rather than guess.
+ *
+ * Bumping `DEFAULT_PROXY_RELEASE` only ever changed what a *new* install
+ * gets. Someone who installed the previous pin has no reason to run
+ * `install` again and no signal that anything moved, so a fix that motivated
+ * a bump reaches exactly the people who never needed it. This is the signal.
+ */
+export function proxyUpdateGuidance(status: ProxyStatus): string[] {
+  if (!status.installed || !status.version || status.version === DEFAULT_PROXY_RELEASE) return [];
+  return [
+    '',
+    `An update is available — installed v${status.version}, current pin v${DEFAULT_PROXY_RELEASE}.`,
+    `  ${PROXY_COMMAND} update              Re-verify and replace with v${DEFAULT_PROXY_RELEASE}`,
+  ];
+}
+
 export function proxyConsoleGuidance(status: ProxyStatus): string[] {
   if (!status.installed) {
     return [
@@ -53,6 +72,8 @@ export function proxyConsoleGuidance(status: ProxyStatus): string[] {
     ];
   }
 
+  const update = proxyUpdateGuidance(status);
+
   if (!status.running) {
     return [
       '',
@@ -61,6 +82,7 @@ export function proxyConsoleGuidance(status: ProxyStatus): string[] {
       '',
       'Foreground mode (shows live logs; Ctrl+C stops it):',
       `  ${PROXY_COMMAND} start`,
+      ...update,
       '',
       'Optional: enable Cognitum cloud routing (local-only is the default):',
       `  ${AUTH_COMMAND} login`,
@@ -73,6 +95,7 @@ export function proxyConsoleGuidance(status: ProxyStatus): string[] {
     'Meta Proxy is ready.',
     `  Logs:    ${PROXY_COMMAND} logs`,
     `  Stop:    ${PROXY_COMMAND} stop`,
+    ...update,
     '',
     'Optional: enable Cognitum cloud routing (local-only is the default):',
     `  ${AUTH_COMMAND} login`,
@@ -151,10 +174,21 @@ const installSub: Command = {
 
 const updateSub: Command = {
   name: 'update',
-  description: 'Re-verify and replace the installed binary with a specific version (never automatic)',
-  options: [{ name: 'release', description: 'Release version to install', type: 'string', required: true }],
+  description: 'Re-verify and replace the installed binary with the pinned release (never automatic)',
+  options: [
+    // Defaults to the pin, matching `install`. `--release` was previously
+    // required, which meant the only in-product way to reach a newer binary
+    // was to already know its version number — so bumping the pin moved
+    // nothing for anyone who had already installed. Still never automatic:
+    // this runs only when a user types it.
+    {
+      name: 'release',
+      description: `Release version to install (default: ${DEFAULT_PROXY_RELEASE})`,
+      type: 'string',
+    },
+  ],
   action: async (ctx): Promise<CommandResult> => {
-    const version = typeof ctx.flags.release === 'string' ? ctx.flags.release : undefined;
+    const version = typeof ctx.flags.release === 'string' ? ctx.flags.release : DEFAULT_PROXY_RELEASE;
     if (!version) {
       output.printError('ruflo proxy update requires --release <x.y.z>');
       return { success: false, exitCode: 1 };
@@ -243,6 +277,11 @@ const statusSub: Command = {
     }
     output.writeln('Meta Proxy');
     output.writeln(`  Installation: ${status.installed ? 'ready' : 'not installed'}`);
+    if (status.installed) {
+      // "unknown" rather than an assumed version: the manifest is the only
+      // record of what was installed, and asking the binary would start it.
+      output.writeln(`  Version: ${status.version ?? 'unknown (no install manifest)'}`);
+    }
     output.writeln(`  Process: ${status.running ? `running (pid ${status.pid})` : 'not running'}`);
     if (status.stalePidFile) output.writeln('  (a stale PID file was found and will be cleared on next start)');
     printProxyConsoleGuidance(status);

--- a/v3/@claude-flow/cli/src/commands/proxy.ts
+++ b/v3/@claude-flow/cli/src/commands/proxy.ts
@@ -25,7 +25,7 @@ import { clearRateLimitStatus, readRateLimitStatus } from '../funnel/rate-limit-
 import { clearQuotaLowStatus, readQuotaLowStatus } from '../funnel/power-saver-notifier.js';
 import { getInstalledCliVersion } from '../init/helper-refresh.js';
 import * as path from 'path';
-import { proxyLifecycleSubcommands, printProxyConsoleGuidance } from './proxy-lifecycle.js';
+import { proxyLifecycleSubcommands, printProxyConsoleGuidance, DEFAULT_PROXY_RELEASE } from './proxy-lifecycle.js';
 import { getProxyStatus } from '../proxy/lifecycle.js';
 
 const PROXY_CONFIG_FILE = 'proxy-config.toml';
@@ -410,7 +410,7 @@ export const proxyCommand: Command = {
     trainingShareEnableSub, trainingShareDisableSub, trainingShareStatusSub,
   ],
   examples: [
-    { command: 'ruflo proxy install --yes', description: 'Install the signed Meta-Proxy v0.4.0 binary' },
+    { command: 'ruflo proxy install --yes', description: `Install the signed Meta-Proxy v${DEFAULT_PROXY_RELEASE} binary` },
     { command: 'ruflo proxy start', description: 'Start meta-proxy in the foreground' },
     { command: 'ruflo proxy status', description: 'Show install + process status' },
     { command: 'ruflo proxy config --cloud --yes', description: 'Enable cloud routing (ADR-304)' },

--- a/v3/@claude-flow/cli/src/proxy/lifecycle.ts
+++ b/v3/@claude-flow/cli/src/proxy/lifecycle.ts
@@ -3,10 +3,20 @@
  *
  * Adapts daemon.ts's proven pattern (PID file, O_EXCL lockfile for atomic
  * check-then-start, signal-0 liveness, SIGTERM->1000ms->SIGKILL) to a
- * native binary instead of a forked Node process. The binary itself takes
- * no CLI flags — confirmed empirically (2026-07-16): `meta-proxy.exe` has
- * no `--version`/`--help`, and any invocation just starts the server reading
- * its own config file — so `spawn()` here passes zero arguments, always.
+ * native binary instead of a forked Node process. `spawn()` here passes zero
+ * arguments, always — starting the server is the argument-free behavior and
+ * the only one this module wants.
+ *
+ * That is now a choice rather than a constraint. The 2026-07-16 note here
+ * ("the binary takes no CLI flags — no `--version`/`--help`, any invocation
+ * just starts the server") was true of the release pinned at the time, and
+ * stopped being true: meta-proxy v0.7.2 handles `--help` before binding, and
+ * v0.7.3 makes `--help`/`--version` win from any argv position. Do not read
+ * the old note as "the binary cannot be asked what it is" — it can. The
+ * installed version is still read from the install manifest rather than by
+ * executing the binary, because a filesystem read cannot start a listener
+ * and an exec of an old build can (a `--version` probe against 0.4.0 leaves
+ * a daemon bound to 127.0.0.1:11435).
  *
  * Foreground `start` (the ADR-307 default) uses `stdio: 'inherit'` and
  * blocks directly — simplest and safest, no log-file redirection needed.
@@ -21,7 +31,14 @@
 
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
-import { proxyBinaryPath, proxyPidFilePath, proxyLockFilePath, proxyLogFilePath } from './paths.js';
+import {
+  proxyBinaryPath,
+  proxyPidFilePath,
+  proxyLockFilePath,
+  proxyLogFilePath,
+  proxyInstallManifestPath,
+  type InstallManifest,
+} from './paths.js';
 
 export class ProxyNotInstalledError extends Error {
   constructor() {
@@ -58,21 +75,48 @@ export interface ProxyStatus {
   running: boolean;
   pid: number | null;
   stalePidFile: boolean;
+  /**
+   * The release recorded by the install that produced the binary on disk, or
+   * null when unknown — either nothing is installed, or the binary predates
+   * the manifest / the manifest was hand-removed. Callers must treat null as
+   * "cannot tell", never as "up to date".
+   */
+  version: string | null;
+}
+
+/**
+ * The installed release, from `install.ts`'s manifest. Deliberately a
+ * filesystem read and not `meta-proxy --version`: exec'ing the binary to ask
+ * its version is exactly the probe that starts a listener on the older
+ * builds this is most needed to detect.
+ *
+ * Never throws — a missing, unreadable, or malformed manifest is a normal
+ * "unknown", not a reason to fail `proxy status`.
+ */
+function readInstalledVersion(): string | null {
+  try {
+    const raw = fs.readFileSync(proxyInstallManifestPath(), 'utf-8');
+    const manifest = JSON.parse(raw) as Partial<InstallManifest>;
+    return typeof manifest.version === 'string' && manifest.version ? manifest.version : null;
+  } catch {
+    return null;
+  }
 }
 
 export function getProxyStatus(): ProxyStatus {
   const installed = fs.existsSync(proxyBinaryPath());
+  const version = installed ? readInstalledVersion() : null;
   const pidPath = proxyPidFilePath();
   if (!fs.existsSync(pidPath)) {
-    return { installed, running: false, pid: null, stalePidFile: false };
+    return { installed, running: false, pid: null, stalePidFile: false, version };
   }
   const raw = fs.readFileSync(pidPath, 'utf-8').trim();
   const pid = parseInt(raw, 10);
   if (!Number.isFinite(pid)) {
-    return { installed, running: false, pid: null, stalePidFile: true };
+    return { installed, running: false, pid: null, stalePidFile: true, version };
   }
   const running = isProcessRunning(pid);
-  return { installed, running, pid: running ? pid : null, stalePidFile: !running };
+  return { installed, running, pid: running ? pid : null, stalePidFile: !running, version };
 }
 
 function writePidFile(pid: number): void {

--- a/v3/docs/adr/ADR-307-proxy-runtime-packaging-lifecycle.md
+++ b/v3/docs/adr/ADR-307-proxy-runtime-packaging-lifecycle.md
@@ -152,12 +152,41 @@ The bridge is implemented by meta-proxy v0.2.0 and ruflo's resident supervisor: 
 access token crosses the process boundary, while ruflo retains the rotating refresh token in the OS
 keychain. Production installation is implemented through the signed public distribution channel.
 
-### v0.4.0 pinned install default (2026-07-17)
+### Pinned install default (2026-07-17; pin updated 2026-08-05)
 
-`ruflo proxy install --yes` now selects the reviewed Meta-Proxy v0.4.0 release
+`ruflo proxy install --yes` selects a single reviewed Meta-Proxy release
 without requiring a user to discover and type a version. This is a pinned,
 reproducible default, not an unauthenticated "latest" lookup: the installer
 continues to verify the public distribution's Ed25519-signed `SHA256SUMS` and
 the selected platform archive before extraction. An operator keeps control of
-later changes through explicit `ruflo proxy update --release <x.y.z>` or an
-explicit `install --release <x.y.z>` override.
+later changes through explicit `ruflo proxy update` (which defaults to the same
+pin) or an explicit `install --release <x.y.z>` override.
+
+The pin itself lives in exactly one place — `DEFAULT_PROXY_RELEASE` in
+`src/commands/proxy-lifecycle.ts` — and this ADR deliberately no longer names
+a version. The original text pinned **v0.4.0** and stayed there through six
+upstream releases; the value was additionally copied as a literal into
+`proxy.ts`'s example text and into two test files, so nothing in the tree
+disagreed with itself while all four fell behind together. Interpolate the
+constant; do not restate it.
+
+### Surfacing pin drift to already-installed users (2026-08-05)
+
+Bumping the pin only ever changed what a *new* install receives. A user who
+installed a previous pin had no signal that anything had moved: `proxy status`
+reported installation as a boolean, and `proxy update` required an explicit
+`--release`, so reaching a newer binary meant already knowing its version
+number. A fix significant enough to motivate a bump therefore reached only the
+users who did not yet have the problem.
+
+`ProxyStatus` now carries `version`, read from the install manifest that
+`install.ts` already writes. `proxy status` prints it, and the console guidance
+names the gap and the command to close it when the installed release differs
+from the pin. The version is read from the manifest and never by executing the
+binary: releases before v0.7.2 start the server and bind a port on *any*
+invocation, so a `--version` probe against an old build leaves a listener
+running — the precise state this check exists to detect. An unreadable or
+absent manifest reports `unknown`, never "up to date".
+
+Updating remains explicit and user-initiated; nothing here installs anything on
+its own.


### PR DESCRIPTION
## Problem

`DEFAULT_PROXY_RELEASE` has been pinned at `0.4.0` while meta-proxy has shipped through **v0.7.3** — six releases. `ruflo proxy install` therefore installs a binary predating every fix since v0.4.0.

Traced each fix to its first containing release with `git tag --contains`:

| Fix | First released in | In `0.4.0`? |
|---|---|---|
| `require explicit Cognitum Cloud routing consent` (#60) | **v0.7.0** | ❌ |
| `handle --help before binding` (#74 / #76) | v0.7.2 | ❌ |
| `--help`/`--version` win from any argv position (#85) | v0.7.3 | ❌ |
| `reload live daemon config on login/logout` (#28) | v0.4.1 | ❌ |
| `pin the Linux glibc floor to 2.28` (#66) | v0.7.1 | ❌ |

### The consent gap is the one that matters

The install disclosure in `proxy-lifecycle.ts` promises:

> The proxy routes to LOCAL backends by default — no prompt leaves this machine. Cloud routing is a separate, explicit opt-in (`ruflo proxy config --cloud`), **never enabled by install alone**.

The commit that separated authentication from routing consent (#60) first shipped in **v0.7.0** — after the pinned build. Its message describes closing four adversarial boundary findings, including *paste-key Cloud activation* and *remote OAuth-target exfiltration*.

I have **not** audited whether `0.4.0` is exploitable, and this PR does not claim that. The point is narrower and checkable: we advertise a guarantee whose implementing commit is not in the binary we install.

### Directly observable on 0.4.0

`meta-proxy`'s own source documents `--version` as side-effect-free ("print the build version and exit — no server, no I/O") and has tests for it. The pinned `0.4.0` binary instead:

```
$ meta-proxy --version
processed file: C:\Users\profa\.ruflo\proxy-token
Successfully processed 1 files; Failed processing 0 files
INFO meta_proxy: meta-proxy starting bind=127.0.0.1:11435 version="0.4.0"
```

It starts the daemon, writes the token file, and binds a port. Any probe silently leaves a listener running. After the bump:

```
$ meta-proxy --version
meta-proxy 0.7.3          # exits 0; no process, no port bound
```

## Changes

- **`proxy-lifecycle.ts`** — `DEFAULT_PROXY_RELEASE`: `0.4.0` → `0.7.3`.
- **`proxy.ts`** — the example text hardcoded `'…Meta-Proxy v0.4.0 binary'` as a literal instead of interpolating the constant. That is *how this drifted*: the advertised version could diverge from the installed one with nothing to catch it. Now interpolated.
- **Both test files** — switched from hardcoded `'0.4.0'` to reading `DEFAULT_PROXY_RELEASE` from the module. Asserting a literal means every bump needs hand-edited expectations, which is the same drift in the tests.

## Verification

Windows x64, `x86_64-pc-windows-msvc`:

- `ruflo proxy install --release 0.7.3 --yes` — installs with Ed25519 signature + sha256 verification intact.
- `--version` confirmed side-effect-free afterwards: exits 0, no stray process, port 11435 not bound.
- **9 proxy test files, 56 tests, all passing.**

## For reviewers — two things I could not settle myself

1. **Cross-release compatibility.** I verified 0.7.3 installs and runs, not that ruflo's integration is correct across all six releases. #60 alone reworked `anthropic_auth.rs`, `oauth/login.rs` and `routes/messages.rs`. That judgement belongs to someone who knows the integration.

2. **Pre-existing test failure, unrelated to this PR.** On a fresh clone `proxy-install-command.test.ts` fails all 3 tests with `Cannot find package '@claude-flow/cli-core/output'` until `@claude-flow/cli-core` is built. I confirmed this on unmodified `main` by stashing these changes. Fixed locally with `pnpm --filter @claude-flow/cli-core build`; worth a separate look.

Only the 9 proxy test files were run, not the full `npm test` — the machine used here could not safely run the whole monorepo suite.
