### PR TITLE
fix: support --objective-file for multiline hive-mind spawn objectives (#570)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hive-mind-objective-file.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hive-mind-objective-file.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression test for #570.
+ *
+ * Multi-line objectives are error-prone to quote/escape directly on the
+ * shell command line. `hive-mind spawn --claude` now accepts `--objective-file
+ * <path>` (short: `-f`) to read the objective from a file instead, which
+ * preserves newlines natively.
+ *
+ * Like hive-mind-skip-permissions.test.ts (#2269), this pins down the
+ * CommandParser's kebab-case -> camelCase flag normalization AND the
+ * resolution helper from hive-mind.ts, so a future parser or helper
+ * refactor can't silently regress the flag-drop bug that class of issue
+ * describes: the parser stores flags ONLY under the normalized camelCase
+ * key, so reading `flags['objective-file']` alone is always undefined.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CommandParser } from '../src/parser.js';
+import { resolveObjectiveFile } from '../src/commands/hive-mind.js';
+
+describe('#570 hive-mind --objective-file flag handling', () => {
+  it('parser normalizes the kebab flag to camelCase and leaves the kebab key undefined', () => {
+    const parser = new CommandParser({ allowUnknownFlags: true });
+    const { flags } = parser.parse(['--objective-file', 'objective.txt']);
+
+    expect(flags['objective-file']).toBeUndefined();
+    expect(flags.objectiveFile).toBe('objective.txt');
+  });
+
+  it('parser handles the short -f alias', () => {
+    const parser = new CommandParser({ allowUnknownFlags: true });
+    const { flags } = parser.parse(['-f', 'objective.txt']);
+
+    expect(flags.f).toBe('objective.txt');
+  });
+
+  it('resolveObjectiveFile reads the parser-normalized camelCase key', () => {
+    const parser = new CommandParser({ allowUnknownFlags: true });
+    const { flags } = parser.parse(['--objective-file', 'objective.txt']);
+
+    expect(resolveObjectiveFile(flags as Record<string, unknown>)).toBe('objective.txt');
+  });
+
+  it('resolveObjectiveFile still accepts the legacy kebab key (back-compat with hand-built flag maps)', () => {
+    expect(resolveObjectiveFile({ 'objective-file': 'objective.txt' })).toBe('objective.txt');
+  });
+
+  it('resolveObjectiveFile returns undefined when the flag is absent', () => {
+    expect(resolveObjectiveFile({})).toBeUndefined();
+    expect(resolveObjectiveFile({ objective: 'inline objective' })).toBeUndefined();
+  });
+
+  it('resolveObjectiveFile ignores a non-string value', () => {
+    expect(resolveObjectiveFile({ objectiveFile: true })).toBeUndefined();
+    expect(resolveObjectiveFile({ objectiveFile: '' })).toBeUndefined();
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/v3/@claude-flow/cli/src/commands/hive-mind.ts
@@ -11,7 +11,7 @@ import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { spawn as childSpawn } from 'child_process';
-import { mkdir, writeFile } from 'fs/promises';
+import { mkdir, writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { resolveClaudeLaunchCommand } from '../runtime/claude-command.js';
@@ -44,6 +44,23 @@ const CONSENSUS_STRATEGIES = [
   { value: 'crdt', label: 'CRDT', hint: 'Conflict-free replicated data' },
   { value: 'quorum', label: 'Quorum', hint: 'Simple majority voting' }
 ];
+
+/**
+ * Resolve the --objective-file flag value from a parsed flags map.
+ *
+ * #570: read a (possibly multi-line) objective from a file instead of
+ * forcing users to quote/escape it on the shell command line.
+ *
+ * Dual-reads both the kebab-case key and the parser-normalized camelCase
+ * key (see #2269 / hive-mind-skip-permissions.test.ts): CommandParser
+ * stores flags under the normalized camelCase key, but some callers
+ * (tests, programmatic invocations) hand-build the flags object with the
+ * kebab key, so both are accepted defensively.
+ */
+export function resolveObjectiveFile(flags: Record<string, unknown>): string | undefined {
+  const value = flags['objective-file'] ?? flags.objectiveFile;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
 
 /**
  * Group workers by their type for prompt generation
@@ -614,6 +631,16 @@ const spawnCommand: Command = {
       type: 'string'
     },
     {
+      // #570: quoting/escaping a multi-line objective directly on the shell
+      // command line is brittle. Read it from a file instead, which
+      // preserves newlines natively and needs no shell-specific workarounds.
+      // Takes precedence over --objective/-o when both are given.
+      name: 'objective-file',
+      short: 'f',
+      description: 'Read the objective from a file (supports multi-line objectives; overrides --objective)',
+      type: 'string'
+    },
+    {
       name: 'dangerously-skip-permissions',
       description: 'Skip permission prompts in Claude Code (use with caution)',
       type: 'boolean',
@@ -648,6 +675,7 @@ const spawnCommand: Command = {
     { command: 'claude-flow hive-mind spawn -n 3 -r specialist', description: 'Spawn 3 specialists' },
     { command: 'claude-flow hive-mind spawn -t coder -p my-coder', description: 'Spawn coder with custom prefix' },
     { command: 'claude-flow hive-mind spawn --claude -o "Build a REST API"', description: 'Launch Claude Code with objective' },
+    { command: 'claude-flow hive-mind spawn --claude -f objective.txt', description: 'Launch Claude Code with a multi-line objective read from a file' },
     { command: 'claude-flow hive-mind spawn -n 5 --claude -o "Research AI patterns"', description: 'Spawn workers and launch Claude Code' }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
@@ -658,6 +686,19 @@ const spawnCommand: Command = {
     const prefix = (ctx.flags.prefix as string) || 'hive-worker';
     const launchClaude = ctx.flags.claude as boolean;
     let objective = (ctx.flags.objective as string) || ctx.args.join(' ');
+
+    // #570: --objective-file wins over --objective/positional args when given.
+    const objectiveFile = resolveObjectiveFile(ctx.flags as Record<string, unknown>);
+    if (objectiveFile) {
+      try {
+        objective = (await readFile(objectiveFile, 'utf8')).trim();
+      } catch (err) {
+        output.printError(
+          `Failed to read objective file "${objectiveFile}": ${err instanceof Error ? err.message : String(err)}`
+        );
+        return { success: false, exitCode: 1 };
+      }
+    }
 
     output.printInfo(`Spawning ${count} ${role} agent(s)...`);
 


### PR DESCRIPTION
Fixes #570. Adds a `--objective-file`/`-f` option to `hive-mind spawn` so a multi-line objective can be read from a file instead of requiring shell-specific quoting/escaping on the command line (here-docs, `$'...'`, etc.).

**What changed** (`v3/@claude-flow/cli/src/commands/hive-mind.ts`):
- New `--objective-file`/`-f` CLI option on `hive-mind spawn`.
- New exported `resolveObjectiveFile(flags)` helper that dual-reads the kebab-case and parser-normalized camelCase flag keys, following the existing convention in this file established by the #2269 fix (the `CommandParser` stores flags only under the normalized camelCase key, so a naive single-key read silently drops the flag).
- When `--objective-file` is given, its content (trimmed) is used as the objective, taking precedence over `--objective`/`-o` and positional args. A missing/unreadable file fails fast with a clear error instead of silently falling through.
- New example in the command's help output.

**Testing**
- Added `v3/@claude-flow/cli/__tests__/hive-mind-objective-file.test.ts`, mirroring the style of the existing `hive-mind-skip-permissions.test.ts` (#2269) regression test: verifies the `CommandParser`'s kebab→camelCase normalization for `--objective-file` and the short `-f` alias, and exercises `resolveObjectiveFile` directly (camelCase key, legacy kebab key, absent flag, non-string value).
- Confirmed the new test fails against pre-fix `main` (`resolveObjectiveFile` doesn't exist) and passes after the fix (6/6).
- `npx tsc --noEmit` in `v3/@claude-flow/cli` shows the same pre-existing unrelated errors before and after this change (missing sibling-package builds for `@claude-flow/memory`/`@claude-flow/swarm` in a fresh worktree) — nothing new introduced.
- Full `vitest run` in the package: same 21 pre-existing failing test files before and after (unrelated WASM/network/docker-dependent tests); the new test file and `hive-mind-skip-permissions.test.ts` both pass.

Opened by the nightly triage routine — human review required before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_011rc8DwhHm2VwEXCYDpWFmn)_