### PR TITLE
fix: preserve unrelated MCP servers when init --force rewrites .mcp.json (#420)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/init-mcp-force-merge-420.test.ts
+++ b/v3/@claude-flow/cli/__tests__/init-mcp-force-merge-420.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression coverage for #420: `init --force` blindly overwrote the whole
+ * `.mcp.json`, destroying any unrelated MCP server entries a user had
+ * registered alongside ruflo's own (claude-flow/ruv-swarm/flow-nexus).
+ *
+ * Fix: when `--force` targets an existing `.mcp.json`, merge the generated
+ * servers into the existing file instead of replacing it outright.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeInit } from '../src/init/executor.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+import type { InitOptions } from '../src/init/types.js';
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'ruflo-420-mcp-force-'));
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function baseOptions(overrides: Partial<InitOptions> = {}): InitOptions {
+  return {
+    ...DEFAULT_INIT_OPTIONS,
+    targetDir: testDir,
+    interactive: false,
+    components: {
+      ...DEFAULT_INIT_OPTIONS.components,
+      settings: false,
+      skills: false,
+      commands: false,
+      agents: false,
+      helpers: false,
+      statusline: false,
+      runtime: false,
+      claudeMd: false,
+      mcp: true,
+    },
+    ...overrides,
+  };
+}
+
+describe('.mcp.json --force preserves unrelated MCP servers (#420)', () => {
+  it('merges the generated servers into an existing file instead of overwriting it', async () => {
+    mkdirSync(testDir, { recursive: true });
+    const mcpPath = join(testDir, '.mcp.json');
+    const existingConfig = {
+      mcpServers: {
+        'my-custom-server': {
+          command: 'node',
+          args: ['custom-server.js'],
+          env: { CUSTOM_VAR: 'keep-me' },
+        },
+      },
+    };
+    writeFileSync(mcpPath, JSON.stringify(existingConfig, null, 2), 'utf-8');
+
+    const result = await executeInit(baseOptions({ force: true }));
+
+    expect(result.errors).toEqual([]);
+    expect(existsSync(mcpPath)).toBe(true);
+
+    const written = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+    // Pre-fix: the unrelated server was wiped out by a blind overwrite —
+    // this is exactly the assertion the bug made false.
+    expect(written.mcpServers['my-custom-server']).toEqual(existingConfig.mcpServers['my-custom-server']);
+    // Our own server registration should still be written.
+    expect(written.mcpServers['claude-flow']).toBeDefined();
+  });
+
+  it('still writes a fresh file when none exists', async () => {
+    mkdirSync(testDir, { recursive: true });
+    const mcpPath = join(testDir, '.mcp.json');
+
+    const result = await executeInit(baseOptions({ force: true }));
+
+    expect(result.errors).toEqual([]);
+    const written = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+    expect(written.mcpServers['claude-flow']).toBeDefined();
+  });
+
+  it('falls back to overwrite when the existing file is not valid JSON', async () => {
+    mkdirSync(testDir, { recursive: true });
+    const mcpPath = join(testDir, '.mcp.json');
+    writeFileSync(mcpPath, '{ not valid json', 'utf-8');
+
+    const result = await executeInit(baseOptions({ force: true }));
+
+    expect(result.errors).toEqual([]);
+    const written = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+    expect(written.mcpServers['claude-flow']).toBeDefined();
+  });
+});

--- a/v3/@claude-flow/cli/src/init/executor.ts
+++ b/v3/@claude-flow/cli/src/init/executor.ts
@@ -1110,6 +1110,34 @@ async function writeMCPConfig(
   }
 
   const content = generateMCPJson(options);
+
+  // #420 — `--force` used to blindly overwrite the whole file, destroying
+  // any unrelated MCP servers the user had registered alongside ours. Merge
+  // our generated `claude-flow`/`ruv-swarm`/`flow-nexus` entries into the
+  // existing file instead, preserving every other key (both other server
+  // entries and any other top-level fields the file may carry).
+  if (options.force && fs.existsSync(mcpPath)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(mcpPath, 'utf-8')) as {
+        mcpServers?: Record<string, unknown>;
+        [key: string]: unknown;
+      };
+      const generated = JSON.parse(content) as { mcpServers: Record<string, unknown> };
+      const existingServers =
+        existing.mcpServers && typeof existing.mcpServers === 'object' ? existing.mcpServers : {};
+      const merged = {
+        ...existing,
+        mcpServers: { ...existingServers, ...generated.mcpServers },
+      };
+      fs.writeFileSync(mcpPath, JSON.stringify(merged, null, 2), 'utf-8');
+      result.created.files.push('.mcp.json');
+      return;
+    } catch {
+      // Existing file isn't valid JSON — nothing sensible to merge with,
+      // fall through to the original overwrite behavior.
+    }
+  }
+
   fs.writeFileSync(mcpPath, content, 'utf-8');
   result.created.files.push('.mcp.json');
 }


### PR DESCRIPTION
Fixes #420.

## Problem

`npx claude-flow@alpha init --force` blindly overwrote the whole `.mcp.json`
with `writeFileSync(mcpPath, content, 'utf-8')`, where `content` only ever
contains ruflo's own generated servers (`claude-flow`/`ruv-swarm`/`flow-nexus`).
Any unrelated MCP server entries a user had registered in that same file were
silently destroyed.

Note: the *default* (non-`--force`) path was already hardened in a separate,
earlier fix — it now safely skips writing `.mcp.json` when one already exists,
with a helpful message pointing at `--force`. That default-path fix doesn't
cover this issue: `--force` is exactly the escape hatch that path tells users
to reach for, and it still did a destructive full overwrite.

## Fix

In `writeMCPConfig` (`v3/@claude-flow/cli/src/init/executor.ts`), when
`--force` targets an existing `.mcp.json`, parse the existing file and merge
the generated servers into its `mcpServers` map instead of replacing the
file outright — preserving any other server keys and other top-level fields.
Falls back to the original overwrite behavior if the existing file isn't
valid JSON (nothing sensible to merge with).

## Test plan

- New test `v3/@claude-flow/cli/__tests__/init-mcp-force-merge-420.test.ts`
  (3 cases: merges into an existing file, still writes fresh when no file
  exists, falls back to overwrite on invalid JSON).
- Confirmed the merge-preservation test **fails on the pre-fix code**
  (`expected undefined to deeply equal {...}` — the unrelated server was
  wiped) and **passes after the fix**.
- Ran the broader `__tests__/init-*.test.ts` suite: no regressions in files
  that exercise `executeInit` directly. Two unrelated failures
  (`init-kebab-flags-2952`, `init-memory-package-resolver-2545`) are
  pre-existing environment/build-configuration issues in this sandbox
  (missing built `dist/` output, `@claude-flow/memory` package resolution)
  — reproduced with the fix reverted, so not caused by this change.
- `tsc --noEmit` on the package shows pre-existing baseline errors (missing
  workspace-linked type exports, unrelated to this change) but zero errors
  in the two files this PR touches.

Opened by the nightly triage routine — human review required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01489xWscrCkHGP7MfaFVGC4)_