### PR TITLE
fix(cli): honor MCP tool selection when listing

### DIFF
--- a/v3/@claude-flow/cli/__tests__/mcp-tools-command-3055.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-tools-command-3055.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/mcp-client.js', () => ({
+  listMCPTools: () => [
+    { name: 'memory_store', category: 'memory', description: 'Store memory' },
+    { name: 'swarm_init', category: 'swarm', description: 'Initialize a swarm' },
+    { name: 'agent_spawn', category: 'agent', description: 'Spawn an agent' },
+  ],
+  callMCPTool: vi.fn(),
+  hasTool: vi.fn(),
+  getToolMetadata: vi.fn(),
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    printJson: vi.fn(),
+    writeln: vi.fn(),
+    bold: (value: string) => value,
+    highlight: (value: string) => value,
+    printTable: vi.fn(),
+    printInfo: vi.fn(),
+    success: (value: string) => value,
+    dim: (value: string) => value,
+  },
+}));
+
+import { mcpCommand } from '../src/commands/mcp.js';
+
+const originalSelection = process.env.CLAUDE_FLOW_MCP_TOOLS;
+
+afterEach(() => {
+  if (originalSelection === undefined) delete process.env.CLAUDE_FLOW_MCP_TOOLS;
+  else process.env.CLAUDE_FLOW_MCP_TOOLS = originalSelection;
+});
+
+describe('mcp tools environment filtering (#3055)', () => {
+  it('lists only tools selected by CLAUDE_FLOW_MCP_TOOLS', async () => {
+    process.env.CLAUDE_FLOW_MCP_TOOLS = 'memory,agent';
+    const toolsCommand = mcpCommand.subcommands?.find((command) => command.name === 'tools');
+    expect(toolsCommand).toBeDefined();
+
+    const result = await toolsCommand!.action({ flags: { format: 'json' } } as never);
+    expect((result.data as Array<{ name: string }>).map((tool) => tool.name))
+      .toEqual(['memory_store', 'agent_spawn']);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/mcp.ts
+++ b/v3/@claude-flow/cli/src/commands/mcp.ts
@@ -19,6 +19,8 @@ import {
   getMCPServerStatus,
   type MCPServerOptions,
   type MCPServerStatus,
+  filterAdvertisedMcpTools,
+  parseMcpToolSelection,
 } from '../mcp-server.js';
 import { listMCPTools, callMCPTool, hasTool, getToolMetadata } from '../mcp-client.js';
 
@@ -455,7 +457,8 @@ const toolsCommand: Command = {
     let tools: Array<{ name: string; category: string; description: string; enabled: boolean }>;
 
     // Get tools from local registry
-    const registeredTools = listMCPTools(category);
+    const selection = parseMcpToolSelection(process.env.CLAUDE_FLOW_MCP_TOOLS);
+    const registeredTools = filterAdvertisedMcpTools(listMCPTools(category), selection);
 
     if (registeredTools.length > 0) {
       tools = registeredTools.map(tool => ({
@@ -466,7 +469,7 @@ const toolsCommand: Command = {
       }));
     } else {
       // Fallback to static tool list
-      tools = [
+      tools = filterAdvertisedMcpTools([
         // Agent tools
         { name: 'agent_spawn', category: 'agent', description: 'Spawn a new agent', enabled: true },
         { name: 'agent_list', category: 'agent', description: 'List all agents', enabled: true },
@@ -503,7 +506,7 @@ const toolsCommand: Command = {
         { name: 'system_info', category: 'system', description: 'System information', enabled: true },
         { name: 'system_health', category: 'system', description: 'Health status', enabled: true },
         { name: 'system_metrics', category: 'system', description: 'Server metrics', enabled: true },
-      ].filter(t => !category || t.category === category);
+      ].filter(t => !category || t.category === category), selection);
     }
 
     if (ctx.flags.format === 'json') {


### PR DESCRIPTION
## Summary

- apply `CLAUDE_FLOW_MCP_TOOLS` to the `mcp tools` catalogue, matching the server and doctor behavior
- keep the existing `--category` filter and static fallback under the same selection contract
- add a command-level regression test for category selection through the environment variable

## Validation

- `vitest run __tests__/mcp-tools-command-3055.test.ts __tests__/mcp-tool-filter-2726.test.ts` — 7 passed
- `git diff --check`
- `npm run build` remains blocked by existing main-worktree prerequisites/errors: unbuilt internal workspace outputs, unresolved `@claude-flow/{security,memory,neural}` declarations, and pre-existing type errors in `auth/client.ts` and `hooks-tools.ts`; no error points to the changed command or test

Closes #3055