### PR TITLE
fix(intelligence): same-ID content edits were cached/dropped instead of refreshed (#2920)

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -169,6 +169,20 @@ function fingerprintContent(text) {
   return `${h1.toString(16)}_${h2.toString(16)}_${norm.length}`;
 }
 
+// #2920 — aggregate content fingerprint for a whole store, used to detect
+// same-ID content edits (e.g. hand-editing a MEMORY.md section's body while
+// its heading/key, and therefore its generated ID, stays the same). Neither
+// entry count nor ID set changes on a same-ID edit, so any staleness check
+// based only on those two signals misses it; this folds each entry's own
+// content fingerprint into one combined value that does change.
+function storeFingerprint(entries) {
+  if (!entries || !entries.length) return '0';
+  const parts = entries
+    .map((e) => `${e.id || e.key || ''}:${fingerprintContent(e.content || e.summary || e.value || '')}`)
+    .sort();
+  return fingerprintContent(parts.join('|'));
+}
+
 function deduplicateByContent(entries) {
   if (!entries || !Array.isArray(entries)) return entries;
   const seen = new Map();
@@ -487,8 +501,14 @@ function init() {
     writeJSON(STORE_PATH, deduped);
   }
 
-  // Skip rebuild if graph is fresh and store hasn't changed
-  if (graphState && graphState.nodeCount === deduped.length) {
+  // Skip rebuild if graph is fresh and store hasn't changed. #2920: nodeCount
+  // alone doesn't detect a same-ID content edit (e.g. hand-editing a
+  // MEMORY.md section's body while its heading/key stays the same) — the
+  // count and ID set are unchanged, so a count-only check returns a stale
+  // cache hit and never refreshes ranked-context.json. Require the content
+  // fingerprint to match too.
+  const currentFingerprint = storeFingerprint(deduped);
+  if (graphState && graphState.nodeCount === deduped.length && graphState.contentFingerprint === currentFingerprint) {
     const age = Date.now() - (graphState.updatedAt || 0);
     if (age < 60000) {
       return {
@@ -532,6 +552,7 @@ function init() {
     version: 1,
     updatedAt: Date.now(),
     nodeCount: Object.keys(nodes).length,
+    contentFingerprint: currentFingerprint,
     nodes,
     edges,
     pageRanks,
@@ -847,8 +868,15 @@ function consolidate() {
     entries: rankedEntries,
   });
 
-  // 8. Persist updated store (deduped or with new insight entries)
-  if (newEntries > 0 || store.length < preDedupCount) writeJSON(STORE_PATH, store);
+  // 8. Persist updated store. #2920: this used to skip the write whenever
+  // dedup didn't shrink the array and no insight entries were added — but
+  // that's blind to a same-ID content edit (entry count and ID set both
+  // stay the same, only a field value changes), so an in-memory content
+  // update could be silently dropped instead of persisted. GRAPH_PATH and
+  // RANKED_PATH are rewritten unconditionally just above; writing the
+  // (already deduped, size-bounded per ADR-095 G6) store alongside them
+  // costs nothing near the <500ms budget and removes the whole bug class.
+  writeJSON(STORE_PATH, store);
 
   // 9. Save snapshot for delta tracking
   const updatedGraph = readJSON(GRAPH_PATH);

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -2,12 +2,12 @@
   "manifest": {
     "version": "3.38.5",
     "files": {
-      "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
+      "auto-memory-hook.mjs": "85fe05c757421c52137c0bc8545a0896bab6b4714538c2a11d1d0835bfcc8c1c",
       "hook-handler.cjs": "dae295fb9ae2626b89899c19a20cc911541af82b52d2eeb9b214d618b96e9a86",
       "intelligence.cjs": "66d63fdeab5f2ce0546bff80e69144911508fa2bf88f7b167ba0905762ecb314",
       "statusline.cjs": "0457fe53f8cd2c56458ff178392536a5868efd1a573665fa43bc01d2d95ca677"
     }
   },
-  "signature": "zYJ0v4rtRlzSERc3dan2I8BrYZZ9ESzOe29L5EiB2AXZx8TEOck3+nTQsbWzkZtCv4RP0EjMPTHk4VAJuF08Ag==",
+  "signature": "gn62A4tYOd3CtXZZIVfgZXhSLkZyz95CXU60I61R58dviABR9fLcBolD9jaZP9DiN7dxfc0co5lrfMW56CE6Dw==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest": {
-    "version": "3.34.0",
+    "version": "3.38.5",
     "files": {
       "auto-memory-hook.mjs": "68be7e9a9eba7bf9c4e8a230db7bf61a243b965639f8504842799d6c6ca28762",
       "hook-handler.cjs": "dae295fb9ae2626b89899c19a20cc911541af82b52d2eeb9b214d618b96e9a86",
-      "intelligence.cjs": "4e637e065b8f712ce6cf28cccab4244fe222dff2b984690d830bfc40d21fd050",
+      "intelligence.cjs": "66d63fdeab5f2ce0546bff80e69144911508fa2bf88f7b167ba0905762ecb314",
       "statusline.cjs": "0457fe53f8cd2c56458ff178392536a5868efd1a573665fa43bc01d2d95ca677"
     }
   },
-  "signature": "GyTvYvhL7vIta/4yyz1rIyl+DWJ+x4dJVfmcrKZJXlh4E/TcQK2bszRznlaG1o7LWSZTudaYj50w+/7dlv6lDg==",
+  "signature": "zYJ0v4rtRlzSERc3dan2I8BrYZZ9ESzOe29L5EiB2AXZx8TEOck3+nTQsbWzkZtCv4RP0EjMPTHk4VAJuF08Ag==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
@@ -169,6 +169,20 @@ function fingerprintContent(text) {
   return `${h1.toString(16)}_${h2.toString(16)}_${norm.length}`;
 }
 
+// #2920 — aggregate content fingerprint for a whole store, used to detect
+// same-ID content edits (e.g. hand-editing a MEMORY.md section's body while
+// its heading/key, and therefore its generated ID, stays the same). Neither
+// entry count nor ID set changes on a same-ID edit, so any staleness check
+// based only on those two signals misses it; this folds each entry's own
+// content fingerprint into one combined value that does change.
+function storeFingerprint(entries) {
+  if (!entries || !entries.length) return '0';
+  const parts = entries
+    .map((e) => `${e.id || e.key || ''}:${fingerprintContent(e.content || e.summary || e.value || '')}`)
+    .sort();
+  return fingerprintContent(parts.join('|'));
+}
+
 function deduplicateByContent(entries) {
   if (!entries || !Array.isArray(entries)) return entries;
   const seen = new Map();
@@ -487,8 +501,14 @@ function init() {
     writeJSON(STORE_PATH, deduped);
   }
 
-  // Skip rebuild if graph is fresh and store hasn't changed
-  if (graphState && graphState.nodeCount === deduped.length) {
+  // Skip rebuild if graph is fresh and store hasn't changed. #2920: nodeCount
+  // alone doesn't detect a same-ID content edit (e.g. hand-editing a
+  // MEMORY.md section's body while its heading/key stays the same) — the
+  // count and ID set are unchanged, so a count-only check returns a stale
+  // cache hit and never refreshes ranked-context.json. Require the content
+  // fingerprint to match too.
+  const currentFingerprint = storeFingerprint(deduped);
+  if (graphState && graphState.nodeCount === deduped.length && graphState.contentFingerprint === currentFingerprint) {
     const age = Date.now() - (graphState.updatedAt || 0);
     if (age < 60000) {
       return {
@@ -532,6 +552,7 @@ function init() {
     version: 1,
     updatedAt: Date.now(),
     nodeCount: Object.keys(nodes).length,
+    contentFingerprint: currentFingerprint,
     nodes,
     edges,
     pageRanks,
@@ -847,8 +868,15 @@ function consolidate() {
     entries: rankedEntries,
   });
 
-  // 8. Persist updated store (deduped or with new insight entries)
-  if (newEntries > 0 || store.length < preDedupCount) writeJSON(STORE_PATH, store);
+  // 8. Persist updated store. #2920: this used to skip the write whenever
+  // dedup didn't shrink the array and no insight entries were added — but
+  // that's blind to a same-ID content edit (entry count and ID set both
+  // stay the same, only a field value changes), so an in-memory content
+  // update could be silently dropped instead of persisted. GRAPH_PATH and
+  // RANKED_PATH are rewritten unconditionally just above; writing the
+  // (already deduped, size-bounded per ADR-095 G6) store alongside them
+  // costs nothing near the <500ms budget and removes the whole bug class.
+  writeJSON(STORE_PATH, store);
 
   // 9. Save snapshot for delta tracking
   const updatedGraph = readJSON(GRAPH_PATH);

--- a/v3/@claude-flow/cli/__tests__/issue-2920-intelligence-content-staleness.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2920-intelligence-content-staleness.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const HELPER = resolve(__dirname, '../.claude/helpers/intelligence.cjs');
+
+type Entry = { id?: string; content: string; namespace?: string };
+
+function run(root: string, expr: string): string {
+  return execFileSync(process.execPath, ['-e', expr], {
+    cwd: root,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+    encoding: 'utf-8',
+    timeout: 2_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function callInit(root: string): { message?: string } {
+  const script = [
+    `const intelligence = require(${JSON.stringify(HELPER)});`,
+    'process.stdout.write(JSON.stringify(intelligence.init()));',
+  ].join('');
+  return JSON.parse(run(root, script));
+}
+
+function callConsolidate(root: string): unknown {
+  const script = [
+    `const intelligence = require(${JSON.stringify(HELPER)});`,
+    'process.stdout.write(JSON.stringify(intelligence.consolidate()));',
+  ].join('');
+  return JSON.parse(run(root, script));
+}
+
+function writeStore(root: string, entries: Entry[]): string {
+  const dataDir = join(root, '.claude-flow', 'data');
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(join(dataDir, 'auto-memory-store.json'), JSON.stringify(entries), 'utf-8');
+  return dataDir;
+}
+
+describe('#2920 intelligence: same-ID content edits must not stay cached/unpersisted', () => {
+  it('init() rebuilds ranked-context.json when an entry\'s content changes but its ID and the entry count do not', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ruflo-2920-init-'));
+    const dataDir = writeStore(root, [{ id: 'sec-1', content: 'ORIGINAL BODY', namespace: 'auto-memory' }]);
+
+    try {
+      callInit(root);
+      const rankedBefore = JSON.parse(readFileSync(join(dataDir, 'ranked-context.json'), 'utf-8'));
+      expect(rankedBefore.entries[0].content).toBe('ORIGINAL BODY');
+
+      // Same ID, same entry count — only the body changed, as a hand-edit to
+      // a MEMORY.md section would look once re-imported.
+      writeStore(root, [{ id: 'sec-1', content: 'EDITED BODY', namespace: 'auto-memory' }]);
+
+      const second = callInit(root);
+      const rankedAfter = JSON.parse(readFileSync(join(dataDir, 'ranked-context.json'), 'utf-8'));
+
+      expect(second.message).not.toBe('Graph cache hit');
+      expect(rankedAfter.entries[0].content).toBe('EDITED BODY');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('consolidate() persists an ID assigned to a previously ID-less entry instead of silently discarding it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ruflo-2920-consolidate-'));
+    // No id/key — consolidate() must assign one to build edges/nodes. Entry
+    // count and dedup outcome are unchanged (1 entry in, 1 entry out, no
+    // pending insights), which is exactly the condition the old persist
+    // gate (`newEntries > 0 || store.length < preDedupCount`) treated as
+    // "nothing to persist" — silently dropping the assigned id every time.
+    const dataDir = writeStore(root, [{ content: 'a section with no id or key', namespace: 'auto-memory' }]);
+
+    try {
+      const result = callConsolidate(root) as { entries: number };
+      expect(result.entries).toBe(1);
+
+      const persisted = JSON.parse(readFileSync(join(dataDir, 'auto-memory-store.json'), 'utf-8')) as Entry[];
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].id).toBeTruthy();
+
+      const graph = JSON.parse(readFileSync(join(dataDir, 'graph-state.json'), 'utf-8')) as {
+        nodes: Record<string, unknown>;
+      };
+      // The id consolidate() computed for the graph must be the same one
+      // that landed in the persisted store, not a fresh one assigned again
+      // next run.
+      expect(Object.keys(graph.nodes)).toContain(persisted[0].id);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two related staleness bugs in `.claude/helpers/intelligence.cjs`'s graph/store caching, both keyed on entry **count** instead of **content**:

1. **`init()`'s graph-cache-hit gate** compared only `graphState.nodeCount` to the deduped store length. Hand-editing a MEMORY.md section's body while its heading (and therefore generated ID) stays the same changes neither the count nor the ID set, so the stale cache kept being served and `ranked-context.json` was never refreshed — matching the issue's first bullet exactly.

2. **`consolidate()`'s STORE_PATH persist gate** (`newEntries > 0 || store.length < preDedupCount`) only fired on insight creation or a dedup-driven shrink. Any other in-memory content change — e.g. assigning an id to a previously id-less entry while building the graph — left entry count and dedup outcome unchanged, so the update was silently never written back to disk, matching the issue's second bullet.

## Fix

Added a `storeFingerprint()` helper that folds every entry's own content fingerprint (reusing the existing `fingerprintContent()` used for content-dedup) into one aggregate value:
- `init()`'s cache-hit gate now also requires `graphState.contentFingerprint === currentFingerprint`.
- `consolidate()` now always persists the store — `GRAPH_PATH` and `RANKED_PATH` are already rewritten unconditionally on every call, so writing the (already deduped, size-bounded per ADR-095 G6) store alongside them is trivial cost and removes the whole "skip persisting for the wrong reason" bug class.

Also re-signed `helpers.manifest.json` (ADR-174) for the changed `intelligence.cjs` content via `scripts/sign-helpers.mjs`, verified with `scripts/verify-helpers.mjs`.

## Test plan

- [x] New regression test (`issue-2920-intelligence-content-staleness.test.ts`), two cases:
  - `init()`: writes a store, calls `init()`, edits the same entry's content in place (same id, same count), calls `init()` again — asserts the cache is NOT reused and `ranked-context.json` reflects the new content.
  - `consolidate()`: writes an id-less entry, calls `consolidate()` — asserts the id it assigns for graph-building is actually persisted to `auto-memory-store.json`, not silently dropped.
- [x] A/B via git-stash: both new tests fail against unpatched code with exactly the predicted symptoms (`Graph cache hit` returned despite edited content; persisted entry's `id` field `undefined`), and pass with the fix restored.
- [x] Existing intelligence tests (`issue-2628-intelligence-consolidate.test.ts`, `issue-2818-intelligence-project-root.test.ts`) and `helper-signing.test.ts` (manifest/signature integrity) all still pass.

Closes #2920

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)