### PR TITLE
fix: backfill Android tzdata/ICU env for statusline sqlite3 shell-outs (#2897)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -25,6 +25,29 @@ const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
 
+// #2897 — on Android (Termux + PRoot Linux), bionic libc hard-aborts
+// (SIGABRT) any platform binary that touches tzdata/ICU when
+// ANDROID_TZDATA_ROOT is unset, and PRoot doesn't export Android's
+// runtime env roots. sqlite3 is one such binary, so every sqlite3 shell-out
+// below via safeExec() died silently (safeExec swallows the throw and
+// returns ''), permanently pinning Vectors/HNSW at 0 with no error surfaced.
+// Detect Android via /apex/com.android.tzdata and backfill the roots it
+// needs — existing env values always win (the `||` pattern), so a
+// correctly-configured ambient environment is never overridden, and this
+// is a no-op everywhere /apex/com.android.tzdata doesn't exist.
+const EXEC_ENV = (() => {
+  const e = Object.assign({}, process.env);
+  try {
+    if (fs.existsSync('/apex/com.android.tzdata')) {
+      e.ANDROID_ROOT = e.ANDROID_ROOT || '/system';
+      e.ANDROID_DATA = e.ANDROID_DATA || '/data';
+      e.ANDROID_TZDATA_ROOT = e.ANDROID_TZDATA_ROOT || '/apex/com.android.tzdata';
+      e.ANDROID_I18N_ROOT = e.ANDROID_I18N_ROOT || '/apex/com.android.i18n';
+    }
+  } catch { /* not Android, or /apex unreadable -- leave env untouched */ }
+  return e;
+})();
+
 // Configuration
 const CONFIG = {
   maxAgents: 15,
@@ -669,6 +692,7 @@ function safeExec(cmd, timeoutMs) {
     return execSync(cmd, {
       encoding: 'utf-8',
       timeout: timeoutMs || 2000,
+      env: EXEC_ENV,
       stdio: ['pipe', 'pipe', 'pipe'],
       // Windows: without this, every execSync spawns cmd.exe /d /s /c which
       // flashes a visible console window every render (~1/min via the 60s

--- a/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/statusline.cjs
@@ -25,6 +25,29 @@ const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
 
+// #2897 — on Android (Termux + PRoot Linux), bionic libc hard-aborts
+// (SIGABRT) any platform binary that touches tzdata/ICU when
+// ANDROID_TZDATA_ROOT is unset, and PRoot doesn't export Android's
+// runtime env roots. sqlite3 is one such binary, so every sqlite3 shell-out
+// below via safeExec() died silently (safeExec swallows the throw and
+// returns ''), permanently pinning Vectors/HNSW at 0 with no error surfaced.
+// Detect Android via /apex/com.android.tzdata and backfill the roots it
+// needs — existing env values always win (the `||` pattern), so a
+// correctly-configured ambient environment is never overridden, and this
+// is a no-op everywhere /apex/com.android.tzdata doesn't exist.
+const EXEC_ENV = (() => {
+  const e = Object.assign({}, process.env);
+  try {
+    if (fs.existsSync('/apex/com.android.tzdata')) {
+      e.ANDROID_ROOT = e.ANDROID_ROOT || '/system';
+      e.ANDROID_DATA = e.ANDROID_DATA || '/data';
+      e.ANDROID_TZDATA_ROOT = e.ANDROID_TZDATA_ROOT || '/apex/com.android.tzdata';
+      e.ANDROID_I18N_ROOT = e.ANDROID_I18N_ROOT || '/apex/com.android.i18n';
+    }
+  } catch { /* not Android, or /apex unreadable -- leave env untouched */ }
+  return e;
+})();
+
 // Configuration
 const CONFIG = {
   maxAgents: 15,
@@ -673,6 +696,7 @@ function safeExec(cmd, timeoutMs) {
     return execSync(cmd, {
       encoding: 'utf-8',
       timeout: timeoutMs || 2000,
+      env: EXEC_ENV,
       stdio: ['pipe', 'pipe', 'pipe'],
       // Windows: without this, every execSync spawns cmd.exe /d /s /c which
       // flashes a visible console window every render (~1/min via the 60s

--- a/v3/@claude-flow/cli/__tests__/issue-2897-android-tzdata-env.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-2897-android-tzdata-env.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression coverage for issue #2897: on Android (Termux + PRoot Linux),
+ * every `sqlite3` shell-out made by `.claude/helpers/statusline.cjs`'s
+ * safeExec() died with SIGABRT, because Android's bionic libc hard-aborts
+ * platform binaries that touch tzdata/ICU when ANDROID_TZDATA_ROOT is
+ * unset, and PRoot doesn't export Android's runtime env roots. safeExec()
+ * swallows the throw and returns '', so this was completely silent — the
+ * statusline just showed Vectors 0 / HNSW off forever, indistinguishable
+ * from a legitimately empty store.
+ *
+ * Fix: a module-scope EXEC_ENV, gated on detecting
+ * /apex/com.android.tzdata, backfills ANDROID_ROOT / ANDROID_DATA /
+ * ANDROID_TZDATA_ROOT / ANDROID_I18N_ROOT (never overriding an existing
+ * value) and is passed as `env:` into safeExec()'s execSync() call.
+ *
+ * No real Android/PRoot hardware is available in CI, so this tests the
+ * EXEC_ENV construction logic directly: the exact source block is
+ * extracted from the COMMITTED helper (not reimplemented — a
+ * reimplementation could silently drift from the real fix) and evaluated
+ * in an isolated vm context with a stubbed `fs.existsSync` and a
+ * controlled `process.env`, covering both the Android and non-Android
+ * branches. The full file is never `require()`-d directly because its
+ * tail unconditionally runs the render pipeline and console.log()s as a
+ * side effect of import (no `require.main === module` guard).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const HELPER_PATH = path.resolve(HERE, '..', '.claude', 'helpers', 'statusline.cjs');
+const SOURCE = fs.readFileSync(HELPER_PATH, 'utf-8');
+
+const EXEC_ENV_BLOCK_RE = /const EXEC_ENV = \(\(\) => \{[\s\S]*?\n\}\)\(\);/;
+
+interface BuildOpts {
+  androidDetected: boolean;
+  env?: Record<string, string>;
+}
+
+/** Evaluate the committed EXEC_ENV IIFE in isolation and return its result. */
+function buildExecEnv(opts: BuildOpts): Record<string, string> {
+  const match = SOURCE.match(EXEC_ENV_BLOCK_RE);
+  if (!match) {
+    throw new Error(
+      'EXEC_ENV block not found in .claude/helpers/statusline.cjs — ' +
+        'issue #2897 fix is missing, or its shape changed (update this test\'s regex to match).',
+    );
+  }
+  const sandbox: { fs: { existsSync: (p: string) => boolean }; process: { env: Record<string, string> }; result?: Record<string, string> } = {
+    fs: { existsSync: (p: string) => (p === '/apex/com.android.tzdata' ? opts.androidDetected : false) },
+    process: { env: { ...(opts.env || {}) } },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(`${match[0]}\nresult = EXEC_ENV;`, sandbox);
+  return sandbox.result as Record<string, string>;
+}
+
+describe('issue #2897 — Android/PRoot ANDROID_TZDATA_ROOT SIGABRT fix', () => {
+  it('the committed helper still defines the EXEC_ENV construction (guards future refactors from silently dropping the fix)', () => {
+    expect(SOURCE).toMatch(EXEC_ENV_BLOCK_RE);
+  });
+
+  it('safeExec()\'s execSync call is wired with env: EXEC_ENV', () => {
+    expect(SOURCE).toMatch(/function safeExec\([^)]*\)\s*\{[\s\S]*?execSync\(cmd,\s*\{[\s\S]*?env:\s*EXEC_ENV,[\s\S]*?\}\)/);
+  });
+
+  it('is a complete no-op off Android: the returned env carries no new keys', () => {
+    const base = { PATH: '/usr/bin', HOME: '/home/user' };
+    const env = buildExecEnv({ androidDetected: false, env: base });
+    expect(Object.keys(env).sort()).toEqual(Object.keys(base).sort());
+    expect(env).toEqual(base);
+  });
+
+  it('backfills all four Android tzdata/ICU roots when /apex/com.android.tzdata exists', () => {
+    const env = buildExecEnv({ androidDetected: true, env: { PATH: '/usr/bin' } });
+    expect(env.ANDROID_ROOT).toBe('/system');
+    expect(env.ANDROID_DATA).toBe('/data');
+    expect(env.ANDROID_TZDATA_ROOT).toBe('/apex/com.android.tzdata');
+    expect(env.ANDROID_I18N_ROOT).toBe('/apex/com.android.i18n');
+    // Untouched pre-existing vars survive.
+    expect(env.PATH).toBe('/usr/bin');
+  });
+
+  it('never overrides an already-correctly-configured ANDROID_TZDATA_ROOT (or the other three roots)', () => {
+    const env = buildExecEnv({
+      androidDetected: true,
+      env: {
+        PATH: '/usr/bin',
+        ANDROID_TZDATA_ROOT: '/custom/tzdata',
+        ANDROID_ROOT: '/custom/system',
+        ANDROID_DATA: '/custom/data',
+        ANDROID_I18N_ROOT: '/custom/i18n',
+      },
+    });
+    expect(env.ANDROID_TZDATA_ROOT).toBe('/custom/tzdata');
+    expect(env.ANDROID_ROOT).toBe('/custom/system');
+    expect(env.ANDROID_DATA).toBe('/custom/data');
+    expect(env.ANDROID_I18N_ROOT).toBe('/custom/i18n');
+  });
+
+  it('never overrides a single already-set var while still backfilling the rest', () => {
+    // Partial ambient config: only ANDROID_TZDATA_ROOT is pre-set (e.g. a user's
+    // own Termux profile). The other three should still be backfilled.
+    const env = buildExecEnv({
+      androidDetected: true,
+      env: { PATH: '/usr/bin', ANDROID_TZDATA_ROOT: '/already/set' },
+    });
+    expect(env.ANDROID_TZDATA_ROOT).toBe('/already/set');
+    expect(env.ANDROID_ROOT).toBe('/system');
+    expect(env.ANDROID_DATA).toBe('/data');
+    expect(env.ANDROID_I18N_ROOT).toBe('/apex/com.android.i18n');
+  });
+});
+
+describe('issue #2897 — root .claude/helpers/statusline.cjs stays in sync', () => {
+  it('the root copy carries the identical EXEC_ENV fix (repo convention: helper files are duplicated root + package and must match)', () => {
+    const rootPath = path.resolve(HERE, '..', '..', '..', '..', '.claude', 'helpers', 'statusline.cjs');
+    if (!fs.existsSync(rootPath)) return; // package tested in isolation outside the monorepo checkout
+    const rootSource = fs.readFileSync(rootPath, 'utf-8');
+    const rootMatch = rootSource.match(EXEC_ENV_BLOCK_RE);
+    const pkgMatch = SOURCE.match(EXEC_ENV_BLOCK_RE);
+    expect(rootMatch).not.toBeNull();
+    // Normalize CRLF (root copy) vs LF (package copy) before comparing —
+    // the two files intentionally use different line endings; the fix
+    // itself must still be byte-identical modulo that.
+    expect(rootMatch![0].replace(/\r\n/g, '\n')).toBe(pkgMatch![0].replace(/\r\n/g, '\n'));
+  });
+});


### PR DESCRIPTION
Fixes #2897. On Android (Termux + PRoot Linux), every `sqlite3` shell-out made by `.claude/helpers/statusline.cjs`'s `safeExec()` died with SIGABRT because bionic libc hard-aborts platform binaries touching tzdata/ICU when `ANDROID_TZDATA_ROOT` is unset, and PRoot doesn't export Android's runtime env roots; `safeExec()` swallowed the throw and returned `''`, so the statusline silently pinned Vectors/HNSW at 0 forever. Adds a module-scope `EXEC_ENV`, gated on detecting `/apex/com.android.tzdata`, that backfills `ANDROID_ROOT`/`ANDROID_DATA`/`ANDROID_TZDATA_ROOT`/`ANDROID_I18N_ROOT` (never overriding an already-set value) and wires it into `safeExec()`'s `execSync` call — a no-op everywhere the Android tzdata apex doesn't exist. Applied identically to both maintained copies of the helper (root and the `v3/@claude-flow/cli` package copy); added `v3/@claude-flow/cli/__tests__/issue-2897-android-tzdata-env.test.ts`, which extracts and evaluates the real committed `EXEC_ENV` logic in isolation (mocked `fs.existsSync`) to cover the Android/non-Android/already-set-var branches.

Opened by the nightly triage routine — human review required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpeUPeLwJtPC5USnJGukv9)_