### PR TITLE
fix: correct CLAUDECODE env detection and neural-tools source label

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -873,8 +873,10 @@ async function checkApiKeys(): Promise<HealthCheck> {
     }
   }
 
-  // Detect Claude Code environment — API keys are managed internally
-  const inClaudeCode = !!(process.env.CLAUDE_CODE || process.env.CLAUDE_PROJECT_DIR || process.env.MCP_SESSION_ID);
+  // Detect Claude Code environment — API keys are managed internally.
+  // Claude Code sets CLAUDECODE (no underscore); CLAUDE_CODE is kept for
+  // compatibility with anything else that might set it.
+  const inClaudeCode = !!(process.env.CLAUDECODE || process.env.CLAUDE_CODE || process.env.CLAUDE_PROJECT_DIR || process.env.MCP_SESSION_ID);
 
   if (found.includes('ANTHROPIC_API_KEY') || found.includes('CLAUDE_API_KEY')) {
     return { name: 'API Keys', status: 'pass', message: `Found: ${found.join(', ')}` };

--- a/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/neural-tools.ts
@@ -206,11 +206,12 @@ function ensureEmbeddings(): Promise<void> {
   return embeddingsPromise;
 }
 
-// Storage paths
+// Storage paths. Note: `.claude-flow/neural/patterns.json` is a SEPARATE
+// file owned by the ReasoningBank store in memory/intelligence.ts — this
+// module only ever reads/writes MODELS_FILE, never a patterns.json.
 const STORAGE_DIR = '.claude-flow';
 const NEURAL_DIR = 'neural';
 const MODELS_FILE = 'models.json';
-const PATTERNS_FILE = 'patterns.json';
 
 interface NeuralModel {
   id: string;
@@ -308,7 +309,7 @@ export function getNeuralStoreStats(): {
     patternCount: patterns.length,
     byType,
     modelCount: Object.values(store.models ?? {}).length,
-    source: '.claude-flow/neural/patterns.json (loadNeuralStore)',
+    source: '.claude-flow/neural/models.json (loadNeuralStore)',
   };
 }
 


### PR DESCRIPTION
## Summary
- `doctor.ts`'s API-key health check tested `process.env.CLAUDE_CODE`, which Claude Code never sets — the real variable is `CLAUDECODE` (no underscore). Added the correct check alongside existing fallbacks.
- `getNeuralStoreStats()` in `neural-tools.ts` always reads/writes `.claude-flow/neural/models.json` but self-reported its source as `patterns.json` — a separate file actually owned by the ReasoningBank store in `memory/intelligence.ts`. Corrected the label and removed the unused, misleading `PATTERNS_FILE` constant.

Both changes verified against the actual source (not just the issue reports) before fixing.

Fixes #3023
Fixes #3025

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npx vitest run __tests__/pretrain-from-github.test.ts __tests__/unified-stats-2245.test.ts __tests__/self-learning-2245.test.ts __tests__/mcp-tools-deep.test.ts` — all neural/stats-related tests pass; the 7 pre-existing `mcp-tools-deep.test.ts` failures (unrelated `fs` mock gaps in terminal/session/swarm tools) reproduce identically on `origin/main` before this change, confirmed via `git stash`.