### PR TITLE
fix(memory): #3051 memory_store tags lost via write-through cache (3.38.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.38.13",
+  "version": "3.38.14",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",
@@ -67,7 +67,7 @@
   "dependencies": {
     "@claude-flow/cli-core": "3.7.0-alpha.5",
     "@claude-flow/codex": "3.0.3",
-    "@claude-flow/mcp": "3.0.0-alpha.9",
+    "@claude-flow/mcp": "3.0.0-alpha.10",
     "@claude-flow/neural": "3.0.0-alpha.9",
     "@claude-flow/plugin-agent-federation": "1.0.0-alpha.18",
     "@claude-flow/security": "3.0.0-alpha.14",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.38.13",
+  "version": "3.38.14",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/__tests__/memory-store-tags-cache-3051.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-store-tags-cache-3051.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression guard for #3051 — `memory_store` accepted `tags` and returned
+ * `success: true`, but a subsequent `memory_retrieve` (or `memory_list`)
+ * saw `tags: []`.
+ *
+ * Root cause was in `bridgeStoreEntry`: after the DB insert (which DOES
+ * serialize tags correctly into the `tags` column), the write-through
+ * cache set at the end of the write path stored only a partial entry
+ * shape — `{ id, key, namespace, content, embedding }` — with no `tags`.
+ * The very next `bridgeGetEntry` hit that cache and returned
+ * `tags: cached.tags || []` = `[]`, i.e. the tags looked lost even though
+ * they were on disk.
+ *
+ * The fix replaces the partial write-through with cache invalidation, so
+ * the next read re-fetches the row via the DB reader (which correctly
+ * parses the `tags` JSON column) and repopulates the cache with the
+ * full shape.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const root = mkdtempSync(join(tmpdir(), 'ruflo-3051-tags-cache-'));
+const dbPath = join(root, 'memory.db');
+
+function makeDb(): Database.Database {
+  const d = new Database(dbPath);
+  d.exec(`
+    CREATE TABLE IF NOT EXISTS memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT NOT NULL,
+      namespace TEXT DEFAULT 'default',
+      content TEXT NOT NULL,
+      type TEXT DEFAULT 'semantic',
+      embedding TEXT,
+      embedding_dimensions INTEGER,
+      embedding_model TEXT,
+      tags TEXT,
+      metadata TEXT,
+      provenance_type TEXT DEFAULT 'unknown',
+      created_at INTEGER,
+      updated_at INTEGER,
+      last_accessed_at INTEGER,
+      access_count INTEGER DEFAULT 0,
+      expires_at INTEGER,
+      status TEXT DEFAULT 'active',
+      UNIQUE(namespace, key)
+    );
+    CREATE TABLE IF NOT EXISTS vector_indexes (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      dimensions INTEGER
+    );
+  `);
+  return d;
+}
+
+/** Minimal cache wrapper matching what cacheGet/cacheSet/cacheInvalidate expect. */
+function makeTieredCache() {
+  const store = new Map<string, unknown>();
+  return {
+    get: (k: string) => store.get(k),
+    set: (k: string, v: unknown) => { store.set(k, v); },
+    delete: (k: string) => { store.delete(k); },
+    size: () => store.size,
+  };
+}
+
+let db: Database.Database | null = null;
+
+afterAll(() => {
+  db?.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('#3051 — memory_store tags survive the write-through cache path', () => {
+  it('immediate bridgeGetEntry after bridgeStoreEntry returns the real tags, not []', async () => {
+    const {
+      __setMemoryBridgeRegistryForTests,
+      bridgeStoreEntry,
+      bridgeGetEntry,
+    } = await import('../src/memory/memory-bridge.js');
+
+    db = makeDb();
+    const cache = makeTieredCache();
+
+    // Registry that yields the DB context plus the tieredCache the bridge
+    // reads/writes/invalidates. No embedder — we disable embeddings on the
+    // write below so the test doesn't need ONNX.
+    __setMemoryBridgeRegistryForTests({
+      getAgentDB: () => ({ database: db, embedder: null }),
+      get: (kind: string) => (kind === 'tieredCache' ? cache : null),
+    });
+
+    const tags = ['alpha', 'beta', 'gamma'];
+
+    const storeResult = await bridgeStoreEntry({
+      key: 'tag-round-trip',
+      value: 'value with tags',
+      namespace: 'probe-3051',
+      tags,
+      generateEmbeddingFlag: false,
+      dbPath,
+    });
+
+    expect(storeResult).not.toBeNull();
+    expect(storeResult!.success).toBe(true);
+
+    // Sanity: the DB row DOES have the tags (the write side was never the
+    // bug; the bug was on the write-through cache shape). This anchors the
+    // test to the real defect — even without our fix this row read is fine,
+    // but the immediate cached read below would return []-tags.
+    const rawRow = db.prepare(
+      'SELECT tags FROM memory_entries WHERE namespace = ? AND key = ? LIMIT 1'
+    ).get('probe-3051', 'tag-round-trip') as { tags: string | null } | undefined;
+    expect(rawRow).toBeDefined();
+    expect(rawRow!.tags).toBe(JSON.stringify(tags));
+
+    const getResult = await bridgeGetEntry({
+      key: 'tag-round-trip',
+      namespace: 'probe-3051',
+      dbPath,
+    });
+
+    expect(getResult).not.toBeNull();
+    expect(getResult!.success).toBe(true);
+    expect(getResult!.found).toBe(true);
+    expect(getResult!.entry).toBeDefined();
+    // The load-bearing assertion: tags survive round-trip through the cache path.
+    // Pre-fix this returned [] because the partial write-through payload had no `tags`.
+    expect(getResult!.entry!.tags).toEqual(tags);
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.38.13",
+  "version": "3.38.14",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -1011,11 +1011,22 @@ export async function bridgeStoreEntry(options: {
       }
     }
 
-    // Phase 2: Write-through to TieredCache
+    // Phase 2: Invalidate cache so the next read fetches the fresh row.
+    //
+    // #3051 — this used to be a write-through with a partial payload
+    // (`{ id, key, namespace, content, embedding }` — missing `tags`,
+    // access_count, timestamps, metadata, provenance_type). Any read that
+    // hit the cache then returned `tags: cached.tags || []` = `[]` for the
+    // very entry that had just been written with real tags, so
+    // `memory_store({ tags })` → `memory_retrieve()` looked like it silently
+    // dropped tags. Invalidating instead of partial-cache-set forces the
+    // next `bridgeGetEntry` to load the authoritative row (which correctly
+    // parses tags/metadata from the JSON columns) and repopulate the cache
+    // from that full shape.
     const safeNs = String(namespace).replace(/:/g, '_');
     const safeKey = String(key).replace(/:/g, '_');
     const cacheKey = `entry:${safeNs}:${safeKey}`;
-    await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
+    await cacheInvalidate(registry, cacheKey);
 
     // Phase 4: AttestationLog write audit
     await logAttestation(registry, 'store', id, { key, namespace, hasEmbedding: !!embeddingJson });


### PR DESCRIPTION
## Summary

Fixes **#3051** — `memory_store` accepted `tags` and returned `success: true`, but a subsequent `memory_retrieve` (or `memory_list`) came back with `tags: []`.

## Root cause

`bridgeStoreEntry` populated the write-through cache with a partial entry — `{ id, key, namespace, content, embedding }` — with no `tags`, no timestamps, no metadata, no access_count. The DB row itself had the tags JSON-serialized correctly. But any subsequent `bridgeGetEntry` hit the cache first and returned `tags: cached.tags || []` = `[]`, so `memory_store({ tags })` → `memory_retrieve()` looked like it silently dropped tags.

The reporter's version (`@claude-flow/memory@3.0.0-alpha.22`) may have had an additional write-side bug on top; a maintainer already verified the current DB write serializes tags correctly. This PR fixes the remaining cache-layer defect, which is present on current main and reproducible with:

```js
await bridgeStoreEntry({ tags: ['a','b','c'], ... });
const r = await bridgeGetEntry(...);
r.entry.tags   // []  ← BUG (was 'a','b','c')
```

## Fix

Replace the partial write-through with cache invalidation:

```diff
- await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
+ await cacheInvalidate(registry, cacheKey);
```

The next read re-fetches the row via the DB reader (which correctly parses the `tags` JSON column) and repopulates the cache with the full shape. Cleaner than expanding the write-through payload — future entry-shape fields don't need to remember to update the cache-write signature.

Side benefit: the same partial-cache defect would have caused reads to see `access_count` stuck at 0 and drifted `createdAt`/`updatedAt` timestamps from the moment the cache was first populated until eviction. Invalidation fixes those too.

## Test plan

- [x] `npx vitest run __tests__/memory-store-tags-cache-3051.test.ts` — passes with the fix
- [x] Reverted the memory-bridge change, reran the test — fails as expected (`tags` returned `[]`); reapplied — passes. Test catches the bug.
- [x] `npm run build` in `v3/@claude-flow/cli` — clean
- [x] Adjacent memory-store test still green: `memory-store-persist-warning-2968.test.ts`

## Release

Bumps `@claude-flow/cli`, `claude-flow`, `ruflo` from `3.38.13` → `3.38.14` (PATCH).

## Closes

Closes #3051

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_0118jMsYhwHD5dx2vStENsEB