### PR TITLE
fix(memory): stop seeding the bridge's ControllerRegistry with the sql.js dbPath

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-init-bridge-dbpath-3155.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-init-bridge-dbpath-3155.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression for ruvnet/ruflo#3155.
+ *
+ * `initializeMemoryDatabase()` used to pass its just-resolved sql.js-facing
+ * `memory.db` path straight through to `activateControllerRegistry()` ->
+ * `bridge.getControllerRegistry(dbPath)`. That seeded the process-wide
+ * ControllerRegistry singleton with `memory.db` as AgentDB's own native
+ * better-sqlite3 database, instead of the dedicated `agentdb-memory.db`
+ * sibling `getAgentDbPath()` exists specifically to provide (#2786).
+ *
+ * Because this activation only runs on a database's FIRST-EVER init (an
+ * already-initialized `.swarm/` skips it via the #1791.6 idempotent no-op
+ * branch), a bridge started against a brand-new directory would activate
+ * against `memory.db` and work fine for that process's lifetime — then a
+ * restarted bridge process, whose `.swarm/memory.db` already exists, would
+ * skip this call entirely and have its first real bridge operation activate
+ * the registry against `agentdb-memory.db` instead (via the `dbPath ||
+ * getAgentDbPath()` fallback in memory-bridge.ts). That empty file never
+ * received the earlier writes, so every read after a restart silently came
+ * back `found:false` / an empty list, with no error anywhere.
+ *
+ * The fix: `activateControllerRegistry()` no longer forwards the sql.js
+ * `dbPath` to the bridge at all — it calls `bridge.getControllerRegistry()`
+ * with no argument, so both the init-time warm-up and every later bridge
+ * call (bridgeStoreEntry, bridgeGetEntry, ...) resolve the SAME file via
+ * `getAgentDbPath()`, regardless of whether this is a fresh directory or a
+ * restart against an already-initialized one.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const getControllerRegistry = vi.fn(async (_dbPath?: string) => null);
+const shutdownBridge = vi.fn(async () => {});
+
+vi.mock('../src/memory/memory-bridge.js', () => ({
+  getControllerRegistry,
+  shutdownBridge,
+}));
+
+import { initializeMemoryDatabase } from '../src/memory/memory-initializer.js';
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'memory-init-bridge-dbpath-3155-'));
+  getControllerRegistry.mockClear();
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('initializeMemoryDatabase -> ControllerRegistry activation (#3155)', () => {
+  it('activates the bridge registry with NO dbPath on a fresh directory (sql.js path)', async () => {
+    const dbPath = join(testDir, 'memory.db');
+
+    const result = await initializeMemoryDatabase({
+      backend: 'sqlite',
+      dbPath,
+      force: true,
+      migrate: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(dbPath)).toBe(true);
+
+    // The regression: this used to be called with `dbPath` (the sql.js
+    // file just written above) — the bridge's own dedicated file must be
+    // resolved independently, so no dbPath is forwarded here at all.
+    expect(getControllerRegistry).toHaveBeenCalledTimes(1);
+    expect(getControllerRegistry).toHaveBeenCalledWith();
+    const [calledArg] = getControllerRegistry.mock.calls[0]!;
+    expect(calledArg).toBeUndefined();
+    expect(calledArg).not.toBe(dbPath);
+  });
+
+  it('activates the bridge registry with NO dbPath on the schema-file fallback path', async () => {
+    // Force the sql.js import to fail so initializeMemoryDatabase takes the
+    // "fall back to schema file approach" branch (the second call site).
+    vi.doMock('sql.js', () => {
+      throw new Error('sql.js unavailable in this simulated environment');
+    });
+    vi.resetModules();
+    getControllerRegistry.mockClear();
+
+    vi.doMock('../src/memory/memory-bridge.js', () => ({
+      getControllerRegistry,
+      shutdownBridge,
+    }));
+
+    const { initializeMemoryDatabase: initFallback } = await import('../src/memory/memory-initializer.js');
+    const dbPath = join(testDir, 'fallback', 'memory.db');
+
+    const result = await initFallback({
+      backend: 'sqlite',
+      dbPath,
+      force: true,
+      migrate: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(dbPath)).toBe(true);
+    expect(getControllerRegistry).toHaveBeenCalledTimes(1);
+    const [calledArg] = getControllerRegistry.mock.calls[0]!;
+    expect(calledArg).toBeUndefined();
+    expect(calledArg).not.toBe(dbPath);
+
+    vi.doUnmock('sql.js');
+    vi.resetModules();
+  });
+});

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -1438,14 +1438,33 @@ export async function checkAndMigrateLegacy(options: {
  * (ReasoningBank, SkillLibrary, ExplainableRecall, etc.) are instantiated.
  *
  * Uses the memory-bridge's getControllerRegistry() which lazily creates
- * a singleton ControllerRegistry and initializes it with the given dbPath.
- * After this call, all enabled controllers are ready for immediate use.
+ * a singleton ControllerRegistry. Deliberately called with NO dbPath so the
+ * bridge resolves its own dedicated file via `getAgentDbPath()` — the same
+ * resolution every other bridge call (bridgeStoreEntry, bridgeGetEntry, ...)
+ * uses when it omits `dbPath`. After this call, all enabled controllers are
+ * ready for immediate use.
  *
- * Failures are isolated: if @claude-flow/memory or agentdb is not installed,
- * this returns an empty result without throwing.
+ * #3155: this used to be called with the sql.js-facing `memory.db` path
+ * (the one just written by the block above, via `resolveDbPath()`), which
+ * seeded the process-wide ControllerRegistry singleton with THAT file as
+ * AgentDB's native better-sqlite3 database — instead of the dedicated
+ * `agentdb-memory.db` sibling `getAgentDbPath()` exists specifically to
+ * provide (#2786, so native better-sqlite3 doesn't hit a possibly-encrypted
+ * `memory.db`). Because `initializeMemoryDatabase()` only reaches this call
+ * on a database's FIRST-EVER init (the `#1791.6` already-exists branch above
+ * returns early without activating anything), a bridge started against a
+ * brand-new `.swarm/` directory would activate the registry against
+ * `memory.db`, store/retrieve correctly for that process's lifetime, and
+ * then a SUBSEQUENT process — where `.swarm/memory.db` already exists so
+ * this init path is skipped — would have its first bridge call activate the
+ * registry against `agentdb-memory.db` instead (via the `dbPath ||
+ * getAgentDbPath()` fallback in memory-bridge.ts's `getRegistry()`), an
+ * empty file that never received the earlier writes. Restarting the bridge
+ * therefore silently lost read access to everything it had written, with no
+ * error anywhere. Passing no dbPath here makes both code paths agree on
+ * `agentdb-memory.db` every time, regardless of init history.
  */
 async function activateControllerRegistry(
-  dbPath: string,
   verbose?: boolean,
 ): Promise<{ activated: string[]; failed: string[]; initTimeMs: number }> {
   const startTime = performance.now();
@@ -1458,7 +1477,7 @@ async function activateControllerRegistry(
       return { activated, failed, initTimeMs: performance.now() - startTime };
     }
 
-    const registry = await bridge.getControllerRegistry(dbPath);
+    const registry = await bridge.getControllerRegistry();
     if (!registry) {
       return { activated, failed, initTimeMs: performance.now() - startTime };
     }
@@ -1915,7 +1934,7 @@ export async function initializeMemoryDatabase(options: {
 
       // ADR-053: Activate ControllerRegistry so controllers (ReasoningBank,
       // SkillLibrary, ExplainableRecall, etc.) are instantiated during init
-      const controllerResult = await activateControllerRegistry(dbPath, verbose);
+      const controllerResult = await activateControllerRegistry(verbose);
 
       return {
         success: true,
@@ -1978,7 +1997,7 @@ export async function initializeMemoryDatabase(options: {
       writeFileRestricted(dbPath, sqliteHeader, { encrypt: true });
 
       // ADR-053: Activate ControllerRegistry even on fallback path
-      const controllerResult = await activateControllerRegistry(dbPath, verbose);
+      const controllerResult = await activateControllerRegistry(verbose);
 
       return {
         success: true,


### PR DESCRIPTION
## Summary

Fixes #3155 — `ruflo mcp start -t http`: entries stored via the bridge become unreadable after a bridge restart, even though `.swarm/memory.db` (or `agentdb-memory.db`) genuinely holds them.

**Root cause** (`v3/@claude-flow/cli/src/memory/memory-initializer.ts`):

- `initializeMemoryDatabase()` resolves a sql.js-facing path (`.swarm/memory.db`, possibly encrypted) and, on a **fresh** `.swarm/` directory only, calls `activateControllerRegistry(dbPath, verbose)` — passing that same `memory.db` path straight through to `bridge.getControllerRegistry(dbPath)`.
- `getControllerRegistry(dbPath)` → `getRegistry(dbPath)` in `memory-bridge.ts` creates a **process-wide singleton** `ControllerRegistry` and initializes AgentDB's native better-sqlite3 with `dbPath || getAgentDbPath()`. Because the passed-in `dbPath` was truthy, it won on the `||`, so the singleton's AgentDB instance opened `memory.db` — not the dedicated `agentdb-memory.db` sibling that `getAgentDbPath()` exists specifically to provide (#2786, so native better-sqlite3 never touches a possibly-encrypted `memory.db`).
- The `#1791.6` idempotent-no-op branch means `activateControllerRegistry()` is **only reached on a database's first-ever init** — an already-initialized `.swarm/` skips it entirely.

Net effect, reproduced deterministically with instrumented logging (see Test plan):

1. **First-ever process** against a brand-new directory: `initializeMemoryDatabase()` runs, seeds the registry singleton with `memory.db`. Every bridge `memory_store`/`memory_retrieve` call in that process operates on `memory.db` and works correctly for that process's lifetime.
2. **Restarted process** against the same, now-already-initialized directory: `initializeMemoryDatabase()`'s init branch is skipped, so `activateControllerRegistry()` never runs. The *first* real bridge call (e.g. `memory_retrieve`) creates the registry singleton itself, this time with `dbPath` undefined, correctly falling back to `getAgentDbPath()` → `agentdb-memory.db` — a different, essentially empty file that never received the earlier writes. Result: `found:false`, `memory_list` empty, `isError:false`, no error anywhere.

This is not a design choice (no in-memory index needing an explicit rebuild) — it's an accidental cross-wire between the sql.js-facing path and the bridge's own dedicated path, present only on the "warm up the registry at init time" call site.

## Fix

`activateControllerRegistry()` no longer forwards the sql.js `dbPath` to the bridge at all — it calls `bridge.getControllerRegistry()` with **no argument**, so both the init-time warm-up and every later bridge call (`bridgeStoreEntry`, `bridgeGetEntry`, ...) resolve the exact same file via `getAgentDbPath()`, regardless of whether this is a fresh directory or a restart against an already-initialized one. Both call sites (the sql.js-success branch and the schema-file-fallback branch) are updated identically.

## Test plan

- Added `v3/@claude-flow/cli/__tests__/memory-init-bridge-dbpath-3155.test.ts`: mocks `../src/memory/memory-bridge.js` and asserts `getControllerRegistry()` is called with **no** `dbPath` argument from both `initializeMemoryDatabase()` code paths (the sql.js-success branch and the schema-file-fallback branch when `sql.js` import fails).
  - **Before the fix**: both tests fail — `getControllerRegistry` is called with the resolved `memory.db` path.
  - **After the fix**: both tests pass — `getControllerRegistry` is called with no arguments.
- Ran the full memory test suite (`__tests__/memory*.test.ts` + `adr-323-memory-provenance`, `issue-2735-memory-wal-sidecar-guard`, `doctor-2737-memory-structural`, `init-memory-package-resolver-2545`) before and after: 4 pre-existing failing files (environment-only — missing `dist/` build artifacts and an absolute-path leak from a symlinked `node_modules` used for testing this worktree) are unchanged by this fix; my new test file is the only delta (2 failing → 2 passing).
- Independently reproduced the underlying bug end-to-end against the published `ruflo@3.38.20` package with diagnostic logging patched into a scratch copy of the installed `dist/` — confirmed the exact causal chain: `[DIAG2]` shows `getRegistry()` invoked with `dbPath=.swarm/memory.db` on a fresh directory (before any tool call), and `dbPath=undefined → getAgentDbPath()=.swarm/agentdb-memory.db` on a restart against an already-initialized directory, matching the reported `found:false` symptom exactly.

## Not verified

- Whether the same `dbPath || getAgentDbPath()` pattern in `memory-bridge.ts` has other unintended callers elsewhere in the tree that also warm the registry with a non-default path — a repo-wide grep found only the two call sites fixed here.
- Behavior against a custom `--db`/`CLAUDE_FLOW_MEMORY_PATH` override was not specifically exercised beyond the existing `memory-init-db-path-2629` test, which continues to pass.

Co-Authored-By: claude-flow <ruv@ruv.net>
Claude-Session: https://claude.ai/code/session_01MND33UDrtWPRH851k9w8M3

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01MND33UDrtWPRH851k9w8M3