### PR TITLE
chore(release): 3.38.14 → 3.38.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.38.14",
+  "version": "3.38.15",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.38.14",
+  "version": "3.38.15",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.38.14",
+  "version": "3.38.15",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Version-bump-only PR to cut a release train off the 4 landings from today:

- #3060 fix(cli): honor MCP tool selection when listing (closes #3055)
- #3076 fix: resolve Claude Code launches on Windows (closes #3071)
- #3077 fix(hooks): persist real session-end state (closes #3063)
- #3044 dream(security): #3043 advisory scanner for untrusted settings.json hooks/allow-rules

No code changes here — just `3.38.14 → 3.38.15` across the three publishable package.jsons.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_0118jMsYhwHD5dx2vStENsEB