### PR TITLE
fix(github-tools): pass --repo to gh in github_issue_track (#2963)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/github-issue-track-repo-flag-2963.test.ts
+++ b/v3/@claude-flow/cli/__tests__/github-issue-track-repo-flag-2963.test.ts
@@ -1,0 +1,81 @@
+/**
+ * #2963: `github_issue_track`'s `create`/`update`/`close`/`list` actions
+ * validated the caller-supplied `owner`/`repo` but never passed them to
+ * `gh` — every invocation silently resolved the target repository from
+ * the current working directory's git remote instead of the repository
+ * the caller actually asked for.
+ *
+ * Fixed by appending `--repo <owner>/<repo>` to the `gh` argv whenever
+ * both are supplied.
+ *
+ * Mocks `node:child_process` directly (not the shared mocks in
+ * mcp-tools-deep.test.ts, which stub `execSync` generically but not
+ * `execFileSync`) so this test can assert the exact argv `runArgv`
+ * passes to `gh`, matching the pattern in github-tools-injection.test.ts
+ * for the same file.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileSyncMock = vi.fn();
+const execSyncMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+  execSync: (...args: unknown[]) => execSyncMock(...args),
+}));
+
+describe('#2963 github_issue_track passes --repo to gh', () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    execSyncMock.mockReset();
+    // hasGhCli() calls run('gh --version') -> execSync — must succeed so
+    // the tool takes the real-gh-cli branch instead of falling to
+    // local-store, where this bug doesn't manifest.
+    execSyncMock.mockReturnValue('gh version 2.0.0');
+  });
+
+  it('create appends --repo owner/repo when both are supplied', async () => {
+    const { githubTools } = await import('../src/mcp-tools/github-tools.js');
+    const tool = githubTools.find((t) => t.name === 'github_issue_track')!;
+
+    execFileSyncMock.mockReturnValue('https://github.com/acme/widgets/issues/42');
+
+    await tool.handler({
+      action: 'create',
+      owner: 'acme',
+      repo: 'widgets',
+      title: 'Test issue',
+      body: 'Body',
+    });
+
+    expect(execFileSyncMock).toHaveBeenCalled();
+    const [, argv] = execFileSyncMock.mock.calls[0] as [string, string[]];
+    expect(argv).toContain('--repo');
+    expect(argv[argv.indexOf('--repo') + 1]).toBe('acme/widgets');
+  });
+
+  it('create omits --repo when owner/repo are not supplied (falls back to cwd remote)', async () => {
+    const { githubTools } = await import('../src/mcp-tools/github-tools.js');
+    const tool = githubTools.find((t) => t.name === 'github_issue_track')!;
+
+    execFileSyncMock.mockReturnValue('https://github.com/whatever/here/issues/1');
+
+    await tool.handler({ action: 'create', title: 'Test issue', body: 'Body' });
+
+    const [, argv] = execFileSyncMock.mock.calls[0] as [string, string[]];
+    expect(argv).not.toContain('--repo');
+  });
+
+  it('close appends --repo owner/repo when both are supplied', async () => {
+    const { githubTools } = await import('../src/mcp-tools/github-tools.js');
+    const tool = githubTools.find((t) => t.name === 'github_issue_track')!;
+
+    execFileSyncMock.mockReturnValue('');
+
+    await tool.handler({ action: 'close', owner: 'acme', repo: 'widgets', issueNumber: 42 });
+
+    const [, argv] = execFileSyncMock.mock.calls[0] as [string, string[]];
+    expect(argv).toContain('--repo');
+    expect(argv[argv.indexOf('--repo') + 1]).toBe('acme/widgets');
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/github-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/github-tools.ts
@@ -370,10 +370,17 @@ export const githubTools: MCPTool[] = [
       const store = loadGitHubStore();
       const action = (input.action as string) || 'list';
       const gh = hasGhCli();
+      // #2963 — owner/repo were validated but never passed to `gh`, so `gh`
+      // silently resolved the target repo from the cwd's git remote instead
+      // of the caller-specified one. `gh` accepts `--repo owner/repo` on
+      // every issue subcommand used here.
+      const owner = input.owner as string | undefined;
+      const repo = input.repo as string | undefined;
+      const repoArgs: string[] = owner && repo ? ['--repo', `${owner}/${repo}`] : [];
 
       if (action === 'list') {
         if (gh) {
-          const raw = run('gh issue list --state all --limit 20 --json number,title,state,labels,createdAt');
+          const raw = runArgv('gh', ['issue', 'list', '--state', 'all', '--limit', '20', '--json', 'number,title,state,labels,createdAt', ...repoArgs]);
           if (raw) {
             try {
               const issues = JSON.parse(raw);
@@ -393,7 +400,7 @@ export const githubTools: MCPTool[] = [
         // outside [A-Za-z0-9 _\-./] and caps each label at 64 chars.
         const labels = sanitizeLabels(input.labels) ?? [];
         if (gh) {
-          const argv = ['issue', 'create', '--title', title, '--body', body];
+          const argv = ['issue', 'create', '--title', title, '--body', body, ...repoArgs];
           if (labels.length > 0) {
             argv.push('--label', labels.join(','));
           }
@@ -420,7 +427,7 @@ export const githubTools: MCPTool[] = [
             if (labels.length > 0) argv.push('--add-label', labels.join(','));
           }
           if (argv.length > 3) {
-            const result = runArgv('gh', argv);
+            const result = runArgv('gh', [...argv, ...repoArgs]);
             if (result !== null) return { success: true, _real: true, action: 'updated', issueNumber };
           }
         }
@@ -439,7 +446,7 @@ export const githubTools: MCPTool[] = [
       if (action === 'close') {
         const issueNumber = toPositiveInt(input.issueNumber);
         if (gh && issueNumber) {
-          const result = runArgv('gh', ['issue', 'close', String(issueNumber)]);
+          const result = runArgv('gh', ['issue', 'close', String(issueNumber), ...repoArgs]);
           if (result !== null) return { success: true, _real: true, action: 'closed', issueNumber, closedAt: new Date().toISOString() };
         }
         const issueKey = issueNumber ? Object.keys(store.issues).find(k => k.includes(String(issueNumber))) : undefined;


### PR DESCRIPTION
## Summary

- `github_issue_track`'s `list`/`create`/`update`/`close` actions validated the caller-supplied `owner`/`repo` inputs but never passed them to the `gh` invocation — `gh` silently resolved the target repository from the current working directory's git remote instead. A caller supplying `owner`/`repo` expecting the operation to target that specific repository had no guarantee it did, even on the "real", `gh`-backed success path.
- Fixed by appending `--repo <owner>/<repo>` to the `gh` argv whenever both are supplied. Falls back to `gh`'s own cwd-remote resolution (unchanged behavior) when either is omitted.
- Also switched `list`'s shell-string `run()` call to the argv-based `runArgv()` for consistency with the other three actions in this same tool (no shell interpretation of any part of the command).

Scoped to exactly this: didn't touch the report's secondary ask (making the `_real`/`source: 'local-store'` distinction more discoverable via a documented output schema) since that's more of an API-contract addition than a bug fix, and changing `success` semantics on the fallback path risks breaking existing callers that already branch on the current shape.

## Test plan

- [x] New regression test (`__tests__/github-issue-track-repo-flag-2963.test.ts`), mocking `node:child_process` directly (the existing global mock in `mcp-tools-deep.test.ts` stubs `execSync` but not `execFileSync`, which this fix's `--repo` flag needs to be visible on): asserts `create` and `close` append `--repo owner/repo` to the argv passed to `gh` when both are supplied, and that `create` omits `--repo` when they aren't (preserving the existing cwd-remote fallback). Verified A/B via git stash: pre-fix `create`/`close` assertions fail (`expected [...] to include '--repo'`), post-fix all 3 pass.
- [x] `npm run build` (tsc) clean.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)