### PR TITLE
docs(adr): ADR-322D — accept the cross-repo anchor record (was stale PROPOSED-EXTENSION)

### DIFF
--- a/v3/docs/adr/ADR-322D-cross-repo-anchor-record-accepted.md
+++ b/v3/docs/adr/ADR-322D-cross-repo-anchor-record-accepted.md
@@ -1,0 +1,51 @@
+# ADR-322D: Cross-repo anchor record — proposed extension promoted to Accepted
+
+- **Status**: Accepted — implemented and consumed downstream
+- **Parent**: ADR-322C (defines the record types and verification protocol this ADR's record anchors *into* a foreign chain)
+- **Date**: 2026-08-29
+- **Related**: ADR-322 (flywheel receipt protocol), ADR-322C (receipt/ledger verification), `v3/docs/spec/witness-receipt-contract.md` §9, `ruvnet/ruflo#3066` (closed — PIR program tracking issue), `ruvnet/RuVector#837` (PIR program epic)
+
+## Context
+
+`witness-receipt-contract.md` §9 and `schemas/ruflo-anchor-record-v1.schema.json` both currently read as `PROPOSED-EXTENSION` — "Nothing above is decided. It needs an ADR before `rvm`, `autogenous`, or `ruvector` depends on it." That framing is stale. Checked directly against the actual repos (2026-08-29):
+
+- `ruvnet/rvm#37` — **MERGED**: "feat(anchor): verify and anchor ruflo ADR-322C receipts into the witness chain (WP8, #35)".
+- `ruvnet/autogenous#13` — **MERGED**: "feat(radio-moe): export promotion evidence in the ruflo ADR-322C receipt shape (WP8, #10)".
+- `ruvnet/ruflo#3066` (the PIR tracking issue that scoped this work) — **CLOSED**, with its own final status comment confirming the schema (PR #3067, merged 2026-08-20) is canonical on `main` and the two downstream conformance audits (`rvm#37`, `autogenous#13`) cleared.
+
+Two consumers have already built against this "not decided" placeholder and shipped. The ADR this repo's own spec said was a precondition for that dependency was never actually written. This ADR is that missing formal record, written after the fact to match what's already true rather than to authorize something new.
+
+## Decision
+
+Promote the cross-repo anchor record (`ruflo.anchor-record/v1`, schema at `v3/docs/spec/schemas/ruflo-anchor-record-v1.schema.json`) from `PROPOSED-EXTENSION` to **Accepted**, unchanged in shape from what shipped:
+
+- `payload.anchoredContentId` / `anchoredSchemaVersion` — identifies the ADR-322C record being anchored (normally a `receiptId`, since receipt signatures are implemented and ledger-head signatures are not — gap G2, unchanged by this ADR).
+- `payload.chain` (`chainId`, `position`) — opaque foreign-chain pointer.
+- `payload.assuranceLevel` (`service-side` | `hypervisor-side`) — required by `rvm` (its own ADR-285 discipline: a service-side record anchored into a hypervisor chain does not thereby acquire hypervisor-side guarantees) and by `autogenous`.
+- Signing domain `ruflo/flywheel-anchor/v1`, distinct from `ruflo/flywheel-receipt/v1` so an anchor signature can never be replayed as a receipt signature (ADR-322 §Persistence and key boundaries).
+
+No schema changes. This ADR is a status change, not a design change — the two live consumers already built against the shape as specified; changing it now would break them.
+
+### What this does *not* cover
+
+This ADR concerns exactly one cross-repo contract: ruflo's own flywheel evaluation receipts, anchored into `rvm`'s or `autogenous`'s witness chain. It is unrelated to, and should not be conflated with, `ruvnet/LatentMesh`'s own aspiration (its ADR-008/ADR-009) to have RVF/RVM gate *LatentMesh's* candidate cognition specifically — that remains, per a direct check of LatentMesh's own docs on 2026-08-29, explicitly unwired and unreferenced anywhere in RVM's documentation. Two different things share the word "RVM" here: a real, shipped ruflo→RVM receipt-anchoring contract (this ADR), and a still-aspirational LatentMesh→RVM candidate-cognition gate (not this ADR, not yet real anywhere).
+
+## Consequences
+
+**Positive**: `witness-receipt-contract.md` and the schema file's own header stop contradicting the two repos that already built against them. Future readers of either file (including the "external implementers... without reading ruflo's source" audience §9 itself names) get an accurate status instead of a placeholder warning that undersold what's already shipped.
+
+**Negative**: none — this is a documentation-accuracy correction, not a behavior change. `rvm#37` and `autogenous#13` do not need to change anything; they already built the real thing.
+
+## Verification
+
+```bash
+# Schema exists and is the one both downstream consumers built against:
+cat v3/docs/spec/schemas/ruflo-anchor-record-v1.schema.json
+gh pr view 37 --repo ruvnet/rvm --json state,title
+gh pr view 13 --repo ruvnet/autogenous --json state,title
+gh issue view 3066 --repo ruvnet/ruflo --json state
+```
+
+## Implementation status
+
+Already implemented, on both sides, before this ADR was written. This ADR is the record catching up to that reality, per `v3/docs/spec/witness-receipt-contract.md`'s own instruction: "requiring its own ADR before use" — the "before use" window closed on 2026-08-20 when `rvm#37`/`autogenous#13` merged; this ADR closes the paperwork gap that left, not a code gap.

--- a/v3/docs/spec/conformance-checklist.md
+++ b/v3/docs/spec/conformance-checklist.md
@@ -88,8 +88,9 @@ consequences of the same rules.
 - [ ] **C4** An anchored record's stated assurance is the assurance it carries,
   not the assurance of the chain it landed in. A service-side record anchored into
   a hypervisor chain does not acquire hypervisor-side guarantees
-  (`rvm` ADR-285). Uses the `PROPOSED-EXTENSION` field in
-  [`schemas/ruflo-anchor-record-v1.schema.json`](./schemas/ruflo-anchor-record-v1.schema.json).
+  (`rvm` ADR-285). Uses the `assuranceLevel` field in
+  [`schemas/ruflo-anchor-record-v1.schema.json`](./schemas/ruflo-anchor-record-v1.schema.json)
+  (ADR-322D — Accepted).
 - [ ] **C5** No dependency edge is introduced between `rvm-witness` and
   `autogenous`'s witness crate in either direction — both consume this contract
   independently (`rvm#35`, `autogenous#10`).

--- a/v3/docs/spec/schemas/ruflo-anchor-record-v1.schema.json
+++ b/v3/docs/spec/schemas/ruflo-anchor-record-v1.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/ruvnet/ruflo/v3/docs/spec/schemas/ruflo-anchor-record-v1.schema.json",
-  "title": "RufloAnchorRecordV1 (PROPOSED-EXTENSION)",
-  "description": "PROPOSED-EXTENSION - NOT part of ADR-322C. ADR-322C defines records and their verification but is silent on how a record is anchored into a foreign chain. ruvnet/rvm#35 and ruvnet/autogenous#10 both need a pointer format, so this is the minimal placeholder for that need. It requires its own ADR before any repo depends on it. Do not treat conformance to this file as conformance to ADR-322C.",
+  "title": "RufloAnchorRecordV1",
+  "description": "Accepted per ADR-322D (2026-08-29) - an extension to, not part of, ADR-322C. ADR-322C defines records and their verification but is silent on how a record is anchored into a foreign chain; this fills that gap. Consumed by two merged downstream implementations built against this exact shape: ruvnet/rvm#37 and ruvnet/autogenous#13 (tracking ruvnet/rvm#35 and ruvnet/autogenous#10). Do not treat conformance to this file as conformance to ADR-322C itself -- they are separate contracts.",
   "type": "object",
   "required": ["payload"],
   "additionalProperties": false,
@@ -24,7 +24,7 @@
         "algorithm": { "const": "ed25519" },
         "domain": {
           "const": "ruflo/flywheel-anchor/v1",
-          "description": "PROPOSED-EXTENSION signing domain. Distinct from ruflo/flywheel-receipt/v1 so an anchor signature can never be replayed as a receipt signature, per ADR-322 section Persistence and key boundaries."
+          "description": "Signing domain, accepted per ADR-322D. Distinct from ruflo/flywheel-receipt/v1 so an anchor signature can never be replayed as a receipt signature, per ADR-322 section Persistence and key boundaries."
         },
         "publicKeyPem": { "type": "string", "pattern": "^-----BEGIN PUBLIC KEY-----" },
         "signatureBase64": { "type": "string", "pattern": "^[A-Za-z0-9+/]{86}==$" }

--- a/v3/docs/spec/witness-receipt-contract.md
+++ b/v3/docs/spec/witness-receipt-contract.md
@@ -8,9 +8,15 @@
   implementing source under `v3/@claude-flow/cli/src/services/`.
 - **Audience**: external implementers (`ruvnet/rvm#35`, `ruvnet/autogenous#10`,
   `ruvnet/RuVector#840`) producing or verifying these records **without reading
-  ruflo's source**. Tracked by `ruvnet/ruflo#3066`.
-- **`PROPOSED-EXTENSION`** marks anything *not* in ADR-322C: a minimal placeholder
+  ruflo's source**. Tracked by `ruvnet/ruflo#3066` (closed 2026-08-20).
+- **`PROPOSED-EXTENSION`** marked anything *not* in ADR-322C: a minimal placeholder
   for a consumer need 322C does not address, requiring its own ADR before use.
+  The one extension this doc defines (record type 3, §9) cleared that bar on
+  2026-08-29 via [ADR-322D](../adr/ADR-322D-cross-repo-anchor-record-accepted.md)
+  — both downstream consumers (`rvm#37`, `autogenous#13`) had already merged
+  against this exact shape, so the label now reads as stale rather than as an
+  open precondition. Kept as a term for any *future* extension this doc
+  doesn't yet define.
 
 ## 1. Record types
 
@@ -18,7 +24,7 @@
 |---|---|---|---|---|
 | 1 | Evaluation receipt | `ruflo.flywheel-receipt/v1` | `ruflo/flywheel-receipt/v1` | Implemented (`flywheel-receipt.ts:18`) |
 | 2 | Promotion commit + ledger head | *(unnamed in 322C)* | `ruflo/flywheel-ledger-head/v1` | **Commit implemented unsigned**; head signing **specified but not implemented** — see §7 |
-| 3 | Cross-repo anchor record | `ruflo.anchor-record/v1` | `ruflo/flywheel-anchor/v1` | `PROPOSED-EXTENSION` — see §9 |
+| 3 | Cross-repo anchor record | `ruflo.anchor-record/v1` | `ruflo/flywheel-anchor/v1` | **Accepted — implemented, consumed by `rvm#37` and `autogenous#13` (both merged)** — see [ADR-322D](../adr/ADR-322D-cross-repo-anchor-record-accepted.md), §9 |
 
 A third domain-separation string exists but is **not** a signing domain:
 `"ruflo/bootstrap/v1"`, the seed prefix for the paired bootstrap (ADR-322C
@@ -223,11 +229,11 @@ names is a phase-3 artifact.
   without a compatibility ADR. Pin `schemaVersion` + `gateVersion` strings, not
   git SHAs.
 
-## 9. `PROPOSED-EXTENSION`: cross-repo anchoring
+## 9. Cross-repo anchoring — **Accepted** ([ADR-322D](../adr/ADR-322D-cross-repo-anchor-record-accepted.md))
 
 ADR-322C defines records and their verification but **no pointer format** for
-anchoring one into a foreign chain. `rvm#35` and `autogenous#10` both need one.
-Minimal placeholder in `schemas/ruflo-anchor-record-v1.schema.json`:
+anchoring one into a foreign chain. `rvm#35` and `autogenous#10` both needed
+one. Shape, in `schemas/ruflo-anchor-record-v1.schema.json`:
 
 - `anchoredContentId` / `anchoredSchemaVersion` — the `sha256:` ID of the anchored
   record and what kind of record it is.
@@ -238,5 +244,15 @@ Minimal placeholder in `schemas/ruflo-anchor-record-v1.schema.json`:
 - Signing domain `ruflo/flywheel-anchor/v1` — distinct so an anchor signature can
   never be replayed as a receipt signature (§4).
 
-Nothing above is decided. It needs an ADR before `rvm`, `autogenous`, or
-`ruvector` depends on it.
+**No longer a placeholder.** `rvm#37` ("verify and anchor ruflo ADR-322C
+receipts into the witness chain") and `autogenous#13` ("export promotion
+evidence in the ruflo ADR-322C receipt shape") are both merged, built against
+exactly this shape. ADR-322D promotes this record from `PROPOSED-EXTENSION`
+to Accepted to match — schema unchanged, since two live consumers already
+depend on it as specified.
+
+Scope note carried over from ADR-322D: this is ruflo's own flywheel receipts
+anchoring into `rvm`/`autogenous`'s witness chains specifically. It is not the
+same thing as `ruvnet/LatentMesh`'s separate, still-unwired aspiration to have
+RVF/RVM gate its own candidate cognition — a different "RVM" relationship
+that this section does not cover.


### PR DESCRIPTION
## Summary

Found while researching a cross-ecosystem architecture question (`ruvnet/LatentMesh#18`): `witness-receipt-contract.md` §9 and the `ruflo-anchor-record-v1` schema both still say `PROPOSED-EXTENSION... nothing above is decided`, but the two consumers that placeholder was gating already merged real implementations against exactly this shape:

- `ruvnet/rvm#37` (merged) — verify and anchor ruflo ADR-322C receipts into the witness chain
- `ruvnet/autogenous#13` (merged) — export promotion evidence in the ruflo ADR-322C receipt shape
- `ruvnet/ruflo#3066` (closed) — the PIR tracking issue that scoped this work, with its own status comment confirming the schema (PR #3067) is canonical on `main` and both downstream conformance audits cleared

No schema or behavior change — this is a documentation-accuracy fix. `ADR-322D` formally promotes the record from `PROPOSED-EXTENSION` to Accepted to match what's already shipped, and explicitly scopes it against a different, still-unwired "RVM" relationship (LatentMesh's own aspiration to have RVF/RVM gate its own candidate cognition) so future readers don't conflate the two.

## Test plan

- [x] Schema JSON still valid after edits (`python3 -c "import json; json.load(open(...))"`)
- [x] Verified `rvm#37`, `autogenous#13` are both merged and `ruflo#3066` is closed, via `gh`
- [x] Grepped for any code/tests asserting the exact `PROPOSED-EXTENSION` strings changed — none found
- [ ] Human review: confirm this doesn't need a corresponding update in `rvm`'s or `autogenous`'s own docs (out of scope for this PR)

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_013n8ubRUZzQucCs1VtTnxk9