### PR TITLE
chore(release): bump to 3.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.33.0",
+  "version": "3.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.33.0",
+      "version": "3.35.0",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/plugin-agent-federation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/__tests__/services/distill-oracle.test.ts
+++ b/v3/@claude-flow/cli/__tests__/services/distill-oracle.test.ts
@@ -196,7 +196,9 @@ describe('buildOraclePlan — command construction & remote parameterization', (
   it('builds a darwin bench-suite plan when benchSuite/benchCase present', () => {
     const plan = buildOraclePlan({ benchSuite: 'shield', benchCase: 'cve-42' }, 'h');
     expect(plan.kind).toBe('ssh-darwin-bench');
-    expect(plan.evalCommands.join(' ')).toContain('darwin bench run');
+    // Version-pinned per the #2561 cold-npx guard (MH_DARWIN_PIN) — the command
+    // is `@metaharness/darwin@<pin> bench run`, not the bare `darwin bench run`.
+    expect(plan.evalCommands.join(' ')).toContain(`darwin@${MH_DARWIN_PIN} bench run`);
     expect(plan.evalCommands.join(' ')).toContain("--suite 'shield'");
   });
 

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- Version bump 3.34.0 → 3.35.0 (minor) across the three release packages (`@claude-flow/cli`, `claude-flow`, `ruflo`), folding in #2956 (MetaHarness dependency-contract repair + ADR-381 sequential-evidence governance) and its follow-up fix commit for 3 concurrency/epoch-boundary bugs found in review.
- Fixes a stale test assertion in `distill-oracle.test.ts`: the generated darwin bench-run command now embeds the pinned `@metaharness/darwin` version (`MH_DARWIN_PIN`) per the #2561 cold-npx regression guard, so the bare `'darwin bench run'` substring check no longer matched the intentional pinned output.

## Test plan
- [x] `npm run build` clean in `v3/@claude-flow/cli`
- [x] `node scripts/audit-umbrella-version-lockstep.mjs` confirms all three packages at 3.35.0 in lockstep
- [x] `distill-oracle.test.ts` passes in isolation after the fix
- [ ] CI green

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)