### PR TITLE
fix(memory): use ReasoningBank typed-array embeddings

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-embedding-shapes-3113.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-embedding-shapes-3113.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { normalizeEmbeddingOutput } from '../src/memory/embedding-output.js';
+
+describe('ReasoningBank embedding result shapes (#3113, #3114)', () => {
+  it('registers computeEmbedding as a callable model', () => {
+    const initializerPath = fileURLToPath(
+      new URL('../src/memory/memory-initializer.ts', import.meta.url),
+    );
+    const source = readFileSync(initializerPath, 'utf8');
+
+    expect(source).toContain('model: (text: string) => reasoningBank.computeEmbedding(text)');
+    expect(source).not.toContain('model: { embed: reasoningBank.computeEmbedding }');
+  });
+
+  it.each([
+    ['plain arrays', [0.25, -0.5]],
+    ['typed arrays', new Float32Array([0.25, -0.5])],
+    ['transformers data', { data: new Float32Array([0.25, -0.5]) }],
+  ])('accepts non-empty %s', (_description, output) => {
+    expect(normalizeEmbeddingOutput(output)).toEqual([0.25, -0.5]);
+  });
+
+  it.each([
+    ['empty arrays', []],
+    ['empty typed arrays', new Float32Array()],
+    ['DataView values', new DataView(new ArrayBuffer(8))],
+  ])('rejects %s so callers retain hash fallback', (_description, output) => {
+    expect(normalizeEmbeddingOutput(output)).toBeNull();
+  });
+});

--- a/v3/@claude-flow/cli/src/memory/embedding-output.ts
+++ b/v3/@claude-flow/cli/src/memory/embedding-output.ts
@@ -1,0 +1,17 @@
+/** Normalize the output shapes returned by the supported local embedders. */
+export function normalizeEmbeddingOutput(output: unknown): number[] | null {
+  const data = output && typeof output === 'object' && 'data' in output
+    ? (output as { data?: unknown }).data
+    : output;
+
+  if (Array.isArray(data)) {
+    return data.length > 0 ? data : null;
+  }
+
+  if (ArrayBuffer.isView(data) && !(data instanceof DataView)) {
+    const embedding = Array.from(data as unknown as ArrayLike<number>);
+    return embedding.length > 0 ? embedding : null;
+  }
+
+  return null;
+}

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -15,6 +15,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { createRequire } from 'node:module';
 import { readFileMaybeEncrypted, writeFileAtomic, writeFileRestricted } from '../fs-secure.js';
 import { restoreMemoryDbFromBackup } from '../services/memory-backup.js';
+import { normalizeEmbeddingOutput } from './embedding-output.js';
 
 /**
  * ADR-323 — typed memory provenance. Distinguishes WHO/WHAT wrote a memory
@@ -2281,7 +2282,7 @@ export async function loadEmbeddingModel(options?: {
 
       embeddingModelState = {
         loaded: true,
-        model: { embed: reasoningBank.computeEmbedding },
+        model: (text: string) => reasoningBank.computeEmbedding(text),
         tokenizer: null,
         dimensions: 768
       };
@@ -2458,10 +2459,7 @@ export async function generateLocalEmbedding(text: string): Promise<{
   if (state.model && typeof (state.model as any) === 'function') {
     try {
       const output = await (state.model as any)(text, { pooling: 'mean', normalize: true });
-      // Handle both @xenova/transformers (output.data) and ruvector (plain array) formats
-      const embedding = output?.data
-        ? Array.from(output.data as Float32Array)
-        : Array.isArray(output) ? output : null;
+      const embedding = normalizeEmbeddingOutput(output);
       if (embedding) {
         return {
           embedding,


### PR DESCRIPTION
## Problem

The ReasoningBank loader stored computeEmbedding inside an object, while generateLocalEmbedding only invokes callable models. Even after making it callable, direct Float32Array results were not recognized, so memory writes silently used hash embeddings.

## Solution

- register ReasoningBank computeEmbedding as a callable model
- normalize transformers data, plain arrays, and non-DataView typed arrays
- reject empty vectors and DataView values so the existing hash fallback remains in control
- add regression coverage for callable registration and every supported/rejected result shape

Closes #3113
Closes #3114

## Verification

- pnpm exec vitest run __tests__/memory-embedding-shapes-3113.test.ts __tests__/memory-ruvector-deep.test.ts — 154 passed
- pnpm exec tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext src/memory/embedding-output.ts — passed
- git diff --check — passed
- staged diff secret scan — passed

The full CLI suite was also attempted: 2,314 tests passed and 195 failed because this fresh upstream workspace lacks built cli-core, neural, and MCP package outputs and Windows cannot run several symlink/WASM/native checks. The full package build hits the same pre-existing missing workspace exports/packages; the touched helper compiles independently as shown above.