### PR TITLE
fix: validate skill frontmatter as YAML

### DIFF
--- a/plugins/ruflo-metaharness/skills/harness-threat-model/SKILL.md
+++ b/plugins/ruflo-metaharness/skills/harness-threat-model/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: harness-threat-model
-description: >-
-  Enterprise-review-grade threat model from `harness threat-model <path>`.
-  Categorizes MCP-surface threats; emits a worst severity of clean, low,
-  medium, or high plus per-threat findings. Pure-read.
+description: "Enterprise-review-grade threat model from `harness threat-model <path>`. Categorizes MCP-surface threats; emits `worst: 'clean'|'low'|'medium'|'high'` plus per-threat findings. Pure-read."
 argument-hint: "[--path .] [--fail-on clean|low|medium|high] [--format table|json]"
 allowed-tools: Bash
 ---

--- a/plugins/ruflo-metaharness/skills/harness-threat-model/SKILL.md
+++ b/plugins/ruflo-metaharness/skills/harness-threat-model/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: harness-threat-model
-description: Enterprise-review-grade threat model from `harness threat-model <path>`. Categorizes MCP-surface threats; emits `worst: 'clean'|'low'|'medium'|'high'` + per-threat findings. Pure-read.
+description: >-
+  Enterprise-review-grade threat model from `harness threat-model <path>`.
+  Categorizes MCP-surface threats; emits a worst severity of clean, low,
+  medium, or high plus per-threat findings. Pure-read.
 argument-hint: "[--path .] [--fail-on clean|low|medium|high] [--format table|json]"
 allowed-tools: Bash
 ---

--- a/scripts/audit-skill-frontmatter.mjs
+++ b/scripts/audit-skill-frontmatter.mjs
@@ -30,7 +30,6 @@
 import { readdirSync, statSync, readFileSync } from 'node:fs';
 import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseDocument } from 'yaml';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = dirname(SCRIPTS_DIR);
@@ -79,21 +78,30 @@ function existsSync(p) {
 function parseFrontmatter(src) {
   const lines = src.split(/\r?\n/);
   if (lines[0].trim() !== '---') return null;
-  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
-  if (closingIndex === -1) return null;
+  const fields = {};
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return { fields, error: null };
+    const m = /^([\w-]+):\s*(.*)$/.exec(lines[i]);
+    if (!m) continue;
 
-  const document = parseDocument(lines.slice(1, closingIndex).join('\n'), {
-    uniqueKeys: true,
-  });
-  if (document.errors.length > 0) {
-    return { fields: null, error: document.errors.map((error) => error.message).join('; ') };
-  }
+    const [, key, rawValue] = m;
+    if (Object.hasOwn(fields, key)) {
+      return { fields: null, error: `duplicate key \`${key}\`` };
+    }
 
-  const fields = document.toJS();
-  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) {
-    return { fields: null, error: 'frontmatter must be a YAML mapping' };
+    const value = rawValue.trim();
+    const quoted = (value.startsWith('"') && value.endsWith('"'))
+      || (value.startsWith("'") && value.endsWith("'"));
+    const blockScalar = /^[>|][+-]?$/.test(value);
+    if (value && !quoted && !blockScalar && /:\s/.test(value)) {
+      return {
+        fields: null,
+        error: `plain scalar for \`${key}\` contains \": \": quote the value or use a block scalar`,
+      };
+    }
+    fields[key] = quoted ? value.slice(1, -1) : value;
   }
-  return { fields, error: null };
+  return null;
 }
 
 function auditSkill(skill) {

--- a/scripts/audit-skill-frontmatter.mjs
+++ b/scripts/audit-skill-frontmatter.mjs
@@ -30,6 +30,7 @@
 import { readdirSync, statSync, readFileSync } from 'node:fs';
 import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseDocument } from 'yaml';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = dirname(SCRIPTS_DIR);
@@ -76,17 +77,23 @@ function existsSync(p) {
 }
 
 function parseFrontmatter(src) {
-  // First non-empty content must be `---`. Everything until the next `---`
-  // is YAML-ish key:value pairs (we only need flat keys).
   const lines = src.split(/\r?\n/);
   if (lines[0].trim() !== '---') return null;
-  const fields = {};
-  for (let i = 1; i < lines.length; i++) {
-    if (lines[i].trim() === '---') return fields;
-    const m = /^([\w-]+):\s*(.*)$/.exec(lines[i]);
-    if (m) fields[m[1]] = m[2].trim();
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (closingIndex === -1) return null;
+
+  const document = parseDocument(lines.slice(1, closingIndex).join('\n'), {
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0) {
+    return { fields: null, error: document.errors.map((error) => error.message).join('; ') };
   }
-  return null; // never closed
+
+  const fields = document.toJS();
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) {
+    return { fields: null, error: 'frontmatter must be a YAML mapping' };
+  }
+  return { fields, error: null };
 }
 
 function auditSkill(skill) {
@@ -100,16 +107,21 @@ function auditSkill(skill) {
     violations.push({ check: 'readable', detail: e.message });
     return violations;
   }
-  const fm = parseFrontmatter(src);
-  if (!fm) {
+  const parsed = parseFrontmatter(src);
+  if (!parsed) {
     violations.push({ check: 'frontmatter block', detail: 'missing or unclosed `---` block' });
     return violations;
   }
+  if (parsed.error) {
+    violations.push({ check: 'frontmatter YAML', detail: parsed.error });
+    return violations;
+  }
+  const fm = parsed.fields;
   if (!fm.name) violations.push({ check: 'name field', detail: 'missing or empty' });
   if (!fm.description) violations.push({ check: 'description field', detail: 'missing or empty' });
   if (fm['allowed-tools'] === undefined) {
     violations.push({ check: 'allowed-tools field', detail: 'missing (security — no implicit "all tools")' });
-  } else if (fm['allowed-tools'].trim() === '*') {
+  } else if (String(fm['allowed-tools']).trim() === '*') {
     violations.push({ check: 'allowed-tools wildcard', detail: 'value is `*` — explicit list required' });
   }
   if (fm.name && fm.name !== skill.skillDir) {


### PR DESCRIPTION
## Summary

- quote the invalid plain-scalar descriptions in harness-gepa and harness-threat-model
- make the dependency-free fleet audit reject duplicate keys and unquoted `: ` sequences that YAML parsers reject
- preserve the existing required-field, allowed-tools, and directory-name checks

The material assumption is that these flat skill frontmatter documents should remain auditable before dependencies are installed, because the all-plugins smoke runs the audit in a clean checkout. The syntax guard is intentionally limited to the failure class reported here; it does not claim to be a complete YAML parser.

## Validation

- negative control: the audit rejects the original unquoted threat-model description with `frontmatter YAML: plain scalar ... contains ": "`
- `node scripts/audit-skill-frontmatter.mjs --only ruflo-metaharness`
- `node scripts/audit-skill-frontmatter.mjs`
- all 136 skill files across 35 plugins passed
- `git diff --check`

Fixes #3065