### PR TITLE
release: align bundled runtime metadata for 3.38.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.38.10",
+  "version": "3.38.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.38.10",
+      "version": "3.38.11",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/mcp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.38.10",
+  "version": "3.38.11",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.38.10",
+  "version": "3.38.11",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/scripts/__tests__/stage-internal-runtime-bundles.test.mjs
+++ b/scripts/__tests__/stage-internal-runtime-bundles.test.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { createBundledRuntimeManifest } from '../stage-internal-runtime-bundles.mjs';
+import {
+  alignBundledRuntimeVersion,
+  createBundledRuntimeManifest,
+} from '../stage-internal-runtime-bundles.mjs';
 
 const source = {
   name: '@claude-flow/example',
@@ -32,5 +35,19 @@ assert.deepEqual(bundled.rufloBundledRuntime, {
   },
 });
 assert.deepEqual(source.dependencies, { runtime: '^1.0.0' });
+
+const target = {
+  name: 'public-wrapper',
+  dependencies: { '@claude-flow/mcp': '3.0.0-alpha.9' },
+};
+assert.equal(alignBundledRuntimeVersion(target, {
+  name: '@claude-flow/mcp',
+  version: '3.0.0-alpha.10',
+}), true);
+assert.equal(target.dependencies['@claude-flow/mcp'], '3.0.0-alpha.10');
+assert.equal(alignBundledRuntimeVersion(target, {
+  name: '@claude-flow/mcp',
+  version: '3.0.0-alpha.10',
+}), false);
 
 console.log('bundled runtime manifest is self-contained and preserves source metadata');

--- a/scripts/stage-internal-runtime-bundles.mjs
+++ b/scripts/stage-internal-runtime-bundles.mjs
@@ -142,6 +142,16 @@ export function createBundledRuntimeManifest(packageJson) {
   return bundledManifest;
 }
 
+export function alignBundledRuntimeVersion(targetPackageJson, runtimePackageJson) {
+  const current = targetPackageJson.dependencies?.[runtimePackageJson.name];
+  if (current === undefined) {
+    throw new Error(`${runtimePackageJson.name} must be a dependency of ${targetPackageJson.name}`);
+  }
+  if (current === runtimePackageJson.version) return false;
+  targetPackageJson.dependencies[runtimePackageJson.name] = runtimePackageJson.version;
+  return true;
+}
+
 /**
  * Build reviewed internal packages and stage only their runtime artifacts under
  * a public package's node_modules tree. npm's bundledDependencies mechanism
@@ -181,6 +191,8 @@ export async function stageInternalRuntimeBundles(
     }
   }
 
+  let targetManifestChanged = false;
+
   for (const runtimePackage of INTERNAL_RUNTIME_PACKAGES) {
     const sourceRoot = join(repoRoot, 'v3', '@claude-flow', runtimePackage.directory);
     if (build) runBuild(sourceRoot);
@@ -191,6 +203,8 @@ export async function stageInternalRuntimeBundles(
         `Internal bundle identity mismatch: expected ${runtimePackage.name}, got ${String(packageJson.name)}`,
       );
     }
+    targetManifestChanged =
+      alignBundledRuntimeVersion(targetPackageJson, packageJson) || targetManifestChanged;
 
     const packageLeaf = runtimePackage.name.slice('@claude-flow/'.length);
     const target = join(scopeRoot, packageLeaf);
@@ -214,6 +228,16 @@ export async function stageInternalRuntimeBundles(
     } finally {
       await rm(temporary, { recursive: true, force: true });
     }
+  }
+
+  // The source-built runtime may be newer than the registry bootstrap used by
+  // `npm ci`. The packed manifest must name the bytes actually embedded in the
+  // archive or npm correctly reports the bundle as invalid during install.
+  if (targetManifestChanged) {
+    await writeFile(
+      join(targetRoot, 'package.json'),
+      `${JSON.stringify(targetPackageJson, null, 2)}\n`,
+    );
   }
 }
 

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": {
-    "version": "3.38.10",
+    "version": "3.38.11",
     "files": {
       "auto-memory-hook.mjs": "85fe05c757421c52137c0bc8545a0896bab6b4714538c2a11d1d0835bfcc8c1c",
       "hook-handler.cjs": "dae295fb9ae2626b89899c19a20cc911541af82b52d2eeb9b214d618b96e9a86",
@@ -8,6 +8,6 @@
       "statusline.cjs": "0457fe53f8cd2c56458ff178392536a5868efd1a573665fa43bc01d2d95ca677"
     }
   },
-  "signature": "barP4/Ox7uiTZsehKf4ItZy9FJQnQu5xHJ4ZVKq/ZbtVt19p6zH6ktGBAXRbcE04E6+uKj8+uCvn5AyXlCxEAg==",
+  "signature": "rNkivgIb+R5mwQcChrNF+m4lsfPPlKBn4oizP9Q7nuuIi8en/J3NJYf5l6mPRfEc4vdlqnnf0+Oid/007092Dw==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.38.10",
+  "version": "3.38.11",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- keep registry bootstrap coordinates for release-time `npm ci`
- rewrite packed dependency metadata to the exact source-built runtime version embedded in each archive
- advance the stable train to 3.38.11 because failed-release tag v3.38.10 remains immutable
- re-sign the helper manifest for 3.38.11

## Evidence
- reproduces and fixes failed stable run 31849712037
- staged root manifest identifies bundled MCP 3.0.0-alpha.10
- fresh root archive install, `npm ls --all`, and `ruflo --version` pass
- version lockstep, wrapper ranges, helper signature, and staging unit tests pass