### PR TITLE
Fix #3045: cache Git statusline probe and prevent duplicate Git work

### DIFF
--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -43,6 +43,11 @@ const CONFIG = {
 };
 
 const CWD = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// Git status changes less frequently than the statusline renders. Keep this
+// cache separate from the delegated CLI cache so branch/dirty state refreshes
+// independently without spawning the five-command Git probe on every render.
+const GIT_CACHE_FILE = path.join(os.tmpdir(), 'ruflo-statusline-git-cache-' + require('crypto').createHash('md5').update(CWD).digest('hex').slice(0, 8) + '.json');
+const GIT_CACHE_TTL_MS = 10000;
 // Replaced by statusline-generator with the package root of the CLI that
 // installed this helper. This survives custom npm prefixes and bundled Node
 // runtimes whose process.execPath belongs to a different tree (#2811).
@@ -634,7 +639,32 @@ function readJSON(filePath) {
 
 // ─── Git info (pure-Node / single exec — needed for branch display) ──────────
 
+function readGitCache() {
+  try {
+    if (!fs.existsSync(GIT_CACHE_FILE)) return null;
+    const raw = JSON.parse(fs.readFileSync(GIT_CACHE_FILE, 'utf-8'));
+    if (raw && typeof raw._ts === 'number' && raw.data && typeof raw.data === 'object' && Date.now() - raw._ts < GIT_CACHE_TTL_MS) {
+      return raw.data;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function writeGitCache(data) {
+  let tmpPath = '';
+  try {
+    tmpPath = GIT_CACHE_FILE + '.' + process.pid + '.' + Date.now() + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify({ _ts: Date.now(), data }), { encoding: 'utf-8', mode: 0o600 });
+    fs.renameSync(tmpPath, GIT_CACHE_FILE);
+  } catch {
+    try { if (tmpPath) fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  }
+}
+
 function getGitInfo() {
+  const cached = readGitCache();
+  if (cached) return cached;
+
   const result = {
     name: path.basename(CWD) || 'project', gitBranch: '', modified: 0, untracked: 0,
     staged: 0, ahead: 0, behind: 0,
@@ -653,7 +683,10 @@ function getGitInfo() {
   ].join('; ');
 
   const raw = safeExec("sh -c '" + script + "'", 3000);
-  if (!raw) return result;
+  if (!raw) {
+    writeGitCache(result);
+    return result;
+  }
 
   const parts = raw.split('---SEP---').map(function(s) { return s.trim(); });
   if (parts.length >= 5) {
@@ -677,6 +710,7 @@ function getGitInfo() {
     result.behind = parseInt(ab[1]) || 0;
   }
 
+  writeGitCache(result);
   return result;
 }
 

--- a/v3/@claude-flow/cli/__tests__/statusline-cost-display.test.ts
+++ b/v3/@claude-flow/cli/__tests__/statusline-cost-display.test.ts
@@ -19,11 +19,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { execFileSync, spawn } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, readdirSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
 
 import { generateStatuslineScript } from '../src/init/statusline-generator.js';
 import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
@@ -78,6 +79,173 @@ describe('statusline cost display — generator contract', () => {
 
   it('guards the cost segment with the hide toggle', () => {
     expect(SCRIPT).toContain('!CONFIG.hideCost && costInfo && costInfo.costUsd > 0');
+  });
+});
+
+function writeFakeGit(bin: string, log: string): void {
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(path.join(bin, 'git'), [
+    '#!/bin/sh',
+    'printf \'%s\\n\' "$*" >> "$GIT_PROBE_LOG"',
+    'if [ "${FAKE_GIT_MODE:-success}" = "fail" ]; then exit 1; fi',
+    'case "$1" in',
+    '  rev-parse) printf \'%s\\n\' "$FAKE_GIT_ROOT" ;;',
+    '  config) printf \'%s\\n\' "test-user" ;;',
+    '  branch) printf \'%s\\n\' "${FAKE_GIT_BRANCH:-main}" ;;',
+    '  status) : ;;',
+    '  rev-list) printf \'%s\\n\' "0 0" ;;',
+    'esac',
+  ].join('\n') + '\n', 'utf-8');
+  chmodSync(path.join(bin, 'git'), 0o755);
+}
+
+function cacheFileFor(cwd: string): string {
+  return path.join(
+    tmpdir(),
+    'ruflo-statusline-git-cache-' + createHash('md5').update(cwd).digest('hex').slice(0, 8) + '.json',
+  );
+}
+
+function runStatusline(scriptPath: string, cwd: string, env: Record<string, string>, args: string[] = []): string {
+  return execFileSync(process.execPath, [scriptPath, ...args], {
+    input: JSON.stringify({ model: { display_name: 'Opus 4.8' } }),
+    encoding: 'utf-8',
+    cwd,
+    env,
+    timeout: 15000,
+  });
+}
+
+function runStatuslineAsync(scriptPath: string, cwd: string, env: Record<string, string>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code !== 0) return reject(new Error(`statusline exited ${code}: ${stderr}`));
+      resolve(stdout);
+    });
+    child.stdin.end(JSON.stringify({ model: { display_name: 'Opus 4.8' } }));
+  });
+}
+
+describe('statusline Git probe cache', () => {
+  it('defines a short-lived cache and atomic writes for the Git probe', () => {
+    expect(SCRIPT).toContain('const GIT_CACHE_TTL_MS = 10000;');
+    expect(SCRIPT).toContain('function readGitCache()');
+    expect(SCRIPT).toContain('const cached = readGitCache();');
+    expect(SCRIPT).toContain('writeGitCache(result);');
+    expect(SCRIPT).toContain('fs.renameSync(tmpPath, GIT_CACHE_FILE);');
+  });
+
+  it('uses fresh cached Git info without spawning a Git probe', () => {
+    const home = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-git-home-'));
+    const cwd = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-git-cwd-'));
+    const cacheFile = cacheFileFor(cwd);
+    const scriptPath = path.join(cwd, 'statusline.cjs');
+    const cachedGit = {
+      name: 'cached-project', gitBranch: 'cached-branch', modified: 0, untracked: 0,
+      staged: 0, ahead: 0, behind: 0,
+    };
+    writeFileSync(cacheFile, JSON.stringify({ _ts: Date.now(), data: cachedGit }), 'utf-8');
+    writeFileSync(scriptPath, SCRIPT, 'utf-8');
+    try {
+      const out = runStatusline(scriptPath, cwd, { PATH: '/nonexistent', HOME: home, CLAUDE_PROJECT_DIR: cwd });
+      const header = stripAnsi(out).split('\n')[0];
+      expect(header).toContain('cached-project');
+      expect(header).toContain('cached-branch');
+    } finally {
+      rmSync(cacheFile, { force: true });
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('probes once, reuses the cache, then probes again after TTL expiry', () => {
+    const home = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-ttl-home-'));
+    const cwd = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-ttl-cwd-'));
+    const bin = path.join(home, 'bin');
+    const log = path.join(home, 'git-probe.log');
+    const cacheFile = cacheFileFor(cwd);
+    const scriptPath = path.join(cwd, 'statusline.cjs');
+    writeFakeGit(bin, log);
+    writeFileSync(scriptPath, SCRIPT, 'utf-8');
+    const env = {
+      PATH: `${bin}:/usr/bin:/bin`, HOME: home, GIT_PROBE_LOG: log,
+      FAKE_GIT_ROOT: cwd, CLAUDE_PROJECT_DIR: cwd, FAKE_GIT_BRANCH: 'first-branch',
+    };
+    try {
+      const first = runStatusline(scriptPath, cwd, env);
+      expect(stripAnsi(first)).toContain('first-branch');
+      expect(readFileSync(log, 'utf-8').trim().split('\n')).toHaveLength(5);
+
+      const cached = JSON.parse(readFileSync(cacheFile, 'utf-8'));
+      cached._ts = Date.now() - 10001;
+      writeFileSync(cacheFile, JSON.stringify(cached), 'utf-8');
+      const second = runStatusline(scriptPath, cwd, { ...env, FAKE_GIT_BRANCH: 'refreshed-branch' });
+      expect(stripAnsi(second)).toContain('refreshed-branch');
+      expect(readFileSync(log, 'utf-8').trim().split('\n')).toHaveLength(10);
+    } finally {
+      rmSync(cacheFile, { force: true });
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a safe fallback and writes valid cache data when Git fails', () => {
+    const home = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-fail-home-'));
+    const cwd = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-fail-cwd-'));
+    const bin = path.join(home, 'bin');
+    const log = path.join(home, 'git-probe.log');
+    const cacheFile = cacheFileFor(cwd);
+    const scriptPath = path.join(cwd, 'statusline.cjs');
+    writeFakeGit(bin, log);
+    writeFileSync(scriptPath, SCRIPT, 'utf-8');
+    try {
+      runStatusline(scriptPath, cwd, {
+        PATH: `${bin}:/usr/bin:/bin`, HOME: home, GIT_PROBE_LOG: log,
+        FAKE_GIT_ROOT: cwd, CLAUDE_PROJECT_DIR: cwd, FAKE_GIT_MODE: 'fail',
+      });
+      expect(JSON.parse(readFileSync(cacheFile, 'utf-8')).data.gitBranch).toBe('');
+    } finally {
+      rmSync(cacheFile, { force: true });
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the cache file valid under concurrent statusline renders', async () => {
+    const home = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-concurrent-home-'));
+    const cwd = mkdtempSync(path.join(tmpdir(), 'ruflo-statusline-concurrent-cwd-'));
+    const bin = path.join(home, 'bin');
+    const log = path.join(home, 'git-probe.log');
+    const cacheFile = cacheFileFor(cwd);
+    const scriptPath = path.join(cwd, 'statusline.cjs');
+    writeFakeGit(bin, log);
+    writeFileSync(scriptPath, SCRIPT, 'utf-8');
+    const env = {
+      PATH: `${bin}:/usr/bin:/bin`, HOME: home, GIT_PROBE_LOG: log,
+      FAKE_GIT_ROOT: cwd, CLAUDE_PROJECT_DIR: cwd, FAKE_GIT_BRANCH: 'parallel-branch',
+    };
+    try {
+      const results = await Promise.all(Array.from({ length: 8 }, () => runStatuslineAsync(scriptPath, cwd, env)));
+      expect(results).toHaveLength(8);
+      expect(results.every((result) => stripAnsi(result).includes('parallel-branch'))).toBe(true);
+      expect(JSON.parse(readFileSync(cacheFile, 'utf-8')).data.gitBranch).toBe('parallel-branch');
+      const temporaryFiles = readdirSync(tmpdir()).filter((name) => name.startsWith(path.basename(cacheFile) + '.') && name.endsWith('.tmp'));
+      expect(temporaryFiles).toHaveLength(0);
+    } finally {
+      rmSync(cacheFile, { force: true });
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #3045 by adding a short-lived cache for the statusline Git probe. Cache writes use a same-directory temporary file followed by atomic rename, preventing readers from observing partial JSON during concurrent renders. The cache remains independent from the delegated CLI cache, so Git branch and working-tree information refreshes on its own 10-second TTL.

## Issue / motivation

`getGitInfo()` shells out to a five-command Git probe on every statusline render. Frequent renders can create unnecessary Git subprocesses and disk work, especially when several sessions target the same large repository.

Closes #3045.

## Approach

The result is keyed by a short hash of `CLAUDE_PROJECT_DIR` and stored in the system temporary directory. Fresh entries are reused for 10 seconds. Successful and failed probes are cached for that interval so a missing or temporarily unavailable Git executable cannot cause a spawn storm. Cache writes use a unique temporary filename followed by `fs.renameSync` in the same directory.

## Test plan

- [x] Node syntax check for the generated helper.
- [x] 19/19 statusline tests pass, including cache contract, fresh-cache reuse, TTL expiry, Git failure fallback, and eight concurrent renders.
- [x] 34/34 tests pass with the related CLI regression suite.
- [x] `git diff --check` passes.
- [x] Baseline comparison completed from the original HEAD: the same pre-existing workspace build failure occurred before and after this change.

## Build note

The full `@claude-flow/cli` TypeScript build remains blocked by the same 17 errors observed in the baseline, including unresolved `@claude-flow/security` declarations and unbuilt `swarm` declaration outputs. None of those errors are in the files changed by this PR.

## Risks / open questions

The cache is shared by processes using the same project path. Atomic replacement prevents cache corruption, but multiple processes reaching an expired cache at exactly the same time may still perform their own probe. The 10-second TTL favors low statusline overhead over instant branch/status freshness.