### PR TITLE
fix: policy_evaluate crash on missing/malformed request (#2894)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/policy-evaluate-requestId-2894.test.ts
+++ b/v3/@claude-flow/cli/__tests__/policy-evaluate-requestId-2894.test.ts
@@ -1,0 +1,62 @@
+// #2894 finding 1: `policy_evaluate` crashed with JSON-RPC -32603
+// ("Cannot read properties of undefined (reading 'requestId')") when called
+// with a missing/malformed `request` argument — including the exact
+// `policy_evaluate {}` repro from the issue. Root cause: the handler cast
+// `input.request` straight to `PolicyRequest` with no validation, so a
+// missing `request` flowed all the way into
+// `AgenticPolicyEngine.evaluate()`, which unconditionally reads
+// `request.requestId` on an `undefined` request.
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { policyTools } from '../src/mcp-tools/policy-tools.js';
+
+const policyEvaluate = policyTools.find((tool) => tool.name === 'policy_evaluate')!;
+
+describe('#2894 policy_evaluate — missing `request` no longer crashes', () => {
+  it('rejects a call with no arguments with a clear validation error, not a TypeError', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'policy-evaluate-2894-'));
+    try {
+      await expect(policyEvaluate.handler({}, { projectRoot: root })).rejects.toThrow(
+        /request/i,
+      );
+      // The historical crash surfaced as this exact TypeError message —
+      // assert we no longer produce it.
+      await expect(policyEvaluate.handler({}, { projectRoot: root })).rejects.not.toThrow(
+        /Cannot read propert(y|ies) of undefined/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the issue\'s exact "plausible arguments" repro (fields at the top level, not under `request`)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'policy-evaluate-2894-'));
+    try {
+      await expect(
+        policyEvaluate.handler({ action: 'read', resource: 'file' }, { projectRoot: root }),
+      ).rejects.not.toThrow(/Cannot read propert(y|ies) of undefined/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still evaluates a well-formed request normally', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'policy-evaluate-2894-'));
+    try {
+      const decision = await policyEvaluate.handler(
+        {
+          request: {
+            identity: { id: 'test-user', type: 'user' },
+            action: { type: 'read', resource: 'file' },
+          },
+        },
+        { projectRoot: root },
+      );
+      expect(decision).toMatchObject({ outcome: expect.any(String) });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/policy-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/policy-tools.ts
@@ -25,6 +25,33 @@ function requireAuthenticatedAdministrator(
   }
 }
 
+// #2894: `input.request` was cast straight to `PolicyRequest` with no
+// validation, so a missing/malformed `request` argument (including the
+// documented `policy_evaluate {}` repro) flowed all the way into
+// `AgenticPolicyEngine.evaluate()`, which unconditionally reads
+// `request.requestId` — crashing with a bare
+// "Cannot read properties of undefined (reading 'requestId')" TypeError
+// that surfaced to MCP clients as an opaque JSON-RPC -32603. Validate the
+// shape here so a missing/malformed request is a clear, catchable error
+// instead of an internal crash.
+function requireWellFormedPolicyRequest(
+  input: Record<string, unknown>,
+): asserts input is Record<string, unknown> & { request: PolicyRequest } {
+  const { request } = input;
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    throw new Error(
+      "policy_evaluate requires a `request` object argument (e.g. { request: { identity, action } }), not top-level fields",
+    );
+  }
+  const { identity, action } = request as Record<string, unknown>;
+  if (!identity || typeof identity !== 'object') {
+    throw new Error('policy_evaluate requires `request.identity` ({ id, type })');
+  }
+  if (!action || typeof action !== 'object') {
+    throw new Error('policy_evaluate requires `request.action` ({ type, resource, ... })');
+  }
+}
+
 export const policyTools: MCPTool[] = [
   {
     name: 'policy_evaluate',
@@ -37,10 +64,13 @@ export const policyTools: MCPTool[] = [
       },
       required: ['request'],
     },
-    handler: async (input, context) => evaluatePolicyRequest(
-      input.request as PolicyRequest,
-      typeof context?.projectRoot === 'string' ? context.projectRoot : process.cwd(),
-    ),
+    handler: async (input, context) => {
+      requireWellFormedPolicyRequest(input);
+      return evaluatePolicyRequest(
+        input.request,
+        typeof context?.projectRoot === 'string' ? context.projectRoot : process.cwd(),
+      );
+    },
   },
   {
     name: 'policy_status',


### PR DESCRIPTION
Fixes #2894 (finding 1 only — see below for findings 2 and 3, which are **not** addressed here).

## What changed

`policy_evaluate`'s handler cast `input.request` straight to `PolicyRequest` with no validation:

```ts
handler: async (input, context) => evaluatePolicyRequest(
  input.request as PolicyRequest,
  ...
),
```

`evaluatePolicyRequest` → `AgenticPolicyEngine.evaluate()` (in `@claude-flow/security/src/policy/engine.ts`) unconditionally reads `request.requestId` on line 1. When `input.request` is `undefined` — e.g. the issue's exact `policy_evaluate {}` repro, or arguments passed at the top level instead of nested under `request` — this crashes with a bare `TypeError: Cannot read properties of undefined (reading 'requestId')`, which the MCP dispatcher (`src/mcp-server.ts`) surfaces to clients as an opaque JSON-RPC `-32603` — reproduced byte-for-byte against the issue's report.

The fix adds a small guard in the `policy_evaluate` handler (`v3/@claude-flow/cli/src/mcp-tools/policy-tools.ts`) that validates `request`/`request.identity`/`request.action` are present before calling `evaluatePolicyRequest`, turning a missing/malformed request into a clear, catchable validation `Error` instead of an internal crash.

## Testing

New test file: `v3/@claude-flow/cli/__tests__/policy-evaluate-requestId-2894.test.ts`, calling the real `policy_evaluate` handler directly (no mocks).

```
cd v3/@claude-flow/cli
npx vitest run __tests__/policy-evaluate-requestId-2894.test.ts
```

- **Pre-fix** (verified via `git stash`): 2 of 3 tests fail — the handler throws the exact reported message `"Cannot read properties of undefined (reading 'requestId')"` for both `policy_evaluate {}` and the issue's "plausible arguments" repro (`{action:'read', resource:'file'}`, i.e. fields at the top level instead of under `request`).
- **Post-fix**: all 3 tests pass — missing/malformed `request` now throws a clear validation error (not the TypeError), and a well-formed request still evaluates normally.

Also ran `npx tsc --noEmit`: 467 pre-existing errors both before and after this change (confirmed via `git stash` comparison — all pre-existing, unrelated to this file, coming from unbuilt workspace packages in this fresh worktree). No new errors introduced.

## Diff summary

- `v3/@claude-flow/cli/src/mcp-tools/policy-tools.ts` — added `requireWellFormedPolicyRequest()` guard, called at the top of the `policy_evaluate` handler (34 insertions / 4 deletions).
- `v3/@claude-flow/cli/__tests__/policy-evaluate-requestId-2894.test.ts` — new test file (regression coverage).

No CI/workflow, release-tooling, or unrelated files touched.

## Findings NOT addressed here (human input needed)

**Finding 2 — validation errors returned in-band, outer `isError` never set.** Confirmed real and broader than the issue's framing: the stdio dispatcher (`mcp-server.ts`'s `handleMCPMessage`, the actual code path for the reporter's `npx -y @claude-flow/cli@latest` + stdio setup) never sets `isError` at all on its `tools/call` success path, and there are **two different, inconsistent** error-signaling conventions already in use across ~50+ tool handlers: some (e.g. `security-tools.ts`'s `aidefence_*` family, `browser-tools.ts`, `ruvllm-tools.ts`, `wasm-agent-tools.ts`, `guidance-tools.ts`) return a full MCP-envelope-shaped object (`{content, isError:true}`) on validation failure, which the dispatcher then re-wraps wholesale into `content[0].text` of a fresh envelope — exactly the "double-wrapped, isError never reaches the outer envelope" bug described in the issue. Others (e.g. `memory_search` on missing `query`) return a plain data object with an `error` field and no `content`/`isError` at all, which is a related but structurally different gap. A correct fix requires either normalizing ~50+ handler return shapes to one contract, or teaching the dispatcher a heuristic for "this payload is an error" — both are judgment calls beyond a safe, single-file, unattended nightly patch, so I did not guess at one. Left for a dedicated follow-up.

**Finding 3 — `swarm_health` vs `swarm status` disagreement.** Per the task instructions, not investigated for a fix; the reporter's own caveat (the two commands may be reading different state-store paths) looks plausible from a first read of the two commands, but confirming that needs deliberate product/architecture judgment on what "healthy" should mean with `agentCount: 0`.

Opened by the nightly triage routine — human review required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpeUPeLwJtPC5USnJGukv9)_