### PR TITLE
chore: sync pnpm lockfile for mcp alpha.10

### DIFF
--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
         specifier: 3.0.3
         version: link:../codex
       '@claude-flow/mcp':
-        specifier: ^3.0.0-alpha.9
+        specifier: 3.0.0-alpha.10
         version: link:../mcp
       '@claude-flow/neural':
         specifier: 3.0.0-alpha.9


### PR DESCRIPTION
## Summary

- align the `@claude-flow/mcp` lockfile specifier with the CLI manifest's exact `3.0.0-alpha.10` pin
- restore frozen-lockfile installs on `main`

## Root cause

`v3/@claude-flow/cli/package.json` was updated to `3.0.0-alpha.10`, while the corresponding importer in `v3/pnpm-lock.yaml` still recorded `^3.0.0-alpha.9`.

## Validation

- `corepack pnpm install --frozen-lockfile --lockfile-only`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`

Fixes #3101