### PR TITLE
feat(federation): add latent Mixture of Roles composition contract

### DIFF
--- a/v3/@claude-flow/plugin-agent-federation/__tests__/unit/latent-role-composer.test.ts
+++ b/v3/@claude-flow/plugin-agent-federation/__tests__/unit/latent-role-composer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { composeLatentRoles } from '../../src/application/latent-role-composer.js';
+
+const roles = [
+  { id: 'skeptic', vectorRef: 'rvf://roles/skeptic', logit: 2 },
+  { id: 'engineer', vectorRef: 'rvf://roles/engineer', logit: 4 },
+  { id: 'teacher', vectorRef: 'rvf://roles/teacher', logit: 1 },
+  { id: 'scientist', vectorRef: 'rvf://roles/scientist', logit: 3 },
+] as const;
+
+describe('composeLatentRoles', () => {
+  it('falls back when the backend cannot expose hidden state', () => {
+    expect(
+      composeLatentRoles({
+        candidates: roles,
+        hiddenStateAccess: false,
+      }),
+    ).toEqual({
+      mode: 'fallback',
+      fallback: 'multi-agent',
+      reason: 'hidden-state-access-required',
+      authority: 'none',
+    });
+  });
+
+  it('selects top K roles and normalizes their weights', () => {
+    const result = composeLatentRoles({
+      candidates: roles,
+      hiddenStateAccess: true,
+      topK: 3,
+    });
+
+    expect(result.mode).toBe('latent');
+    if (result.mode !== 'latent') throw new Error('expected latent route');
+
+    expect(result.roles.map((role) => role.id)).toEqual([
+      'engineer',
+      'scientist',
+      'skeptic',
+    ]);
+    expect(result.roles.map((role) => role.rank)).toEqual([1, 2, 3]);
+    expect(result.roles.reduce((sum, role) => sum + role.weight, 0)).toBeCloseTo(1, 12);
+    expect(result.authority).toBe('none');
+  });
+
+  it('is invariant to a common additive logit shift', () => {
+    const base = composeLatentRoles({ candidates: roles, hiddenStateAccess: true, topK: 3 });
+    const shifted = composeLatentRoles({
+      candidates: roles.map((role) => ({ ...role, logit: role.logit + 10_000 })),
+      hiddenStateAccess: true,
+      topK: 3,
+    });
+
+    if (base.mode !== 'latent' || shifted.mode !== 'latent') {
+      throw new Error('expected latent routes');
+    }
+
+    expect(shifted.roles.map((role) => role.id)).toEqual(base.roles.map((role) => role.id));
+    shifted.roles.forEach((role, index) => {
+      expect(role.weight).toBeCloseTo(base.roles[index].weight, 12);
+    });
+  });
+
+  it('breaks equal logit ties deterministically by id', () => {
+    const result = composeLatentRoles({
+      candidates: [
+        { id: 'zeta', vectorRef: 'rvf://zeta', logit: 1 },
+        { id: 'alpha', vectorRef: 'rvf://alpha', logit: 1 },
+      ],
+      hiddenStateAccess: true,
+      topK: 2,
+    });
+
+    if (result.mode !== 'latent') throw new Error('expected latent route');
+    expect(result.roles.map((role) => role.id)).toEqual(['alpha', 'zeta']);
+    expect(result.roles[0].weight).toBeCloseTo(0.5, 12);
+    expect(result.roles[1].weight).toBeCloseTo(0.5, 12);
+  });
+
+  it('handles very large finite logits without overflow', () => {
+    const result = composeLatentRoles({
+      candidates: [
+        { id: 'a', vectorRef: 'rvf://a', logit: 1e300 },
+        { id: 'b', vectorRef: 'rvf://b', logit: 1e300 - 1e290 },
+      ],
+      hiddenStateAccess: true,
+    });
+
+    if (result.mode !== 'latent') throw new Error('expected latent route');
+    for (const role of result.roles) expect(Number.isFinite(role.weight)).toBe(true);
+    expect(result.roles.reduce((sum, role) => sum + role.weight, 0)).toBeCloseTo(1, 12);
+  });
+
+  it('rejects duplicate ids, invalid top K, and non finite logits', () => {
+    expect(() =>
+      composeLatentRoles({
+        candidates: [
+          { id: 'same', vectorRef: 'rvf://1', logit: 1 },
+          { id: 'same', vectorRef: 'rvf://2', logit: 2 },
+        ],
+        hiddenStateAccess: true,
+      }),
+    ).toThrow('duplicate latent role candidate id');
+
+    expect(() =>
+      composeLatentRoles({ candidates: roles, hiddenStateAccess: true, topK: 0 }),
+    ).toThrow('topK must be an integer');
+
+    expect(() =>
+      composeLatentRoles({
+        candidates: [{ id: 'bad', vectorRef: 'rvf://bad', logit: Number.NaN }],
+        hiddenStateAccess: true,
+      }),
+    ).toThrow('non-finite logit');
+  });
+});

--- a/v3/@claude-flow/plugin-agent-federation/docs/adrs/0001-latent-role-composition.md
+++ b/v3/@claude-flow/plugin-agent-federation/docs/adrs/0001-latent-role-composition.md
@@ -1,0 +1,55 @@
+# ADR 0001: Latent role composition for local model backends
+
+Status: Proposed
+
+Date: 2026 08 29
+
+## Context
+
+Ruflo already supports textual mixture of agents fanout. The MoRe paper, arXiv 2608.27338, reports that multiple learned latent roles can be composed into one steering vector and applied in one model generation. The originating team reports performance near multi agent systems while using about 20 times fewer generated tokens on its evaluated settings.
+
+The result is not yet independently reproduced in Ruflo. It also requires hidden state access, so hosted black box APIs cannot use the latent path directly.
+
+## Decision
+
+Introduce a model agnostic latent role composition contract inside the federation plugin.
+
+The contract accepts caller supplied role logits and immutable references to steering vectors, performs deterministic top K selection, normalizes selected weights with stable softmax, and returns either a latent composition plan or an explicit fallback.
+
+The contract never infers permissions. Its output carries `authority: none`. Tool authority, capability expansion, network access, and execution remain governed by existing Ruflo and RVM controls.
+
+## Invariants
+
+1. No hidden state access means no latent steering. Fall back to the existing single agent or multi agent path.
+2. Role identifiers are unique and steering vector references are explicit.
+3. Logits must be finite.
+4. Selection is deterministic for equal inputs.
+5. Weights are finite and sum to one within floating point tolerance.
+6. Latent role composition never grants execution authority.
+7. Existing textual multi agent behavior remains unchanged unless a caller opts into a future backend integration.
+
+## Rejected alternatives
+
+### Replace textual multi agent routing immediately
+
+Rejected because the published result does not support black box model APIs and does not uniformly beat the strongest multi agent baseline on both evaluated backbones.
+
+### Train role vectors inside the federation plugin
+
+Rejected because training belongs in the model runtime or training subsystem. Federation should consume validated artifacts, not own opaque model state mutation.
+
+### Treat role confidence as trust
+
+Rejected. A router score is inference evidence, not identity or authority.
+
+## Validation plan
+
+Compare three conditions with identical tasks and base models: single agent, current textual mixture of agents, and latent role composition. Report accuracy, generated tokens, wall time, time to first token, GPU memory, energy when available, failures, and variance.
+
+Promotion requires either performance within 1.5 absolute percentage points of the stronger textual multi agent baseline with at least 8 times fewer coordination tokens, or at least 2 absolute points over the single agent baseline at no more than 1.1 times its generated token cost.
+
+Security evaluation must include poisoned role vectors, malformed logits, missing vector artifacts, out of distribution prompts, and attempts to convert router output into execution authority.
+
+## Rollback
+
+Remove the exported composer and backend opt in. Existing routing remains the fallback and requires no data migration.

--- a/v3/@claude-flow/plugin-agent-federation/docs/research/2026-08-29-more-reproduction.md
+++ b/v3/@claude-flow/plugin-agent-federation/docs/research/2026-08-29-more-reproduction.md
@@ -1,0 +1,65 @@
+# MoRe reproduction protocol
+
+Source: arXiv 2608.27338, submitted 2026 08 27.
+
+Evidence class: originating team report. No Ruflo reproduction yet.
+
+## Question
+
+Can a local open model preserve most of the quality benefit of Ruflo textual multi agent fanout by composing learned latent roles into one generation?
+
+## Conditions
+
+A. Single agent baseline.
+
+B. Existing Ruflo textual mixture of agents with matched task budget.
+
+C. Latent role composition using a frozen backbone and validated role vector artifacts.
+
+Use the same prompt set, model revision, tokenizer revision, decoding parameters, seeds, hardware, and evaluator across conditions.
+
+## Initial models
+
+1. Llama 3.1 8B Instruct.
+2. Qwen3 8B.
+
+Pin exact model revisions before execution.
+
+## Workloads
+
+Use a stratified subset first, then full suites only if the direction survives.
+
+1. MMLU.
+2. GSM8K.
+3. MATH.
+4. TriviaQA.
+5. One Ruflo repository task set representing tool planning and software reasoning.
+
+## Metrics
+
+Report task score, generated tokens, prompt tokens, wall time, time to first token, tokens per second, peak GPU memory, energy when measurable, router overhead, failure count, and variance across seeds.
+
+Report absolute and relative deltas. Keep failed and regressed tasks in the artifact.
+
+## Ablations
+
+1. Top K equals 1, 2, 3, and 5.
+2. Uniform role weights versus learned router weights.
+3. Random role vector control.
+4. Text role prompting without vector steering.
+5. Latent path with one role artifact removed.
+
+## Adversarial tests
+
+1. Non finite router logits.
+2. Duplicate role identifiers.
+3. Missing or mismatched vector artifact digest.
+4. Poisoned vector artifact.
+5. Out of distribution prompts.
+6. Attempted use of role confidence as execution authority.
+
+## Acceptance gate
+
+Graduate only if either condition C is within 1.5 absolute percentage points of the stronger condition B while using at least 8 times fewer coordination tokens, or condition C beats condition A by at least 2 absolute points while using no more than 1.1 times its generated token count.
+
+No authority expansion is permitted. All vector artifacts require provenance and digest binding before runtime integration.

--- a/v3/@claude-flow/plugin-agent-federation/src/application/latent-role-composer.ts
+++ b/v3/@claude-flow/plugin-agent-federation/src/application/latent-role-composer.ts
@@ -1,0 +1,114 @@
+export interface LatentRoleCandidate {
+  id: string;
+  vectorRef: string;
+  logit: number;
+}
+
+export type LatentRoleFallback = 'single' | 'multi-agent';
+
+export interface LatentRoleComposeRequest {
+  candidates: readonly LatentRoleCandidate[];
+  hiddenStateAccess: boolean;
+  topK?: number;
+  fallback?: LatentRoleFallback;
+}
+
+export interface ComposedLatentRole {
+  id: string;
+  vectorRef: string;
+  weight: number;
+  rank: number;
+}
+
+export type LatentRoleRoute =
+  | {
+      mode: 'latent';
+      roles: ComposedLatentRole[];
+      authority: 'none';
+      requiresHiddenStateAccess: true;
+    }
+  | {
+      mode: 'fallback';
+      fallback: LatentRoleFallback;
+      reason: 'hidden-state-access-required';
+      authority: 'none';
+    };
+
+function validateCandidates(candidates: readonly LatentRoleCandidate[]): void {
+  if (candidates.length === 0) {
+    throw new Error('at least one latent role candidate is required');
+  }
+
+  const ids = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate.id.trim()) {
+      throw new Error('latent role candidate id must be non-empty');
+    }
+    if (!candidate.vectorRef.trim()) {
+      throw new Error(`latent role candidate ${candidate.id} must include vectorRef`);
+    }
+    if (!Number.isFinite(candidate.logit)) {
+      throw new Error(`latent role candidate ${candidate.id} has non-finite logit`);
+    }
+    if (ids.has(candidate.id)) {
+      throw new Error(`duplicate latent role candidate id: ${candidate.id}`);
+    }
+    ids.add(candidate.id);
+  }
+}
+
+/**
+ * Compose a bounded set of latent roles from caller supplied router logits.
+ *
+ * This function is intentionally model agnostic. It does not infer roles or
+ * touch model hidden states. Backends with hidden state access can use the
+ * returned normalized weights to combine prevalidated steering vectors.
+ * Hosted black box backends receive an explicit fallback instead.
+ *
+ * The result carries no execution authority. Role routing is evidence about
+ * how to shape inference, never permission to call tools or expand capabilities.
+ */
+export function composeLatentRoles(request: LatentRoleComposeRequest): LatentRoleRoute {
+  validateCandidates(request.candidates);
+
+  const fallback = request.fallback ?? 'multi-agent';
+  if (!request.hiddenStateAccess) {
+    return {
+      mode: 'fallback',
+      fallback,
+      reason: 'hidden-state-access-required',
+      authority: 'none',
+    };
+  }
+
+  const topK = request.topK ?? Math.min(3, request.candidates.length);
+  if (!Number.isInteger(topK) || topK < 1 || topK > request.candidates.length) {
+    throw new Error(`topK must be an integer in [1, ${request.candidates.length}]`);
+  }
+
+  const selected = [...request.candidates]
+    .sort((a, b) => b.logit - a.logit || a.id.localeCompare(b.id))
+    .slice(0, topK);
+
+  // Stable softmax. Subtracting the maximum makes large magnitude logits safe
+  // and preserves invariance to a common additive shift.
+  const maxLogit = selected[0].logit;
+  const exp = selected.map((candidate) => Math.exp(candidate.logit - maxLogit));
+  const denominator = exp.reduce((sum, value) => sum + value, 0);
+
+  if (!Number.isFinite(denominator) || denominator <= 0) {
+    throw new Error('latent role weights could not be normalized');
+  }
+
+  return {
+    mode: 'latent',
+    roles: selected.map((candidate, index) => ({
+      id: candidate.id,
+      vectorRef: candidate.vectorRef,
+      weight: exp[index] / denominator,
+      rank: index + 1,
+    })),
+    authority: 'none',
+    requiresHiddenStateAccess: true,
+  };
+}

--- a/v3/@claude-flow/plugin-agent-federation/src/index.ts
+++ b/v3/@claude-flow/plugin-agent-federation/src/index.ts
@@ -121,6 +121,14 @@ export {
   type FederationClaimCheckerConfig,
 } from './application/claim-checker.js';
 export {
+  composeLatentRoles,
+  type ComposedLatentRole,
+  type LatentRoleCandidate,
+  type LatentRoleComposeRequest,
+  type LatentRoleFallback,
+  type LatentRoleRoute,
+} from './application/latent-role-composer.js';
+export {
   DEFAULT_ENVELOPE_SIGNATURE_MODE,
   JCS_SIGNATURE_PROTOCOL,
   canonicalizeEnvelopeForVerify,


### PR DESCRIPTION
Implements the reusable latent role composition contract tracked in #3125.

The federation plugin now supports deterministic top K role selection from caller supplied logits, numerically stable normalized weights, explicit steering vector references, strict malformed input rejection, and an explicit fallback when hidden state access is unavailable. The result carries no execution authority.

Unit tests cover fallback behavior, normalization, additive logit shift invariance, deterministic ties, very large finite logits, duplicate identities, invalid top K, and non finite scores. An ADR and reproduction protocol compare this path against single agent and the existing textual mixture of agents.

This PR is draft. It does not train role vectors or integrate a model backend. Do not merge until the published result is independently reproduced and steering artifacts are provenance and digest bound.