### PR TITLE
fix(plugins): pin ruflo-core MCP launch + register 3 missing marketplace plugins (ADR-382 Part A)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -180,6 +180,21 @@
       "name": "ruflo-arena",
       "source": "./plugins/ruflo-arena",
       "description": "Competitive ruliology for ruflo swarms — arenas, tournaments, and adaptive co-evolution of program strategies (ADR-147/148); strategies-as-programs compete under payoff games"
+    },
+    {
+      "name": "ruflo-agntcy",
+      "source": "./plugins/ruflo-agntcy",
+      "description": "AGNTCY/Outshift Internet-of-Cognition runtime integration — SLIM secure transport, CASA intent-scoped tool authorization, and AGNTCY identity/observability spans (ADR-380); optional, removable augmentation per ADR-150"
+    },
+    {
+      "name": "ruflo-bbs-federation",
+      "source": "./plugins/ruflo-bbs-federation",
+      "description": "AgentBBS federated business-domain BBS room integration (ADR-164 Phase 1) — register/publish/watch/human-join MCP tools wrapping the agentbbs Rust workspace as a federation peer; degrades gracefully when agentbbs is absent"
+    },
+    {
+      "name": "ruflo-business-pods",
+      "source": "./plugins/ruflo-business-pods",
+      "description": "Business-domain pod templates for the federated business autopilot (ADR-164 Phase 2) — pod templates plus a dry-run-by-default single-tick runner that validates, reserves budget, and resolves agent roles before posting to the BBS room"
     }
   ]
 }

--- a/plugins/ruflo-core/.mcp.json
+++ b/plugins/ruflo-core/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "ruflo": {
-      "command": "npx",
-      "args": ["-y", "@claude-flow/cli@latest"],
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-launch.cjs"],
       "env": {
         "CLAUDE_FLOW_MCP_TRANSPORT": "stdio"
       }

--- a/plugins/ruflo-core/scripts/mcp-launch.cjs
+++ b/plugins/ruflo-core/scripts/mcp-launch.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * .mcp.json's command/args are static strings, so they can't run
+ * resolution logic inline. This launcher exists to do that work before
+ * exec'ing the real server: it resolves a local @claude-flow/cli install
+ * and runs its MCP server directly (`<bin>/cli.js mcp start`), falling
+ * back to `npx -y @claude-flow/cli@latest mcp start` only when no local
+ * install resolves.
+ *
+ * Without this, plugins/ruflo-core/.mcp.json's `npx -y
+ * @claude-flow/cli@latest` always re-resolved to whatever was newest on
+ * the registry, independent of — and frequently diverging from — any
+ * version a user separately pinned via `npm install @claude-flow/cli`
+ * (ADR-382 Gap 3 / issue #2971).
+ *
+ * Candidate list and the dist/src/index.js existence guard mirror
+ * .claude/helpers/hook-handler.cjs's resolveCliBinForHook(): a
+ * marketplace-plugin checkout is installed by `git clone`/`git pull`
+ * with no build step, so bin/cli.js can be present on disk while
+ * importing dist/src/index.js throws ERR_MODULE_NOT_FOUND on every real
+ * command. Checking for dist/ alongside bin/ prevents that doomed
+ * candidate from winning ahead of a real local install or the npx
+ * fallback.
+ */
+
+const { existsSync } = require('fs');
+const { join, dirname } = require('path');
+const { spawn } = require('child_process');
+const os = require('os');
+
+const MCP_ARGS = ['mcp', 'start'];
+
+function resolveLocalCliBin(cwd, home) {
+  const candidates = [
+    join(home, '.claude', 'plugins', 'marketplaces', 'ruflo', 'bin', 'cli.js'),
+    join(cwd, 'node_modules', '@claude-flow', 'cli', 'bin', 'cli.js'),
+    join(cwd, 'node_modules', 'ruflo', 'bin', 'cli.js'),
+    join(cwd, 'v3', '@claude-flow', 'cli', 'bin', 'cli.js'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const distEntry = join(dirname(candidate), '..', 'dist', 'src', 'index.js');
+      if (existsSync(candidate) && existsSync(distEntry)) {
+        return candidate;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+function buildLaunchSpec(localBin) {
+  if (localBin) {
+    return { command: process.execPath, args: [localBin, ...MCP_ARGS], shell: false };
+  }
+  const npxCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  // Windows .cmd shims aren't directly executable via CreateProcess — they
+  // need shell:true (or an explicit cmd.exe /c wrapper) or spawn throws
+  // EINVAL/ENOENT. Args here are hardcoded constants, not user input, so
+  // shell:true carries no injection risk on this branch.
+  return {
+    command: npxCmd,
+    args: ['-y', '@claude-flow/cli@latest', ...MCP_ARGS],
+    shell: process.platform === 'win32',
+  };
+}
+
+function launch({ command, args, shell }) {
+  const child = spawn(command, args, { stdio: 'inherit', env: process.env, shell });
+
+  // Forward termination signals so Claude Code can stop the MCP server the
+  // same way it would if it had spawned the real binary directly.
+  const forward = (signal) => child.kill(signal);
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, forward);
+  }
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code === null ? 1 : code);
+    }
+  });
+  child.on('error', (err) => {
+    process.stderr.write(`[mcp-launch] failed to start ${command}: ${err.message}\n`);
+    process.exit(1);
+  });
+}
+
+if (require.main === module) {
+  const localBin = resolveLocalCliBin(process.cwd(), os.homedir());
+  launch(buildLaunchSpec(localBin));
+}
+
+module.exports = { resolveLocalCliBin, buildLaunchSpec, MCP_ARGS };

--- a/plugins/ruflo-core/scripts/mcp-launch.test.cjs
+++ b/plugins/ruflo-core/scripts/mcp-launch.test.cjs
@@ -1,0 +1,103 @@
+'use strict';
+/**
+ * Unit tests for mcp-launch.cjs's local-vs-npx resolution logic.
+ *
+ * Mirrors tests/hook-handler-runwithtimeout.test.cjs's convention: uses
+ * node:test (built-in) so it runs without installing dependencies.
+ * resolveLocalCliBin() takes (cwd, home) explicitly rather than reading
+ * process.cwd()/os.homedir() itself, so these tests can point it at
+ * disposable tmp-dir fixtures instead of mutating real process state.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveLocalCliBin, buildLaunchSpec, MCP_ARGS } = require(
+  path.join(__dirname, 'mcp-launch.cjs')
+);
+
+function makeCliInstall(root, { withDist } = { withDist: true }) {
+  const binDir = path.join(root, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'cli.js'), '// fixture\n');
+  if (withDist) {
+    const distDir = path.join(root, 'dist', 'src');
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(path.join(distDir, 'index.js'), '// fixture\n');
+  }
+  return path.join(binDir, 'cli.js');
+}
+
+test('picks the node_modules/@claude-flow/cli candidate when it has a built dist/', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-home-'));
+  try {
+    const expected = makeCliInstall(path.join(cwd, 'node_modules', '@claude-flow', 'cli'));
+    const resolved = resolveLocalCliBin(cwd, home);
+    assert.equal(resolved, expected);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('skips a source-only checkout (bin/cli.js with no dist/) and falls through', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-home-'));
+  try {
+    // marketplace candidate: bin/cli.js present, dist/ missing — must be skipped
+    makeCliInstall(
+      path.join(home, '.claude', 'plugins', 'marketplaces', 'ruflo'),
+      { withDist: false }
+    );
+    const expected = makeCliInstall(path.join(cwd, 'node_modules', 'ruflo'));
+    const resolved = resolveLocalCliBin(cwd, home);
+    assert.equal(resolved, expected);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('resolves the v3/@claude-flow/cli in-repo candidate last', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-home-'));
+  try {
+    const expected = makeCliInstall(path.join(cwd, 'v3', '@claude-flow', 'cli'));
+    const resolved = resolveLocalCliBin(cwd, home);
+    assert.equal(resolved, expected);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('returns null when no candidate resolves', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-launch-home-'));
+  try {
+    assert.equal(resolveLocalCliBin(cwd, home), null);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('buildLaunchSpec uses process.execPath + the resolved bin plus "mcp start" when a local candidate resolves', () => {
+  const spec = buildLaunchSpec('/fake/path/to/bin/cli.js');
+  assert.equal(spec.command, process.execPath);
+  assert.deepEqual(spec.args, ['/fake/path/to/bin/cli.js', ...MCP_ARGS]);
+  assert.equal(spec.shell, false);
+});
+
+test('buildLaunchSpec falls back to npx -y @claude-flow/cli@latest mcp start when nothing resolves', () => {
+  const spec = buildLaunchSpec(null);
+  const expectedCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  assert.equal(spec.command, expectedCmd);
+  assert.deepEqual(spec.args, ['-y', '@claude-flow/cli@latest', ...MCP_ARGS]);
+  // Windows .cmd shims need shell:true to spawn at all; other platforms
+  // spawn npx directly with no shell involved.
+  assert.equal(spec.shell, process.platform === 'win32');
+});


### PR DESCRIPTION
## Summary

ADR-382 Part A — two independent, low-risk fixes (the ADR itself lives on branch `docs/adr-382-init-scaffold-drift`, commit [ba0f5cf13](https://github.com/ruvnet/ruflo/commit/ba0f5cf13a75e6f629925c575a2bfb449ec65e34); not yet merged to main, so it can't be linked as a main-relative file path here).

**Fix 1 — pin `plugins/ruflo-core/.mcp.json`'s launch path.** The marketplace-plugin MCP server launched via a bare `npx -y @claude-flow/cli@latest`, which always re-resolves to the newest registry version regardless of any local `npm install @claude-flow/cli` a user separately pinned — silently diverging the npm-install track from the marketplace-plugin track. Added `plugins/ruflo-core/scripts/mcp-launch.cjs`, a small launcher that mirrors `.claude/helpers/hook-handler.cjs`'s `resolveCliBinForHook()` (same candidate list: marketplace checkout, `node_modules/@claude-flow/cli`, `node_modules/ruflo`, `v3/@claude-flow/cli`; same `dist/src/index.js` existence guard against a source-only marketplace checkout that has `bin/cli.js` but no build). `.mcp.json` now points at the launcher via the documented `${CLAUDE_PLUGIN_ROOT}` substitution (confirmed supported for stdio-transport `command`/`args`/`env` per the [Plugins reference](https://code.claude.com/docs/en/plugins-reference#environment-variables)). Falls back to the original `npx -y @claude-flow/cli@latest mcp start` only when no local install resolves; the npx fallback branch uses `shell: true` on Windows since `.cmd` shims aren't directly executable via `CreateProcess` without it.

**Fix 2 — register 3 missing plugins in `.claude-plugin/marketplace.json`.** `plugins/` has 38 plugin directories but the marketplace manifest listed only 35. Verified the exact diff empirically (`ls plugins/` minus marketplace names minus `README.md`): `ruflo-agntcy`, `ruflo-bbs-federation`, `ruflo-business-pods`. Added matching entries; descriptions sourced from each plugin's own `.claude-plugin/plugin.json`, not guessed.

## Test plan

- [x] `node --test plugins/ruflo-core/scripts/mcp-launch.test.cjs` — 6/6 pass (local-candidate resolution, source-only-checkout skip, npx fallback, Windows `shell:true` branch, `mcp start` args). Not wired into any CI job, matching the existing precedent for `tests/hook-handler-runwithtimeout.test.cjs`.
- [x] `bash plugins/ruflo-core/scripts/smoke.sh` — 11/11 pass (unchanged; step 2 still finds `"ruflo"`/`"command"` in `.mcp.json`).
- [x] `node scripts/smoke-all-plugins.mjs` — 34/34 plugin smoke contracts pass, 550/550 steps.
- [x] `python3 -c "... assert {'ruflo-agntcy','ruflo-bbs-federation','ruflo-business-pods'} <= {p['name'] for p in marketplace['plugins']}"` — passes (ADR's own acceptance check).
- [x] Ran `plugins/ruflo-core/scripts/mcp-launch.cjs` directly against this repo's real `v3/@claude-flow/cli` checkout — resolves the local candidate and starts MCP stdio mode correctly.
- [x] `git status --short` / `git diff --stat` — only the 4 intended files changed; no `.claude/helpers/*` drift from a concurrent session.
- Not run: `cd v3/@claude-flow/cli && npm test` — out of scope, this PR touches nothing under `v3/@claude-flow/cli`.

Part of #2971 — Part A only. Do not auto-close #2971 on merge; Parts B and C are tracked/landed separately (Part C: #2974) and the umbrella issue should stay open until all three land.
