### PR TITLE
fix: address #3045 #3064 #3065 + new ruflo-deepseek-harness plugin (3.38.13)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -630,7 +630,47 @@ function readJSON(filePath) {
 
 // ─── Git info (pure-Node / single exec — needed for branch display) ──────────
 
+// #3045 — getGitInfo() shells out to a 5-command chain per render. Uncached,
+// it queues subprocesses faster than they finish on large repos with multiple
+// concurrent Claude Code sessions, producing the pileup reported in that
+// issue (hundreds of orphan git children, load-avg in the hundreds). Cache
+// the parsed result in a per-cwd tmp file with a short TTL — dirty/branch
+// status doesn't need per-render freshness, and 5s is short enough to feel
+// live.
+const GIT_INFO_CACHE_FILE = path.join(
+  os.tmpdir(),
+  'ruflo-statusline-gitinfo-' +
+    require('crypto').createHash('md5').update(CWD).digest('hex').slice(0, 8) +
+    '.json'
+);
+const GIT_INFO_TTL_MS = 5000;
+
+function readGitInfoCache() {
+  try {
+    if (fs.existsSync(GIT_INFO_CACHE_FILE)) {
+      const raw = JSON.parse(fs.readFileSync(GIT_INFO_CACHE_FILE, 'utf-8'));
+      if (raw && typeof raw._ts === 'number' && Date.now() - raw._ts < GIT_INFO_TTL_MS && raw.data) {
+        return raw.data;
+      }
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function writeGitInfoCache(data) {
+  try {
+    fs.writeFileSync(
+      GIT_INFO_CACHE_FILE,
+      JSON.stringify({ _ts: Date.now(), data }),
+      'utf-8'
+    );
+  } catch { /* ignore */ }
+}
+
 function getGitInfo() {
+  const cached = readGitInfoCache();
+  if (cached) return cached;
+
   const result = {
     name: path.basename(CWD) || 'project', gitBranch: '', modified: 0, untracked: 0,
     staged: 0, ahead: 0, behind: 0,
@@ -649,7 +689,12 @@ function getGitInfo() {
   ].join('; ');
 
   const raw = safeExec("sh -c '" + script + "'", 3000);
-  if (!raw) return result;
+  if (!raw) {
+    // Cache even the empty result — if git is slow/unavailable, we don't want
+    // to re-attempt on every render either.
+    writeGitInfoCache(result);
+    return result;
+  }
 
   const parts = raw.split('---SEP---').map(function(s) { return s.trim(); });
   if (parts.length >= 5) {
@@ -673,6 +718,7 @@ function getGitInfo() {
     result.behind = parseInt(ab[1]) || 0;
   }
 
+  writeGitInfoCache(result);
   return result;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.38.12",
+  "version": "3.38.13",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/plugins/ruflo-deepseek-harness/agents/deepseek-architect.md
+++ b/plugins/ruflo-deepseek-harness/agents/deepseek-architect.md
@@ -1,0 +1,62 @@
+---
+name: deepseek-architect
+description: DeepSeek harness architect for ruflo. Surfaces DeepSeek's chat and reasoning models via skills; enforces the ADR-150 removability contract (this plugin as optional augmentation, never a required runtime dep); routes between deepseek-chat and deepseek-reasoner based on task shape
+model: haiku
+---
+
+You are the deepseek-architect for ruflo. Your job is to expose the
+DeepSeek API (`deepseek-chat`, `deepseek-reasoner`) through ruflo's UX
+while keeping ruflo independently operational at all times.
+
+## ADR-150 invariants (load-bearing)
+
+1. **Removable** — deleting `plugins/ruflo-deepseek-harness/` must not
+   break any other ruflo functionality.
+2. **No hard dependency** — nothing in this plugin gets added to ruflo's
+   `dependencies` in `package.json`. Scripts use `fetch` (Node 18+) and
+   Node built-ins only.
+3. **Graceful degradation** — every script exits 0 with a
+   `{ status: 'degraded'|'error', reason, hint? }` JSON envelope when
+   `DEEPSEEK_API_KEY` is unset or the API is unreachable. The
+   `emitAndExit(...)` helper in `scripts/_deepseek.mjs` is the reference
+   implementation. Pass `--alert-on-error` to opt into hard failure for
+   CI gates.
+4. **No secret in logs** — the API key is only read from
+   `process.env.DEEPSEEK_API_KEY` and sent as a Bearer header. It is
+   never printed to stdout/stderr.
+
+If a PR breaks any of these four rules, it is a breaking change and
+needs its own ADR.
+
+## Skills
+
+| Skill | Role | Invoke when |
+|-------|------|-------------|
+| `deepseek-chat` | Non-reasoning single-turn completion via `deepseek-chat` | Summarization, extraction, quick classification, cheap Q&A |
+| `deepseek-reason` | Reasoning-mode completion via `deepseek-reasoner` (surfaces the CoT) | Proofs, plans, root-cause analysis, audits that need explicit reasoning |
+
+## Routing heuristic
+
+- Default to `deepseek-chat` for anything a smaller model can plausibly
+  do in one turn.
+- Escalate to `deepseek-reason` when the task calls for multi-step
+  reasoning AND the caller either wants to see the chain-of-thought or
+  is willing to pay the higher token cost for the quality lift.
+- If the caller wants the CoT displayed, use `deepseek-reason
+  --show-reasoning` in table mode; for programmatic consumption, use
+  JSON mode which always includes `reasoning` and a `reasoningTokens`
+  breakdown.
+
+## Extending the plugin
+
+Add a new skill by:
+
+1. Creating `skills/<skill-name>/SKILL.md` with YAML frontmatter (name,
+   description in **quotes** — see #3065 for why unquoted colons break
+   `npx skills add`).
+2. Adding a matching `scripts/<name>.mjs` that imports
+   `deepseekChat` / `parseArgs` / `emitAndExit` from `_deepseek.mjs` so
+   it inherits the graceful-degradation contract for free.
+3. Documenting the new subcommand in
+   `commands/ruflo-deepseek-harness.md` so the top-level command
+   dispatcher lists it.

--- a/plugins/ruflo-deepseek-harness/commands/ruflo-deepseek-harness.md
+++ b/plugins/ruflo-deepseek-harness/commands/ruflo-deepseek-harness.md
@@ -1,0 +1,39 @@
+---
+name: ruflo-deepseek-harness
+description: DeepSeek harness integration — chat and reasoning-mode completions via the OpenAI-compatible DeepSeek API, wrapped as ruflo skills with graceful degradation (ADR-150 pattern)
+---
+
+DeepSeek harness commands. All shell out to
+[`scripts/_deepseek.mjs`](../scripts/_deepseek.mjs) which hits DeepSeek's
+`https://api.deepseek.com/v1/chat/completions` endpoint using
+`DEEPSEEK_API_KEY` from the environment. The plugin never becomes a hard
+runtime dependency of ruflo — with the key unset or the API unreachable
+every script exits 0 with a `{ status: 'degraded', reason }` envelope,
+matching the ADR-150 removability contract used by the sibling
+`ruflo-metaharness` plugin.
+
+**`deepseek chat --prompt <text> [--system <text>] [--model deepseek-chat] [--temperature 0.7] [--max-tokens 1024] [--format table|json] [--alert-on-error]`** — one-shot completion against the non-reasoning `deepseek-chat` model.
+1. Run `node plugins/ruflo-deepseek-harness/scripts/chat.mjs --prompt "..."`
+2. Emits `{ status, model, content, finishReason, usage }` as JSON (default) or the bare content (`--format table`)
+3. `--alert-on-error` exits 1 on any degraded/error status — CI-friendly gate
+4. See [`skills/deepseek-chat/SKILL.md`](../skills/deepseek-chat/SKILL.md)
+
+**`deepseek reason --prompt <text> [--system <text>] [--model deepseek-reasoner] [--max-tokens 4096] [--show-reasoning] [--format table|json] [--alert-on-error]`** — reasoning-mode completion; separates `reasoning_content` (chain of thought) from `content` (final answer).
+1. Run `node plugins/ruflo-deepseek-harness/scripts/reason.mjs --prompt "..."`
+2. `temperature`/`top_p` are NOT forwarded — DeepSeek ignores them for reasoner models
+3. JSON output always includes `reasoning` + a `reasoningTokens` cost breakdown; table mode omits reasoning unless `--show-reasoning` is passed
+4. See [`skills/deepseek-reason/SKILL.md`](../skills/deepseek-reason/SKILL.md)
+
+## Environment
+
+- `DEEPSEEK_API_KEY` — required to actually call the API. Without it every
+  script exits 0 with `{ status: 'degraded', reason: 'DEEPSEEK_API_KEY is not set' }`.
+  Get a key at https://platform.deepseek.com.
+
+## ADR-150 invariants (same as ruflo-metaharness)
+
+1. **Removable** — `rm -rf plugins/ruflo-deepseek-harness/` must leave ruflo working.
+2. **No hard dependency** — nothing in ruflo's `dependencies`. This plugin's
+   scripts import only Node built-ins + `fetch` (Node 18+).
+3. **Graceful degradation** — every script exits 0 with a JSON envelope on
+   failure. Pass `--alert-on-error` to opt into hard failure for CI gates.

--- a/plugins/ruflo-deepseek-harness/scripts/_deepseek.mjs
+++ b/plugins/ruflo-deepseek-harness/scripts/_deepseek.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Shared helper for the ruflo-deepseek-harness plugin.
+ *
+ * Calls the DeepSeek OpenAI-compatible Chat Completions API
+ * (https://api.deepseek.com/v1/chat/completions). Reads the key from
+ * DEEPSEEK_API_KEY. Never crashes ruflo on boot — every failure emits a
+ * JSON object with { status: 'degraded', reason } and exits 0 by default;
+ * pass --alert-on-error to exit 1 on a hard failure (missing key, HTTP
+ * error, timeout).
+ *
+ * Modeled on plugins/ruflo-metaharness/scripts/_harness.mjs' graceful
+ * degradation shape (ADR-150), so this plugin never becomes a hard runtime
+ * dependency of ruflo — remove it and everything else keeps working.
+ */
+
+const API_URL = 'https://api.deepseek.com/v1/chat/completions';
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * Parse a minimal --key value CLI. Booleans: --flag with no value.
+ */
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (!tok.startsWith('--')) continue;
+    const key = tok.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      out[key] = next;
+      i++;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+/**
+ * Emit a degraded/OK JSON envelope and exit.
+ * status: 'ok' | 'degraded' | 'error'
+ */
+export function emitAndExit(payload, { alertOnError = false } = {}) {
+  process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  const isFailure = payload.status === 'degraded' || payload.status === 'error';
+  process.exit(isFailure && alertOnError ? 1 : 0);
+}
+
+/**
+ * Call DeepSeek's chat/completions endpoint.
+ *
+ * @param {object} opts
+ * @param {string} opts.model            e.g. "deepseek-chat", "deepseek-reasoner"
+ * @param {Array}  opts.messages         OpenAI-style messages
+ * @param {number} [opts.temperature]
+ * @param {number} [opts.maxTokens]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{ok: true, data: object} | {ok: false, reason: string, hint?: string}>}
+ */
+export async function deepseekChat({ model, messages, temperature, maxTokens, timeoutMs }) {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) {
+    return {
+      ok: false,
+      reason: 'DEEPSEEK_API_KEY is not set',
+      hint: 'Get a key at https://platform.deepseek.com and export DEEPSEEK_API_KEY=... in your shell.',
+    };
+  }
+
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs || DEFAULT_TIMEOUT_MS);
+
+  try {
+    const body = { model, messages };
+    if (typeof temperature === 'number') body.temperature = temperature;
+    if (typeof maxTokens === 'number') body.max_tokens = maxTokens;
+
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer ' + apiKey,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      return {
+        ok: false,
+        reason: 'HTTP ' + res.status + ' from DeepSeek',
+        hint: text.slice(0, 500),
+      };
+    }
+
+    const data = await res.json();
+    return { ok: true, data };
+  } catch (err) {
+    if (err && err.name === 'AbortError') {
+      return { ok: false, reason: 'DeepSeek call timed out after ' + (timeoutMs || DEFAULT_TIMEOUT_MS) + 'ms' };
+    }
+    return { ok: false, reason: err && err.message ? err.message : String(err) };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/**
+ * Convenience: pull the first choice's message content (and reasoning_content
+ * when present, for deepseek-reasoner).
+ */
+export function extractCompletion(data) {
+  const choice = data && data.choices && data.choices[0];
+  if (!choice || !choice.message) return { content: '', reasoning: '' };
+  return {
+    content: choice.message.content || '',
+    reasoning: choice.message.reasoning_content || '',
+    finishReason: choice.finish_reason || null,
+  };
+}

--- a/plugins/ruflo-deepseek-harness/scripts/chat.mjs
+++ b/plugins/ruflo-deepseek-harness/scripts/chat.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * DeepSeek chat completion — non-reasoning model (`deepseek-chat`).
+ *
+ * Usage:
+ *   node plugins/ruflo-deepseek-harness/scripts/chat.mjs \
+ *     --prompt "Summarize the following in one sentence: ..." \
+ *     [--system "You are a concise assistant."] \
+ *     [--model deepseek-chat] \
+ *     [--temperature 0.7] \
+ *     [--max-tokens 1024] \
+ *     [--format table|json] \
+ *     [--alert-on-error]
+ */
+
+import { parseArgs, emitAndExit, deepseekChat, extractCompletion } from './_deepseek.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+const alertOnError = args['alert-on-error'] === true;
+
+const prompt = args.prompt;
+if (!prompt || prompt === true) {
+  emitAndExit(
+    { status: 'error', reason: '--prompt is required (a string of at least 1 char)' },
+    { alertOnError: true } // hard-error even without the flag: this is a usage bug
+  );
+}
+
+const messages = [];
+if (args.system && args.system !== true) messages.push({ role: 'system', content: args.system });
+messages.push({ role: 'user', content: prompt });
+
+const model = (args.model && args.model !== true) ? args.model : 'deepseek-chat';
+const temperature = args.temperature !== undefined ? Number(args.temperature) : undefined;
+const maxTokens = args['max-tokens'] !== undefined ? Number(args['max-tokens']) : undefined;
+
+const result = await deepseekChat({ model, messages, temperature, maxTokens });
+
+if (!result.ok) {
+  emitAndExit(
+    { status: 'degraded', model, reason: result.reason, hint: result.hint || null },
+    { alertOnError }
+  );
+}
+
+const { content, finishReason } = extractCompletion(result.data);
+const usage = result.data.usage || {};
+
+const payload = {
+  status: 'ok',
+  model,
+  content,
+  finishReason,
+  usage: {
+    promptTokens: usage.prompt_tokens ?? null,
+    completionTokens: usage.completion_tokens ?? null,
+    totalTokens: usage.total_tokens ?? null,
+  },
+};
+
+if (args.format === 'table') {
+  process.stdout.write(content + '\n');
+  process.exit(0);
+}
+
+emitAndExit(payload);

--- a/plugins/ruflo-deepseek-harness/scripts/reason.mjs
+++ b/plugins/ruflo-deepseek-harness/scripts/reason.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * DeepSeek reasoning completion — `deepseek-reasoner` (aka R1).
+ *
+ * Surfaces the model's `reasoning_content` (chain-of-thought) separately
+ * from the final `content`, so tooling can display or discard the CoT
+ * without re-parsing the message.
+ *
+ * Usage:
+ *   node plugins/ruflo-deepseek-harness/scripts/reason.mjs \
+ *     --prompt "Prove that sqrt(2) is irrational." \
+ *     [--system "..."] \
+ *     [--model deepseek-reasoner] \
+ *     [--max-tokens 4096] \
+ *     [--show-reasoning] \
+ *     [--format table|json] \
+ *     [--alert-on-error]
+ *
+ * Notes:
+ * - `deepseek-reasoner` ignores `temperature`/`top_p` per DeepSeek's API
+ *   docs, so this script does not forward them.
+ * - `--show-reasoning` in table mode prints the chain-of-thought before
+ *   the answer; in JSON mode the reasoning is always included.
+ */
+
+import { parseArgs, emitAndExit, deepseekChat, extractCompletion } from './_deepseek.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+const alertOnError = args['alert-on-error'] === true;
+
+const prompt = args.prompt;
+if (!prompt || prompt === true) {
+  emitAndExit(
+    { status: 'error', reason: '--prompt is required (a string of at least 1 char)' },
+    { alertOnError: true }
+  );
+}
+
+const messages = [];
+if (args.system && args.system !== true) messages.push({ role: 'system', content: args.system });
+messages.push({ role: 'user', content: prompt });
+
+const model = (args.model && args.model !== true) ? args.model : 'deepseek-reasoner';
+const maxTokens = args['max-tokens'] !== undefined ? Number(args['max-tokens']) : undefined;
+
+const result = await deepseekChat({ model, messages, maxTokens });
+
+if (!result.ok) {
+  emitAndExit(
+    { status: 'degraded', model, reason: result.reason, hint: result.hint || null },
+    { alertOnError }
+  );
+}
+
+const { content, reasoning, finishReason } = extractCompletion(result.data);
+const usage = result.data.usage || {};
+
+if (args.format === 'table') {
+  if (args['show-reasoning']) {
+    process.stdout.write('--- reasoning ---\n' + reasoning + '\n--- answer ---\n');
+  }
+  process.stdout.write(content + '\n');
+  process.exit(0);
+}
+
+emitAndExit({
+  status: 'ok',
+  model,
+  content,
+  reasoning,
+  finishReason,
+  usage: {
+    promptTokens: usage.prompt_tokens ?? null,
+    completionTokens: usage.completion_tokens ?? null,
+    reasoningTokens:
+      usage.completion_tokens_details && usage.completion_tokens_details.reasoning_tokens
+        ? usage.completion_tokens_details.reasoning_tokens
+        : null,
+    totalTokens: usage.total_tokens ?? null,
+  },
+});

--- a/plugins/ruflo-deepseek-harness/skills/deepseek-chat/SKILL.md
+++ b/plugins/ruflo-deepseek-harness/skills/deepseek-chat/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: deepseek-chat
+description: "One-shot chat completion against DeepSeek's `deepseek-chat` model via the OpenAI-compatible /v1/chat/completions endpoint. Reads DEEPSEEK_API_KEY from the environment; degrades gracefully (exit 0 with a JSON status:degraded envelope) when the key is missing or the API is unreachable. Use for non-reasoning tasks — summarization, extraction, quick classification — where deepseek-reasoner would be overkill."
+argument-hint: "--prompt <text> [--system <text>] [--model deepseek-chat] [--temperature 0.7] [--max-tokens 1024] [--format table|json] [--alert-on-error]"
+allowed-tools: Bash
+---
+
+Wraps DeepSeek's chat/completions endpoint in the same subprocess-invocation
+shape as the other `ruflo-*-harness` skills (see ruflo-metaharness's
+`harness-score` for the reference). No library import on ruflo's boot path.
+
+## When to use
+
+- You want a cheap, fast completion from a non-reasoning model.
+- The task fits in a single request/response — no multi-turn context.
+- You want the raw content back as JSON so downstream tooling can consume it.
+- For reasoning-heavy tasks (proofs, multi-step planning, hard debugging),
+  use `deepseek-reason` instead — same plugin, different model.
+
+## Algorithm
+
+Implementation: [`scripts/chat.mjs`](../../scripts/chat.mjs).
+
+1. Read `DEEPSEEK_API_KEY` from env. If missing, emit
+   `{ status: 'degraded', reason: 'DEEPSEEK_API_KEY is not set', ... }`
+   and exit 0 (ADR-150-style graceful degradation).
+2. POST to `https://api.deepseek.com/v1/chat/completions` with
+   `{ model, messages, temperature?, max_tokens? }`. 60s hard timeout.
+3. Extract `choices[0].message.content` and usage counters.
+4. `--format table` prints only the content (for piping); `--format json`
+   (default) returns the full envelope.
+5. `--alert-on-error` exits 1 on any degraded/error status (CI-friendly).
+
+## Example
+
+```bash
+node plugins/ruflo-deepseek-harness/scripts/chat.mjs \
+  --prompt "In one sentence: what is HNSW?" \
+  --temperature 0.2
+```
+
+Sample output:
+
+```json
+{
+  "status": "ok",
+  "model": "deepseek-chat",
+  "content": "HNSW is a graph-based approximate nearest neighbor …",
+  "finishReason": "stop",
+  "usage": { "promptTokens": 12, "completionTokens": 34, "totalTokens": 46 }
+}
+```

--- a/plugins/ruflo-deepseek-harness/skills/deepseek-reason/SKILL.md
+++ b/plugins/ruflo-deepseek-harness/skills/deepseek-reason/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: deepseek-reason
+description: "Reasoning-mode completion against DeepSeek's `deepseek-reasoner` model (R1) via /v1/chat/completions. Surfaces the model's chain-of-thought (`reasoning_content`) separately from the final answer (`content`), so callers can display or discard the CoT without re-parsing. Reads DEEPSEEK_API_KEY; degrades gracefully (exit 0 with status:degraded envelope) when unset or the API is unreachable. Ignores temperature/top_p per DeepSeek's spec for reasoner models."
+argument-hint: "--prompt <text> [--system <text>] [--model deepseek-reasoner] [--max-tokens 4096] [--show-reasoning] [--format table|json] [--alert-on-error]"
+allowed-tools: Bash
+---
+
+Wraps DeepSeek's reasoning model so ruflo callers can get an explicit
+chain-of-thought back with the final answer, without having to parse it
+out of the message content. Same subprocess-invocation shape as the sibling
+`deepseek-chat` skill.
+
+## When to use
+
+- Multi-step reasoning tasks: proofs, plans, root-cause analysis, hard
+  bug triage.
+- You want to *see* the model's thinking (for audit, for training data,
+  or to sanity-check its final answer).
+- You can tolerate the higher latency and token cost of a reasoner vs
+  `deepseek-chat`.
+
+## Algorithm
+
+Implementation: [`scripts/reason.mjs`](../../scripts/reason.mjs).
+
+1. Read `DEEPSEEK_API_KEY` from env. Degrade gracefully when missing.
+2. POST to `/v1/chat/completions` with `{ model: 'deepseek-reasoner', messages, max_tokens? }`.
+   Per DeepSeek's docs, `temperature`/`top_p` are ignored for reasoner
+   models — this script does not forward them.
+3. Extract `choices[0].message.content` AND `choices[0].message.reasoning_content`.
+4. JSON output always includes `reasoning`; table mode omits it unless
+   `--show-reasoning` is passed.
+5. `reasoningTokens` (from `usage.completion_tokens_details.reasoning_tokens`)
+   is surfaced separately so callers can attribute cost.
+
+## Example
+
+```bash
+node plugins/ruflo-deepseek-harness/scripts/reason.mjs \
+  --prompt "Prove that sqrt(2) is irrational." \
+  --format table --show-reasoning
+```
+
+Table output shows the reasoning block, then the answer. JSON mode returns:
+
+```json
+{
+  "status": "ok",
+  "model": "deepseek-reasoner",
+  "content": "sqrt(2) is irrational because …",
+  "reasoning": "Assume for contradiction that sqrt(2) = p/q in lowest terms …",
+  "finishReason": "stop",
+  "usage": {
+    "promptTokens": 14,
+    "completionTokens": 812,
+    "reasoningTokens": 640,
+    "totalTokens": 826
+  }
+}
+```

--- a/plugins/ruflo-metaharness/skills/harness-gepa/SKILL.md
+++ b/plugins/ruflo-metaharness/skills/harness-gepa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-gepa
-description: Inspect and audit GEPA genomes via the `@metaharness/darwin/gepa` library entry (darwin 0.8.0) — load/validate a genome (default: the shipped cand-6 promotion), render the system prompt a genome compiles to, or classify failure modes in a run transcript. The `gepaOptimize` loop itself is library-only (bring your own evaluator) and not surfaced here — use `harness-evolve` for sandbox-scored evolution. Degrades gracefully when @metaharness/darwin is absent.
+description: "Inspect and audit GEPA genomes via the `@metaharness/darwin/gepa` library entry (darwin 0.8.0) — load/validate a genome (default is the shipped cand-6 promotion), render the system prompt a genome compiles to, or classify failure modes in a run transcript. The `gepaOptimize` loop itself is library-only (bring your own evaluator) and not surfaced here — use `harness-evolve` for sandbox-scored evolution. Degrades gracefully when @metaharness/darwin is absent."
 argument-hint: "--op genome|validate|render|analyze [--path <genome.json>] [--transcript <t.json>] [--alert-on-invalid]"
 allowed-tools: Bash
 ---

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.38.12",
+  "version": "3.38.13",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/__tests__/hooks-post-task-colon-agent-3064.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-post-task-colon-agent-3064.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression guard for #3064 — `hooks_post-task` silently dropped the
+ * routing-outcome write when `--agent` contained a colon.
+ *
+ * The narrow ad-hoc regex `/^[a-zA-Z0-9_-]+$/` at the write gate rejected
+ * every Claude Code plugin agent (which are always namespaced
+ * `plugin:agent` — e.g. `ruflo-core:reviewer`, `feature-dev:code-explorer`),
+ * so any project driving `post-task` from a `PostToolUse:Task` hook fed
+ * the router zero usable signal from plugin agents.
+ *
+ * The canonical `validateIdentifier()` check earlier in the handler
+ * already allows `:` and `.` (IDENTIFIER_RE in validate-input.ts), so the
+ * redundant narrow regex was simply removed. This test locks in that
+ * colon-namespaced agents now produce a routing-outcomes.json append.
+ *
+ * NOTE: hooks-tools.ts captures `ROUTING_OUTCOMES_PATH = resolve('.') + ...`
+ * at module load, so the chdir MUST happen before the dynamic import.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Move cwd into a temp dir BEFORE the dynamic import below runs — otherwise
+// the routing-outcomes file gets written into whatever cwd vitest ran from.
+const testRoot = mkdtempSync(join(tmpdir(), 'ruflo-3064-'));
+const origCwd = process.cwd();
+process.chdir(testRoot);
+
+const bridgeRecordFeedback = vi.fn(async () => ({ success: true, controller: 'mock', updated: 1 }));
+const bridgeRecordCausalEdge = vi.fn(async () => ({ success: true, controller: 'mock' }));
+const bridgeStoreEntry = vi.fn(async () => ({ success: true, controller: 'mock' }));
+
+vi.mock('../src/memory/memory-bridge.js', () => ({
+  bridgeRecordFeedback,
+  bridgeRecordCausalEdge,
+  bridgeStoreEntry,
+}));
+
+vi.mock('../src/memory/intelligence.js', () => ({
+  recordTrajectory: vi.fn(async () => undefined),
+}));
+vi.mock('../src/memory/graph-edge-writer.js', () => ({
+  insertGraphEdge: vi.fn(async () => undefined),
+}));
+
+const { hooksPostTask } = await import('../src/mcp-tools/hooks-tools.js');
+
+const outcomesPath = join(testRoot, '.claude-flow', 'routing-outcomes.json');
+
+function readOutcomes(): Array<{ task: string; agent: string; success: boolean }> {
+  if (!existsSync(outcomesPath)) return [];
+  const raw = JSON.parse(readFileSync(outcomesPath, 'utf-8'));
+  if (Array.isArray(raw)) return raw;
+  if (raw && Array.isArray(raw.outcomes)) return raw.outcomes;
+  return [];
+}
+
+beforeAll(() => {
+  // Restore cwd for the rest of the test runner — the module has already
+  // captured its own path, so it doesn't matter what cwd is now.
+  process.chdir(origCwd);
+});
+
+beforeEach(() => {
+  // Fresh outcomes file per test so counts start at 0.
+  mkdirSync(join(testRoot, '.claude-flow'), { recursive: true });
+  writeFileSync(outcomesPath, JSON.stringify({ outcomes: [] }));
+});
+
+afterAll(() => {
+  try { rmSync(testRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('#3064 — hooks_post-task accepts colon-namespaced plugin agents', () => {
+  const cases = [
+    { label: 'plain identifier (baseline)', agent: 'reviewer' },
+    { label: 'hyphenated identifier (baseline)', agent: 'ruflo-core-reviewer' },
+    { label: 'colon-namespaced plugin agent (bug case)', agent: 'ruflo-core:reviewer' },
+    { label: 'nested colon-namespaced plugin agent', agent: 'feature-dev:code-explorer' },
+  ];
+
+  for (const { label, agent } of cases) {
+    it(`records the routing outcome for ${label}: "${agent}"`, async () => {
+      const taskId = `probe-${agent.replace(/[^a-z0-9]/gi, '_')}`;
+
+      await hooksPostTask.handler({
+        taskId,
+        task: `test task for ${agent}`,
+        agent,
+        success: true,
+        quality: 0.85,
+      });
+
+      const outcomes = readOutcomes();
+      expect(outcomes.length).toBe(1);
+
+      const [only] = outcomes;
+      expect(only.agent).toBe(agent);
+      expect(only.success).toBe(true);
+      expect(only.task).toBe(`test task for ${agent}`);
+    });
+  }
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.38.12",
+  "version": "3.38.13",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hooks-tools.ts
@@ -1550,7 +1550,12 @@ export const hooksPostTask: MCPTool = {
     const taskText = (params.task as string) || '';
     const outcomeKeywords = extractKeywords(taskText);
     let outcomePersisted = false;
-    if (taskText && agent && agent.length <= 100 && /^[a-zA-Z0-9_-]+$/.test(agent)) {
+    // #3064 — the previous ad-hoc regex `/^[a-zA-Z0-9_-]+$/` silently dropped
+    // colon-namespaced plugin agents (`ruflo-core:reviewer`, etc.) — i.e. every
+    // Claude Code plugin agent. Colons are already allowed by the canonical
+    // validateIdentifier() check on line 1456 above (IDENTIFIER_RE includes ':'
+    // and '.'), so no additional charset gating is needed here.
+    if (taskText && agent) {
       try {
         const outcomes = loadRoutingOutcomes();
         outcomes.push({


### PR DESCRIPTION
## Summary

- **#3065** — Fix YAML parse error in `plugins/ruflo-metaharness/skills/harness-gepa/SKILL.md`. Unquoted colon in `description` broke `npx skills add`. Quoted the description; rephrased the bare `(default:` to avoid the leading colon.
- **#3064** — Fix `hooks post-task` silently dropping the routing outcome when `--agent` contains a colon (every Claude Code plugin agent). Removed the narrow ad-hoc regex `/^[a-zA-Z0-9_-]+$/`; the canonical `validateIdentifier()` upstream already allows `:` and `.`. Regression test proved to catch the bug (2 pass / 2 fail on revert; 4/4 with the fix).
- **#3045** — Fix `.claude/helpers/statusline.cjs` `getGitInfo()` running uncached on every render. Reporter observed hundreds of orphan git children and load-avg in the hundreds on large repos with concurrent Claude Code sessions. Added a per-cwd tmp-file cache with 5s TTL.
- **New plugin** — `plugins/ruflo-deepseek-harness/`: sibling to `ruflo-metaharness` (ADR-150 shape). Two skills — `deepseek-chat` (non-reasoning) and `deepseek-reason` (surfaces `reasoning_content` separately). Reads `DEEPSEEK_API_KEY`; degrades gracefully (`{status: 'degraded', reason, hint}`) when the key is missing or the API is unreachable. `--alert-on-error` opts into hard exit 1 for CI gates.

## Version

Bumps `@claude-flow/cli`, `claude-flow`, and `ruflo` from `3.38.12` → `3.38.13` (PATCH: bug fixes; the new plugin is scaffolding under `plugins/` and not part of the npm-published CLI packages).

## Not fixed

**#3051** (`memory_store` tags dropped) — Current source's `memory_store` handler passes `tags` straight through to `storeEntry`; a maintainer already verified round-trip works on `fa13ee4ad`. Reporter has not yet supplied the `ruflo`/`@claude-flow/cli` version hosting the affected MCP server, so the release path is unknown. Left as-is pending that reply — not silently patched based on speculation.

## Test plan

- [x] `npx vitest run __tests__/hooks-post-task-colon-agent-3064.test.ts` — 4/4 pass (added regression)
- [x] Adjacent post-task suites still green: `hooks-post-task-routing-dual-write-2786.test.ts`, `hooks-post-task-graph-edge-2961.test.ts` — 7/7 across 3 files
- [x] `v3/@claude-flow/security` + `v3/@claude-flow/cli` build cleanly (`npm run build`)
- [x] Regression counter-check: temporarily reverted the hooks-tools fix, ran the new test — 2 fail (colon cases) / 2 pass (plain identifiers); reapplied — 4/4. Test catches the bug.
- [x] Plugin smoke test: `node plugins/ruflo-deepseek-harness/scripts/chat.mjs --prompt "test"` (no key) → exits 0 with `{status: "degraded", reason: "DEEPSEEK_API_KEY is not set", hint: "..."}`. With `--alert-on-error` → exits 1.
- [x] Syntax-check: `node --check` on all three `.mjs` scripts and `statusline.cjs` passes.

## Closes

Closes #3065
Closes #3064
Closes #3045

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_0118jMsYhwHD5dx2vStENsEB