### PR TITLE
feat(metaharness): pull in @metaharness/turn-credit + fix stale router/darwin pins

### DIFF
--- a/.github/workflows/no-cli-optdep-bloat-2561.yml
+++ b/.github/workflows/no-cli-optdep-bloat-2561.yml
@@ -55,7 +55,16 @@ jobs:
             // no lifecycle scripts, zero transitive deps — measured 753ms to
             // cold-install all three into an empty dir on 2026-08-10). That
             // profile is the opposite of the #2561 native/wasm trees.
-            const CLI_MAX = 10;
+            // Raised 10 → 13 for @metaharness/turn-credit (ADR-248, added
+            // 2026-08-10): 64.9K unpacked, zero transitive deps, no lifecycle
+            // scripts, measured ~110ms cold-install — same profile as
+            // darwin/flywheel/radio. The prior bump left the budget exactly
+            // at the post-PR count (10 == 10, zero slack), which meant the
+            // very next unrelated optional-dep addition would trip this
+            // guard for no reason connected to #2561; this bump leaves 2
+            // slots of real headroom (11 declared today, budget 13) rather
+            // than repeating that mistake.
+            const CLI_MAX = 13;
             const RUFLO_MAX = 0;
 
             // Specific packages proven to trigger the cold-npx timeout in

--- a/scripts/check-metaharness-pins.mjs
+++ b/scripts/check-metaharness-pins.mjs
@@ -20,11 +20,12 @@
 //     a clean `npm install` actually materializes them; an optional PEER
 //     dependency is never auto-installed, which is how a fresh ruflo install
 //     shipped with zero MetaHarness packages on disk.
-//   - metaharness            — the umbrella / MCP subprocess CLI (npx path; peer ok)
-//   - @metaharness/router    — neural-router.ts dynamic import (peer ok — triple-gated)
-//   - @metaharness/darwin    — Darwin evolve / GEPA subprocess (must be installable)
-//   - @metaharness/flywheel  — receipt/gate interop (must be installable)
-//   - @metaharness/radio     — coordination-policy optimizer (must be installable)
+//   - metaharness              — the umbrella / MCP subprocess CLI (npx path; peer ok)
+//   - @metaharness/router      — neural-router.ts dynamic import (peer ok — triple-gated)
+//   - @metaharness/darwin      — Darwin evolve / GEPA subprocess (must be installable)
+//   - @metaharness/flywheel    — receipt/gate interop (must be installable)
+//   - @metaharness/radio       — coordination-policy optimizer (must be installable)
+//   - @metaharness/turn-credit — recursive turn-level credit assignment, ADR-248 (must be installable)
 // Plus a lock-step check: the MH_DARWIN_PIN constant in distill-oracle.ts (used
 // for the Tier-1 oracle's `npx @metaharness/darwin@<pin>` calls) must satisfy
 // the declared @metaharness/darwin range, so the two can't drift apart.
@@ -106,6 +107,7 @@ async function main() {
     { name: '@metaharness/darwin', installable: true },
     { name: '@metaharness/flywheel', installable: true },
     { name: '@metaharness/radio', installable: true },
+    { name: '@metaharness/turn-credit', installable: true },
   ];
   const pins = WATCHED.map((w) => ({ ...w, ...declaredRange(pkg, w.name) }));
 
@@ -141,11 +143,14 @@ async function main() {
   if (ARGS.requireInstalled) {
     const cliDir = dirname(CLI_PKG);
     // Advertised symbol contract per package — verified against the real
-    // published artifacts (darwin 0.8.3 / flywheel 0.1.10 / radio 0.1.0).
+    // published artifacts (darwin 0.9.0 / flywheel 0.1.10 / radio 0.1.0 / turn-credit 0.1.0).
     const API_CONTRACT = {
       '@metaharness/darwin': ['evolve', 'RefineMutator', 'summarizeFailedTraces'],
       '@metaharness/flywheel': ['runFlywheelGenerations', 'meetsPromotionRule', 'makeSigner', 'verifyReplayBundle', 'sequentialEvidence', 'withSequentialEvidence'],
       '@metaharness/radio': ['RadioBus', 'runProtocol', 'runSim'],
+      // PAPER_DEFAULTS/GOVERNED_DEFAULTS are exported consts, not functions —
+      // excluded here since this contract only asserts `typeof === 'function'`.
+      '@metaharness/turn-credit': ['processTrajectory', 'creditByLabel', 'evidenceFromLogProbs', 'buildCreditReceiptPayload'],
     };
     for (const [pkgName, symbols] of Object.entries(API_CONTRACT)) {
       try {

--- a/scripts/metaharness-clean-install-test.mjs
+++ b/scripts/metaharness-clean-install-test.mjs
@@ -31,12 +31,13 @@ const CLI_PKG = join(HERE, '..', 'v3', '@claude-flow', 'cli', 'package.json');
 const FORMAT = process.argv.includes('--format') && process.argv[process.argv.indexOf('--format') + 1] === 'json' ? 'json' : 'table';
 
 // Advertised symbol contract per package — verified against the real published
-// artifacts (darwin 0.8.3 / flywheel 0.1.10 / radio 0.1.0). Keep in sync with
-// the --require-installed check in check-metaharness-pins.mjs.
+// artifacts (darwin 0.9.0 / flywheel 0.1.10 / radio 0.1.0 / turn-credit 0.1.0).
+// Keep in sync with the --require-installed check in check-metaharness-pins.mjs.
 const API_CONTRACT = {
   '@metaharness/darwin': ['evolve', 'RefineMutator', 'summarizeFailedTraces'],
   '@metaharness/flywheel': ['runFlywheelGenerations', 'meetsPromotionRule', 'makeSigner', 'verifyReplayBundle', 'sequentialEvidence', 'withSequentialEvidence'],
   '@metaharness/radio': ['RadioBus', 'runProtocol', 'runSim'],
+  '@metaharness/turn-credit': ['processTrajectory', 'creditByLabel', 'evidenceFromLogProbs', 'buildCreditReceiptPayload'],
 };
 
 async function main() {

--- a/v3/@claude-flow/cli/__tests__/services/distill-oracle.test.ts
+++ b/v3/@claude-flow/cli/__tests__/services/distill-oracle.test.ts
@@ -19,6 +19,7 @@ import {
   hasMechanicalSpec,
   resolveRemote,
   createSshOracleRunner,
+  MH_DARWIN_PIN,
   type Trajectory,
   type OracleRunner,
   type CommandExec,

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -123,16 +123,17 @@
     "@agntcy/slim-bindings": "2.0.0-alpha.5",
     "@napi-rs/keyring": "1.3.0",
     "@claude-flow/memory": "^3.0.0-alpha.21",
-    "@metaharness/darwin": "~0.8.3",
+    "@metaharness/darwin": "~0.9.0",
     "@metaharness/flywheel": "~0.1.10",
     "@metaharness/radio": "~0.1.0",
+    "@metaharness/turn-credit": "~0.1.0",
     "agentdb": "^3.0.0-alpha.17",
     "agentic-flow": "^3.0.0-alpha.1",
     "better-sqlite3": "^12.9.0",
     "ruvector": "^0.2.27"
   },
   "peerDependencies": {
-    "@metaharness/router": "^0.3.2",
+    "@metaharness/router": "^0.4.0",
     "metaharness": "^0.4.1"
   },
   "peerDependenciesMeta": {

--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -1844,7 +1844,7 @@ async function checkMetaharnessDeclaredPackages(): Promise<HealthCheck> {
         name: NAME,
         status: 'fail',
         message: 'no @metaharness/* packages declared in optionalDependencies — the dependency contract regressed (peer-only declarations are never installed)',
-        fix: 'Restore @metaharness/darwin, @metaharness/flywheel, @metaharness/radio to optionalDependencies in @claude-flow/cli',
+        fix: 'Restore @metaharness/darwin, @metaharness/flywheel, @metaharness/radio, @metaharness/turn-credit to optionalDependencies in @claude-flow/cli',
       };
     }
 

--- a/v3/@claude-flow/cli/src/commands/neural.ts
+++ b/v3/@claude-flow/cli/src/commands/neural.ts
@@ -1990,7 +1990,7 @@ const routerTrainCommand: Command = {
     try {
       mh = await import(metaharnessRouterPkg);
     } catch {
-      output.printError('@metaharness/router is not installed. `npm install @metaharness/router@^0.3.2` then re-run.');
+      output.printError('@metaharness/router is not installed. `npm install @metaharness/router@^0.4.0` then re-run.');
       return { success: false, exitCode: 1 };
     }
     const { neuralRouterStatus } = await import('../ruvector/neural-router.js');

--- a/v3/@claude-flow/cli/src/services/distill-oracle.ts
+++ b/v3/@claude-flow/cli/src/services/distill-oracle.ts
@@ -52,7 +52,7 @@ import {
 // scripts/check-metaharness-pins.mjs watch this constant for drift. Kept in
 // lock-step with the optionalDependencies pin in package.json and the plugin
 // darwin cache (versioned by the plugin's own `~0.8.0` pin in _darwin.mjs).
-export const MH_DARWIN_PIN = '0.8.3';
+export const MH_DARWIN_PIN = '0.9.0';
 
 // ── Provenance ─────────────────────────────────────────────────────────────
 

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5
       '@metaharness/router':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.4.0
+        version: 0.4.0
       '@noble/ed25519':
         specifier: 2.3.0
         version: 2.3.0
@@ -191,12 +191,15 @@ importers:
         specifier: ^3.0.0-alpha.21
         version: link:../memory
       '@metaharness/darwin':
-        specifier: ~0.8.3
-        version: 0.8.3
+        specifier: ~0.9.0
+        version: 0.9.0
       '@metaharness/flywheel':
         specifier: ~0.1.10
         version: 0.1.10
       '@metaharness/radio':
+        specifier: ~0.1.0
+        version: 0.1.0
+      '@metaharness/turn-credit':
         specifier: ~0.1.0
         version: 0.1.0
       '@napi-rs/keyring':
@@ -1755,8 +1758,8 @@ packages:
     hasBin: true
     dev: false
 
-  /@metaharness/darwin@0.8.3:
-    resolution: {integrity: sha512-v5Ph7y9U6nqfvWajOjJiSuQDjPwvCKwOui793cSGUxIYUcfMoVoMzDfEDxOczFU61z0UUd7lD0I1b2zl+eYnag==}
+  /@metaharness/darwin@0.9.0:
+    resolution: {integrity: sha512-X/u0sI4QNFi/YUhcQwZ2hcmthgc3H3n4PdPoKMbAE/y+rUWOQCS9oc1wqCcUysBN5K0jHV7U+3QApdMFvwKvRQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     requiresBuild: true
@@ -1779,8 +1782,8 @@ packages:
     hasBin: true
     dev: false
 
-  /@metaharness/router@0.3.2:
-    resolution: {integrity: sha512-LQElU6mUrWd3ffJ5bwoonEIgw7oFQZpwZaehffyl/Pg+iozpRjIBPEXdb4uTOBnKH+yPiTEWKc+h9AiZr9Os9w==}
+  /@metaharness/router@0.4.0:
+    resolution: {integrity: sha512-VOfjHM7AMWwDH41AAMHOHFbH1r898xJqhqyE3G/r8OAxxrMgujX2SZsYkj/eXfBEmoPMhDVRkuO2abxvzCgEUA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@ruvector/tiny-dancer': ^0.1.21
@@ -1788,6 +1791,13 @@ packages:
       '@ruvector/tiny-dancer':
         optional: true
     dev: false
+
+  /@metaharness/turn-credit@0.1.0:
+    resolution: {integrity: sha512-A752c0eEYEVodBB8HLOaSvcUMA65TX6/Cru2apZ7EE7aL2FSO74GFbgFWPo85bgqgNuMjhHkl/kG+lkC0TunNA==}
+    engines: {node: '>=20.0.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@metaharness/weight-eft@0.1.1:
     resolution: {integrity: sha512-GSg0APPAbRK93OzrzlE+R8hfEK+I5+Zhmh0Z28RC9Mk5/MjhPo3shqINO7ye8VPGYHIO4rars9FwCWbe/V4cEQ==}
@@ -7501,8 +7511,6 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
     peerDependenciesMeta:
-      agentic-flow:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -12285,9 +12293,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.1


### PR DESCRIPTION
## Summary
- Adds `@metaharness/turn-credit@~0.1.0` (ADR-248) as a new installable optionalDependency, matching darwin/flywheel/radio's pattern.
- Fixes two stale pins caught while doing this: `@metaharness/darwin` (`~0.8.3` → `~0.9.0`, tilde no longer covered the published minor bump) and `@metaharness/router` peer range (`^0.3.2` → `^0.4.0`).
- Bumps `CLI_MAX` in the #2561 optdep-bloat guard from 10 to 13 — the prior bump left zero slack (a latent trap flagged in review of #2956), this leaves real headroom.
- Fixes a live `ReferenceError` in `distill-oracle.test.ts` (`MH_DARWIN_PIN` referenced but never imported — a gap from #2957 that somehow didn't surface in that PR's CI).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `node scripts/check-metaharness-pins.mjs` — all pins current
- [x] `node scripts/metaharness-clean-install-test.mjs` — all 4 packages PASS (real clean install + export-contract check)
- [x] `distill-oracle.test.ts` + `doctor-*.test.ts` — 48/48 pass
- [ ] CI green

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)