### PR TITLE
fix(security): realpath allowed prefixes so a symlinked prefix isn't rejected

### DIFF
--- a/v3/@claude-flow/security/__tests__/path-validator.test.ts
+++ b/v3/@claude-flow/security/__tests__/path-validator.test.ts
@@ -8,8 +8,10 @@
  * - Blocked file detection
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as path from 'path';
+import * as os from 'os';
+import * as fsPromises from 'fs/promises';
 import {
   PathValidator,
   PathValidatorError,
@@ -297,6 +299,52 @@ describe('PathValidator', () => {
       // Path starts with project root but escapes via traversal
       const result = await validator.validate('/workspaces/project/../../etc/passwd');
       expect(result.isValid).toBe(false);
+    });
+  });
+
+  // #3010 — validate() realpath's the candidate but the constructor only
+  // path.resolve()d the allowed prefixes, so a prefix reached through a
+  // real symlink (e.g. macOS os.tmpdir() under /var -> /private/var) could
+  // never match its own realpath'd contents. Uses actual fs.symlinkSync,
+  // not a path-traversal string, to reproduce the real-world failure mode.
+  describe('Symlinked prefix handling (#3010)', () => {
+    let tmpRoot: string;
+    let realDir: string;
+    let symlinkedPrefix: string;
+
+    beforeEach(async () => {
+      tmpRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'path-validator-3010-'));
+      realDir = path.join(tmpRoot, 'real-target');
+      await fsPromises.mkdir(realDir, { recursive: true });
+      symlinkedPrefix = path.join(tmpRoot, 'symlinked-prefix');
+      await fsPromises.symlink(realDir, symlinkedPrefix, 'dir');
+    });
+
+    afterEach(async () => {
+      await fsPromises.rm(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('accepts a file under an allowedPrefix that is itself a symlink', async () => {
+      const filePath = path.join(realDir, 'file.txt');
+      await fsPromises.writeFile(filePath, 'content');
+
+      const symlinkValidator = new PathValidator({
+        allowedPrefixes: [symlinkedPrefix],
+      });
+
+      // Validate via the symlinked path, exactly as a caller resolving
+      // through os.tmpdir() would.
+      const result = await symlinkValidator.validate(path.join(symlinkedPrefix, 'file.txt'));
+      expect(result.isValid).toBe(true);
+      expect(result.errors).not.toContain('Path is outside allowed directories');
+    });
+
+    it('accepts the prefix directory itself, reached via the symlink', async () => {
+      const symlinkValidator = new PathValidator({
+        allowedPrefixes: [symlinkedPrefix],
+      });
+      const result = await symlinkValidator.validate(symlinkedPrefix);
+      expect(result.isValid).toBe(true);
     });
   });
 });

--- a/v3/@claude-flow/security/src/path-validator.ts
+++ b/v3/@claude-flow/security/src/path-validator.ts
@@ -18,6 +18,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { realpathSync } from 'fs';
 
 export interface PathValidatorConfig {
   /**
@@ -173,10 +174,27 @@ export class PathValidator {
       );
     }
 
-    // Pre-resolve all prefixes
-    this.resolvedPrefixes = this.config.allowedPrefixes.map(p =>
-      path.resolve(p)
-    );
+    // Pre-resolve all prefixes. #3010 — validate() canonicalizes the
+    // *candidate* through fs.realpath (when resolveSymlinks is on, the
+    // default) but prefixes were only ever path.resolve()d, never
+    // realpath'd. On any platform where the prefix itself is reached
+    // through a symlink (e.g. macOS os.tmpdir() -> /var/folders/... while
+    // /var is itself a symlink to /private/var), the realpath'd candidate
+    // can never match the non-realpath'd prefix, and every path under that
+    // prefix is rejected as "outside allowed directories" — including the
+    // prefix's own contents. Mirror validate()'s own ENOENT-tolerant
+    // fallback: a prefix that doesn't exist yet (or otherwise can't be
+    // realpath'd) still gets a resolved value via path.resolve, matching
+    // allowNonExistent's semantics for candidates.
+    this.resolvedPrefixes = this.config.allowedPrefixes.map(p => {
+      const resolved = path.resolve(p);
+      if (!this.config.resolveSymlinks) return resolved;
+      try {
+        return realpathSync(resolved);
+      } catch {
+        return resolved;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #3010. `PathValidator.validate()` canonicalizes the *candidate* path
through `fs.realpath` (when `resolveSymlinks` is on, the default), but the
constructor only ever `path.resolve()`d the allowed *prefixes* — never
`realpath`'d them. On any platform where a prefix is itself reached through
a symlink (e.g. macOS `os.tmpdir()` under `/var`, itself a symlink to
`/private/var`), the realpath'd candidate can never match the
non-realpath'd prefix, and every path under that prefix — including the
prefix's own contents — is rejected as "outside allowed directories".

This is a live regression: it breaks `ruflo proxy install` on macOS today.
The download and Ed25519 signature/checksum verification both succeed;
install then fails on the defense-in-depth path check in
`proxy/install.ts` (`workDir` is created via `os.tmpdir()`) with
`extracted binary path failed validation: Path is outside allowed
directories`.

## Fix

Realpath the prefixes at construction time too, using the same
ENOENT-tolerant fallback to `path.resolve()` that `validate()` already
uses for candidates — a prefix directory that doesn't exist yet degrades
gracefully instead of throwing. Kept the constructor synchronous (no
breaking API change) via `realpathSync` rather than the async
`fs/promises` variant already imported for `validate()`.

## Test plan

- [x] New tests use a real filesystem symlink (`fs.symlinkSync`), not a
      path-traversal string, to reproduce the actual failure mode —
      platform-independent, doesn't require running on macOS to catch the
      regression
- [x] A/B verified via git-stash: both new tests fail against the
      unpatched constructor (`expected true, received false`), pass with
      the fix
- [x] Full `@claude-flow/security` suite: 572/572 passing (24 files)
- [x] `tsc --noEmit` clean in both `@claude-flow/security` and
      `@claude-flow/cli` (the latter consumes `PathValidator` in
      `proxy/install.ts`)
- [x] Package builds clean; confirmed `realpathSync` present in the
      compiled `dist/path-validator.js` output

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)