### PR TITLE
fix(cli): report persisted swarm health

### DIFF
--- a/v3/@claude-flow/cli/__tests__/system-health-swarm-state.test.ts
+++ b/v3/@claude-flow/cli/__tests__/system-health-swarm-state.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { swarmTools } from '../src/mcp-tools/swarm-tools.js';
+import { systemTools } from '../src/mcp-tools/system-tools.js';
+
+describe('system_health swarm state', () => {
+  let workdir: string;
+  let previousCwd: string | undefined;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'ruflo-system-health-'));
+    previousCwd = process.env.CLAUDE_FLOW_CWD;
+    process.env.CLAUDE_FLOW_CWD = workdir;
+  });
+
+  afterEach(() => {
+    if (previousCwd === undefined) delete process.env.CLAUDE_FLOW_CWD;
+    else process.env.CLAUDE_FLOW_CWD = previousCwd;
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it('reports the active swarm and its persisted state store as healthy', async () => {
+    const init = swarmTools.find((tool) => tool.name === 'swarm_init')!;
+    const health = systemTools.find((tool) => tool.name === 'system_health')!;
+
+    const initialized = await init.handler({ topology: 'hierarchical', maxAgents: 4 }) as {
+      swarmId: string;
+    };
+    const result = await health.handler({ deep: true }) as {
+      checks: Array<{ name: string; status: string; message?: string }>;
+    };
+
+    expect(initialized.swarmId).toBeDefined();
+    expect(result.checks.find((check) => check.name === 'swarm')).toMatchObject({
+      status: 'healthy',
+      message: expect.stringContaining(initialized.swarmId),
+    });
+    expect(result.checks.find((check) => check.name === 'database')).toMatchObject({
+      status: 'healthy',
+      message: 'Persistent swarm state store available',
+    });
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts
@@ -62,6 +62,13 @@ interface SwarmStore {
   version: string;
 }
 
+export interface ActiveSwarmHealth {
+  status: 'healthy' | 'degraded' | 'unknown';
+  stateFileExists: boolean;
+  swarmId?: string;
+  message: string;
+}
+
 function getSwarmDir(): string {
   return join(getProjectCwd(), SWARM_DIR);
 }
@@ -203,6 +210,35 @@ function latestRunningSwarm(store: SwarmStore): SwarmState | undefined {
   return Object.values(store.swarms)
     .filter((swarm) => swarm.status === 'running')
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+}
+
+/** Real, persisted swarm state for aggregate system health reporting. */
+export function inspectActiveSwarmHealth(): ActiveSwarmHealth {
+  const store = loadSwarmStore();
+  const active = latestRunningSwarm(store);
+  const stateFileExists = existsSync(getSwarmStatePath());
+
+  if (active) {
+    return {
+      status: stateFileExists ? 'healthy' : 'degraded',
+      stateFileExists,
+      swarmId: active.swarmId,
+      message: stateFileExists
+        ? `Active swarm ${active.swarmId} is running with persisted state`
+        : `Active swarm ${active.swarmId} is running but its state file is missing`,
+    };
+  }
+
+  const latest = Object.values(store.swarms)
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+  return {
+    status: 'unknown',
+    stateFileExists,
+    swarmId: latest?.swarmId,
+    message: latest
+      ? `No active swarm; latest swarm ${latest.swarmId} is ${latest.status}`
+      : 'No active swarm found',
+  };
 }
 
 function apscStateOf(swarm: SwarmState | undefined): ApscState | undefined {

--- a/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/system-tools.ts
@@ -11,6 +11,7 @@
 
 import { type MCPTool, getProjectCwd } from './types.js';
 import { validateIdentifier } from './validate-input.js';
+import { inspectActiveSwarmHealth } from './swarm-tools.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statfsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -374,11 +375,12 @@ export const systemTools: MCPTool[] = [
         });
       }
 
-      // Swarm — cannot verify real connectivity, report unknown
+      // Swarm — inspect the same persisted state used by swarm_status/health.
+      const swarmHealth = inspectActiveSwarmHealth();
       checks.push({
         name: 'swarm',
-        status: 'unknown',
-        message: 'Swarm connectivity not monitored — check coordination store manually',
+        status: swarmHealth.status,
+        message: swarmHealth.message,
       });
 
       // Neural — cannot verify, report unknown
@@ -443,17 +445,23 @@ export const systemTools: MCPTool[] = [
           }
         }
 
-        // Database — check if coordination store exists
+        // Database — accept both the coordination store and the canonical
+        // swarm state store written by swarm_init.
         {
           const t0 = performance.now();
-          const coordPath = join(projectCwd, '.claude-flow', 'coordination', 'store.json');
-          const dbExists = existsSync(coordPath);
+          const stores = [
+            { path: join(projectCwd, '.claude-flow', 'coordination', 'store.json'), label: 'coordination store' },
+            { path: join(projectCwd, '.claude-flow', 'swarm', 'swarm-state.json'), label: 'swarm state store' },
+          ];
+          const availableStore = stores.find((store) => existsSync(store.path));
           const elapsed = performance.now() - t0;
           checks.push({
             name: 'database',
-            status: dbExists ? 'healthy' : 'unknown',
+            status: availableStore ? 'healthy' : 'unknown',
             latency: Math.round(elapsed * 100) / 100,
-            message: dbExists ? undefined : 'Coordination store not found',
+            message: availableStore
+              ? `Persistent ${availableStore.label} available`
+              : 'No coordination or swarm state store found',
           });
         }
       }


### PR DESCRIPTION
﻿## Summary

- inspect the persisted swarm store used by swarm_status and swarm_health
- report an active persisted swarm as healthy from system_health
- recognize both coordination and canonical swarm state stores in the deep database check
- add an integration regression from swarm_init to system_health

## Scope

This addresses Bug 2 from #2967 only. The uptime behavior identified as Bug 1 was already fixed on main and is unchanged.

## Validation

- npx pnpm@8.15.0 exec vitest run __tests__/system-health-swarm-state.test.ts
- npx pnpm@8.15.0 build
- git diff --check

Closes #2967
