### PR TITLE
fix: honor generic capabilities.tool_calling for supportsTools (#2900)

### DIFF
--- a/ruflo/src/ruvocal/src/lib/server/models.spec.ts
+++ b/ruflo/src/ruvocal/src/lib/server/models.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import type {
+	listSchema as ListSchema,
+	deriveSupportsTools as DeriveSupportsTools,
+} from "./models";
+
+// models.ts performs a top-level `await rebuildModels()` on import (it fetches
+// `${OPENAI_BASE_URL}/models` eagerly so the model registry is warm at
+// startup). We stub `fetch` with an empty-but-valid response before importing
+// so the module loads without hitting the network, then grab the two pure
+// exports under test.
+let listSchema: typeof ListSchema;
+let deriveSupportsTools: typeof DeriveSupportsTools;
+
+beforeAll(async () => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify({ data: [{ id: "startup-placeholder-model" }] }), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		})) as typeof fetch;
+	try {
+		const mod = await import("./models");
+		listSchema = mod.listSchema;
+		deriveSupportsTools = mod.deriveSupportsTools;
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+// Regression coverage for #2900: "MCP silently disabled for every model when
+// OPENAI_BASE_URL is not HuggingFace's router".
+//
+// Root cause was two-layered:
+//   1. `supportsTools` was derived only from `providers[].supports_tools`,
+//      which is an HF-router-specific shape. Any other OpenAI-compatible
+//      provider (e.g. one that reports `capabilities.tool_calling`) always
+//      resolved to `supportsTools = false`.
+//   2. Even after widening the derivation, the per-model zod schema stripped
+//      any field it didn't know about (no `.passthrough()`), so a generic
+//      provider's `capabilities` field never reached the derivation logic in
+//      the first place.
+describe("models.ts — supportsTools derivation (#2900)", () => {
+	describe("deriveSupportsTools", () => {
+		it("returns true for the HF-router shape (providers[].supports_tools) — unchanged behavior", () => {
+			expect(
+				deriveSupportsTools({
+					providers: [{ supports_tools: false }, { supports_tools: true }],
+				})
+			).toBe(true);
+		});
+
+		it("returns false for the HF-router shape when no provider supports tools", () => {
+			expect(
+				deriveSupportsTools({
+					providers: [{ supports_tools: false }, { supports_tools: undefined }],
+				})
+			).toBe(false);
+		});
+
+		it("returns true for a generic OpenAI-compatible capabilities.tool_calling signal", () => {
+			expect(
+				deriveSupportsTools({
+					providers: undefined,
+					capabilities: { tool_calling: true },
+				})
+			).toBe(true);
+		});
+
+		it("fails closed when neither providers nor capabilities advertise tool support", () => {
+			expect(
+				deriveSupportsTools({
+					providers: undefined,
+					capabilities: { tool_calling: false },
+				})
+			).toBe(false);
+			expect(deriveSupportsTools({})).toBe(false);
+		});
+	});
+
+	describe("listSchema parsing", () => {
+		it("preserves providers[].supports_tools for the HF-router shape", () => {
+			const parsed = listSchema.parse({
+				data: [
+					{
+						id: "hf-model",
+						providers: [{ provider: "together", supports_tools: true }],
+					},
+				],
+			});
+			expect(deriveSupportsTools(parsed.data[0])).toBe(true);
+		});
+
+		it("preserves a generic capabilities.tool_calling field instead of stripping it", () => {
+			// This is the exact shape from the issue report: an OpenAI-compatible
+			// provider with no `providers` array at all.
+			const parsed = listSchema.parse({
+				data: [
+					{
+						id: "generic-model",
+						capabilities: { tool_calling: true },
+					},
+				],
+			});
+			expect(parsed.data[0].capabilities?.tool_calling).toBe(true);
+			expect(deriveSupportsTools(parsed.data[0])).toBe(true);
+		});
+
+		it("end-to-end: a full generic OpenAI-compatible /models response resolves supportsTools per model", () => {
+			const parsed = listSchema.parse({
+				data: [
+					{ id: "tool-model", capabilities: { tool_calling: true } },
+					{ id: "no-tool-model", capabilities: { tool_calling: false } },
+					{ id: "no-capabilities-model" },
+				],
+			});
+			const results = Object.fromEntries(parsed.data.map((m) => [m.id, deriveSupportsTools(m)]));
+			expect(results).toEqual({
+				"tool-model": true,
+				"no-tool-model": false,
+				"no-capabilities-model": false,
+			});
+		});
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/server/models.ts
+++ b/ruflo/src/ruvocal/src/lib/server/models.ts
@@ -83,7 +83,10 @@ const openaiBaseUrl = config.OPENAI_BASE_URL
 	: undefined;
 const isHFRouter = openaiBaseUrl === "https://router.huggingface.co/v1";
 
-const listSchema = z
+// Exported for tests — validates parsing/passthrough behavior for both the
+// HF-router `providers[].supports_tools` shape and the generic
+// OpenAI-compatible `capabilities.tool_calling` shape (#2900).
+export const listSchema = z
 	.object({
 		data: z.array(
 			z.object({
@@ -92,6 +95,9 @@ const listSchema = z
 				providers: z
 					.array(z.object({ supports_tools: z.boolean().optional() }).passthrough())
 					.optional(),
+				// Generic OpenAI-compatible tool-calling signal (non-HF-router providers,
+				// e.g. `{ "id": "...", "capabilities": { "tool_calling": true } }`).
+				capabilities: z.object({ tool_calling: z.boolean().optional() }).passthrough().optional(),
 				architecture: z
 					.object({
 						input_modalities: z.array(z.string()).optional(),
@@ -102,6 +108,19 @@ const listSchema = z
 		),
 	})
 	.passthrough();
+
+// Exported for tests — a model supports tools if either an HF-router-style
+// provider advertises `supports_tools`, or the model itself advertises a
+// generic `capabilities.tool_calling` signal. Fails closed when neither is
+// present (#2900).
+export const deriveSupportsTools = (m: {
+	providers?: Array<{ supports_tools?: boolean } | null | undefined> | null;
+	capabilities?: { tool_calling?: boolean } | null;
+}): boolean =>
+	Boolean(
+		(m.providers ?? []).some((p) => p?.supports_tools === true) ||
+			m.capabilities?.tool_calling === true
+	);
 
 function getChatPromptRender(_m: ModelConfig): (inputs: ChatTemplateInput) => string {
 	// Minimal template to support legacy "completions" flow if ever used.
@@ -345,8 +364,9 @@ const buildModels = async (): Promise<ProcessedModel[]> => {
 			const supportsImageInput =
 				inputModalities.includes("image") || inputModalities.includes("vision");
 
-			// If any provider supports tools, consider the model as supporting tools
-			const supportsTools = Boolean((m.providers ?? []).some((p) => p?.supports_tools === true));
+			// A model supports tools if any provider advertises it (HF router), or the
+			// model itself advertises a generic tool-calling capability (#2900).
+			const supportsTools = deriveSupportsTools(m);
 			return {
 				id: m.id,
 				name: m.id,
@@ -382,9 +402,7 @@ const buildModels = async (): Promise<ProcessedModel[]> => {
 			const filteredAndOrdered: ModelConfig[] = [];
 			for (const override of overrides) {
 				const matchKey = override.name?.trim() || override.id?.trim() || "";
-				const found = modelsRaw.find(
-					(model) => model.id === matchKey || model.name === matchKey
-				);
+				const found = modelsRaw.find((model) => model.id === matchKey || model.name === matchKey);
 				if (found) {
 					const { id, name, ...rest } = override;
 					void id;


### PR DESCRIPTION
Fixes #2900. `supportsTools` in `ruflo/src/ruvocal/src/lib/server/models.ts` was derived only from `providers[].supports_tools`, an HF-router-specific shape, so any other OpenAI-compatible provider (e.g. one that reports `capabilities.tool_calling`) got `supportsTools = false` for every model, silently disabling MCP tool use with no error. The per-model `/models` zod schema also had no slot for that field, so it was stripped before the derivation logic ever saw it. This adds an explicit `capabilities.tool_calling` field to the schema and widens the derivation (extracted as `deriveSupportsTools`) to honor either signal while still failing closed when neither is present, plus a new `models.spec.ts` covering both the unchanged HF-router shape and the previously-broken generic shape.

Opened by the nightly triage routine — human review required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpeUPeLwJtPC5USnJGukv9)_