### PR TITLE
fix(security): loosen Stripe/OpenAI secret regex boundaries (#2931)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/security-scan-secret-regex-2931.test.ts
+++ b/v3/@claude-flow/cli/__tests__/security-scan-secret-regex-2931.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #2931: `security scan`'s hardcoded-secret regex for Stripe/OpenAI-shaped
+ * keys (`sk-`/`sk_live_`/`sk_test_`) had two false-negative gaps:
+ *
+ * 1. Required 20+ chars after the prefix — missed shorter-but-real keys
+ *    like `sk-1234567890abcdef` (16 chars).
+ * 2. Required a quote literally adjacent to the prefix (`['"]sk-...['"]`)
+ *    — missed the extremely common `Authorization: "Bearer sk_live_..."`
+ *    shape, where the quote sits next to "Bearer", not the key.
+ *
+ * Fixed with lookaround boundaries instead of a length floor + quote
+ * anchor, so the prefix matches as a standalone token wherever it
+ * appears. Black-box against the real built CLI (same pattern as
+ * security-scan-persistence.test.ts) — reconstructing CommandContext by
+ * hand isn't done anywhere else in this repo's tests.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const CLI_BIN = fileURLToPath(new URL('../bin/cli.js', import.meta.url));
+
+let scanTarget: string;
+
+beforeEach(() => {
+  scanTarget = mkdtempSync(join(tmpdir(), 'security-scan-secret-regex-'));
+  writeFileSync(
+    join(scanTarget, 'package.json'),
+    JSON.stringify({ name: 'security-scan-secret-regex-fixture', version: '1.0.0' }),
+  );
+  writeFileSync(
+    join(scanTarget, 'config.ts'),
+    [
+      "const API_KEY = 'sk-1234567890abcdef';",
+      'const headers = { Authorization: "Bearer sk_live_51234567890abcdef" };',
+    ].join('\n'),
+  );
+});
+
+afterEach(() => {
+  rmSync(scanTarget, { recursive: true, force: true });
+});
+
+describe('#2931 security scan catches shorter/embedded Stripe-shaped secrets', () => {
+  it('flags both repro shapes as "API Key (Stripe/OpenAI)" findings', () => {
+    // Finding real HIGH-severity secrets makes the command exit non-zero
+    // (security.ts: `success: criticalCount === 0 && highCount === 0`) —
+    // that's expected here, the persisted report is what this test checks.
+    try {
+      execFileSync(
+        process.execPath,
+        [CLI_BIN, 'security', 'scan', '--target', scanTarget, '--depth', 'standard', '--type', 'code'],
+        { encoding: 'utf-8', timeout: 30_000 },
+      );
+    } catch { /* non-zero exit expected when secrets are found */ }
+
+    const outFile = join(scanTarget, '.claude', 'security-scans', 'scan-code-standard.json');
+    expect(existsSync(outFile)).toBe(true);
+    const record = JSON.parse(readFileSync(outFile, 'utf-8'));
+
+    const stripeFindings = record.findings.filter(
+      (f: { description: string }) => f.description === 'API Key (Stripe/OpenAI)',
+    );
+    // Pre-fix: 0 — neither line matched (one too short, one quote-detached).
+    expect(stripeFindings.length).toBe(2);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/security.ts
+++ b/v3/@claude-flow/cli/src/commands/security.ts
@@ -192,7 +192,14 @@ const scanCommand: Command = {
       if (scanType === 'all' || scanType === 'code') {
         spinner.setText('Scanning for hardcoded secrets...');
         const secretPatterns = [
-          { pattern: /['"](?:sk-|sk_live_|sk_test_)[a-zA-Z0-9]{20,}['"]/g, type: 'API Key (Stripe/OpenAI)' },
+          // #2931: was `['"](?:sk-|...)...{20,}['"]` — the 20-char floor
+          // missed shorter-but-real keys like `sk-1234567890abcdef` (16
+          // chars), and the quote-adjacency anchor required a quote
+          // literally next to the prefix, missing the extremely common
+          // `Authorization: "Bearer sk_live_..."` shape where the quote
+          // sits next to "Bearer", not the key. Lookaround boundaries
+          // match the prefix wherever it appears as a standalone token.
+          { pattern: /(?<![a-zA-Z0-9_])(?:sk-|sk_live_|sk_test_)[a-zA-Z0-9]{10,}(?![a-zA-Z0-9_])/g, type: 'API Key (Stripe/OpenAI)' },
           { pattern: /['"]AKIA[A-Z0-9]{16}['"]/g, type: 'AWS Access Key' },
           { pattern: /['"]ghp_[a-zA-Z0-9]{36}['"]/g, type: 'GitHub Token' },
           { pattern: /['"]xox[baprs]-[a-zA-Z0-9-]+['"]/g, type: 'Slack Token' },
@@ -834,7 +841,7 @@ const secretsCommand: Command = {
       { pattern: /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, type: 'JWT Token', risk: 'High', action: 'Remove from source' },
       { pattern: /-----BEGIN (?:RSA|EC|DSA|OPENSSH) PRIVATE KEY-----/g, type: 'Private Key', risk: 'Critical', action: 'Remove and regenerate' },
       { pattern: /(?:mongodb|postgres|mysql|redis):\/\/[^\s'"]+/g, type: 'Connection String', risk: 'High', action: 'Use env variable' },
-      { pattern: /['"](?:sk-|sk_live_|sk_test_)[a-zA-Z0-9]{20,}['"]/g, type: 'API Key (Stripe/OpenAI)', risk: 'Critical', action: 'Rotate immediately' },
+      { pattern: /(?<![a-zA-Z0-9_])(?:sk-|sk_live_|sk_test_)[a-zA-Z0-9]{10,}(?![a-zA-Z0-9_])/g, type: 'API Key (Stripe/OpenAI)', risk: 'Critical', action: 'Rotate immediately' },
       { pattern: /['"]xox[baprs]-[a-zA-Z0-9-]+['"]/g, type: 'Slack Token', risk: 'High', action: 'Revoke and rotate' },
       { pattern: /[a-zA-Z0-9_-]*(?:api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token|private[_-]?key)\s*[:=]\s*['"][^'"]{8,}['"]/gi, type: 'Generic Secret/API Key', risk: 'High', action: 'Use env variable' },
       { pattern: /(?:password|passwd|pwd)\s*[:=]\s*['"][^'"]{8,}['"]/gi, type: 'Hardcoded Password', risk: 'High', action: 'Use secrets manager' },


### PR DESCRIPTION
## Summary

- `security scan`'s hardcoded-secret regex for Stripe/OpenAI-shaped keys had two false-negative gaps, both confirmed reproducible:
  1. Required 20+ chars after the `sk-`/`sk_live_`/`sk_test_` prefix — missed shorter-but-real keys like `sk-1234567890abcdef` (16 chars).
  2. Required a quote character literally adjacent to the prefix — missed the very common `Authorization: "Bearer sk_live_..."` shape, where the quote sits next to "Bearer", not the key.
- Fixed by replacing the quote-anchor + length-floor with lookaround word-boundaries (`(?<![a-zA-Z0-9_])...(?![a-zA-Z0-9_])`) and a lower length floor (10 vs 20) — matches the prefix as a standalone token wherever it appears, while still requiring a non-trivial payload to avoid matching a bare prefix substring inside an identifier (verified: `my_sk_test_variable_name` does NOT match).
- Scoped to exactly the reported pattern (both duplicate copies of it in this file — `security.ts` has two independent scan functions with their own `secretPatterns` arrays). Left AWS/GitHub/Slack/password patterns untouched since they weren't reported/repro'd, even though some share a similar limitation.

## Test plan

- [x] New regression test (`__tests__/security-scan-secret-regex-2931.test.ts`), black-box against the real built CLI (same pattern as `security-scan-persistence.test.ts`): scans a fixture containing both exact repro lines, asserts the persisted scan report contains 2 "API Key (Stripe/OpenAI)" findings. Verified A/B via git stash + rebuild: pre-fix 0 findings (`expected +0 to be 2`), post-fix 2.
- [x] Manually verified the new regex against both repro strings plus a false-positive guard case (a longer identifier containing `sk_test_` as a substring correctly does NOT match).
- [x] `npm run build` (tsc) clean.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)