### PR TITLE
fix(doctor): use pathToFileURL for MetaHarness dynamic imports on Windows

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -9,7 +9,7 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { existsSync, readFileSync, statSync, openSync, readSync, closeSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { createHash } from 'crypto';
 import { execSync, exec } from 'child_process';
 import { promisify } from 'util';
@@ -1793,7 +1793,7 @@ async function checkMetaharnessIntegration(): Promise<HealthCheck> {
   // Runtime smoke: import the similarity module and exercise it
   try {
     const modPath = join(pluginDir, 'scripts', '_similarity.mjs');
-    const mod = await import(modPath) as { similarity?: (a: unknown, b: unknown) => { overall?: number } };
+    const mod = await import(pathToFileURL(modPath).href) as { similarity?: (a: unknown, b: unknown) => { overall?: number } };
     if (typeof mod.similarity !== 'function') {
       return {
         name: 'MetaHarness integration (ADR-150)',
@@ -1821,7 +1821,7 @@ async function checkMetaharnessIntegration(): Promise<HealthCheck> {
     // parallelization primitives oia-audit depends on; if they're
     // missing, oia-audit's import fails and the whole pipeline breaks.
     const harnessPath = join(pluginDir, 'scripts', '_harness.mjs');
-    const harnessMod = await import(harnessPath) as {
+    const harnessMod = await import(pathToFileURL(harnessPath).href) as {
       parseMcpScanText?: (s: string) => unknown;
       runHarnessAsync?: (args: string[]) => Promise<unknown>;
       runMetaharnessAsync?: (args: string[]) => Promise<unknown>;


### PR DESCRIPTION
## Problem

On Windows, the MetaHarness integration check always fails:

```
⚠ MetaHarness integration (ADR-150): Module import errored:
  Only URLs with a scheme in: file, data, and node are supported
```

`checkMetaharnessIntegration()` builds absolute paths with `join()` and passes them
straight to `await import()`:

```ts
const modPath = join(pluginDir, 'scripts', '_similarity.mjs');
const mod = await import(modPath);          // C:\...\_similarity.mjs
```

ESM `import()` takes a **URL**, not a filesystem path. On Windows the drive letter
`C:` is parsed as a URL scheme, so Node rejects it. On POSIX the leading `/` happens
to resolve, which is why this only shows up on Windows.

## Impact

The check is a false negative — it reports a module-import error regardless of whether
the plugin scripts are actually intact, so it masks the real state of
`_similarity.mjs` / `_harness.mjs` for every Windows user.

Scope is limited to `doctor`: the `metaharness_*` MCP tools invoke the same scripts via
`spawn('node', [scriptPath, ...])` (`mcp-tools/metaharness-tools.js:130`), where a plain
path is a valid argv, so those were never affected.

## Fix

Wrap both call sites in `pathToFileURL(...).href`. No behaviour change on POSIX.

## Verification

Windows 11, Node v24.18.0, ruflo v3.38.16 (global install).

Before:
```
⚠ MetaHarness integration (ADR-150): Module import errored: Only URLs with a scheme in: file, data, and node are support
Summary: 20 passed, 7 warnings
```

After:
```
✓ MetaHarness integration (ADR-150): plugin scripts intact, _similarity.mjs + parseMcpScanText load, smoke OK
Summary: 21 passed, 6 warnings
```

`ruflo metaharness score` continues to run normally (unchanged — spawn path):
```
# harness-score — trading
| harnessFit | 61 |
| toolSafety | 90 |
| recommendedMode | CLI + MCP |
```

I checked the rest of the package for the same pattern: `commands/appliance.js:27` and the
six dynamic imports under `mcp-tools/` all pass bare or relative specifiers, which are
valid ESM. These two were the only path-based sites.
