### PR TITLE
ci: extend npm-ci-retry coverage to the OS-conditional fallback blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,21 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ runner.os }}" == "Linux" ]; then
-            npm ci --legacy-peer-deps
-          else
-            npm ci --legacy-peer-deps --omit=optional || npm ci --legacy-peer-deps --force
-          fi
+          # Retries absorb the transient sharp/libvips "socket hang up" /
+          # 503 download flake (see .github/actions/npm-ci-retry) — this
+          # step predates that composite action and can't call it directly
+          # since it needs the OS-conditional --omit=optional fallback too.
+          for attempt in 1 2 3; do
+            if [ "${{ runner.os }}" == "Linux" ]; then
+              npm ci --legacy-peer-deps && exit 0
+            else
+              (npm ci --legacy-peer-deps --omit=optional || npm ci --legacy-peer-deps --force) && exit 0
+            fi
+            echo "npm ci failed (attempt $attempt/3) — retrying in 15s"
+            sleep 15
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
         shell: bash
 
       - name: Build project

--- a/.github/workflows/verification-pipeline.yml
+++ b/.github/workflows/verification-pipeline.yml
@@ -195,12 +195,22 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ runner.os }}" == "Linux" ]; then
-            npm ci --legacy-peer-deps
-          else
-            # Skip optional platform-specific dependencies on macOS/Windows
-            npm ci --legacy-peer-deps --omit=optional || npm ci --legacy-peer-deps --force
-          fi
+          # Retries absorb the transient sharp/libvips "socket hang up" /
+          # 503 download flake (see .github/actions/npm-ci-retry) — this
+          # step predates that composite action and can't call it directly
+          # since it needs the OS-conditional --omit=optional fallback too.
+          for attempt in 1 2 3; do
+            if [ "${{ runner.os }}" == "Linux" ]; then
+              npm ci --legacy-peer-deps && exit 0
+            else
+              # Skip optional platform-specific dependencies on macOS/Windows
+              (npm ci --legacy-peer-deps --omit=optional || npm ci --legacy-peer-deps --force) && exit 0
+            fi
+            echo "npm ci failed (attempt $attempt/3) — retrying in 15s"
+            sleep 15
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
         shell: bash
 
       - name: Run unit tests


### PR DESCRIPTION
## Summary

#2998 wrapped 15 plain `npm ci` call sites with a retry composite action but deliberately left two Linux/non-Linux `--omit=optional` fallback blocks (in `ci.yml` and `verification-pipeline.yml`) untouched, reasoning they were a separate concern (optional native deps on macOS/Windows) from the sharp/libvips download flake.

That gap was real: PR #2999's `Test Verification (ubuntu-latest, Node 20)` job hit the exact same `sharp`/`libvips` `Installation error: socket hang up` flake on the untouched **Linux branch** of this exact block, within hours of #2998 merging.

## Fix

These two steps can't call `.github/actions/npm-ci-retry` directly — they need the OS branch to choose between a plain `npm ci` and the `--omit=optional || --force` fallback chain — so this wraps the existing logic in the same 3-attempt/15s-backoff retry inline instead, preserving both branches' exact commands.

## Test plan

- [x] Both touched workflow files parse as valid YAML.
- [x] Careful review of the retry loop's exit semantics: the non-Linux branch's `(cmd1 || cmd2) && exit 0` only exits 0 when one of the two install attempts actually succeeded — an earlier draft of this fix had a bug where it exited 0 unconditionally on that branch, silently swallowing a genuine failure. Fixed before commit.
- [x] This PR's own CI exercises every touched call site.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)