### PR TITLE
fix(init): read the parser's actual camelCase flag keys (#2952)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/init-kebab-flags-2952.test.ts
+++ b/v3/@claude-flow/cli/__tests__/init-kebab-flags-2952.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #2952: `init --all-agents`, `--skip-claude`, `--only-claude`, `--cloud-mcp`
+ * were silent no-ops.
+ *
+ * Root cause: every long-flag write path in the parser goes through
+ * `normalizeKey()` (parser.ts), which converts kebab-case to camelCase
+ * before storing — `--all-agents` lands as `flags.allAgents`, never as the
+ * literal `flags['all-agents']`. `initClaudeAction` (commands/init.ts) read
+ * the literal kebab-case keys, so all four reads were always `undefined`.
+ * Same bug class the code already fixed for `--no-global` (#2098A) five
+ * lines above — that fix was never applied to these sibling flags.
+ *
+ * `--all-agents` is the most observable of the four: it switches the
+ * installed agent set from the ~17-agent curated default to the full
+ * ~89-agent catalog (ADR-128 Phase 3, `options.agents.all = true`). Black-box
+ * against the real built CLI — same pattern as mcp-http-foreground-2984 —
+ * because the bug is in how the parser's actual output key and the command's
+ * read key disagree, which a unit test against either side alone wouldn't
+ * catch.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const CLI_BIN = fileURLToPath(new URL('../bin/cli.js', import.meta.url));
+const CLI_BUILT = existsSync(CLI_BIN);
+
+function countAgentFiles(cwd: string): number {
+  const dir = join(cwd, '.claude', 'agents');
+  if (!existsSync(dir)) return 0;
+  let count = 0;
+  const walk = (d: string) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('.md')) count++;
+    }
+  };
+  walk(dir);
+  return count;
+}
+
+describe.skipIf(!CLI_BUILT)('#2952 init reads the parser\'s actual (camelCase) flag keys', () => {
+  it('--all-agents installs strictly more agents than the curated default', () => {
+    const defaultCwd = mkdtempSync(join(tmpdir(), 'ruflo-2952-default-'));
+    const allAgentsCwd = mkdtempSync(join(tmpdir(), 'ruflo-2952-all-'));
+    try {
+      execFileSync(process.execPath, [CLI_BIN, 'init', '--force'], {
+        cwd: defaultCwd,
+        timeout: 30_000,
+        stdio: 'pipe',
+      });
+      execFileSync(process.execPath, [CLI_BIN, 'init', '--force', '--all-agents'], {
+        cwd: allAgentsCwd,
+        timeout: 30_000,
+        stdio: 'pipe',
+      });
+
+      const defaultCount = countAgentFiles(defaultCwd);
+      const allAgentsCount = countAgentFiles(allAgentsCwd);
+
+      // Pre-fix: `ctx.flags['all-agents']` was always undefined, so both
+      // runs installed the same curated default set — this assertion is
+      // exactly what the bug made false.
+      expect(allAgentsCount).toBeGreaterThan(defaultCount);
+    } finally {
+      rmSync(defaultCwd, { recursive: true, force: true });
+      rmSync(allAgentsCwd, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/v3/@claude-flow/cli/src/commands/init.ts
+++ b/v3/@claude-flow/cli/src/commands/init.ts
@@ -552,8 +552,16 @@ const initClaudeAction = async (ctx: CommandContext): Promise<CommandResult> => 
   const force = ctx.flags.force as boolean;
   const minimal = ctx.flags.minimal as boolean;
   const full = ctx.flags.full as boolean;
-  const skipClaude = ctx.flags['skip-claude'] as boolean;
-  const onlyClaude = ctx.flags['only-claude'] as boolean;
+  // #2952 — every long-flag write path in the parser goes through
+  // normalizeKey() (parser.ts:399-402), which converts kebab-case to
+  // camelCase before storing. `--skip-claude`/`--only-claude`/
+  // `--all-agents`/`--cloud-mcp` land as `flags.skipClaude`/`flags.onlyClaude`/
+  // `flags.allAgents`/`flags.cloudMcp` — there is no code path that ever
+  // stores the literal kebab-case key. Reading `ctx.flags['skip-claude']`
+  // etc. was always undefined, so all four flags were silent no-ops. Same
+  // bug class as #2098A below, just never applied to these siblings.
+  const skipClaude = ctx.flags.skipClaude as boolean;
+  const onlyClaude = ctx.flags.onlyClaude as boolean;
   // #2098A — the parser handles `--no-foo` by stripping the prefix and
   // storing `flags.foo = false` (parser.ts:291-294), not by storing
   // `flags['no-foo'] = true`. So `--no-global` lands as
@@ -561,8 +569,8 @@ const initClaudeAction = async (ctx: CommandContext): Promise<CommandResult> => 
   // was always undefined and silently no-op'd — every user with the flag
   // set still got `~/.claude/CLAUDE.md` modified. Read the real key.
   const noGlobal = ctx.flags['no-global'] === true || ctx.flags['global'] === false;
-  const allAgents = ctx.flags['all-agents'] as boolean;
-  const cloudMcp = ctx.flags['cloud-mcp'] as boolean;
+  const allAgents = ctx.flags.allAgents as boolean;
+  const cloudMcp = ctx.flags.cloudMcp as boolean;
   const cwd = ctx.cwd;
 
   // Check if already initialized


### PR DESCRIPTION
## Summary

- `ruflo init --all-agents`, `--skip-claude`, `--only-claude`, and `--cloud-mcp` were silent no-ops. Root cause, exactly as diagnosed in #2952: every long-flag write path in `parser.ts` runs through `normalizeKey()`, converting kebab-case to camelCase before storing (`--all-agents` → `flags.allAgents`) — there is no code path that ever stores the literal kebab-case key. `initClaudeAction` (`commands/init.ts`) read `ctx.flags['all-agents']` etc., which the parser never produces, so all four reads were always `undefined`.
- Same bug class the code already fixed for `--no-global` (#2098A, five lines above in the same function) — the fix pattern (read the real normalized key) was never applied to these sibling flags.
- Fixed by reading `ctx.flags.allAgents`, `ctx.flags.skipClaude`, `ctx.flags.onlyClaude`, `ctx.flags.cloudMcp`.

## Test plan

- [x] New regression test (`__tests__/init-kebab-flags-2952.test.ts`), black-box against the real built CLI: `init --force` (default) vs `init --force --all-agents` in separate fresh temp dirs, asserts the `--all-agents` run installs strictly more agent files. Verified A/B via git stash: pre-fix both runs install the same 17-agent curated set (`expected 17 to be greater than 17`), post-fix `--all-agents` installs the full 89-agent catalog.
- [x] `npm run build` (tsc) clean
- [x] Manually confirmed the counts match the reporter's own repro shape (curated ~17-24 agent subset vs full catalog).

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)