### PR TITLE
fix: verify source memory DB integrity before backing it up (#2895)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-backup.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-backup.test.ts
@@ -4,8 +4,8 @@
  * Proves the WAL-safe snapshot is consistent, non-destructive, rotated, and
  * degrades cleanly when there's nothing to back up.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdtempSync, existsSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -72,5 +72,44 @@ describe.skipIf(!haveNative)('backupMemoryDb', () => {
     const r = await backupMemoryDb({ dbPath: join(workdir, 'nope.db') });
     expect(r.backedUp).toBe(false);
     expect(r.skipped).toBe('no-db');
+  });
+
+  it('marks a healthy source clean and untagged (#2895)', async () => {
+    const dbPath = join(workdir, 'memory.db');
+    seedDb(dbPath, 5);
+    const r = await backupMemoryDb({ dbPath, timestamp: 1_700_000_000_000 });
+    expect(r.backedUp).toBe(true);
+    expect(r.sourceCorrupt).toBe(false);
+    expect(r.sourceIntegrity?.toLowerCase()).toBe('ok');
+    expect(r.path).not.toContain('CORRUPT');
+  });
+
+  it('#2895 — still backs up a corrupt source, but tags it CORRUPT and warns instead of reporting a clean success', async () => {
+    const dbPath = join(workdir, 'memory.db');
+    // Garbage bytes: not a valid SQLite file at all (truncated/invalid header).
+    writeFileSync(dbPath, Buffer.from('this is not a sqlite database, just garbage bytes '.repeat(20)));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const r = await backupMemoryDb({ dbPath, timestamp: 1_700_000_000_000 });
+
+      // (a) a backup file is still created
+      expect(r.backedUp).toBe(true);
+      expect(existsSync(r.path!)).toBe(true);
+
+      // (b) it's tagged/marked as corrupt in the result and the filename
+      expect(r.sourceCorrupt).toBe(true);
+      expect(r.sourceIntegrity).toBeTruthy();
+      expect(r.sourceIntegrity?.toLowerCase()).not.toBe('ok');
+      expect(r.path).toMatch(/\.CORRUPT\.db$/);
+      // Still discoverable by the same rotation/restore glob.
+      expect(/^memory-.*\.db$/.test(join(r.path!).split(/[\\/]/).pop()!)).toBe(true);
+
+      // (c) a warning is emitted (unconditional — not gated behind --verbose)
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls.some(args => String(args[0]).includes('integrity check'))).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/v3/@claude-flow/cli/src/services/memory-backup.ts
+++ b/v3/@claude-flow/cli/src/services/memory-backup.ts
@@ -36,6 +36,14 @@ export interface BackupResult {
   rotatedAway?: string[];
   gcsUri?: string;
   skipped?: string;
+  /** Result of `PRAGMA integrity_check` on the SOURCE DB before snapshotting it. */
+  sourceIntegrity?: string;
+  /** True when the source failed its integrity check (or couldn't be opened at
+   *  all). The snapshot is still taken — a corrupt-but-present DB beats none —
+   *  but is tagged `*.CORRUPT.db` so `restoreMemoryDbFromBackup` skips it in
+   *  favor of an older clean snapshot instead of silently rotating the last
+   *  good one out of the retention window (#2895). */
+  sourceCorrupt?: boolean;
 }
 
 export function defaultMemoryDbPath(cwd: string = process.cwd()): string {
@@ -61,7 +69,31 @@ export async function backupMemoryDb(opts: BackupOptions = {}): Promise<BackupRe
 
   const destDir = opts.destDir ?? path.join(path.dirname(dbPath), 'backups');
   try { fs.mkdirSync(destDir, { recursive: true }); } catch { /* */ }
-  const destPath = path.join(destDir, `memory-${fileStamp(opts.timestamp ?? Date.now())}.db`);
+
+  // Verify the SOURCE before snapshotting it (#2895). Without this, a corrupt
+  // .swarm/memory.db gets copied forward every night, reported as a success,
+  // and the last clean snapshot silently rotates out of the retention window.
+  // Mirrors the check restoreMemoryDbFromBackup() already runs on the way out.
+  let sourceIntegrity = 'unknown';
+  try {
+    const srcDb = new Database(dbPath, { readonly: true });
+    sourceIntegrity = String(srcDb.pragma('integrity_check', { simple: true }) ?? '');
+    srcDb.close();
+  } catch (e) {
+    sourceIntegrity = `unreadable: ${(e as Error)?.message ?? e}`;
+  }
+  const sourceCorrupt = sourceIntegrity.toLowerCase() !== 'ok';
+  if (sourceCorrupt) {
+    // Unconditional — this is not a "verbose" nice-to-have, it's the whole
+    // point of the check: a silently-corrupt backup is worse than a loud one.
+    console.warn(
+      `memory-backup: source DB ${dbPath} failed integrity check (${sourceIntegrity}) — ` +
+      `backing it up anyway (a corrupt snapshot beats none), tagged CORRUPT so restore skips it.`,
+    );
+  }
+
+  const stamp = fileStamp(opts.timestamp ?? Date.now());
+  const destPath = path.join(destDir, sourceCorrupt ? `memory-${stamp}.CORRUPT.db` : `memory-${stamp}.db`);
 
   // WAL-safe online backup: read-only source, consistent snapshot to destPath.
   let db: any;
@@ -106,7 +138,7 @@ export async function backupMemoryDb(opts: BackupOptions = {}): Promise<BackupRe
         if (opts.verbose) {
           console.log(`memory DB backed up (byte-copy, encrypted-at-rest) → ${destPath} (${Math.round(copiedBytes / 1024)} KB)`);
         }
-        return { backedUp: true, path: destPath, sizeBytes: copiedBytes, rotatedAway, gcsUri };
+        return { backedUp: true, path: destPath, sizeBytes: copiedBytes, rotatedAway, gcsUri, sourceIntegrity, sourceCorrupt };
       }
     } catch { /* byte-copy also failed — report the original error */ }
     return { backedUp: false, skipped: `backup failed: ${(e as Error)?.message ?? e}` };
@@ -144,7 +176,7 @@ export async function backupMemoryDb(opts: BackupOptions = {}): Promise<BackupRe
       (gcsUri ? `, offsite ${gcsUri}` : ''),
     );
   }
-  return { backedUp: true, path: destPath, sizeBytes, rotatedAway, gcsUri };
+  return { backedUp: true, path: destPath, sizeBytes, rotatedAway, gcsUri, sourceIntegrity, sourceCorrupt };
 }
 
 export interface RestoreResult {

--- a/v3/@claude-flow/cli/src/services/worker-daemon.ts
+++ b/v3/@claude-flow/cli/src/services/worker-daemon.ts
@@ -1830,7 +1830,12 @@ export class WorkerDaemon extends EventEmitter {
         rotatedAway: r.rotatedAway?.length ?? 0,
         gcsUri: r.gcsUri,
         skipped: r.skipped,
+        sourceIntegrity: r.sourceIntegrity,
+        sourceCorrupt: r.sourceCorrupt ?? false,
       };
+      if (r.sourceCorrupt) {
+        this.log('warn', `Backup worker: source memory DB failed integrity check (${r.sourceIntegrity}) — backed up anyway, tagged CORRUPT.`);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.log('warn', `Backup worker failed: ${message}`);


### PR DESCRIPTION
Fixes #2895. `backupMemoryDb()` never ran `PRAGMA integrity_check` on the SOURCE `.swarm/memory.db` before snapshotting it, so a corrupt DB was copied forward every night and reported as a clean success, silently rotating the last good snapshot out of the retention window. This adds the same integrity check `restoreMemoryDbFromBackup()` already runs on the way out, to both the online-backup and byte-copy-fallback success paths in `memory-backup.ts`: a corrupt/unreadable source is still backed up (a corrupt snapshot beats none), but the file is tagged `*.CORRUPT.db` (still matched by the existing rotation/restore glob, so it stays discoverable but correctly fails its own integrity check and is skipped by restore), an unconditional `console.warn` is emitted, and the result now carries `sourceIntegrity`/`sourceCorrupt` which `runBackupWorker()` surfaces into its metrics. Opened by the nightly triage routine — human review required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpeUPeLwJtPC5USnJGukv9)_