### PR TITLE
fix: force protobufjs >=8.2.0 in ruflo-graph-intelligence to remediate CVE-2026-41242

### DIFF
--- a/plugins/ruflo-graph-intelligence/package-lock.json
+++ b/plugins/ruflo-graph-intelligence/package-lock.json
@@ -1618,17 +1618,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@claude-flow/cli/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/@claude-flow/cli/node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -7131,89 +7120,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -8625,14 +8531,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/node": {
       "version": "20.19.41",
@@ -12699,42 +12597,6 @@
         "protobufjs": "^6.8.8"
       }
     },
-    "node_modules/onnx-proto/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/onnx-proto/node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/onnxruntime-common": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
@@ -13183,24 +13045,13 @@
       "peer": true
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "hasInstallScript": true,
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
       "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
         "long": "^5.3.2"
       },
       "engines": {

--- a/plugins/ruflo-graph-intelligence/package.json
+++ b/plugins/ruflo-graph-intelligence/package.json
@@ -23,7 +23,8 @@
     "zod": "^3.22.4"
   },
   "overrides": {
-    "ws": ">=8.21.0"
+    "ws": ">=8.21.0",
+    "protobufjs": ">=8.2.0"
   },
   "peerDependencies": {
     "@claude-flow/cli": ">=3.5.0"


### PR DESCRIPTION
## Summary
Force `protobufjs` to `>=8.2.0` in `plugins/ruflo-graph-intelligence`'s own `overrides`
to remediate CVE-2026-41242 in that plugin's local dev/CI install tree.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-41242 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-41242` |
| **File** | `plugins/ruflo-graph-intelligence/package-lock.json` (dependency: `protobufjs`) |
| **Assessment** | Present in the plugin's own dev/CI install tree; not present in a clean downstream-consumer install (see evidence below) |

**Description**: protobufjs: Arbitrary code execution via injected protobuf definition type
fields.

**Corrected version facts** (the original auto-generated title said "upgrade to 8.0.1,
7.5.5" — those are actually the *last vulnerable* versions in each line, not the fixed
ones; fixing this was raised in review):
- Real advisory boundary: vulnerable `<=7.5.5` and `8.0.0-8.0.1`; fixed at `7.5.6+` /
  `8.0.2+`. `npm audit` against this plugin's pre-fix lockfile additionally surfaces
  `GHSA-xq3m-2v4x-88gg` ("Arbitrary code execution in protobufjs", **critical**, range
  `<7.5.5`) plus several other protobufjs GHSAs with ranges extending up to `<=7.6.4`.
- Chosen override floor: `>=8.2.0` (comfortably past every advisory range found).
- Resolved version after `npm install` in the plugin directory: `8.7.2`.

## Evidence (acceptance-gate validation performed 2026-09-03)

A stricter automated review correctly pointed out that the numbers above needed to be
reconciled and validated against a real build/pack/install, not inferred from the
lockfile. That validation was run end-to-end:

1. **Dev/CI tree (what `npm ci` inside this plugin directory actually produces — the
   environment where trivy found the CVE):**
   - Pre-fix (`main`): `protobufjs` resolves to **two** vulnerable copies —
     `6.11.6` (via `onnx-proto` → `onnxruntime-web` → `@xenova/transformers` →
     `@claude-flow/embeddings`, pulled in transitively through the auto-installed
     `@claude-flow/cli` peer dependency) and `7.6.4` (via `@grpc/proto-loader` →
     `agentdb`). `npm audit --omit=dev`: **50 advisories (1 critical, 15 high, 33
     moderate, 1 low)**, with 12 distinct protobufjs GHSAs including the critical RCE
     above.
   - Post-fix (this PR): both consumers dedupe to a single `protobufjs@8.7.2`.
     `npm audit --omit=dev`: **47 advisories (0 critical, 13 high, 33 moderate, 1
     low)** — protobufjs no longer appears in the report at all. (The remaining 47 are
     pre-existing, unrelated to this PR.)
   - `npm test` (vitest): **96/96 tests pass**; one unrelated pre-existing suite failure
     (`tests/phase4-adapters.test.ts`, an `@claude-flow/cli` package-exports-map issue,
     nothing to do with protobufjs/onnx).
   - **ONNX/protobuf compatibility probe**: loaded `onnx-proto`'s generated
     `dist/onnx.js` against the now-installed `protobufjs@8.7.2` and round-tripped both
     a leaf message (`TensorProto`, including a repeated `floatData` field) and a nested
     composite message (`ModelProto` → `GraphProto` → `TensorProto`) through
     create/verify/encode/decode/toObject. **Byte-exact round-trip, PASS** — `onnx-proto`'s
     protobufjs-6-generated static code runs correctly against protobufjs 8.7.2.

2. **Real downstream consumer (`npm pack` the plugin, then `npm install` the tarball
   into an unrelated fresh project — no monorepo context, no root overrides):**
   - This plugin's own `overrides` field has **no effect** here — npm only applies a
     package's `overrides` when that package's `package.json` is the root of the
     install, so a downstream consumer's install is unaffected by this PR either way.
   - The peer dependency `@claude-flow/cli` *does* get auto-installed (npm 7+
     auto-installs peers), but it resolves the **currently-published**
     `@claude-flow/cli@3.38.21` — not the older `3.10.46` locked in this plugin's own
     dev lockfile — and that tree does **not** pull in `onnx-proto`/`@xenova/transformers`
     at all. The only protobufjs consumer present is `@grpc/proto-loader`, resolving to
     `protobufjs@7.6.6` — above every vulnerable range found in step 1.
   - **Conclusion**: this specific CVE was never reachable through a real downstream
     install of this plugin, matching the PR's original "not confirmed reachable" note.
     The fix's actual value is protecting the plugin's own local dev/CI install surface
     (where trivy scans and where contributors/CI actually run `npm ci`), not a shipped
     end-user artifact.

## Changes
- `package.json` — add `"protobufjs": ">=8.2.0"` to `overrides` (alongside the existing
  `ws` override).
- `package-lock.json` — re-resolves to `protobufjs@8.7.2`, drops the vulnerable nested
  `6.11.6`/`7.6.4` copies and the `@protobufjs/*` transitive sub-packages.

## Behavior Preservation
Scoped to this plugin's own manifest/lockfile; no source code changed. Verified via the
ONNX compatibility probe above that the forced protobufjs major bump does not break
`onnx-proto`'s generated (de)serialization code.

---
*This change addresses a pattern flagged by static analysis. Acceptance-gate evidence
above was gathered manually since `.github/workflows/cve-audit.yml` audits only the repo
root and `v3/` workspaces — it does not cover `plugins/**` lockfiles, so a green CI run
alone would not have validated this file.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com); evidence-gate
validation added in response to review.*
