### PR TITLE
fix(hooks): await the ADR-130 reinforced-by graph edge write (#2961)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-post-task-graph-edge-2961.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-post-task-graph-edge-2961.test.ts
@@ -1,0 +1,62 @@
+/**
+ * #2961: `ruflo hooks post-task` (CLI) reliably dropped the ADR-130 Phase 3
+ * "reinforced-by" graph edge that the identical `hooks_post-task` MCP tool
+ * handler writes when invoked from a long-running MCP server.
+ *
+ * Root cause: the edge write was a fire-and-forget async IIFE, never
+ * `await`ed by the handler. The long-running MCP server stays alive long
+ * enough for the detached write to finish in the background — invisible
+ * there. But `hooks post-task` (CLI) is the exact same handler, invoked
+ * from a one-shot process that calls `process.exit(0)` immediately after
+ * the command action resolves (bin/cli.js, #1552) — the still-pending
+ * dynamic `import(...)` + `insertGraphEdge()` call was killed before its
+ * first tick, every time, not intermittently.
+ *
+ * Fixed by awaiting the write in `mcp-tools/hooks-tools.ts`'s post-task
+ * handler.
+ *
+ * Verification pitfall this test deliberately avoids: an sql.js read of the
+ * main `.swarm/memory.db` image file misses rows that landed in the
+ * `-wal` sidecar and haven't been checkpointed back yet — a native
+ * better-sqlite3 read (what `countGraphEdges` uses) sees them correctly.
+ * Reading via sql.js here would produce a false "still 0 edges" negative
+ * even against the fixed code, masking the fix as broken.
+ *
+ * Black-box against the real built CLI (matches this session's other
+ * end-to-end regression tests) because the bug is specifically about the
+ * one-shot-process exit race, which only a real spawned process exhibits.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const CLI_BIN = fileURLToPath(new URL('../bin/cli.js', import.meta.url));
+const CLI_BUILT = existsSync(CLI_BIN);
+
+describe.skipIf(!CLI_BUILT)('#2961 hooks post-task (CLI) writes the reinforced-by edge', () => {
+  it('a successful CLI post-task call leaves a graph_edges row behind, not just a trajectory', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'ruflo-2961-'));
+    try {
+      execFileSync(process.execPath, [CLI_BIN, 'memory', 'init'], { cwd, timeout: 30_000, stdio: 'pipe' });
+      execFileSync(
+        process.execPath,
+        [CLI_BIN, 'hooks', 'post-task', '--task-id', 'quenzibar2961', '--success', 'true', '-q', '0.9'],
+        { cwd, timeout: 30_000, stdio: 'pipe' },
+      );
+
+      const { _resetBridgeDb, countGraphEdges } = await import('../src/memory/graph-edge-writer.js');
+      _resetBridgeDb();
+      const dbPath = join(cwd, '.swarm', 'memory.db');
+      const count = await countGraphEdges(dbPath);
+
+      // Pre-fix: the CLI process exits before the detached write's first
+      // await resolves — this is exactly 0 every time, not flaky.
+      expect(count).toBeGreaterThan(0);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -1515,25 +1515,35 @@ export const hooksPostTask: MCPTool = {
       // Intelligence module not available — non-fatal
     }
 
-    // ADR-130 Phase 3: fire-and-forget "reinforced-by" edge on task success
+    // ADR-130 Phase 3: "reinforced-by" edge on task success.
     // Writes: context node → task pattern node (relation: "reinforced-by")
+    //
+    // #2961 — this used to be fire-and-forget (no `await` on the IIFE). That
+    // was invisible from the long-running MCP server, where the process
+    // stays alive long enough for the detached write to finish in the
+    // background. But `hooks post-task` (CLI) is the exact same handler
+    // invoked from a one-shot process that calls `process.exit(0)`
+    // immediately after this action resolves (bin/cli.js, #1552) — the
+    // still-pending dynamic `import(...)` + `insertGraphEdge()` call was
+    // killed before its first tick, so the CLI form dropped this edge on
+    // every single success, not intermittently. Await it — this is a
+    // single fast DB write, not worth losing correctness on one call site
+    // to save latency on the other.
     if (success) {
-      (async () => {
-        try {
-          const { insertGraphEdge } = await import('../memory/graph-edge-writer.js');
-          const sessionCtxId = `task:${taskId}`;
-          const patternId = `pattern:${taskId}`;
-          await insertGraphEdge({
-            sourceId: sessionCtxId,
-            targetId: patternId,
-            relation: 'reinforced-by',
-            weight: quality,
-            confidence: quality,
-            lastReinforced: new Date().toISOString(),
-            metadata: { success, agent, taskId },
-          });
-        } catch { /* non-fatal */ }
-      })().catch(() => {});
+      try {
+        const { insertGraphEdge } = await import('../memory/graph-edge-writer.js');
+        const sessionCtxId = `task:${taskId}`;
+        const patternId = `pattern:${taskId}`;
+        await insertGraphEdge({
+          sourceId: sessionCtxId,
+          targetId: patternId,
+          relation: 'reinforced-by',
+          weight: quality,
+          confidence: quality,
+          lastReinforced: new Date().toISOString(),
+          metadata: { success, agent, taskId },
+        });
+      } catch { /* non-fatal */ }
     }
 
     // Persist routing outcome for runtime learning (file-based, always reliable)


### PR DESCRIPTION
## Summary

- `ruflo hooks post-task` (CLI) and the `hooks_post-task` MCP tool are the same handler — the CLI command calls `callMCPTool('hooks_post-task', …)`, which invokes the identical registered tool. So this isn't a two-implementations bug.
- The actual defect, exactly as diagnosed in #2961: the ADR-130 Phase 3 "reinforced-by" graph edge write inside the handler was a fire-and-forget async IIFE the handler never `await`ed. Invisible from the long-running MCP server (the process stays alive long enough for the detached write to finish in the background). But `hooks post-task` (CLI) is the exact same handler invoked from a one-shot process that calls `process.exit(0)` immediately after the command action resolves (`bin/cli.js`, #1552) — the still-pending dynamic `import(...)` + `insertGraphEdge()` call was killed before its first tick, every time, not intermittently.
- Fixed by awaiting the write. A single fast DB write isn't worth losing correctness on the CLI call site to save a small amount of latency on the MCP server call site.

## Test plan

- [x] New regression test (`__tests__/hooks-post-task-graph-edge-2961.test.ts`), black-box against the real built CLI: `memory init` → `hooks post-task --success true` → asserts `graph_edges` has at least one row, read via the exported `countGraphEdges()` (native better-sqlite3, WAL-safe — deliberately not sql.js, which reads only the main DB image and would falsely report 0 rows still sitting in the `-wal` sidecar even against the fixed code; I hit exactly this false negative once while investigating before switching the verification method). Verified A/B via git stash: pre-fix consistently `expected 0 to be greater than 0`, post-fix passes.
- [x] `npm run build` (tsc) clean
- [x] Manually reproduced and confirmed both the original 0-edges symptom (pre-fix) and its resolution (post-fix) against real DB reads.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)