### PR TITLE
chore(release): 3.38.15 → 3.38.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.38.15",
+  "version": "3.38.16",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/plugin-agent-federation",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.38.15",
+  "version": "3.38.16",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.38.15",
+  "version": "3.38.16",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Version-bump-only PR to cut a release train off the 3 dream-cycle landings from today:

- #3062 dream(swarm): bound MessageBus retry attempts (closes #3061)
- #3057 dream(memory): hybridSearch opt-in (closes #3056)
- #3049 dream(intelligence): discounted Thompson bandit (closes #3048)

No code changes — just `3.38.15 → 3.38.16` across the three package.jsons.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_0118jMsYhwHD5dx2vStENsEB