### PR TITLE
ci: retry npm ci to absorb sharp/libvips transient download flakes

### DIFF
--- a/.github/actions/npm-ci-retry/action.yml
+++ b/.github/actions/npm-ci-retry/action.yml
@@ -1,0 +1,40 @@
+name: 'npm ci with retry'
+description: >-
+  Runs `npm ci` with retries to absorb transient prebuilt-binary download
+  failures (observed repeatedly as sharp/libvips "socket hang up" / 503
+  errors from GitHub Releases during postinstall — unrelated to the PR's
+  own changes, and not fixed by npm's own package cache since the failing
+  request is a separate direct download, not an npm registry fetch).
+inputs:
+  args:
+    description: 'Extra flags to pass to npm ci'
+    required: false
+    default: '--legacy-peer-deps'
+  attempts:
+    description: 'Number of attempts before failing the step'
+    required: false
+    default: '3'
+  working-directory:
+    description: >-
+      Directory to run npm ci in. NOTE: working-directory on the calling
+      (uses:) step itself has no effect on a composite action's internal
+      run steps — GitHub rejects "working-directory cannot be used with
+      uses" at parse time — so it must be threaded through as an input.
+    required: false
+    default: '.'
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        n=0
+        max=${{ inputs.attempts }}
+        until [ "$n" -ge "$max" ]; do
+          npm ci ${{ inputs.args }} && exit 0
+          n=$((n + 1))
+          echo "npm ci failed (attempt $n/$max) — retrying in 15s (known transient prebuilt-binary download flake, e.g. sharp/libvips)"
+          [ "$n" -lt "$max" ] && sleep 15
+        done
+        echo "npm ci failed after $max attempts"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Run security audit
         run: |
@@ -70,7 +70,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Run all tests
         run: npm test || echo "⚠️ Some tests failed (Jest teardown issues - non-blocking)"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,7 +55,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Install SQLite3
         run: |
@@ -160,7 +160,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Download integration setup
         uses: actions/download-artifact@v4
@@ -309,7 +309,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Download integration setup
         uses: actions/download-artifact@v4
@@ -431,7 +431,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Test agent failure recovery
         run: |
@@ -559,7 +559,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Test multi-agent performance
         run: |

--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -710,8 +710,10 @@ jobs:
           node-version: '22'
 
       - name: Install plugin dependencies (npm — plugin is outside v3 workspace)
-        working-directory: plugins/ruflo-graph-intelligence
-        run: npm ci --no-audit --no-fund --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
+        with:
+          working-directory: plugins/ruflo-graph-intelligence
+          args: --no-audit --no-fund --legacy-peer-deps
 
       - name: Type-check
         working-directory: plugins/ruflo-graph-intelligence
@@ -758,8 +760,10 @@ jobs:
           node-version: '22'
 
       - name: Install ruflo-graph-intelligence deps (for npm audit)
-        working-directory: plugins/ruflo-graph-intelligence
-        run: npm ci --no-audit --no-fund --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
+        with:
+          working-directory: plugins/ruflo-graph-intelligence
+          args: --no-audit --no-fund --legacy-peer-deps
 
       - name: Install @claude-flow/browser deps (for npm audit)
         working-directory: v3/@claude-flow/browser
@@ -876,7 +880,7 @@ jobs:
           node-version: '22'
 
       - name: Install root dependencies (provides @noble/ed25519 for Case 3)
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Drive precondition + built-tree shapes through verify.mjs
         shell: bash

--- a/.github/workflows/verification-pipeline.yml
+++ b/.github/workflows/verification-pipeline.yml
@@ -51,7 +51,7 @@ jobs:
           echo "cache-key=${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -87,7 +87,7 @@ jobs:
           key: ${{ needs.setup-verification.outputs.cache-key }}
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Security audit
         run: |
@@ -140,7 +140,7 @@ jobs:
           key: ${{ needs.setup-verification.outputs.cache-key }}
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: ESLint code analysis
         run: |
@@ -255,7 +255,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Build CLI package
         run: |
@@ -330,7 +330,7 @@ jobs:
       # while `download-artifact@v3` returned a warning; @v4 makes it a
       # hard error and surfaces this as a failure. Build locally instead.
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: ./.github/actions/npm-ci-retry
 
       - name: Build CLI for benchmarks
         run: |


### PR DESCRIPTION
## Summary

`npm ci` intermittently fails during `sharp`'s postinstall with
`Installation error: socket hang up` fetching a prebuilt `libvips`
binary directly from GitHub Releases. This is outside npm's own
package cache (a separate HTTPS download, not a registry fetch), so
`actions/setup-node`'s `cache: npm` doesn't help at all.

Confirmed on at least 8 unrelated PRs across this session — #2988,
#2989, #2991, #2994, #2995, #2996, #2997, and jobs on this PR's own
first CI run — always on unrelated code changes, always fixed by a
manual `gh run rerun --failed`. Worth fixing once instead of
babysitting every PR's CI.

## Change

- New local composite action `.github/actions/npm-ci-retry`: retries
  `npm ci` up to 3 attempts with a 15s backoff before failing the step.
- Switched the 15 plain `npm ci --legacy-peer-deps` /
  `npm ci --no-audit --no-fund --legacy-peer-deps` call sites (across
  `ci.yml`, `integration-tests.yml`, `verification-pipeline.yml`,
  `v3-ci.yml`) to use it, including two that need a `working-directory`
  input (`plugins/ruflo-graph-intelligence`) — note `working-directory:`
  on the *outer* `uses:` step is rejected by GitHub Actions itself
  (`working-directory cannot be used with uses, with`), so those are
  threaded through as a composite-action input instead.

**Left untouched, deliberately:**
- `rollback-manager.yml`'s three `npm ci` calls — a separate, low-traffic
  rollback-validation path, not implicated in any of the observed flakes.
- The existing Linux/non-Linux `--omit=optional || --force` fallback
  blocks in `ci.yml` and `verification-pipeline.yml` — that's resilience
  for a different failure mode (optional native deps on macOS/Windows),
  not this one.

## Test plan

- [x] All 4 touched workflow files + the new action.yml parse as valid
      YAML (`python3 -c "import yaml; yaml.safe_load(open(f))"`).
- [x] Verified via GitHub Actions documentation + community discussions
      that `working-directory:` is rejected on `uses:` steps, and fixed
      the two plugin-install call sites to pass it as a composite-action
      input instead (caught before merge, not after a broken CI run).
- [x] This PR's own CI run exercises every touched call site.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)