### PR TITLE
fix(proxy): fall back to tar when Expand-Archive fails, and cover extraction

### DIFF
--- a/v3/@claude-flow/cli/__tests__/proxy-extract-archive.test.ts
+++ b/v3/@claude-flow/cli/__tests__/proxy-extract-archive.test.ts
@@ -1,0 +1,209 @@
+/**
+ * `extractArchive` (proxy/install.ts) — the only platform-divergent step in
+ * the install pipeline, and previously the only one with no direct coverage.
+ *
+ * Motivating failure, observed on a healthy Windows 11 machine running
+ * `ruflo proxy install --yes`, after the release had already been downloaded
+ * and its Ed25519 signature + sha256 verified:
+ *
+ *   [ERROR] Install failed
+ *     Expand-Archive failed (exit 1): Expand-Archive : The 'Expand-Archive'
+ *     command was found in the module 'Microsoft.PowerShell.Archive', but the
+ *     module could not be loaded.
+ *
+ * `Microsoft.PowerShell.Archive` is a *script* module reached through
+ * PowerShell's autoloading, so it can fail for environment reasons unrelated
+ * to the archive. The same command succeeded on the same machine minutes
+ * later — intermittent, not a hard platform break. With no fallback, a
+ * verified archive was discarded and the install aborted.
+ *
+ * These tests pin the contract rather than the mechanism: Expand-Archive stays
+ * the primary zip path, tar backs it up, and only a failure of BOTH is fatal.
+ * The executor is mocked, so they assert routing on every platform without
+ * depending on a real powershell.exe or bsdtar.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+interface ExecCall {
+  allowedCommands: string[];
+  command: string;
+  args: string[];
+}
+
+interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const OK: ExecResult = { exitCode: 0, stdout: '', stderr: '' };
+
+/** The real-world PowerShell failure this fallback exists for. */
+const AUTOLOAD_FAILURE: ExecResult = {
+  exitCode: 1,
+  stdout: '',
+  stderr:
+    "Expand-Archive : The 'Expand-Archive' command was found in the module " +
+    "'Microsoft.PowerShell.Archive', but the module could not be loaded.",
+};
+
+let workDir: string;
+let calls: ExecCall[];
+
+/**
+ * Installs a fake `@claude-flow/security` whose SafeExecutor records every
+ * invocation and defers the result to `handler`, keyed by the command name.
+ */
+function mockExecutor(handler: (call: ExecCall) => ExecResult | Promise<ExecResult>): void {
+  calls = [];
+  class FakeSafeExecutor {
+    private allowedCommands: string[];
+    constructor(config: { allowedCommands: string[]; timeout?: number }) {
+      this.allowedCommands = config.allowedCommands;
+    }
+    async execute(command: string, args: string[]): Promise<ExecResult> {
+      const call: ExecCall = { allowedCommands: this.allowedCommands, command, args };
+      calls.push(call);
+      return handler(call);
+    }
+  }
+  vi.doMock('@claude-flow/security', () => ({ SafeExecutor: FakeSafeExecutor }));
+}
+
+async function loadExtractArchive() {
+  const mod = await import('../src/proxy/install.js');
+  return mod.extractArchive;
+}
+
+const commandsUsed = () => calls.map((c) => c.command);
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-extract-test-'));
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock('@claude-flow/security');
+});
+
+describe('extractArchive — tar.gz', () => {
+  it('extracts with tar and never invokes powershell', async () => {
+    mockExecutor(() => OK);
+    const extractArchive = await loadExtractArchive();
+    const dest = path.join(workDir, 'out');
+
+    await extractArchive(path.join(workDir, 'meta-proxy.tar.gz'), dest, 'tar.gz');
+
+    expect(commandsUsed()).toEqual(['tar']);
+    expect(calls[0].args[0]).toBe('xzf');
+    expect(calls[0].args).toContain('-C');
+  });
+
+  it('creates the destination directory', async () => {
+    mockExecutor(() => OK);
+    const extractArchive = await loadExtractArchive();
+    const dest = path.join(workDir, 'nested', 'out');
+
+    await extractArchive(path.join(workDir, 'a.tar.gz'), dest, 'tar.gz');
+
+    expect(fs.existsSync(dest)).toBe(true);
+  });
+
+  it('throws when tar fails — there is no second path for tar.gz', async () => {
+    mockExecutor(() => ({ exitCode: 2, stdout: '', stderr: 'not in gzip format' }));
+    const extractArchive = await loadExtractArchive();
+
+    await expect(extractArchive(path.join(workDir, 'a.tar.gz'), path.join(workDir, 'out'), 'tar.gz')).rejects.toThrow(
+      /tar extraction failed \(exit 2\).*not in gzip format/s,
+    );
+    expect(commandsUsed()).toEqual(['tar']);
+  });
+});
+
+describe('extractArchive — zip', () => {
+  it('uses Expand-Archive as the primary path and does not fall back when it succeeds', async () => {
+    mockExecutor(() => OK);
+    const extractArchive = await loadExtractArchive();
+
+    await extractArchive(path.join(workDir, 'meta-proxy.zip'), path.join(workDir, 'out'), 'zip');
+
+    expect(commandsUsed()).toEqual(['powershell']);
+    expect(calls[0].args).toContain('-NonInteractive');
+    expect(calls[0].args.join(' ')).toContain('Expand-Archive');
+  });
+
+  it('falls back to tar when Expand-Archive cannot autoload its module', async () => {
+    mockExecutor((call) => (call.command === 'powershell' ? AUTOLOAD_FAILURE : OK));
+    const extractArchive = await loadExtractArchive();
+
+    await expect(
+      extractArchive(path.join(workDir, 'meta-proxy.zip'), path.join(workDir, 'out'), 'zip'),
+    ).resolves.toBeUndefined();
+
+    expect(commandsUsed()).toEqual(['powershell', 'tar']);
+  });
+
+  it('passes "xf" to the tar fallback — a zip is not gzip-compressed', async () => {
+    mockExecutor((call) => (call.command === 'powershell' ? AUTOLOAD_FAILURE : OK));
+    const extractArchive = await loadExtractArchive();
+
+    await extractArchive(path.join(workDir, 'meta-proxy.zip'), path.join(workDir, 'out'), 'zip');
+
+    const tarCall = calls.find((c) => c.command === 'tar');
+    expect(tarCall?.args[0]).toBe('xf');
+  });
+
+  it('falls back when the powershell process throws rather than exiting non-zero', async () => {
+    mockExecutor((call) => {
+      if (call.command === 'powershell') throw new Error('spawn powershell ENOENT');
+      return OK;
+    });
+    const extractArchive = await loadExtractArchive();
+
+    await expect(
+      extractArchive(path.join(workDir, 'meta-proxy.zip'), path.join(workDir, 'out'), 'zip'),
+    ).resolves.toBeUndefined();
+
+    expect(commandsUsed()).toEqual(['powershell', 'tar']);
+  });
+
+  it('only fails when BOTH extractors fail, and reports both causes', async () => {
+    mockExecutor((call) =>
+      call.command === 'powershell' ? AUTOLOAD_FAILURE : { exitCode: 1, stdout: '', stderr: 'tar: unrecognized format' },
+    );
+    const extractArchive = await loadExtractArchive();
+
+    const attempt = extractArchive(path.join(workDir, 'meta-proxy.zip'), path.join(workDir, 'out'), 'zip');
+
+    await expect(attempt).rejects.toThrow(/Expand-Archive:.*module could not be loaded/s);
+    await expect(attempt).rejects.toThrow(/tar fallback:.*unrecognized format/s);
+    expect(commandsUsed()).toEqual(['powershell', 'tar']);
+  });
+
+  it('keeps each extractor on its own command allowlist', async () => {
+    mockExecutor((call) => (call.command === 'powershell' ? AUTOLOAD_FAILURE : OK));
+    const extractArchive = await loadExtractArchive();
+
+    await extractArchive(path.join(workDir, 'meta-proxy.zip'), path.join(workDir, 'out'), 'zip');
+
+    expect(calls.find((c) => c.command === 'powershell')?.allowedCommands).not.toContain('tar');
+    expect(calls.find((c) => c.command === 'tar')?.allowedCommands).toEqual(['tar']);
+  });
+
+  it('quotes literal paths so a single quote cannot break out of the command string', async () => {
+    mockExecutor(() => OK);
+    const extractArchive = await loadExtractArchive();
+    const awkward = path.join(workDir, "it's here.zip");
+
+    await extractArchive(awkward, path.join(workDir, 'out'), 'zip');
+
+    const command = calls[0].args[calls[0].args.length - 1];
+    expect(command).toContain("it''s here.zip");
+  });
+});

--- a/v3/@claude-flow/cli/src/proxy/install.ts
+++ b/v3/@claude-flow/cli/src/proxy/install.ts
@@ -27,36 +27,79 @@ function binaryNameInArchive(): string {
   return process.platform === 'win32' ? 'meta-proxy.exe' : 'meta-proxy';
 }
 
-/**
- * Extracts the archive via the OS's own tools — `tar` for `.tar.gz`
- * (present on macOS/Linux/Windows 10+), PowerShell `Expand-Archive`
- * specifically for `.zip` on Windows (not tar's bsdtar zip support — not
- * reliable enough to lean on). Zero new archive-parsing dependency, matching
- * this repo's existing taste for shelling out over adding a parser dep.
- */
-async function extractArchive(archivePath: string, extractDir: string, ext: 'zip' | 'tar.gz'): Promise<void> {
+/** `tar` handles `.tar.gz` everywhere, and `.zip` via bsdtar on Windows 10+. */
+async function extractWithTar(archivePath: string, extractDir: string, flags: 'xzf' | 'xf'): Promise<void> {
   const { SafeExecutor } = await import('@claude-flow/security');
-  fs.mkdirSync(extractDir, { recursive: true });
-
-  if (ext === 'tar.gz') {
-    const exec = new SafeExecutor({ allowedCommands: ['tar'], timeout: 60_000 });
-    const result = await exec.execute('tar', ['xzf', archivePath, '-C', extractDir]);
-    if (result.exitCode !== 0) {
-      throw new ExtractionError(`tar extraction failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
-    }
-    return;
+  const exec = new SafeExecutor({ allowedCommands: ['tar'], timeout: 60_000 });
+  const result = await exec.execute('tar', [flags, archivePath, '-C', extractDir]);
+  if (result.exitCode !== 0) {
+    throw new ExtractionError(`tar extraction failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
   }
+}
 
-  // .zip — PowerShell Expand-Archive, single-quoted literal paths (doubling
-  // any embedded single quote per PowerShell string-literal escaping) passed
-  // as ONE argv element to -Command. shell:false means no OS shell ever
-  // tokenizes this string — only powershell.exe's own parser does.
+/**
+ * Single-quoted literal paths (doubling any embedded single quote per
+ * PowerShell string-literal escaping) passed as ONE argv element to
+ * `-Command`. shell:false means no OS shell ever tokenizes this string —
+ * only powershell.exe's own parser does.
+ */
+async function extractWithPowerShell(archivePath: string, extractDir: string): Promise<void> {
+  const { SafeExecutor } = await import('@claude-flow/security');
   const escape = (p: string) => p.replace(/'/g, "''");
   const command = `Expand-Archive -LiteralPath '${escape(archivePath)}' -DestinationPath '${escape(extractDir)}' -Force`;
   const exec = new SafeExecutor({ allowedCommands: ['powershell', 'powershell.exe'], timeout: 60_000 });
   const result = await exec.execute('powershell', ['-NoProfile', '-NonInteractive', '-Command', command]);
   if (result.exitCode !== 0) {
     throw new ExtractionError(`Expand-Archive failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
+  }
+}
+
+/**
+ * Extracts the archive via the OS's own tools — `tar` for `.tar.gz`
+ * (present on macOS/Linux/Windows 10+), PowerShell `Expand-Archive`
+ * specifically for `.zip` on Windows. Zero new archive-parsing dependency,
+ * matching this repo's existing taste for shelling out over adding a parser dep.
+ *
+ * `Expand-Archive` stays the PRIMARY `.zip` path — bsdtar's zip support is
+ * still not something to lean on by default. But `Microsoft.PowerShell.Archive`
+ * is a *script* module resolved through PowerShell's module autoloading, so it
+ * can fail for environment reasons entirely unrelated to the archive. Observed
+ * in the wild on a healthy Windows 11 box, from ruflo's own `-NonInteractive`
+ * child process:
+ *
+ *   Expand-Archive : The 'Expand-Archive' command was found in the module
+ *   'Microsoft.PowerShell.Archive', but the module could not be loaded.
+ *
+ * The same command succeeded on the same machine minutes later, so this is
+ * intermittent rather than a hard platform break. Previously that aborted the
+ * install outright with nothing to fall back on, stranding an already
+ * downloaded-and-verified archive. Retrying through bsdtar costs one extra
+ * process on a path that was going to fail anyway.
+ *
+ * Exported for tests — extraction is the only platform-divergent step in the
+ * install pipeline and had no direct coverage.
+ */
+export async function extractArchive(archivePath: string, extractDir: string, ext: 'zip' | 'tar.gz'): Promise<void> {
+  fs.mkdirSync(extractDir, { recursive: true });
+
+  if (ext === 'tar.gz') {
+    await extractWithTar(archivePath, extractDir, 'xzf');
+    return;
+  }
+
+  try {
+    await extractWithPowerShell(archivePath, extractDir);
+  } catch (primary) {
+    const primaryMessage = primary instanceof Error ? primary.message : String(primary);
+    try {
+      // 'xf', not 'xzf' — a zip is not gzip-compressed; bsdtar sniffs the format.
+      await extractWithTar(archivePath, extractDir, 'xf');
+    } catch (fallback) {
+      const fallbackMessage = fallback instanceof Error ? fallback.message : String(fallback);
+      throw new ExtractionError(
+        `zip extraction failed via both available extractors. Expand-Archive: ${primaryMessage} — tar fallback: ${fallbackMessage}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`ruflo proxy install` aborted on Windows *after* the release had already been downloaded and its Ed25519 signature + sha256 verified:

```
... Verified — sha256 bb40d9928be3ffd1…[ERROR] Install failed
  Expand-Archive failed (exit 1): Expand-Archive : The 'Expand-Archive' command
  was found in the module 'Microsoft.PowerShell.Archive', but the module could
  not be loaded. For more information, run 'Import-Module Microsoft.PowerShell.Archive'.
    + FullyQualifiedErrorId : CouldNotAutoloadMatchingModule
```

`Microsoft.PowerShell.Archive` is a **script** module reached through PowerShell's autoloading, so it can fail for environment reasons unrelated to the archive. The same command succeeded on the same machine minutes later — this is **intermittent, not a hard platform break**, which makes it worse rather than better: a fully verified archive was discarded and the install left with nothing to fall back on.

Windows is the only platform exposed. `releaseArchiveExtension()` routes `*-windows-msvc` to `.zip` and every other target to `.tar.gz`, and the `.tar.gz` branch already shells out to `tar`.

I could not reproduce the trigger on demand — cleared `PSModulePath`, PowerShell 7's ACL-restricted WindowsApps module path, `-ExecutionPolicy Restricted`, and a cleared `PSExecutionPolicyPreference` all extracted fine. So this PR does **not** claim a root cause. It addresses what is true regardless of trigger: a single-path extractor with no recovery, and no test coverage.

## Changes

`Expand-Archive` stays the **primary** zip path — bsdtar's zip support is still not something to lean on by default, per the existing comment. What changes:

- On failure it now falls back to `tar -xf` (bsdtar ships on Windows 10+) instead of giving up. `xf`, not `xzf` — a zip is not gzip-compressed; bsdtar sniffs the format.
- The fallback catches a thrown spawn error as well as a non-zero exit.
- Only failure of **both** extractors is fatal, and the error reports each cause rather than just the last.
- Extraction is split into `extractWithPowerShell` / `extractWithTar` so each path is independently exercisable. Each keeps its own `SafeExecutor` allowlist — the powershell executor never gains `tar`.
- `.tar.gz` behaviour is unchanged, including its existing error message.

## Tests

Adds `__tests__/proxy-extract-archive.test.ts` — **10 tests**. Extraction was the only platform-divergent step in the install pipeline and had no direct coverage: nothing under `__tests__` referenced `extractArchive`, `ExtractionError`, or `Expand-Archive` (the only `powershell` hits were shell-completion tests).

The executor is mocked, so routing is asserted on **every** platform without needing a real `powershell.exe` or bsdtar. Coverage: tar.gz routing and its no-fallback contract, zip happy path (asserts tar is *not* invoked), fallback on module-autoload failure, fallback on thrown spawn error, `xf` flag selection, both-fail error content, allowlist separation, destination-directory creation, and single-quote escaping in literal paths.

`extractArchive` is exported for these tests.

### The tests pin the fallback, not just the new export

Reverting the implementation makes all 10 fail — but with `extractArchive is not a function`, which only proves the export. So I mutation-tested it instead: keeping the export but disabling the fallback,

```
× falls back to tar when Expand-Archive cannot autoload its module
× passes "xf" to the tar fallback — a zip is not gzip-compressed
× falls back when the powershell process throws rather than exiting non-zero
× only fails when BOTH extractors fail, and reports both causes
× keeps each extractor on its own command allowlist
  Tests  5 failed | 5 passed (10)
```

Exactly the 5 fallback-specific tests fail; the other 5 still pass.

## Verification

- 10 proxy test files, **66 tests, all passing**.
- Changed files typecheck clean. (`tsc --noEmit` reports 17 pre-existing errors in this package from unbuilt sibling workspaces — `@claude-flow/memory`, `@claude-flow/neural`, `@claude-flow/swarm` — none in `src/proxy/` or the new test.)
- Only the 10 proxy test files were run, not the full `npm test`; the machine used here could not safely run the whole monorepo suite.
