### PR TITLE
fix(test): resolve CI-breaking flaky duration assertion in agentic-flow-agent tests

### DIFF
--- a/v3/@claude-flow/integration/src/__tests__/agentic-flow-agent.test.ts
+++ b/v3/@claude-flow/integration/src/__tests__/agentic-flow-agent.test.ts
@@ -67,7 +67,8 @@ describe('AgenticFlowAgent', () => {
 
       expect(result.success).toBe(true);
       expect(result.taskId).toBe('task-1');
-      expect(result.duration).toBeGreaterThan(0);
+      // Date.now()-based duration on a ~1ms task can legitimately read 0 under coarse CI clock resolution
+      expect(result.duration).toBeGreaterThanOrEqual(0);
       expect(agent.metrics?.tasksCompleted).toBe(1);
     });
 
@@ -100,7 +101,7 @@ describe('AgenticFlowAgent', () => {
       });
 
       expect(agent.metrics?.tasksCompleted).toBe(2);
-      expect(agent.metrics?.avgTaskDuration).toBeGreaterThan(0);
+      expect(agent.metrics?.avgTaskDuration).toBeGreaterThanOrEqual(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes the CI break on `main` reported by the test ratchet (run [32091740244](https://github.com/ruvnet/ruflo/actions/runs/32091740244), commit `fa13ee4a` — the same commit had passed CI the previous day, confirming this is timing flakiness, not a real regression).
- `agentic-flow-agent.test.ts` asserted `result.duration` / `agent.metrics.avgTaskDuration` are strictly `> 0`. The implementation measures `Date.now()` before/after a task whose local-execution fallback only guarantees a `setTimeout(1)` delay. Under CI's coarser clock resolution, both samples can land in the same millisecond, making duration legitimately `0`.
- Relaxed both assertions to `toBeGreaterThanOrEqual(0)`, which still verifies duration is a valid non-negative measurement without depending on sub-millisecond CI clock precision.

## Test plan
- `npx vitest run src/__tests__/agentic-flow-agent.test.ts` in `v3/@claude-flow/integration` — 11/11 passing locally.
- No production code changed; this is a test-assertion correction only.