### PR TITLE
fix(ruflo-adr): skip .brain when walking for ADRs (#2911)

### DIFF
--- a/plugins/ruflo-adr/scripts/__tests__/skip-brain-dir-2911.test.mjs
+++ b/plugins/ruflo-adr/scripts/__tests__/skip-brain-dir-2911.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { SKIP_DIRS, findAdrs } from '../lib/parse-adrs.mjs';
+
+// #2911: ruvnet-brain clones ~50 external repos under `.brain/repo/clones/`,
+// many with their own docs/adr/. Without `.brain` in SKIP_DIRS, findAdrs()
+// walks into those clones and returns hundreds of foreign ADRs alongside
+// the project's own — and since `.brain` sorts before `docs`, the
+// project's ADRs land at the end of the walk, dead last.
+
+test('SKIP_DIRS includes .brain', () => {
+  assert.ok(SKIP_DIRS.has('.brain'));
+});
+
+test('findAdrs does not descend into .brain', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ruflo-adr-2911-'));
+  try {
+    // Project's own ADR
+    mkdirSync(join(root, 'docs', 'adr'), { recursive: true });
+    writeFileSync(join(root, 'docs', 'adr', 'ADR-001-real.md'), '# ADR-001\n');
+
+    // A foreign clone under .brain with its own docs/adr/
+    mkdirSync(join(root, '.brain', 'repo', 'clones', 'some-external-repo', 'docs', 'adr'), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(root, '.brain', 'repo', 'clones', 'some-external-repo', 'docs', 'adr', 'ADR-999-foreign.md'),
+      '# ADR-999\n',
+    );
+
+    const found = findAdrs(root);
+    const names = found.map((p) => p.split('/').pop());
+
+    assert.deepEqual(names, ['ADR-001-real.md']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/plugins/ruflo-adr/scripts/lib/parse-adrs.mjs
+++ b/plugins/ruflo-adr/scripts/lib/parse-adrs.mjs
@@ -12,7 +12,15 @@ import { join, basename } from 'node:path';
 // #2474 bonus: `.claude/worktrees/*` mirrors the repo so every ADR was
 // indexed 2-3x. Skip the whole `.claude` tree — it's all ruflo runtime
 // state (worktrees, scheduled tasks, etc.), never authored content.
-export const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'v2', '.next', '.turbo', 'build', '.claude']);
+//
+// #2911: `.brain` is ruvnet-brain's own tree, holding shallow clones of
+// ~50 external repos under `.brain/repo/clones/` — many carrying their
+// own `docs/adr/`. Left unskipped, a walk from the project root picks up
+// every foreign ADR (measured: 1,415 foreign vs 19 belonging to the
+// project) and, because `.brain` sorts before `docs`, the project's own
+// ADRs land dead last in the walk order — an interrupted run can index
+// hundreds of foreign ADRs and zero of the project's.
+export const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'v2', '.next', '.turbo', 'build', '.claude', '.brain']);
 
 // #2474 Bug 4: parseId padded ADR numbers, but extractAdrRefs's
 // padStart-then-strip pipeline produced different results for the same

--- a/plugins/ruflo-adr/scripts/smoke.sh
+++ b/plugins/ruflo-adr/scripts/smoke.sh
@@ -180,8 +180,12 @@ ADR="$ROOT/docs/adrs/0002-reconcile-deleted-adrs.md"
 # 22. Behavioral contracts for #2660/#2659/#2651
 step "22. ADR indexing + adr-create regression contracts"
 TEST_DIR="$ROOT/scripts/__tests__"
+# #2911: was `-eq 3`, hard-coding the exact file count at the time this
+# step was written — every later addition to __tests__/ broke it even
+# though the new tests themselves passed. `-ge 3` keeps the "regression
+# tests actually exist and run" guarantee without re-breaking on growth.
 test_count=$(find "$TEST_DIR" -maxdepth 1 -name '*.test.mjs' 2>/dev/null | wc -l | tr -d ' ')
-[[ "$test_count" -eq 3 ]] && node --test "$TEST_DIR"/*.test.mjs >/dev/null 2>&1 \
+[[ "$test_count" -ge 3 ]] && node --test "$TEST_DIR"/*.test.mjs >/dev/null 2>&1 \
   && ok || bad "contract tests failed (run: node --test $TEST_DIR/*.test.mjs)"
 
 printf "\n%s passed, %s failed\n" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- `plugins/ruflo-adr/scripts/lib/parse-adrs.mjs`'s `SKIP_DIRS` omitted `.brain`. ruvnet-brain clones ~50 external repos under `.brain/repo/clones/`, many carrying their own `docs/adr/`. A walk from the project root over `.brain` swept in every foreign ADR (reporter measured 1,415 foreign vs 19 belonging to the project) — and since `.brain` sorts before `docs`, the project's own ADRs landed dead last in the walk order, so an interrupted run could index hundreds of foreign ADRs and zero of the project's own.
- Fixed by adding `.brain` to `SKIP_DIRS`, matching the same reasoning already applied to `.claude` (#2474 bonus, same file).

## Test plan

- [x] New regression test (`scripts/__tests__/skip-brain-dir-2911.test.mjs`, plain `node:test` matching this plugin's existing test convention): asserts `SKIP_DIRS.has('.brain')`, and that `findAdrs()` over a tree with both a real project ADR and a foreign one nested under `.brain/repo/clones/.../docs/adr/` returns only the real one. Verified A/B via git stash: pre-fix returns both (foreign first, project's own pushed to the end — matching the reported ordering symptom exactly), post-fix returns only the project's own.
- [x] `node --test` passes clean.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)