### PR TITLE
fix: resolve Claude Code launches on Windows

### DIFF
--- a/v3/@claude-flow/cli/__tests__/claude-command-windows-3071.test.ts
+++ b/v3/@claude-flow/cli/__tests__/claude-command-windows-3071.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { win32 } from 'node:path';
+import { resolveClaudeLaunchCommand } from '../src/runtime/claude-command.js';
+
+describe('#3071 Claude Code command resolution', () => {
+  it('uses which and the resolved executable on POSIX', () => {
+    const lookup = vi.fn(() => '/usr/local/bin/claude\n');
+
+    expect(resolveClaudeLaunchCommand({
+      platform: 'linux',
+      lookup,
+      fileExists: (path) => path === '/usr/local/bin/claude',
+    })).toEqual({ command: '/usr/local/bin/claude', argsPrefix: [] });
+    expect(lookup).toHaveBeenCalledWith('which', ['claude']);
+  });
+
+  it('resolves the native Claude executable behind a Windows npm shim', () => {
+    const npmBin = 'C:\\Users\\tester\\AppData\\Roaming\\npm';
+    const nativeExecutable = win32.join(
+      npmBin,
+      'node_modules',
+      '@anthropic-ai',
+      'claude-code',
+      'bin',
+      'claude.exe',
+    );
+    const lookup = vi.fn(() => [
+      win32.join(npmBin, 'claude'),
+      win32.join(npmBin, 'claude.cmd'),
+    ].join('\r\n'));
+
+    expect(resolveClaudeLaunchCommand({
+      platform: 'win32',
+      lookup,
+      fileExists: (path) => path === nativeExecutable,
+    })).toEqual({ command: nativeExecutable, argsPrefix: [] });
+    expect(lookup).toHaveBeenCalledWith('where.exe', ['claude']);
+  });
+
+  it('runs older JavaScript installs through Node without a shell', () => {
+    const npmBin = 'C:\\Users\\tester\\AppData\\Roaming\\npm';
+    const javascriptEntry = win32.join(
+      npmBin,
+      'node_modules',
+      '@anthropic-ai',
+      'claude-code',
+      'cli.js',
+    );
+
+    expect(resolveClaudeLaunchCommand({
+      platform: 'win32',
+      nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+      lookup: () => win32.join(npmBin, 'claude.cmd'),
+      fileExists: (path) => path === javascriptEntry,
+    })).toEqual({
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      argsPrefix: [javascriptEntry],
+    });
+  });
+
+  it('returns null when lookup fails or no safe direct target exists', () => {
+    expect(resolveClaudeLaunchCommand({
+      platform: 'win32',
+      lookup: () => { throw new Error('not found'); },
+    })).toBeNull();
+
+    expect(resolveClaudeLaunchCommand({
+      platform: 'win32',
+      lookup: () => 'C:\\npm\\claude.cmd',
+      fileExists: () => false,
+    })).toBeNull();
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -10,10 +10,11 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
-import { spawn as childSpawn, execSync } from 'child_process';
+import { spawn as childSpawn } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { resolveClaudeLaunchCommand } from '../runtime/claude-command.js';
 
 // Worker type definitions for prompt generation
 interface HiveWorker {
@@ -232,12 +233,11 @@ async function spawnClaudeCodeInstance(
     output.writeln();
     output.printSuccess(`Hive Mind prompt saved to: ${promptFile}`);
 
-    // Check if claude command exists
-    let claudeAvailable = false;
-    try {
-      execSync('which claude', { stdio: 'ignore' });
-      claudeAvailable = true;
-    } catch {
+    // Resolve a directly spawnable command. On Windows, npm exposes shell
+    // shims that Node cannot launch with shell:false, so the resolver follows
+    // the shim to Claude Code's executable or JavaScript entry point.
+    const claudeLaunch = resolveClaudeLaunchCommand();
+    if (!claudeLaunch) {
       output.writeln();
       output.printWarning('Claude Code CLI not found in PATH');
       output.writeln(output.dim('Install it with: npm install -g @anthropic-ai/claude-code'));
@@ -246,7 +246,7 @@ async function spawnClaudeCodeInstance(
 
     const dryRun = flags.dryRun || flags['dry-run'];
 
-    if (claudeAvailable && !dryRun) {
+    if (claudeLaunch && !dryRun) {
       // Build arguments - flags first, then prompt
       const claudeArgs: string[] = [];
 
@@ -323,7 +323,10 @@ async function spawnClaudeCodeInstance(
       output.writeln(output.dim('Press Ctrl+C to pause the session'));
 
       // Spawn claude with properly ordered arguments
-      const claudeProcess = childSpawn('claude', claudeArgs, {
+      const claudeProcess = childSpawn(claudeLaunch.command, [
+        ...claudeLaunch.argsPrefix,
+        ...claudeArgs,
+      ], {
         stdio: 'inherit',
         shell: false,
       });

--- a/v3/@claude-flow/cli/src/runtime/claude-command.ts
+++ b/v3/@claude-flow/cli/src/runtime/claude-command.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, extname, join } from 'node:path';
+
+export interface ClaudeLaunchCommand {
+  command: string;
+  argsPrefix: string[];
+}
+
+interface ClaudeCommandResolverOptions {
+  platform?: NodeJS.Platform;
+  nodeExecutable?: string;
+  lookup?: (command: string, args: string[]) => string;
+  fileExists?: (path: string) => boolean;
+}
+
+/**
+ * Resolve Claude Code to a target that Node can spawn without a shell.
+ *
+ * Windows npm shims (`claude.cmd` and `claude.ps1`) are shell scripts and
+ * cannot be passed directly to spawn with `shell: false`. Resolve the native
+ * executable used by current Claude Code releases, or the JavaScript entry
+ * used by older releases, while keeping user-provided prompts out of a shell.
+ */
+export function resolveClaudeLaunchCommand(
+  options: ClaudeCommandResolverOptions = {},
+): ClaudeLaunchCommand | null {
+  const platform = options.platform ?? process.platform;
+  const nodeExecutable = options.nodeExecutable ?? process.execPath;
+  const lookup = options.lookup ?? ((command, args) =>
+    execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }));
+  const fileExists = options.fileExists ?? existsSync;
+
+  let matches: string[];
+  try {
+    const output = platform === 'win32'
+      ? lookup('where.exe', ['claude'])
+      : lookup('which', ['claude']);
+    matches = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  } catch {
+    return null;
+  }
+
+  if (platform !== 'win32') {
+    const command = matches.find(fileExists);
+    return command ? { command, argsPrefix: [] } : null;
+  }
+
+  const executable = matches.find((candidate) =>
+    extname(candidate).toLowerCase() === '.exe' && fileExists(candidate));
+  if (executable) return { command: executable, argsPrefix: [] };
+
+  for (const shim of matches) {
+    const npmBin = dirname(shim);
+    const packageRoot = join(npmBin, 'node_modules', '@anthropic-ai', 'claude-code');
+    const nativeExecutable = join(packageRoot, 'bin', 'claude.exe');
+    if (fileExists(nativeExecutable)) {
+      return { command: nativeExecutable, argsPrefix: [] };
+    }
+
+    const javascriptEntry = join(packageRoot, 'cli.js');
+    if (fileExists(javascriptEntry)) {
+      return { command: nodeExecutable, argsPrefix: [javascriptEntry] };
+    }
+  }
+
+  return null;
+}

--- a/v3/@claude-flow/cli/src/runtime/claude-command.ts
+++ b/v3/@claude-flow/cli/src/runtime/claude-command.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { dirname, extname, join } from 'node:path';
+import { posix, win32 } from 'node:path';
 
 export interface ClaudeLaunchCommand {
   command: string;
@@ -26,6 +26,7 @@ export function resolveClaudeLaunchCommand(
   options: ClaudeCommandResolverOptions = {},
 ): ClaudeLaunchCommand | null {
   const platform = options.platform ?? process.platform;
+  const path = platform === 'win32' ? win32 : posix;
   const nodeExecutable = options.nodeExecutable ?? process.execPath;
   const lookup = options.lookup ?? ((command, args) =>
     execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }));
@@ -47,18 +48,18 @@ export function resolveClaudeLaunchCommand(
   }
 
   const executable = matches.find((candidate) =>
-    extname(candidate).toLowerCase() === '.exe' && fileExists(candidate));
+    path.extname(candidate).toLowerCase() === '.exe' && fileExists(candidate));
   if (executable) return { command: executable, argsPrefix: [] };
 
   for (const shim of matches) {
-    const npmBin = dirname(shim);
-    const packageRoot = join(npmBin, 'node_modules', '@anthropic-ai', 'claude-code');
-    const nativeExecutable = join(packageRoot, 'bin', 'claude.exe');
+    const npmBin = path.dirname(shim);
+    const packageRoot = path.join(npmBin, 'node_modules', '@anthropic-ai', 'claude-code');
+    const nativeExecutable = path.join(packageRoot, 'bin', 'claude.exe');
     if (fileExists(nativeExecutable)) {
       return { command: nativeExecutable, argsPrefix: [] };
     }
 
-    const javascriptEntry = join(packageRoot, 'cli.js');
+    const javascriptEntry = path.join(packageRoot, 'cli.js');
     if (fileExists(javascriptEntry)) {
       return { command: nodeExecutable, argsPrefix: [javascriptEntry] };
     }


### PR DESCRIPTION
## Summary

- use where.exe on Windows and which on POSIX without invoking a shell
- resolve Windows npm shims to the Claude Code native executable or older JavaScript entry point
- pass the hive prompt only as child-process arguments with shell disabled

This assumes the standard npm package layout reported in the issue. If the lookup yields only an unsupported shell shim, Ruflo retains the existing manual fallback instead of passing the objective through a command shell.

## Validation

- corepack pnpm exec vitest run __tests__/claude-command-windows-3071.test.ts __tests__/hive-mind-skip-permissions.test.ts
- 13 tests passed
- targeted TypeScript check for src/runtime/claude-command.ts
- live Windows resolution returned the installed @anthropic-ai/claude-code bin/claude.exe
- git diff --check

Fixes #3071