### PR TITLE
fix(intelligence): stamp contentFingerprint in consolidate()'s graph write too

### DIFF
--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -830,11 +830,16 @@ function consolidate() {
     pageRanks = computePageRank(nodes, edges, 0.85, 30);
   }
 
-  // 6. Write updated graph
+  // 6. Write updated graph. #2920 follow-up: include contentFingerprint so
+  // init()'s cache-hit gate (line ~511) doesn't unconditionally miss on the
+  // very next init after a consolidate — without this, nodeCount alone
+  // matched but contentFingerprint was undefined here vs a real hash in
+  // init()'s own write, forcing a full rebuild every time.
   writeJSON(GRAPH_PATH, {
     version: 1,
     updatedAt: Date.now(),
     nodeCount: Object.keys(nodes).length,
+    contentFingerprint: storeFingerprint(store),
     nodes,
     edges,
     pageRanks,

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest": {
-    "version": "3.38.5",
+    "version": "3.38.6",
     "files": {
       "auto-memory-hook.mjs": "85fe05c757421c52137c0bc8545a0896bab6b4714538c2a11d1d0835bfcc8c1c",
       "hook-handler.cjs": "dae295fb9ae2626b89899c19a20cc911541af82b52d2eeb9b214d618b96e9a86",
-      "intelligence.cjs": "66d63fdeab5f2ce0546bff80e69144911508fa2bf88f7b167ba0905762ecb314",
+      "intelligence.cjs": "30e42ed7ec4ca5a94ac54fdb1330d2d47ac5f3fdeeef207753574723a9e77b5c",
       "statusline.cjs": "0457fe53f8cd2c56458ff178392536a5868efd1a573665fa43bc01d2d95ca677"
     }
   },
-  "signature": "gn62A4tYOd3CtXZZIVfgZXhSLkZyz95CXU60I61R58dviABR9fLcBolD9jaZP9DiN7dxfc0co5lrfMW56CE6Dw==",
+  "signature": "Oj0UauSDsoxdVB2jga0l+7u7bNKytCMLVPBR/dHhjxBIt2GoekMvRGSeq1SxcLos9Jl8xYV+xFVCVkyTGclWDQ==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/intelligence.cjs
@@ -830,11 +830,16 @@ function consolidate() {
     pageRanks = computePageRank(nodes, edges, 0.85, 30);
   }
 
-  // 6. Write updated graph
+  // 6. Write updated graph. #2920 follow-up: include contentFingerprint so
+  // init()'s cache-hit gate (line ~511) doesn't unconditionally miss on the
+  // very next init after a consolidate — without this, nodeCount alone
+  // matched but contentFingerprint was undefined here vs a real hash in
+  // init()'s own write, forcing a full rebuild every time.
   writeJSON(GRAPH_PATH, {
     version: 1,
     updatedAt: Date.now(),
     nodeCount: Object.keys(nodes).length,
+    contentFingerprint: storeFingerprint(store),
     nodes,
     edges,
     pageRanks,

--- a/v3/@claude-flow/cli/__tests__/issue-2920-intelligence-content-staleness.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2920-intelligence-content-staleness.test.ts
@@ -94,4 +94,21 @@ describe('#2920 intelligence: same-ID content edits must not stay cached/unpersi
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('init() cache-hits right after consolidate() when content is unchanged (consolidate must stamp contentFingerprint too)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ruflo-2920-consolidate-cache-'));
+    writeStore(root, [{ id: 'sec-1', content: 'STABLE BODY', namespace: 'auto-memory' }]);
+
+    try {
+      // consolidate() is the session-end path and writes graph-state.json
+      // itself (step 6) — it must stamp the same contentFingerprint init()
+      // computes, or every init() immediately after a consolidate misses
+      // the cache and does a full rebuild even though nothing changed.
+      callConsolidate(root);
+      const afterConsolidate = callInit(root);
+      expect(afterConsolidate.message).toBe('Graph cache hit');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2920 / v3.38.6 (PR #2999). `consolidate()` (the session-end
path) rebuilds `graph-state.json` unconditionally per the shipped #2920 fix,
but its write never stamped the `contentFingerprint` field that `init()`'s
cache-hit gate checks — only `init()`'s own write set it. So every `init()`
immediately following a `consolidate()` saw `nodeCount` match but
`contentFingerprint` `undefined !== <real hash>`, missed the cache, and did a
full rebuild even with zero content changes.

The fail direction was safe (extra rebuilds, never stale data), so this
didn't block the v3.38.6 release — but it meant the 60s graph cache never
actually fired across a consolidate/restart boundary, which is a real perf
gap on every session start after a clean session end.

## Fix

`consolidate()`'s graph write now includes `contentFingerprint:
storeFingerprint(store)`, mirroring `init()`'s own write.

## Test plan

- [x] New test: `init()` cache-hits right after `consolidate()` when content
      is unchanged
- [x] A/B verified via git-stash: fails without the fix ("Graph built and
      ranked" instead of "Graph cache hit"), passes with it
- [x] All 3 tests in `issue-2920-intelligence-content-staleness.test.ts` pass

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)