### PR TITLE
fix: persist routing outcomes for namespaced agents

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-post-task-routing-dual-write-2786.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-post-task-routing-dual-write-2786.test.ts
@@ -39,15 +39,17 @@ vi.mock('../src/memory/graph-edge-writer.js', () => ({
   insertGraphEdge: vi.fn(async () => undefined),
 }));
 
-const { hooksPostTask } = await import('../src/mcp-tools/hooks-tools.js');
+let hooksPostTask: (typeof import('../src/mcp-tools/hooks-tools.js'))['hooksPostTask'];
 
 let origCwd: string;
 let workdir: string;
 
-beforeEach(() => {
+beforeEach(async () => {
   origCwd = process.cwd();
   workdir = mkdtempSync(join(tmpdir(), 'ruflo-2786-'));
   process.chdir(workdir);
+  vi.resetModules();
+  ({ hooksPostTask } = await import('../src/mcp-tools/hooks-tools.js'));
   bridgeRecordFeedback.mockClear();
   bridgeStoreEntry.mockClear();
 });
@@ -105,5 +107,28 @@ describe('#2786 fix-2 — hooks_post-task JSON dual-write for metrics reader', (
       const store = JSON.parse(readFileSync(storePath, 'utf-8')) as { entries: Record<string, any> };
       expect(store.entries['routing-decision:task-2786-no-store']).toBeUndefined();
     }
+  });
+
+  it('persists routing outcomes for valid namespaced plugin agent IDs', async () => {
+    const result = await hooksPostTask.handler({
+      taskId: 'task-3064-namespaced-agent',
+      task: 'review the plugin integration',
+      agent: 'ruflo-core:reviewer',
+      success: true,
+      quality: 0.95,
+    }) as { learningUpdates: { outcomePersisted: boolean } };
+
+    expect(result.learningUpdates.outcomePersisted).toBe(true);
+
+    const outcomesPath = join(workdir, '.claude-flow', 'routing-outcomes.json');
+    expect(existsSync(outcomesPath)).toBe(true);
+
+    const data = JSON.parse(readFileSync(outcomesPath, 'utf-8')) as {
+      outcomes: Array<{ agent: string; task: string }>;
+    };
+    expect(data.outcomes).toContainEqual(expect.objectContaining({
+      agent: 'ruflo-core:reviewer',
+      task: 'review the plugin integration',
+    }));
   });
 });

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -1550,7 +1550,10 @@ export const hooksPostTask: MCPTool = {
     const taskText = (params.task as string) || '';
     const outcomeKeywords = extractKeywords(taskText);
     let outcomePersisted = false;
-    if (taskText && agent && agent.length <= 100 && /^[a-zA-Z0-9_-]+$/.test(agent)) {
+    // `agent` has already passed validateIdentifier above. Reuse that contract
+    // here so valid namespaced plugin IDs (for example `ruflo-core:reviewer`)
+    // are not silently excluded from routing outcomes.
+    if (taskText && agent && agent.length <= 100) {
       try {
         const outcomes = loadRoutingOutcomes();
         outcomes.push({


### PR DESCRIPTION
## Summary

- reuse the existing validated agent identifier contract when persisting post-task routing outcomes
- preserve the existing 100-character persistence cap
- add a regression case for namespaced plugin IDs such as ruflo-core:reviewer

The MCP handler already accepts namespaced identifiers. The separate persistence-only regex was the narrower contract and silently dropped otherwise valid IDs, so this removes only that redundant restriction.

## Validation

- corepack pnpm exec vitest run __tests__/hooks-post-task-routing-dual-write-2786.test.ts
- 3 tests passed
- git diff --check

Fixes #3064