### PR TITLE
fix(memory): stop misreporting bridge brute-force search as HNSW-accelerated

### DIFF
--- a/v3/@claude-flow/cli/__tests__/issue-2922-hnsw-status-honesty.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2922-hnsw-status-honesty.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// #2922: the bridge's default search path (bridgeSearchBruteForceCosine, née
+// bridgeSearchHNSW) is a full-table SELECT + brute-force cosine loop — it
+// never touches @ruvector/core or an HNSW index. getHNSWStatus() used to
+// report `available: true` whenever the bridge was loaded regardless of
+// this, which is exactly the misleading-status-indicator bug the issue
+// documents with line-numbered evidence. These tests exercise the real
+// bridge (better-sqlite3 is present in this env) and assert the status
+// functions stop claiming HNSW acceleration that isn't in the request path.
+describe('#2922 getHNSWStatus() must not claim HNSW when the bridge (brute-force) path is active', () => {
+  it('reports available=false and algorithm=brute-force-cosine once the bridge has loaded', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ruflo-2922-'));
+    const dbPath = join(root, 'memory.db');
+
+    try {
+      const { initializeMemoryDatabase, storeEntry, getHNSWStatus } = await import('../src/memory/memory-initializer.js');
+
+      await initializeMemoryDatabase({ dbPath, force: true, verbose: false });
+
+      // Any real write forces the lazy bridge singleton to load (ADR-053).
+      const result = await storeEntry({
+        key: 'k1',
+        value: 'hello world',
+        namespace: 'test',
+        dbPath,
+      });
+      expect(result.success).toBe(true);
+
+      const status = getHNSWStatus();
+      // #2922: `available` must be false while the bridge (brute-force cosine)
+      // is the active search path — asserted unconditionally so a reverted
+      // fix (missing `algorithm` field entirely) fails loudly here instead of
+      // being silently skipped by a too-permissive environment guard.
+      expect(status.available).toBe(false);
+      expect(status.initialized).toBe(false);
+      expect(status.algorithm).toBe('brute-force-cosine');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#2922 memory-bridge status/search functions are honestly named', () => {
+  it('bridgeGetVectorSearchStatus reports algorithm=brute-force-cosine, not silence about acceleration', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ruflo-2922-bridge-'));
+    const dbPath = join(root, 'memory.db');
+
+    try {
+      const bridge = await import('../src/memory/memory-bridge.js');
+      const { initializeMemoryDatabase, storeEntry } = await import('../src/memory/memory-initializer.js');
+      await initializeMemoryDatabase({ dbPath, force: true, verbose: false });
+      await storeEntry({ key: 'k1', value: 'hello', namespace: 'test', dbPath });
+
+      const status = await bridge.bridgeGetVectorSearchStatus(dbPath);
+      if (!status) return; // bridge unavailable in this environment — not what's under test
+      expect(status.algorithm).toBe('brute-force-cosine');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -245,6 +245,23 @@ async function getMemoryFunctions() {
 }
 
 /**
+ * #2922: every `backend:` field in this file's tool responses used to be the
+ * hardcoded literal `'sql.js + HNSW'` regardless of which search path was
+ * actually active — most of the time that's the bridge doing a brute-force
+ * cosine scan, not HNSW. This reports the real algorithm via the same
+ * capability probe `getHNSWStatus()` already exposes.
+ */
+async function describeBackend(): Promise<string> {
+  try {
+    const { getHNSWStatus } = await import('../memory/memory-initializer.js');
+    const status = getHNSWStatus();
+    return status.algorithm === 'hnsw' ? 'sql.js + HNSW' : 'sqlite (bridge, brute-force cosine)';
+  } catch {
+    return 'sqlite';
+  }
+}
+
+/**
  * Ensure memory database is initialized and migrate legacy data if needed.
  * #1606: Wrapped in try/catch to prevent process-level crashes that kill
  * the stdio MCP transport on Windows/Codex.
@@ -369,7 +386,7 @@ export const memoryTools: MCPTool[] = [
           hasEmbedding: !!result.embedding,
           embeddingDimensions: result.embedding?.dimensions || null,
           provenanceType: provenanceType || 'unknown',
-          backend: 'sql.js + HNSW',
+          backend: await describeBackend(),
           storeTime: `${duration.toFixed(2)}ms`,
           error: result.error,
         };
@@ -425,7 +442,7 @@ export const memoryTools: MCPTool[] = [
             accessCount: result.entry.accessCount,
             hasEmbedding: result.entry.hasEmbedding,
             found: true,
-            backend: 'sql.js + HNSW',
+            backend: await describeBackend(),
           };
         }
 
@@ -652,7 +669,7 @@ export const memoryTools: MCPTool[] = [
           namespace,
           deleted: result.deleted,
           hnswIndexInvalidated: result.deleted,
-          backend: 'sql.js + HNSW',
+          backend: await describeBackend(),
         };
       } catch (error) {
         return {
@@ -709,7 +726,7 @@ export const memoryTools: MCPTool[] = [
           total: result.total,
           limit,
           offset,
-          backend: 'sql.js + HNSW',
+          backend: await describeBackend(),
         };
       } catch (error) {
         return {
@@ -755,7 +772,7 @@ export const memoryTools: MCPTool[] = [
             ? `${((withEmbeddings / allEntries.total) * 100).toFixed(1)}%`
             : '0%',
           namespaces,
-          backend: 'sql.js + HNSW',
+          backend: await describeBackend(),
           version: status.version || '3.0.0',
           features: status.features || {
             vectorEmbeddings: true,
@@ -809,7 +826,7 @@ export const memoryTools: MCPTool[] = [
         success: true,
         message: 'Migration completed',
         migrated: Object.keys(legacyStore.entries).length,
-        backend: 'sql.js + HNSW',
+        backend: await describeBackend(),
       };
     },
   },
@@ -1202,7 +1219,7 @@ export const memoryTools: MCPTool[] = [
         bytes += (e.size as number) || 0;
       }
       return {
-        backend: 'sql.js + HNSW',
+        backend: await describeBackend(),
         entries: all.total ?? all.entries.length,
         size: bytes,
         namespaces: Object.entries(nsCounts).map(([name, entries]) => ({ name, entries })),

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -1686,16 +1686,24 @@ export async function bridgeLoadEmbeddingModel(
 // ===== Phase 3: HNSW bridge =====
 
 /**
- * Get HNSW status from AgentDB v3's vector backend or HNSW index.
+ * Get vector search status from AgentDB v3's SQLite-backed store.
  * Returns null if unavailable.
+ *
+ * #2922: previously named `bridgeGetHNSWStatus` and unconditionally returned
+ * `available: true` whenever a DB connection succeeded — but the search this
+ * status describes (`bridgeSearchBruteForceCosine`, below) is a full-table
+ * SELECT + brute-force cosine scan, not an HNSW index lookup. Renamed and
+ * given an explicit `algorithm` field so callers can't mistake "vector
+ * search works" for "vector search is HNSW-accelerated".
  */
-export async function bridgeGetHNSWStatus(
+export async function bridgeGetVectorSearchStatus(
   dbPath?: string,
 ): Promise<{
   available: boolean;
   initialized: boolean;
   entryCount: number;
   dimensions: number;
+  algorithm: 'brute-force-cosine';
 } | null> {
   const registry = await getRegistry(dbPath);
   if (!registry) return null;
@@ -1720,6 +1728,7 @@ export async function bridgeGetHNSWStatus(
       initialized: true,
       entryCount,
       dimensions: 384,
+      algorithm: 'brute-force-cosine',
     };
   } catch {
     return null;
@@ -1727,11 +1736,11 @@ export async function bridgeGetHNSWStatus(
 }
 
 /**
- * Search using AgentDB v3's embedder + SQLite entries.
- * This is the HNSW-equivalent search through the bridge.
- * Returns null if unavailable.
+ * Search AgentDB v3's embedder + SQLite entries via a full-table scan and
+ * brute-force cosine similarity. NOT HNSW-accelerated — see #2922. Returns
+ * null if unavailable.
  */
-export async function bridgeSearchHNSW(
+export async function bridgeSearchBruteForceCosine(
   queryEmbedding: number[],
   options?: { k?: number; namespace?: string; threshold?: number },
   dbPath?: string,
@@ -1806,10 +1815,11 @@ export async function bridgeSearchHNSW(
 }
 
 /**
- * Add entry to the bridge's database with embedding.
- * Returns null if unavailable.
+ * Add entry to the bridge's database with embedding. No HNSW index is built
+ * or updated here — see #2922; the embedding is only stored for a later
+ * brute-force scan. Returns null if unavailable.
  */
-export async function bridgeAddToHNSW(
+export async function bridgeAddEmbedding(
   id: string,
   embedding: number[],
   entry: { id: string; key: string; namespace: string; content: string },

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -803,7 +803,7 @@ export async function addToHNSWIndex(
   // ADR-053: Try AgentDB v3 bridge first
   const bridge = await getBridge();
   if (bridge) {
-    const bridgeResult = await bridge.bridgeAddToHNSW(id, embedding, entry);
+    const bridgeResult = await bridge.bridgeAddEmbedding(id, embedding, entry);
     if (bridgeResult === true) return true;
   }
 
@@ -840,7 +840,7 @@ export async function searchHNSWIndex(
   // ADR-053: Try AgentDB v3 bridge first
   const bridge = await getBridge();
   if (bridge) {
-    const bridgeResult = await bridge.bridgeSearchHNSW(queryEmbedding, options);
+    const bridgeResult = await bridge.bridgeSearchBruteForceCosine(queryEmbedding, options);
     if (bridgeResult) return bridgeResult;
   }
 
@@ -897,15 +897,25 @@ export function getHNSWStatus(): {
   initialized: boolean;
   entryCount: number;
   dimensions: number;
+  algorithm: 'hnsw' | 'brute-force-cosine';
 } {
-  // ADR-053: If bridge was previously loaded, report availability
+  // #2922: this branch previously reported `available: true` whenever the
+  // bridge was loaded, on the theory that "AgentDB v3 is HNSW-equivalent" —
+  // but the bridge's actual search path (bridgeSearchBruteForceCosine, see
+  // memory-bridge.ts) does a full-table SELECT + brute-force cosine loop and
+  // never touches @ruvector/core or an HNSW index, regardless of whether
+  // ruvector-core itself is installed. `available` here means "an HNSW
+  // index is the one actually searched", matching what this function's own
+  // name promises — that's false while the bridge is the active path, so
+  // this no longer claims otherwise. Vector search itself still works via
+  // the bridge; `algorithm` tells callers it's brute-force, not HNSW.
   if (_bridge && _bridge !== null) {
-    // Bridge is loaded — HNSW-equivalent is available via AgentDB v3
     return {
-      available: true,
-      initialized: true,
+      available: false,
+      initialized: false,
       entryCount: hnswIndex?.entries.size ?? 0,
-      dimensions: hnswIndex?.dimensions ?? 384
+      dimensions: hnswIndex?.dimensions ?? 384,
+      algorithm: 'brute-force-cosine',
     };
   }
 
@@ -918,7 +928,8 @@ export function getHNSWStatus(): {
     available: hnswIndex !== null || isRuvectorCoreResolvable(),
     initialized: hnswIndex?.initialized ?? false,
     entryCount: hnswIndex?.entries.size ?? 0,
-    dimensions: hnswIndex?.dimensions ?? 384
+    dimensions: hnswIndex?.dimensions ?? 384,
+    algorithm: 'hnsw',
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the honesty/naming portion of #2922. The reporter did thorough
code-path tracing showing that:

1. The bridge's default search path (renamed here from `bridgeSearchHNSW` to
   `bridgeSearchBruteForceCosine`) is a full-table SELECT + brute-force
   cosine similarity loop — it never touches `@ruvector/core` or an HNSW
   index.
2. `getHNSWStatus()` reported `available: true` whenever the bridge was
   loaded regardless of this, and `bridgeGetHNSWStatus` did the same
   unconditionally on any successful DB connection.
3. Three bridge functions were named `*HNSW*` while doing zero HNSW work:
   `bridgeSearchHNSW`, `bridgeAddToHNSW`, `bridgeGetHNSWStatus`.
4. `memory_stats` and 6 other MCP tool responses hardcoded
   `backend: 'sql.js + HNSW'` regardless of which path actually ran.

**Out of scope**: actually wiring `AgentDBBackend`'s real HNSW
implementation into the bridge's default search path is the issue's larger
architectural question (their question #1) and deserves its own design
discussion, not an autopilot iteration bundled with a naming/status fix.
Commented on the issue with that split and cross-referenced the reporter's
Windows ~4GB OOM against #2948.

## Changes

- `getHNSWStatus()` (`memory-initializer.ts`): `available=false` +
  new `algorithm: 'hnsw' | 'brute-force-cosine'` field when the bridge is
  the active path, instead of a blanket `available=true`.
- `memory-bridge.ts`: `bridgeGetHNSWStatus` → `bridgeGetVectorSearchStatus`
  (adds `algorithm: 'brute-force-cosine'`), `bridgeSearchHNSW` →
  `bridgeSearchBruteForceCosine`, `bridgeAddToHNSW` → `bridgeAddEmbedding`.
  Confirmed via repo-wide grep these have no callers outside
  `memory-bridge.ts`/`memory-initializer.ts` (not part of the package's
  public export surface) — pure rename, no behavior change.
- `memory-tools.ts`: replaced the hardcoded `backend: 'sql.js + HNSW'`
  literal (7 call sites) with `describeBackend()`, which reports the real
  algorithm via the now-fixed `getHNSWStatus()` probe.

## Test plan

- [x] New test file exercises the real bridge (better-sqlite3) end-to-end:
      `storeEntry` → `getHNSWStatus()` asserts `available=false`,
      `algorithm='brute-force-cosine'`; `bridgeGetVectorSearchStatus`
      asserts the same
- [x] A/B verified via git-stash: both assertions fail against the
      unpatched code (`available: true` and `TypeError: ... is not a
      function` for the old name), pass with the fix
- [x] Full existing suite (`memory-ruvector-deep.test.ts`, 149 tests total
      combined) still passes
- [x] `tsc --noEmit` clean

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)