### PR TITLE
fix(hooks): persist real session-end state

### DIFF
--- a/v3/@claude-flow/cli/__tests__/issue-2691-session-end-cleanup.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2691-session-end-cleanup.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const bridgeSessionEnd = vi.fn();
 const shutdownBridge = vi.fn();
@@ -11,11 +14,30 @@ vi.mock('../src/memory/memory-bridge.js', () => ({
 import { hooksSessionEnd } from '../src/mcp-tools/hooks-tools.js';
 
 describe('hooks session-end native resource cleanup (#2691)', () => {
+  let workdir: string;
+  let previousCwd: string | undefined;
+
   beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'ruflo-2691-'));
+    previousCwd = process.env.CLAUDE_FLOW_CWD;
+    process.env.CLAUDE_FLOW_CWD = workdir;
+    const sessionDir = join(workdir, '.claude-flow', 'sessions');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'current.json'), JSON.stringify({
+      id: 'session-cleanup-test',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      metrics: { edits: 0, commands: 0, tasks: 0, errors: 0 },
+    }));
     bridgeSessionEnd.mockReset();
     shutdownBridge.mockReset();
     bridgeSessionEnd.mockResolvedValue({ controller: 'test', persisted: true });
     shutdownBridge.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+    if (previousCwd === undefined) delete process.env.CLAUDE_FLOW_CWD;
+    else process.env.CLAUDE_FLOW_CWD = previousCwd;
   });
 
   it('shuts down the memory bridge after persisting a session', async () => {

--- a/v3/@claude-flow/cli/__tests__/issue-3063-session-end-state.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-3063-session-end-state.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const bridgeSessionEnd = vi.fn();
+const shutdownBridge = vi.fn();
+
+vi.mock('../src/memory/memory-bridge.js', () => ({
+  bridgeSessionEnd,
+  shutdownBridge,
+}));
+
+import { hooksSessionEnd } from '../src/mcp-tools/hooks-tools.js';
+
+describe('hooks session-end real session state (#3063)', () => {
+  const now = new Date('2026-08-21T10:00:00.000Z');
+  const startedAt = new Date('2026-08-21T09:50:00.000Z');
+  const beforeSession = new Date('2026-08-21T09:40:00.000Z');
+  let workdir: string;
+  let previousCwd: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    workdir = mkdtempSync(join(tmpdir(), 'ruflo-3063-'));
+    previousCwd = process.env.CLAUDE_FLOW_CWD;
+    process.env.CLAUDE_FLOW_CWD = workdir;
+
+    for (const directory of ['sessions', 'tasks', 'memory']) {
+      mkdirSync(join(workdir, '.claude-flow', directory), { recursive: true });
+    }
+
+    writeFileSync(join(workdir, '.claude-flow', 'sessions', 'current.json'), JSON.stringify({
+      id: 'session-real-3063',
+      startedAt: startedAt.toISOString(),
+      metrics: { edits: 4, commands: 2, tasks: 3, errors: 1 },
+    }));
+    writeFileSync(join(workdir, '.claude-flow', 'tasks', 'store.json'), JSON.stringify({
+      version: '3.0.0',
+      tasks: {
+        completedNow: { status: 'completed', completedAt: '2026-08-21T09:55:00.000Z' },
+        failedNow: { status: 'failed', completedAt: '2026-08-21T09:56:00.000Z' },
+        completedBefore: { status: 'completed', completedAt: beforeSession.toISOString() },
+        pending: { status: 'pending', completedAt: null },
+      },
+    }));
+    writeFileSync(join(workdir, '.claude-flow', 'memory', 'store.json'), JSON.stringify({
+      version: '3.0.0',
+      entries: {
+        learnedNow: {
+          key: 'routing-decision:reviewer',
+          value: { success: true },
+          namespace: 'patterns',
+          metadata: { type: 'routing-decision' },
+          storedAt: '2026-08-21T09:57:00.000Z',
+          accessCount: 0,
+          lastAccessed: '2026-08-21T09:57:00.000Z',
+        },
+        oldPattern: {
+          key: 'pattern-old',
+          value: 'old',
+          storedAt: beforeSession.toISOString(),
+          accessCount: 0,
+          lastAccessed: beforeSession.toISOString(),
+        },
+        misleadingTaskKey: {
+          key: 'task-not-a-completed-task',
+          value: 'not a task record or pattern',
+          storedAt: '2026-08-21T09:58:00.000Z',
+          accessCount: 0,
+          lastAccessed: '2026-08-21T09:58:00.000Z',
+        },
+      },
+    }));
+
+    bridgeSessionEnd.mockReset();
+    shutdownBridge.mockReset();
+    bridgeSessionEnd.mockResolvedValue({ controller: 'test', persisted: true });
+    shutdownBridge.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(workdir, { recursive: true, force: true });
+    if (previousCwd === undefined) delete process.env.CLAUDE_FLOW_CWD;
+    else process.env.CLAUDE_FLOW_CWD = previousCwd;
+  });
+
+  it('persists the active session id with session-scoped task and pattern counts', async () => {
+    const result = await hooksSessionEnd.handler({ saveState: true, stopDaemon: false }) as Record<string, any>;
+
+    expect(bridgeSessionEnd).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-real-3063',
+      tasksCompleted: 1,
+      patternsLearned: 1,
+      summary: '1 task completed; 1 pattern learned; 4 edits recorded; 2 commands recorded; 1 error recorded; duration 10 minutes',
+    }));
+    expect(result).toMatchObject({
+      sessionId: 'session-real-3063',
+      duration: 600_000,
+      statePath: '.claude/sessions/session-real-3063.json',
+      summary: {
+        tasksExecuted: 1,
+        filesModified: 4,
+        agentsSpawned: 0,
+      },
+      learningUpdates: { patternsLearned: 1 },
+    });
+  });
+
+  it('refuses to fabricate an id when no active session exists', async () => {
+    unlinkSync(join(workdir, '.claude-flow', 'sessions', 'current.json'));
+
+    await expect(hooksSessionEnd.handler({ saveState: true, stopDaemon: false }))
+      .rejects.toThrow('No active session state found');
+    expect(bridgeSessionEnd).not.toHaveBeenCalled();
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -494,7 +494,7 @@ const MEMORY_DIR = '.claude-flow/memory';
 const MEMORY_FILE = 'store.json';
 
 function getMemoryPath(): string {
-  return resolve(join(MEMORY_DIR, MEMORY_FILE));
+  return resolve(join(getProjectCwd(), MEMORY_DIR, MEMORY_FILE));
 }
 
 function loadMemoryStore(): MemoryStore {
@@ -508,6 +508,105 @@ function loadMemoryStore(): MemoryStore {
     // Return empty store on error
   }
   return { entries: {}, version: '3.0.0' };
+}
+
+interface ActiveSessionState {
+  id: string;
+  startedAt: string;
+  metrics?: {
+    edits?: number;
+    commands?: number;
+    tasks?: number;
+    errors?: number;
+  };
+}
+
+interface SessionActivity {
+  tasksCompleted: number;
+  patternsLearned: number;
+  editsRecorded: number;
+  commandsRecorded: number;
+  errorsRecorded: number;
+}
+
+function isLearnedPatternEntry(entry: MemoryEntry): boolean {
+  return entry.key.includes('pattern') ||
+    entry.metadata?.type === 'pattern' ||
+    entry.key.startsWith('learned-') ||
+    entry.namespace === 'patterns' ||
+    entry.metadata?.type === 'routing-decision';
+}
+
+function timestampInRange(value: unknown, start: number, end: number): boolean {
+  if (typeof value !== 'string' && typeof value !== 'number') return false;
+  const timestamp = typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(timestamp) && timestamp >= start && timestamp <= end;
+}
+
+function nonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
+}
+
+function loadActiveSessionState(): ActiveSessionState | null {
+  try {
+    const sessionPath = join(getProjectCwd(), '.claude-flow', 'sessions', 'current.json');
+    if (!existsSync(sessionPath)) return null;
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8')) as Partial<ActiveSessionState>;
+    if (typeof session.id !== 'string' || session.id.trim().length === 0) return null;
+    if (typeof session.startedAt !== 'string' || !Number.isFinite(Date.parse(session.startedAt))) return null;
+    return session as ActiveSessionState;
+  } catch {
+    return null;
+  }
+}
+
+function loadSessionActivity(session: ActiveSessionState, endedAt: number): SessionActivity {
+  const startedAt = Date.parse(session.startedAt);
+  let tasksCompleted = 0;
+
+  try {
+    const taskPath = join(getProjectCwd(), '.claude-flow', 'tasks', 'store.json');
+    if (existsSync(taskPath)) {
+      const store = JSON.parse(readFileSync(taskPath, 'utf-8')) as {
+        tasks?: Record<string, { status?: string; completedAt?: string }>;
+      };
+      for (const task of Object.values(store.tasks ?? {})) {
+        if (task.status === 'completed' && timestampInRange(task.completedAt, startedAt, endedAt)) {
+          tasksCompleted++;
+        }
+      }
+    }
+  } catch {
+    // Missing or malformed task state contributes no completed tasks.
+  }
+
+  const patternsLearned = Object.values(loadMemoryStore().entries)
+    .filter(entry => isLearnedPatternEntry(entry) && timestampInRange(entry.storedAt, startedAt, endedAt))
+    .length;
+
+  return {
+    tasksCompleted,
+    patternsLearned,
+    editsRecorded: nonNegativeInteger(session.metrics?.edits),
+    commandsRecorded: nonNegativeInteger(session.metrics?.commands),
+    errorsRecorded: nonNegativeInteger(session.metrics?.errors),
+  };
+}
+
+function buildSessionSummary(activity: SessionActivity, duration: number): string {
+  const durationMinutes = Math.max(0, Math.round(duration / 60000));
+  const count = (value: number, singular: string, plural = `${singular}s`) =>
+    `${value} ${value === 1 ? singular : plural}`;
+  return [
+    `${count(activity.tasksCompleted, 'task')} completed`,
+    `${count(activity.patternsLearned, 'pattern')} learned`,
+    `${count(activity.editsRecorded, 'edit')} recorded`,
+    `${count(activity.commandsRecorded, 'command')} recorded`,
+    `${count(activity.errorsRecorded, 'error')} recorded`,
+    `duration ${count(durationMinutes, 'minute')}`,
+  ].join('; ');
 }
 
 /**
@@ -549,13 +648,7 @@ function getIntelligenceStatsFromMemory(): {
   // patterns the metric is meant to count, so include them: any entry
   // whose namespace is `patterns`, plus the original shapes for
   // forward-compatibility with a future explicit `pattern` writer.
-  const patternEntries = entries.filter(e =>
-    e.key.includes('pattern') ||
-    e.metadata?.type === 'pattern' ||
-    e.key.startsWith('learned-') ||
-    e.namespace === 'patterns' ||
-    e.metadata?.type === 'routing-decision'
-  );
+  const patternEntries = entries.filter(isLearnedPatternEntry);
 
   // Categorize patterns
   const categories: Record<string, number> = {};
@@ -2271,7 +2364,15 @@ export const hooksSessionEnd: MCPTool = {
   handler: async (params: Record<string, unknown>) => {
     const saveState = params.saveState !== false;
     const shouldStopDaemon = params.stopDaemon !== false;
-    const sessionId = `session-${Date.now() - 3600000}`; // Default session (1 hour ago)
+    const session = loadActiveSessionState();
+    if (!session) {
+      throw new Error('No active session state found at .claude-flow/sessions/current.json');
+    }
+    const sessionId = session.id;
+    const endedAt = Date.now();
+    const duration = Math.max(0, endedAt - Date.parse(session.startedAt));
+    const activity = loadSessionActivity(session, endedAt);
+    const summary = buildSessionSummary(activity, duration);
 
     // Stop daemon if enabled
     let daemonStopped = false;
@@ -2285,12 +2386,10 @@ export const hooksSessionEnd: MCPTool = {
       }
     }
 
-    // Read actual counts from stores
+    // Read aggregate store data for the remaining compatibility metrics.
     const store = loadMemoryStore();
     const allEntries = Object.values(store.entries);
-    const taskCount = allEntries.filter(e => e.key.includes('task')).length;
     const agentCount = allEntries.filter(e => e.key.includes('agent')).length;
-    const patternCount = allEntries.filter(e => e.key.includes('pattern')).length;
     const trajectoryCount = activeTrajectories.size;
 
     // Check for pending-insights.jsonl
@@ -2312,9 +2411,9 @@ export const hooksSessionEnd: MCPTool = {
       bridge = await import('../memory/memory-bridge.js');
       const result = await bridge.bridgeSessionEnd({
         sessionId,
-        summary: saveState ? 'Session ended with state saved' : 'Session ended',
-        tasksCompleted: taskCount,
-        patternsLearned: patternCount,
+        summary,
+        tasksCompleted: activity.tasksCompleted,
+        patternsLearned: activity.patternsLearned,
       });
       if (result) {
         sessionPersistence = {
@@ -2337,19 +2436,19 @@ export const hooksSessionEnd: MCPTool = {
 
     return {
       sessionId,
-      duration: 3600000, // 1 hour in ms
+      duration,
       statePath: saveState ? `.claude/sessions/${sessionId}.json` : undefined,
       daemon: { stopped: daemonStopped },
       sessionPersistence: sessionPersistence || { controller: 'none', persisted: false },
       summary: {
-        tasksExecuted: taskCount,
-        filesModified: 0,
+        tasksExecuted: activity.tasksCompleted,
+        filesModified: activity.editsRecorded,
         agentsSpawned: agentCount,
         pendingInsights: insightCount,
         memoryEntries: allEntries.length,
       },
       learningUpdates: {
-        patternsLearned: patternCount,
+        patternsLearned: activity.patternsLearned,
         trajectoriesRecorded: trajectoryCount,
       },
     };


### PR DESCRIPTION
## Summary

- resolve `hooks session-end` against the real active session in `.claude-flow/sessions/current.json` instead of fabricating an ID and duration
- build the persisted summary from current-session metrics, completed tasks, and learned patterns
- count tasks from the canonical task store and patterns from the canonical memory store within the session time window
- fail explicitly when no valid active session exists rather than writing an uncorrelatable record

## Scope

This keeps the existing CLI/MCP parameters, defaults, return shape, dependencies, and storage schemas unchanged. It intentionally does not expose the existing MCP-only `exportMetrics` or `stopDaemon` options through the CLI because that would be a separate public-surface decision.

## Validation

- `corepack pnpm exec vitest run __tests__/issue-3063-session-end-state.test.ts __tests__/issue-2691-session-end-cleanup.test.ts`
- `corepack pnpm --filter @claude-flow/cli run build`

Fixes #3063