### PR TITLE
fix(flywheel): compute receipt statistics from encoded scale-12 values — honest receipts no longer fail their own verifier (ruflo#3072)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/flywheel-receipt.test.ts
+++ b/v3/@claude-flow/cli/__tests__/flywheel-receipt.test.ts
@@ -122,6 +122,34 @@ describe('flywheel receipt protocol', () => {
     expect(verifyFlywheelReceipt(receipt, new Set([key.publicKeyPem])).valid).toBe(true);
   });
 
+  it('verifies receipts whose scores need more than twelve decimals (encoded round-trip)', () => {
+    const key = keys();
+    // Mean of a heterogeneous per-task corpus; not representable at scale 12.
+    // Stored as "0.768708333333", so a verifier recomputes from that value —
+    // the producer must have used it too, or relativeLift shifts by one ULP
+    // and an honest receipt reports "statistical decision does not recompute".
+    const candidateScore = 0.7687083333333332;
+    const heldOutDeltas = [0.2687083333333332, 0.26870833333333326, 0.2687083333333333, 0.2687083333333331];
+    const receipt = createFlywheelReceipt({
+      baselineRef: policyCandidateId({ alpha: 0.5 }),
+      candidatePolicy: { alpha: 0.3 },
+      safetyEnvelopeRef: 'sha256:safety',
+      corpusVersion: 'corpus-v1',
+      corpusHash: 'sha256:corpus',
+      baselineScore: 0.5,
+      candidateScore,
+      heldOutDeltas,
+      frozenAnchorRegression: 0,
+      gates: { heldOut: true },
+      bootstrapIterations: 500,
+      ...key,
+    });
+    expect(receipt.payload.candidateScore).toBe('0.768708333333');
+    const verification = verifyFlywheelReceipt(receipt, new Set([key.publicKeyPem]));
+    expect(verification.errors).toEqual([]);
+    expect(verification.valid).toBe(true);
+  });
+
   it('rejects small relative lifts even when every held-out delta is positive', () => {
     const { privateKeyPem, publicKeyPem } = keys();
     const receipt = createFlywheelReceipt({

--- a/v3/@claude-flow/cli/src/services/flywheel-receipt.ts
+++ b/v3/@claude-flow/cli/src/services/flywheel-receipt.ts
@@ -323,11 +323,19 @@ export function createFlywheelReceipt(input: CreateReceiptInput): FlywheelEvalua
   const evaluationRunId = input.evaluationRunId ?? uuidV7(now);
   const lineageId = input.lineageId ?? uuidV7(now);
   const candidateId = policyCandidateId(input.candidatePolicy);
+  // Verifiers recompute the statistics from the payload's scale-12 decimal
+  // strings — the only values they ever have. The encoded values are therefore
+  // the statistical inputs of record: compute the decision from them, not from
+  // full-precision intermediates, or any input that does not terminate within
+  // twelve decimals produces an honest receipt that fails its own verification.
+  const encodedBaselineScore = decimal(input.baselineScore);
+  const encodedCandidateScore = decimal(input.candidateScore);
+  const encodedHeldOutDeltas = input.heldOutDeltas.map((v) => decimal(v));
   const statistics = computePromotionStatistics({
-    baselineScore: input.baselineScore,
-    candidateScore: input.candidateScore,
-    heldOutDeltas: input.heldOutDeltas,
-    frozenAnchorRegression: input.frozenAnchorRegression,
+    baselineScore: Number(encodedBaselineScore),
+    candidateScore: Number(encodedCandidateScore),
+    heldOutDeltas: encodedHeldOutDeltas.map(Number),
+    frozenAnchorRegression: Number(decimal(input.frozenAnchorRegression)),
     corpusHash: input.corpusHash,
     candidateId,
     baselineRef: input.baselineRef,
@@ -352,9 +360,9 @@ export function createFlywheelReceipt(input: CreateReceiptInput): FlywheelEvalua
     ...(input.proposerSubstitution ? { proposerSubstitution: input.proposerSubstitution } : {}),
     corpusVersion: input.corpusVersion,
     corpusHash: input.corpusHash,
-    baselineScore: decimal(input.baselineScore),
-    candidateScore: decimal(input.candidateScore),
-    heldOutDeltas: input.heldOutDeltas.map((v) => decimal(v)),
+    baselineScore: encodedBaselineScore,
+    candidateScore: encodedCandidateScore,
+    heldOutDeltas: encodedHeldOutDeltas,
     ...(input.pairedOutcomes
       ? {
         pairedOutcomes: input.pairedOutcomes.map((o) => ({


### PR DESCRIPTION
Fixes **ruvnet/ruflo#3072**. Companion to the ADR-322C contract work in #3067 (whose amendment makes this fix's rule normative) and to the verifier-enforcement fix in #3070.

## The bug

`createFlywheelReceipt` computed the statistical promotion decision from **full-precision** doubles (`baselineScore`, `candidateScore`, `heldOutDeltas`, `frozenAnchorRegression`) while the payload stored those same inputs as **scale-12 decimal strings**. `verifyFlywheelReceipt` recomputes from the stored strings — the only values a verifier can ever have.

Any input that does not terminate within twelve decimals made producer and verifier run the bootstrap over *different* numbers. Reproduced at a corpus mean of `0.7687083333333332` (stored `"0.768708333333"`): `relativeLift` shifts by one ULP on re-decode, its decimal encoding changes, and an **honest, correctly signed receipt fails its own verification** with `statistical decision does not recompute` — the same error a tampered receipt produces, so consumers cannot triage the two. Existing fixtures only used exactly-representable means, which masked it; the heterogeneous-delta conformance fixture in #3067 (`receipt-bootstrap-reference.example.json`) exercises exactly this path.

This is a live availability risk for WP8 anchoring (ruvnet/rvm#35, ruvnet/autogenous#10) and RuVector WP4, which are about to anchor receipts into witness chains and verify across repo boundaries.

## The fix

`createFlywheelReceipt` now encodes the scores/deltas/regression first and feeds `Number(encoded)` into `computePromotionStatistics` — the encoded values are the statistical inputs of record, so producer and verifier are bit-identical by construction. The payload reuses the same encoded strings. This is exactly the rule the ADR-322C amendment in #3067 makes normative: *the producer must compute the statistical decision from the encoded scale-12 values (what a verifier has), not full-precision intermediates.*

`harness-flywheel.ts`, the other producer path, calls `createFlywheelReceipt` with raw numbers and is covered by the same change.

## Compatibility

Receipt bytes change **only** for receipts whose inputs are not exactly representable at scale 12 — and every such receipt was previously **broken** (it failed its own verifier), not valid. Receipts whose inputs round-trip exactly are byte-identical before and after this change (the pinned-fixture suites pass unmodified).

## Verification

The new regression test (`verifies receipts whose scores need more than twelve decimals (encoded round-trip)`) was first run against the unfixed producer:

```
FAIL  __tests__/flywheel-receipt.test.ts
  AssertionError: expected [ "statistical decision does not recompute" ] to deeply equal []
Tests  1 failed | 7 passed (8)
```

With the fix:

```
Test Files  7 passed (7)
     Tests  58 passed (58)
```

covering `flywheel-receipt`, `flywheel-transaction`, `flywheel-proposer`, `flywheel-sequential-evidence`, `flywheel-envelope-proposer-contract`, `harness-flywheel`, and `harness-flywheel-generations`.

Caveat (same as #3070): run with standalone vitest, since the `workspace:` protocol dependencies block `npm install` outside the workspace; CI is the authority for the rest of the tree.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_012Jib2gQyJpqCoo2xYAbb4X
