### PR TITLE
fix(mcp): resolve optional packages from project roots

### DIFF
--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -775,6 +775,28 @@ claude mcp add claude-flow -- npx -y ruflo@latest mcp start
 claude mcp list
 ```
 
+#### Optional packages with the npx launcher
+
+The generated `npx -y ruflo@latest mcp start` command intentionally uses
+npx's isolated package cache so a new MCP process can resolve the requested
+Ruflo version reproducibly. Treat that cache as disposable: do not install
+optional packages into `~/.npm/_npx/.../node_modules/ruflo`, because a later
+npx launch may reconcile or replace the cached dependency tree.
+
+Install optional packages in the project that launches the MCP server instead:
+
+```bash
+cd /path/to/your/project
+npm install --save @claude-flow/aidefence
+claude mcp add claude-flow -- npx -y ruflo@latest mcp start
+```
+
+Start Claude Code from that project so Ruflo's normal Node.js resolution can
+find the project-local package. This keeps the optional dependency persistent
+across MCP reconnects and Ruflo upgrades while retaining the generated npx
+launcher. If an optional package was installed into the npx cache already,
+remove that manual cache customization and reinstall it in the project.
+
 Once added, Claude Code can use all 313 ruflo MCP tools directly:
 - `swarm_init` - Initialize agent swarms
 - `agent_spawn` - Spawn specialized agents

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -791,8 +791,9 @@ npm install --save @claude-flow/aidefence
 claude mcp add claude-flow -- npx -y ruflo@latest mcp start
 ```
 
-Start Claude Code from that project so Ruflo's normal Node.js resolution can
-find the project-local package. This keeps the optional dependency persistent
+Start Claude Code from that project. Ruflo resolves optional packages from the
+explicit Claude/Ruflo project directory when available, then falls back to the
+MCP process working directory. This keeps the optional dependency persistent
 across MCP reconnects and Ruflo upgrades while retaining the generated npx
 launcher. If an optional package was installed into the npx cache already,
 remove that manual cache customization and reinstall it in the project.

--- a/v3/@claude-flow/cli/__tests__/auto-install-project-local-2946.test.ts
+++ b/v3/@claude-flow/cli/__tests__/auto-install-project-local-2946.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression coverage for #2946: optional packages installed in a project
+ * must remain resolvable when Ruflo itself runs from npx's isolated cache.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { importProjectLocalPackage } from '../src/mcp-tools/auto-install.js';
+
+const originalCwd = process.cwd();
+let projectDir: string;
+
+describe('project-local optional package resolution (#2946)', () => {
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'ruflo-project-package-'));
+    const packageDir = join(projectDir, 'node_modules', 'ruflo-test-optional');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ name: 'ruflo-test-optional', version: '1.0.0', type: 'module', exports: './index.js' }),
+    );
+    writeFileSync(join(packageDir, 'index.js'), 'export const source = "project-local";\n');
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('loads from cwd/node_modules instead of the importing module location', async () => {
+    const module = await importProjectLocalPackage<{ source: string }>('ruflo-test-optional');
+    expect(module?.source).toBe('project-local');
+  });
+
+  it('rejects an invalid package specifier without resolving it', async () => {
+    expect(await importProjectLocalPackage('../outside')).toBeNull();
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/auto-install-project-local-2946.test.ts
+++ b/v3/@claude-flow/cli/__tests__/auto-install-project-local-2946.test.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { importProjectLocalPackage } from '../src/mcp-tools/auto-install.js';
 
 const originalCwd = process.cwd();
+const originalClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
 let projectDir: string;
 
 describe('project-local optional package resolution (#2946)', () => {
@@ -27,12 +28,27 @@ describe('project-local optional package resolution (#2946)', () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    if (originalClaudeProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalClaudeProjectDir;
     rmSync(projectDir, { recursive: true, force: true });
   });
 
   it('loads from cwd/node_modules instead of the importing module location', async () => {
     const module = await importProjectLocalPackage<{ source: string }>('ruflo-test-optional');
     expect(module?.source).toBe('project-local');
+  });
+
+  it('uses the explicit Claude project root when the MCP process cwd differs', async () => {
+    const launchDir = mkdtempSync(join(tmpdir(), 'ruflo-mcp-launch-'));
+    process.env.CLAUDE_PROJECT_DIR = projectDir;
+    process.chdir(launchDir);
+    try {
+      const module = await importProjectLocalPackage<{ source: string }>('ruflo-test-optional');
+      expect(module?.source).toBe('project-local');
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(launchDir, { recursive: true, force: true });
+    }
   });
 
   it('rejects an invalid package specifier without resolving it', async () => {

--- a/v3/@claude-flow/cli/src/mcp-tools/auto-install.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/auto-install.ts
@@ -101,14 +101,27 @@ export async function importProjectLocalPackage<T = unknown>(packageName: string
     return null;
   }
 
-  try {
-    const projectRequire = createRequire(resolve(process.cwd(), 'package.json'));
-    const modulePath = projectRequire.resolve(packageName);
-    const moduleUrl = `${pathToFileURL(modulePath).href}?t=${Date.now()}`;
-    return await import(moduleUrl) as T;
-  } catch {
-    return null;
+  // MCP clients do not all launch the server with the project as cwd. Prefer
+  // explicit project signals used by Claude Code/Ruflo, while retaining cwd
+  // (whose Node resolver also walks parent directories) as the final fallback.
+  const projectRoots = [...new Set([
+    process.env.CLAUDE_PROJECT_DIR,
+    process.env.CLAUDE_FLOW_CWD,
+    process.env.INIT_CWD,
+    process.cwd(),
+  ].filter((root): root is string => Boolean(root)))];
+
+  for (const projectRoot of projectRoots) {
+    try {
+      const projectRequire = createRequire(resolve(projectRoot, 'package.json'));
+      const modulePath = projectRequire.resolve(packageName);
+      const moduleUrl = `${pathToFileURL(modulePath).href}?t=${Date.now()}`;
+      return await import(moduleUrl) as T;
+    } catch {
+      // Try the next explicit project signal.
+    }
   }
+  return null;
 }
 
 /**

--- a/v3/@claude-flow/cli/src/mcp-tools/auto-install.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/auto-install.ts
@@ -6,9 +6,13 @@
  */
 
 import { spawnSync } from 'child_process';
+import { createRequire } from 'module';
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
 
 // Track which packages we've attempted to install this session
 const installAttempts = new Set<string>();
+const validPackageName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@[a-z0-9-._~]+)?$/i;
 
 export interface AutoInstallOptions {
   /**
@@ -42,7 +46,6 @@ export async function autoInstallPackage(
 
   // Validate package name to prevent command injection (CVE fix)
   // Valid npm package names: @scope/name or name, alphanumeric with - . _ ~
-  const validPackageName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@[a-z0-9-._~]+)?$/i;
   if (!validPackageName.test(packageName)) {
     if (!silent) {
       console.error(`[claude-flow] Invalid package name: ${packageName}`);
@@ -86,6 +89,29 @@ export async function autoInstallPackage(
 }
 
 /**
+ * Import an optional package from the MCP process working directory.
+ *
+ * Bare imports inside an npx-launched Ruflo resolve from npx's isolated cache,
+ * not from the user's project. Anchoring createRequire at the project makes an
+ * explicit, persistent project-local install discoverable without mutating the
+ * disposable npx cache.
+ */
+export async function importProjectLocalPackage<T = unknown>(packageName: string): Promise<T | null> {
+  if (!validPackageName.test(packageName)) {
+    return null;
+  }
+
+  try {
+    const projectRequire = createRequire(resolve(process.cwd(), 'package.json'));
+    const modulePath = projectRequire.resolve(packageName);
+    const moduleUrl = `${pathToFileURL(modulePath).href}?t=${Date.now()}`;
+    return await import(moduleUrl) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Try to import a package, auto-install if not found, and retry
  *
  * @param packageName - npm package name
@@ -100,9 +126,19 @@ export async function tryImportOrInstall<T = unknown>(
     // First try to import
     return await import(packageName) as T;
   } catch {
+    const projectLocal = await importProjectLocalPackage<T>(packageName);
+    if (projectLocal) {
+      return projectLocal;
+    }
+
     // Package not found, try to install
     const installed = await autoInstallPackage(packageName, options);
     if (installed) {
+      const installedProjectLocal = await importProjectLocalPackage<T>(packageName);
+      if (installedProjectLocal) {
+        return installedProjectLocal;
+      }
+
       try {
         // ESM caches failed imports, so we need to bust the cache
         // Add a timestamp query parameter to force a fresh import
@@ -156,6 +192,7 @@ export const OPTIONAL_PACKAGES = {
 
 export default {
   autoInstallPackage,
+  importProjectLocalPackage,
   tryImportOrInstall,
   isPackageAvailable,
   resetInstallAttempts,

--- a/v3/@claude-flow/cli/src/mcp-tools/security-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/security-tools.ts
@@ -12,7 +12,7 @@
 
 import type { MCPTool, MCPToolResult } from './types.js';
 import { validateText, validateIdentifier } from './validate-input.js';
-import { autoInstallPackage } from './auto-install.js';
+import { autoInstallPackage, importProjectLocalPackage } from './auto-install.js';
 import { createRequire } from 'module';
 
 // Create require for resolving module paths
@@ -70,6 +70,19 @@ async function getAIDefence(): Promise<AIDefenceInstance> {
     }
   }
 
+  // npx keeps Ruflo in an isolated cache, so a bare import above cannot see a
+  // package installed in the user's project. Resolve explicitly from cwd
+  // before attempting installation; this is the persistent optional-package
+  // path documented for npx-launched MCP servers (#2946).
+  const projectLocal = await importProjectLocalPackage<typeof import('@claude-flow/aidefence')>(packageName);
+  if (projectLocal) {
+    const instance = projectLocal.createAIDefence({ enableLearning: true });
+    if (instance) {
+      aidefenceInstance = instance;
+      return instance;
+    }
+  }
+
   // Don't attempt install more than once per session
   if (installAttempted) {
     throw new Error('AIDefence package not available. Install with: npm install @claude-flow/aidefence');
@@ -82,6 +95,16 @@ async function getAIDefence(): Promise<AIDefenceInstance> {
 
   if (!installed) {
     throw new Error('AIDefence package not available. Install with: npm install @claude-flow/aidefence');
+  }
+
+  const installedProjectLocal = await importProjectLocalPackage<typeof import('@claude-flow/aidefence')>(packageName);
+  if (installedProjectLocal) {
+    const instance = installedProjectLocal.createAIDefence({ enableLearning: true });
+    if (instance) {
+      aidefenceInstance = instance;
+      console.error(`[claude-flow] ${packageName} loaded after install (project-local path)`);
+      return instance;
+    }
   }
 
   // #1807 — auto-install lands the package somewhere Node's standard
@@ -122,7 +145,7 @@ async function getAIDefence(): Promise<AIDefenceInstance> {
       `This usually means npm installed the package somewhere Node's module resolver doesn't search ` +
       `(common with global installs of \`claude-flow\`). Recovery options:\n` +
       `  1. Run \`npm install --save @claude-flow/aidefence\` in your project's working directory.\n` +
-      `  2. Or run \`npx ruflo@latest mcp start\` from a directory whose node_modules contains the package.\n` +
+      `  2. Or run \`npx ruflo@latest mcp start\` from the project where the package is installed.\n` +
       `  3. Or restart the MCP server after the install completes.`
     );
   }


### PR DESCRIPTION
## Summary

- keep the generated `npx -y ruflo@latest mcp start` launcher unchanged
- resolve optional packages explicitly from Claude/Ruflo project-root signals before falling back to the MCP process cwd
- retry the project-local path before and after optional-package auto-install
- document the persistent project-local installation workflow for AIDefence and other optional packages

## Scope

This addresses the symptom reported in #2946: a manually modified npx cache is disposable, so optional packages must live in a persistent project dependency tree and be resolved from there on a fresh launch. It does not change or prevent npx cache pruning itself.

It also does not address #2977's missing AgentDB exports or controller registry; that is a separate failure and requires its own change.

The generated npx launcher remains unchanged. Project-local resolution first uses explicit `CLAUDE_PROJECT_DIR`, `CLAUDE_FLOW_CWD`, or `INIT_CWD` signals when present, then falls back to `process.cwd()` and normal parent-directory module lookup.

## Validation

- `vitest run __tests__/auto-install-project-local-2946.test.ts __tests__/init-wizard-bugs.test.ts` — 16 passed
- regression coverage includes an MCP launch cwd different from the explicit Claude project root
- `git diff --check`
- Full CLI type checking remains blocked on the same unbuilt workspace outputs and existing errors present on `upstream/main`; no changed-file type error was identified.

Related to #2946.