### PR TITLE
fix(codex): close worker stdin so codex exec doesn't hang waiting for EOF (#2947)

### DIFF
--- a/v3/@claude-flow/codex/src/dual-mode/orchestrator.ts
+++ b/v3/@claude-flow/codex/src/dual-mode/orchestrator.ts
@@ -231,6 +231,14 @@ export class DualModeOrchestrator extends EventEmitter {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
+      // #2947: both platforms receive their prompt positionally/via flag
+      // (never over stdin), but the pipe is left open. `claude -p` ignores
+      // an open stdin, so this was invisible in practice — `codex exec`
+      // instead blocks in resolve_root_prompt waiting for stdin EOF that
+      // never comes, hanging every real Codex worker until the orchestrator's
+      // own timeout kills it.
+      proc.stdin?.end();
+
       this.processes.set(config.id, proc);
 
       proc.stdout?.on('data', (data) => {

--- a/v3/@claude-flow/codex/tests/dual-mode-stdin-2947.test.ts
+++ b/v3/@claude-flow/codex/tests/dual-mode-stdin-2947.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @claude-flow/codex - #2947 regression test
+ *
+ * DualModeOrchestrator spawned Codex workers with stdio: ['pipe', 'pipe', 'pipe']
+ * but never wrote to or closed proc.stdin. The prompt is already passed
+ * positionally, so `codex exec` (which blocks in resolve_root_prompt reading
+ * stdin to EOF) hung forever until the orchestrator's own timeout killed it.
+ *
+ * This spawns a real child process standing in for `codex exec`: it does
+ * nothing but wait for stdin EOF before exiting. Without the fix the worker
+ * never receives EOF and the orchestrator's short configured timeout fires,
+ * failing the worker. With the fix (`proc.stdin?.end()`), EOF arrives
+ * immediately and the worker completes well under the timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DualModeOrchestrator } from '../src/dual-mode/index.js';
+import type { WorkerConfig } from '../src/dual-mode/index.js';
+
+describe('DualModeOrchestrator #2947 — codex worker stdin EOF', () => {
+  it('completes a worker that blocks waiting for stdin EOF, within a short timeout', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ruflo-2947-'));
+    const fakeCodex = join(dir, 'fake-codex.mjs');
+    // Stands in for `codex exec`: waits for stdin EOF, then prints and exits 0.
+    // If stdin is never closed, this process hangs until killed.
+    writeFileSync(
+      fakeCodex,
+      "#!/usr/bin/env node\nprocess.stdin.resume();\nprocess.stdin.on('end', () => { process.stdout.write('done'); process.exit(0); });\n",
+    );
+    chmodSync(fakeCodex, 0o755);
+
+    const orchestrator = new DualModeOrchestrator({
+      projectPath: dir,
+      codexCommand: fakeCodex,
+      timeout: 3000,
+    });
+
+    const worker: WorkerConfig = { id: 'w1', platform: 'codex', role: 'coder', prompt: 'irrelevant' };
+
+    const events: string[] = [];
+    orchestrator.on('worker:started', () => events.push('started'));
+    orchestrator.on('worker:completed', () => events.push('completed'));
+    orchestrator.on('worker:failed', () => events.push('failed'));
+
+    const start = Date.now();
+    await orchestrator.spawnWorker(worker);
+    const elapsed = Date.now() - start;
+
+    expect(events).toEqual(['started', 'completed']);
+    // Should resolve almost instantly via EOF, nowhere near the 3s timeout.
+    expect(elapsed).toBeLessThan(1500);
+
+    rmSync(dir, { recursive: true, force: true });
+  }, 5000);
+});


### PR DESCRIPTION
## Summary

`DualModeOrchestrator.executeHeadless()` spawns both Claude and Codex
workers with `stdio: ['pipe', 'pipe', 'pipe']` but never wrote to or
closed `proc.stdin`. Both platforms already receive their prompt
positionally/via a flag — never over stdin. `claude -p` ignores the
unused open pipe, but `codex exec` blocks in `resolve_root_prompt`
waiting for stdin EOF that never arrives, hanging every real Codex
worker until the orchestrator's own multi-minute timeout kills it.

Fix: `proc.stdin?.end()` immediately after spawn, for both platforms.

Reported with a full repro, root cause, and a tested minimal fix in #2947 — thank you.

## Test plan

- [x] New regression test spawns a real child process standing in for
      `codex exec` (waits for stdin EOF before printing+exiting) and
      asserts the worker completes well under a short configured
      timeout (175ms measured) rather than failing via timeout.
- [x] A/B via git-stash: reverting the fix reproduces the exact
      reported failure shape — `worker:started` → `worker:failed`
      (timeout) instead of `worker:started` → `worker:completed`.
- [x] Full `@claude-flow/codex` suite (239 tests) passes with the fix.

Closes #2947

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)