### PR TITLE
feat(ruvocal): governed workspace, runtime integrations and UI refresh

### DIFF
--- a/.github/workflows/ruvocal-workspace.yml
+++ b/.github/workflows/ruvocal-workspace.yml
@@ -1,0 +1,44 @@
+name: Ruvocal workspace
+
+on:
+  pull_request:
+    paths:
+      - 'ruflo/src/ruvocal/**'
+      - '.github/workflows/ruvocal-workspace.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'ruflo/src/ruvocal/**'
+      - '.github/workflows/ruvocal-workspace.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  workspace:
+    name: Workspace contracts and built app
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: ruflo/src/ruvocal
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: ruflo/src/ruvocal/package-lock.json
+      - run: npm ci
+      - name: Workspace contracts and existing storage regressions
+        run: npm run test:workspace -- src/lib/server/database/__tests__/rvf.spec.ts src/lib/server/mcp/clientPool.spec.ts
+      - name: Exact operations visibility and forwarding
+        run: npm test --prefix mcp-bridge
+      - name: Build without provider credentials
+        run: npm run build
+      - name: Built routes with a local model fixture
+        run: npm run test:workspace:smoke
+      # This scoped workflow does not certify the full application type check.
+      # Its existing baseline and remaining release gates are recorded in
+      # docs/reviews/2026-09-05-workspace-validation.md under the app directory.

--- a/ruflo/src/ruvocal/README.md
+++ b/ruflo/src/ruvocal/README.md
@@ -8,6 +8,24 @@ RuVocal is the SvelteKit web app that lets you chat with Qwen, Claude, Gemini, o
 
 It started as a fork of the [HuggingFace chat-ui](https://github.com/huggingface/chat-ui) v0.20.0 and has been extended with a WASM-MCP integration layer, parallel tool execution, an in-browser tool gallery, and a "RuFlo Capabilities" tour modal. See [ADR-033](../../docs/adr/ADR-033-RUVOCAL-WASM-MCP-INTEGRATION.md) for the architecture.
 
+## Workspace and governed integrations
+
+The source now includes `/workspace`: mission drafting, recent conversations, a searchable MCP tool inventory, and administrator runtime observations. Open it from the sidebar or use **Ctrl/Cmd + K**. Mission text stays in the tab until you submit the editable chat draft. Requested iteration limits are instructions, not runtime authorization or enforced budgets.
+
+Tool inventory comes from discovery. Runtime cards distinguish unconfigured, unreachable, degraded and observed services. The optional operations bridge exposes exact status tools and a MetaHarness wrapper fixed to `operation: "status"`; it cannot run or promote candidates. Autogenous exposes libraries and signed receipts upstream; a verified operator adapter is required for a remote connection. ruOS observations cover rendezvous services, not full desktop readiness.
+
+See [configuration and limits](docs/source/configuration/workspace.md), [gap analysis](docs/reviews/2026-09-05-ui-gap-analysis.md), and ADRs [039](docs/adr/ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md), [040](docs/adr/ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md), [041](docs/adr/ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md), [042](docs/adr/ADR-042-BOUNDED-OPERATIONS-TOOLS.md). These source changes do not establish that the published service has been updated.
+
+```bash
+npm ci
+npm run test:workspace
+node --test mcp-bridge/operations-tools.test.js
+npm run build
+npm run test:workspace:smoke
+```
+
+The production build does not contact model providers. The HTTP acceptance test uses a local model list fixture and tests all workspace views, chat, model discovery and administrator denial. It does not run inference or contact production integrations.
+
 ## What RuVocal adds on top of upstream chat-ui
 
 | | |
@@ -32,7 +50,7 @@ It started as a fork of the [HuggingFace chat-ui](https://github.com/huggingface
 ```bash
 git clone https://github.com/ruvnet/ruflo
 cd ruflo/ruflo/src/ruvocal
-cp .env .env.local        # then edit .env.local — see below
+cp config/workspace.env.example .env.local  # configure your model provider
 npm install
 npm run dev               # → http://localhost:5173
 ```

--- a/ruflo/src/ruvocal/config/workspace.env.example
+++ b/ruflo/src/ruvocal/config/workspace.env.example
@@ -1,0 +1,17 @@
+# Runtime model connection. Builds do not require a provider connection.
+OPENAI_BASE_URL=https://router.huggingface.co/v1
+OPENAI_API_KEY=
+PUBLIC_APP_NAME=RuFlo
+PUBLIC_APP_ASSETS=chatui
+COOKIE_NAME=ruvocal-session
+# Administrator runtime snapshots are disabled until an admin session and endpoints exist.
+WORKSPACE_RUFLO_MCP_URL=
+WORKSPACE_RUFLO_TOKEN=
+WORKSPACE_METAHARNESS_MCP_URL=
+WORKSPACE_METAHARNESS_TOKEN=
+WORKSPACE_AUTOGENOUS_MCP_URL=
+WORKSPACE_AUTOGENOUS_TOKEN=
+WORKSPACE_RUOS_BASE_URL=
+WORKSPACE_RUOS_TOKEN=
+# In the separate MCP bridge deployment, opt in with MCP_GROUP_OPERATIONS=true.
+# The Autogenous URL requires an operator supplied adapter, not a guessed SDK endpoint.

--- a/ruflo/src/ruvocal/docs/adr/ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md
+++ b/ruflo/src/ruvocal/docs/adr/ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md
@@ -1,0 +1,114 @@
+# ADR-039: Workspace capability evidence and operator experience
+
+**Status:** Proposed
+**Date:** 2026-09-05
+**Source baseline:** `ruvnet/ruflo@db4991967c45c6f72133dff0bb80b0a492960fc1`
+**Related:** [ADR-035](ADR-035-MCP-TOOL-GROUPS.md), [ADR-040](ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md), [ADR-041](ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md)
+
+## Context
+
+The existing RuVocal application is a SvelteKit chat product inside `ruflo/src/ruvocal`. Its landing component primarily renders a logo; descriptions, model information and examples are commented out in the inspected baseline. Navigation emphasizes conversations and exposes MCP management through a modal. This makes the first useful task difficult to discover and conceals the relationship between a configured tool and an operational capability.
+
+The surrounding Ruflo stack has acquired governance, collaboration and optimization mechanisms that cannot be represented accurately by a static tool total or an optimistic connection indicator. A tool may be registered but unconfigured, unreachable, unsupported by the current host, unauthorized for the caller, or unverified on the deployed build. These are separate facts.
+
+The user requested a substantial UI improvement and integration of changes since publication. The available source commit is an engineering baseline, not proof of the production revision. The supplied web archive is visual context; it does not attest runtime services, credentials, build identity or deployment date.
+
+## Specification
+
+Inputs are the existing chat application, operator configured runtime discovery from ADR-040, the current user's existing MCP tool inventory, and source pinned capability descriptions. Outputs are a workspace console, searchable tools, a mission draft, clearer chat entry points, and explicit evidence states. No source description, mission template or discovery result grants execution authority.
+
+The initial workspace must support these tasks:
+
+1. Understand what Ruflo can help accomplish without memorizing package names.
+2. Find an available tool by name or description and identify its source.
+3. See which operator integrations are configured and which were successfully checked.
+4. Draft a bounded mission with an objective, constraints and an acceptance condition.
+5. Continue through the existing chat submission and execution path deliberately.
+6. Return to conversations without losing the familiar interaction model.
+
+The workspace may be visible without operational privileges. Runtime metadata must remain restricted to an authenticated administrator under ADR-040. An administrator requirement should be described as a visibility boundary, not as an integration failure.
+
+## Decision
+
+Add a dedicated `/workspace` console and retain the existing conversation routes. Improve the chat introduction and navigation so the console and mission examples are discoverable. Group information by operator task: mission, capabilities, runtime connections and verification. Reuse ruOS instrument panel principles while keeping Ruflo branding and the existing SvelteKit application.
+
+Use separate evidence dimensions:
+
+| Dimension | Meaning | Evidence required |
+| --- | --- | --- |
+| Documented capability | A pinned source implements or specifies an interface | Repository, commit and source path |
+| Configured integration | The operator supplied a valid deployment configuration | Server configuration validation |
+| Reachable integration | The configured service answered the bounded probe | Timestamp, probe type and outcome |
+| Advertised tools | A remote MCP deployment returned tools | Valid bounded `tools/list` response |
+| Execution authority | A particular actor can perform a particular action now | Existing authoritative policy and execution path |
+| Verified outcome | An evaluator checked a particular artifact | Artifact identity and trusted evaluator receipt |
+
+Do not collapse these dimensions into a single universal readiness score. A discovery result can establish reachability and advertised tools; it cannot establish safe execution, workload success, cryptographic verification or full upstream integration.
+
+Represent missing values as unknown or unavailable. Zero is reserved for an observed count. A configured endpoint that cannot be reached is different from an absent endpoint. A successful check has an observation time; previously observed success becomes stale when it can no longer be refreshed.
+
+Static integration descriptions must identify their role and limits. Examples are examples, not active missions. A draft remains editable text until the user submits it through the existing chat interaction. Merely visiting the workspace, selecting a template, copying text or filtering tools must not start an autonomous process. Administrator runtime observations may use only the fixed read only status calls in ADR-040; they must not invoke mission actions or provider completions.
+
+## Architecture and data boundaries
+
+The browser renders view models and existing user scoped tool metadata. The same origin server route performs privileged discovery. The browser does not receive operator bearer tokens, unrestricted environment configuration, raw service URLs with credentials, or arbitrary upstream error bodies.
+
+The tool search operates on already available inventory. Search results are escaped text. Descriptions from remote servers are untrusted content and cannot modify application instructions, configure an integration or initiate navigation to arbitrary resources.
+
+The first implementation does not import Autogenous's Node transport into the browser. It does not embed MetaHarness's repository executor or ruOS's fleet mutation API. Those interfaces require dedicated server adapters and explicit policy review.
+
+## Interaction and visual requirements
+
+1. Use a compact desktop navigation and a usable mobile route to the same functions. Prioritize a visible mission entry point over decorative animation.
+2. Keep body and operational text readable at phone sizes; target at least 14 CSS pixels for meaningful content and 44 CSS pixels for primary touch targets.
+3. Support keyboard navigation, visible focus, labeled controls and semantic heading order. Communicate state with text as well as color.
+4. Honor reduced motion. Any background effect must leave controls readable and must not intercept pointer input.
+5. Preserve layout when an integration errors, returns no tools or is not configured. Independent failures must not blank the entire console.
+6. Keep a clear difference between an action that drafts text, an action that requests discovery and an action that submits a mission.
+7. Do not display fabricated activity, agents, spend, throughput, success rates or safety scores.
+
+The ruOS shell uses a sidebar that becomes bottom navigation below 640 pixels and groups service observations with related controls. Those design principles are reusable. Its smallest operational text and static token entry behavior should not be copied uncritically.
+
+## SPARC plan
+
+| Phase | Input | Output | Gate |
+| --- | --- | --- | --- |
+| Specification | Baseline source, task and runtime limits | Operator tasks and evidence invariants above | No ambiguous execution semantics |
+| Pseudocode | Available local data and runtime DTO | Deterministic empty, loaded and failed view states | Unknown cannot become healthy implicitly |
+| Architecture | Existing chat, navigation and server auth | Workspace route with separate discovery boundary | No new execution path |
+| Refinement | Candidate source and fixed browser tasks | Functional checks, responsive inspection and corrections | No regression in chat navigation or submission |
+| Completion | Reviewed candidate and evidence receipt | Reviewable source change and operational instructions | Release remains separately authorized |
+
+Pseudocode for the key distinction:
+
+```text
+when user opens workspace:
+    render documented capabilities and editable mission template
+    render runtime state as not yet checked
+    do not invoke mission actions or execute mission text
+
+when administrator requests runtime status:
+    request the same origin bounded discovery endpoint
+    render each integration independently with observation time
+    show returned tools as advertised capabilities
+    do not infer authority from tool presence
+
+when user chooses a mission example:
+    replace or populate draft text visibly
+    preserve explicit user submission as the execution boundary
+```
+
+## Acceptance and rollback
+
+The decisive test is to open the console with all external integrations absent. Mission drafting, navigation and tool search must remain useful; every external status must be truthful; network inspection must show no outbound integration probe, mission execution or provider completion caused by opening the page.
+
+Additional acceptance checks cover keyboard use, a narrow phone viewport, reduced motion, empty tool inventory, a denied runtime request and a single failed integration. These are required checks, not claims that they have already passed. Results belong in the implementation evidence described by ADR-041.
+
+The change is additive. Rollback reverts the workspace and entry point changes to the recorded source baseline, preserving conversation storage and existing settings. There is no database migration or automatic promotion in this decision.
+
+## Source evidence
+
+1. [Baseline chat introduction](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/lib/components/chat/ChatIntroduction.svelte).
+2. [Baseline navigation](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/lib/components/NavMenu.svelte).
+3. [Existing MCP server inventory](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/routes/api/mcp/servers/%2Bserver.ts).
+4. [ruOS responsive shell](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/control/src/App.svelte) and [independent fleet reads](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/control/src/lib/panels/FleetPanel.svelte).

--- a/ruflo/src/ruvocal/docs/adr/ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md
+++ b/ruflo/src/ruvocal/docs/adr/ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md
@@ -1,0 +1,164 @@
+# ADR-040: Governed runtime integration discovery
+
+**Status:** Proposed
+**Date:** 2026-09-05
+**Source baseline:** `ruvnet/ruflo@db4991967c45c6f72133dff0bb80b0a492960fc1`
+**Related:** [ADR-034](ADR-034-OPTIONAL-MCP-BACKENDS.md), [ADR-039](ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md), [ADR-041](ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md)
+
+## Context
+
+Ruflo, MetaHarness, Autogenous and ruOS have different integration surfaces. Treating all of them as an assumed HTTP status service would manufacture compatibility. Treating an advertised MCP tool as permission to run it would cross an authority boundary.
+
+The existing application already supports MCP servers and a configurable health check. That general user supplied URL path is not the authority for operator integrations. The workspace needs a smaller server controlled observation path with predictable cost, bounded responses and no command execution.
+
+## Verified upstream surfaces
+
+| Component | Pinned source | Verified interface | What it does not establish |
+| --- | --- | --- | --- |
+| Ruflo | `db4991967c45c6f72133dff0bb80b0a492960fc1` | Existing MCP transport and tools registry in this application | Which tool set is deployed at a remote endpoint |
+| MetaHarness | `42f568b7297c59065ea562247937bb25cd353a6a` | `@metaharness/avo` 0.2.0, `@metaharness/router` 0.4.0, `@metaharness/autogenous` 0.1.0 and AgentRadio library APIs | A universal remote MetaHarness status or MCP endpoint |
+| Autogenous | `7bf327a9754ce798364dbee8b2825af42a421fd4` | `radio-moe` 0.3.1 compiled Node package and Rust governed adaptation crates | A universal remote Autogenous status or MCP endpoint |
+| ruOS | `6a9be2514a20c63e570aff219944de9c38184c55` | Authenticated `GET /api/v1/server/health` | Workstation availability, brain readiness or whole fleet health |
+
+MetaHarness and Autogenous MCP URLs therefore identify operator deployed adapters. The source review does not establish a canonical hosted endpoint for either. No endpoint is guessed or enabled merely because its package exists.
+
+## Decision
+
+Expose `GET /api/workspace` as a same origin, authenticated administrator only route for workspace runtime observations. Use the existing `requireAdmin` boundary: no authenticated session returns 401 and a nonadministrator returns 403, before any outbound request. Configure a finite allowlist of integration identities and endpoints on the server. The request may not supply a URL, token, command, tool name, query or additional integration.
+
+For operator supplied MCP endpoints, permit protocol initialization, bounded tool discovery and the following exact registered status calls. The adapter supplies immutable arguments; browser data cannot select an operation or add arguments.
+
+| Registered tool | Fixed arguments | Purpose |
+| --- | --- | --- |
+| `system_status` or its explicit `ruflo__` bridge equivalent | `{ "verbose": false }` | Report the configured Ruflo process status |
+| `policy_status` or its explicit `ruflo__` bridge equivalent | `{}` | Report policy mode, counts and ledger status |
+| `metaharness_flywheel` | `{ "operation": "status" }` | Inspect current flywheel transaction state and ledger |
+| `ruflo__metaharness_flywheel_status` | `{}` | Use the bridge's restricted status wrapper when registered |
+
+Tools absent from the discovered registry are not called. In particular, the flywheel multiplexer also supports consequential operations, but this adapter can only choose its `status` branch. It cannot run prompts, execute commands, write resources, spawn agents, create missions, start evolution or promote candidates. Initialization creates protocol session state where required, but does not constitute mission execution. Autogenous remains discovery only until a separately reviewed status adapter exists.
+
+For ruOS, perform only the fixed health GET. Send any required bearer token from protected server configuration. Never forward the browser's session cookie or unrelated provider credentials to an upstream service.
+
+Configuration uses `WORKSPACE_RUFLO_MCP_URL`, `WORKSPACE_METAHARNESS_MCP_URL`, `WORKSPACE_AUTOGENOUS_MCP_URL`, and `WORKSPACE_RUOS_BASE_URL`, with respective `WORKSPACE_RUFLO_TOKEN`, `WORKSPACE_METAHARNESS_TOKEN`, `WORKSPACE_AUTOGENOUS_TOKEN`, and `WORKSPACE_RUOS_TOKEN` secrets. These are application configuration, not upstream package defaults. If an explicit MetaHarness endpoint is absent, the implementation may use the explicitly configured Ruflo endpoint because the inspected Ruflo source registers the flywheel status tool. The UI must identify this source as the Ruflo integration rather than implying an independent MetaHarness deployment.
+
+The implementation contract sets a 5 second whole integration deadline, 256 KiB decoded bytes per response, 1 MiB total bytes per integration probe, at most 12 requests, 4 tool list pages and 1,024 advertised tools. These are bounds, not measured runtime performance. A truncated or incomplete listing must not be described as a complete inventory.
+
+## Response semantics
+
+The public DTO should contain only the following classes of information:
+
+| Field class | Purpose | Constraint |
+| --- | --- | --- |
+| Integration identity | One of the supported fixed providers | Chosen by server configuration |
+| Configuration state | Missing, invalid or configured | Never return raw configuration or secrets |
+| Observation state | `not_configured`, `available`, `degraded` or `unreachable` | Summaries distinguish configuration, authorization, timeout and schema failures without raw errors |
+| Observation time | When this probe completed | No implication of continuous monitoring |
+| Duration | Measured request duration in milliseconds | Observation only, not a benchmark claim |
+| Advertised tools | Bounded safe tool names and optional bounded descriptions | Discovery is not execution authority |
+| Service summary | Normalized ruOS health observations | Scope is the rendezvous service |
+| Error classification | Stable safe error category | Do not expose upstream stack traces or response bodies |
+
+`WorkspaceSnapshot` is `{ schemaVersion: 1, checkedAt, integrations }`. Each integration contains `id`, `name`, `state`, `summary`, nullable `checkedAt` and `latencyMs`, optional `toolCount`, bounded `{label,value}` metrics, and `source: {kind, label, configuredBy, discoveryOnly}`. The shared TypeScript contract is `src/lib/types/Workspace.ts`. `discoveryOnly` explicitly separates tool advertisement from actual allowed status observations.
+
+An empty advertised tool list is a valid observed count if the protocol response is valid. A failed probe does not become a zero tool count. The response should be private and not cacheable by shared intermediaries. Client rendering must preserve the administrator visibility boundary and discard prior privileged state on sign out or denial.
+
+## Exact ruOS health contract
+
+The inspected service implements:
+
+```ts
+type RuosHealth = {
+  ok: boolean;
+  services: Record<string, string>;
+};
+```
+
+The current producer checks exactly `rustdesk-hbbs` and `rustdesk-hbbr`. Each string is the result of `systemctl is-active`, or an error string if that query fails. `ok` is true only when both are `active`. The adapter must validate the JSON shape and bound entries and strings before rendering. A successful HTTP response with `ok: false` means degraded service state, not a transport failure.
+
+ruOS's API supports static bearer authentication and Cognitum OAuth. OAuth validation and tenant authority belong to ruOS. The workspace forwards only an explicitly configured service credential to the configured ruOS endpoint. It does not install OAuth clients or invent scopes. Certificate verification stays enabled; supporting a private certificate authority requires an operator managed trust configuration.
+
+## Network and resource boundaries
+
+1. Accept only validated operator configuration. Require HTTPS in normal deployments; any explicitly supported local development exception must be narrow and tested.
+2. Reject URL user information, credential query parameters, fragments and malformed destinations. Fixed configuration does not eliminate SSRF risk when configuration itself is compromised.
+3. Refuse redirects so a trusted destination cannot move a credentialed request to an unapproved origin.
+4. Apply a finite timeout and cancellation signal to connection, discovery, body reads and cleanup. No fallback path may restart the full time budget indefinitely.
+5. Bound total response bytes, MCP pages, tool count, string lengths and parser work. Cancel response consumption when a limit is exceeded.
+6. Bound concurrent probes and repeated refresh load. Prefer independent settled results over a single failing aggregate. Consider a short private cache or single flight control only if measured concurrent refresh load warrants it.
+7. Close MCP clients, response readers and timers on success, malformed responses, timeout and exceptions.
+8. Do not disable URL safety or TLS verification to make a demonstration green. Report the configuration requirement instead.
+
+Exact limits are an implementation contract, not a performance result. The integration tests must assert that the implementation respects those constants under a slow stream, oversized response and repeated pagination cursor.
+
+## Threat model
+
+| Threat | Entry point | Required defense | Residual risk |
+| --- | --- | --- | --- |
+| Unauthenticated infrastructure discovery | Workspace GET | Server side session and administrator check before probing | Compromised administrator session |
+| SSRF or credential forwarding | Integration configuration or redirect | Fixed destinations, URL validation, redirect refusal and scoped credentials | Malicious operator configuration or compromised upstream DNS |
+| Metadata leakage | DTO, errors, logs or shared cache | Sanitized summaries, secret redaction, private no store response | Tool names can reveal operational capabilities to administrators |
+| Memory or latency exhaustion | MCP lists, SSE or JSON body | Byte, item, page and time limits; bounded concurrency | Authorized repeated requests still consume bounded resources |
+| Prompt or markup injection | Remote descriptions | Escaped text only; metadata never becomes instructions | Misleading remote descriptions remain untrusted claims |
+| False health or false authority | Successful discovery | Explicit probe scope and separate execution gate | A compromised service can lie about its own state |
+| Accidental mutation | Generic MCP client | Exact registered status tool allowlist, immutable arguments and no shell path | Protocol initialization may allocate a remote session; compromised upstream code may violate its own contract |
+| Stale privileged state | Browser navigation or sign out | Clear prior observations on auth loss; show observation time | A screenshot can outlive its original validity |
+
+## Staged integration plan
+
+### Stage 1: Observe configured deployments
+
+Ship bounded MCP discovery, fixed Ruflo and flywheel status calls, and ruOS service health. Show absent integrations as not configured. An explicit Ruflo deployment can provide MetaHarness flywheel observations; an Autogenous library alone cannot provide remote health. This stage neither executes those SDKs nor claims their governance machinery protects existing chat execution.
+
+### Stage 2: Read verified optimization and collaboration evidence
+
+Add purpose built server adapters only after the deployment supplies explicit schemas and artifact identities. Useful upstream contracts already exist:
+
+| Source contract | Useful UI fields | Boundary |
+| --- | --- | --- |
+| MetaHarness `VariationState` | Run, candidate, branch, budgets, pending approvals, interventions | State is not a trusted verdict by itself |
+| MetaHarness `ActionReceipt` | Sequence, policy decision, artifact digest, state hash and signer | A signature field is not verified until trusted key validation succeeds |
+| MetaHarness `EvaluationBinding` | Branch, workspace digest, state hash and evaluate sequence | Prevents a pass for one artifact from labeling another verified |
+| Autogenous `MixtureSnapshot` | Revision, claims, contradictions, buffered frames and equivocation | Consensus is not external outcome verification |
+| Autogenous `PromotionDecision` | Better, safe, authorized, reversible and final verdict | Every conjunct is independently blocking |
+| Autogenous `EvolutionResult` | Candidate history, fitness, promotions and signed ledger | Verify ledger and signer policy before calling it verified |
+
+Node only Autogenous transports and subprocess adapters stay outside the browser bundle. AgentRadio is a local metadata bus; a cross process bridge needs a separate contract. Unknown model lineage must not be rendered as independent supporting evidence.
+
+`@metaharness/autogenous` already provides an SDK bridge to `@metaharness/flywheel`. It requires an injected runner of the real radio-moe benchmark and preserves five bounded levers, frozen safety checks, correlated and independent quality nonregression, and the governed promotion predicate. It is a useful future implementation seam; it is not a hosted service and does not automatically connect this UI to Autogenous.
+
+### Stage 3: Governed actions under a separate decision
+
+Any future run, rollback, fleet start or promotion endpoint needs action specific authorization, immutable budgets, validated artifact binding, idempotency, audit receipts and a rollback contract. MetaHarness may optimize retrieval, routing, context, test and repair policies; it cannot enlarge its own capabilities. Autogenous promotion requires `Better AND Safe AND Authorized AND Reversible`. Ruflo's governing release and promotion policy remains authoritative.
+
+No deploy, fleet mutation, autonomous promotion or remote adapter installation is authorized by this ADR or by browsing the workspace.
+
+## Pseudocode
+
+```text
+GET workspace runtime:
+    require authenticated administrator before any outbound request
+    load fixed operator integration configuration
+    for each supported integration, within bounded concurrency:
+        if missing: emit not configured
+        if invalid: emit configuration error
+        otherwise:
+            probe allowed protocol using scoped timeout and byte budget
+            validate and sanitize response
+            emit observation with timestamp and safe failure classification
+            release resources in finally
+    return private noncacheable snapshot
+```
+
+## Validation and rollback
+
+Required tests include unauthenticated and nonadministrator denial with zero outbound calls, missing configuration with zero outbound calls, refused redirects, no token leakage, exact allowlisted status calls with immutable arguments, no calls to absent or unlisted tools, timeout, oversized payload, invalid JSON, malformed ruOS shape, valid degraded ruOS health and one failed integration alongside one healthy integration. These are release gates, not reported results.
+
+Rollback removes or disables the additive discovery route and workspace integration section. Server credentials remain in the operator's secret store and may be revoked independently. The feature requires no conversation migration and must not change existing execution policy.
+
+## Source evidence
+
+1. [Autogenous package manifest](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/package.json), [exports](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/src/index.ts), [Node crypto transport](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/src/transport.ts), and [promotion implementation](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/src/mesh-evolve.ts).
+2. [MetaHarness AVO types](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/avo/src/types.ts), [package manifest](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/avo/package.json), and [router implementation](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/router/src/index.ts).
+3. [ruOS exact health producer](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/service/src/serve/health.rs), [API route and middleware](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/service/src/serve/mod.rs), and [fleet API decision](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/docs/adr/ADR-008-fleet-api-and-mcp.md).
+4. [Ruflo status tool](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/v3/%40claude-flow/cli/src/mcp-tools/system-tools.ts), [policy status tool](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/v3/%40claude-flow/cli/src/mcp-tools/policy-tools.ts), and [flywheel status branch](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/v3/%40claude-flow/cli/src/mcp-tools/metaharness-tools.ts).
+5. [MetaHarness Autogenous adapter](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/autogenous/README.md), [injected benchmark seam](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/autogenous/src/evaluator.ts), and [promotion gate](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/autogenous/src/gate.ts).

--- a/ruflo/src/ruvocal/docs/adr/ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md
+++ b/ruflo/src/ruvocal/docs/adr/ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md
@@ -1,0 +1,150 @@
+# ADR-041: Evidence bound implementation and optimization loop
+
+**Status:** Proposed
+**Date:** 2026-09-05
+**Source baseline:** `ruvnet/ruflo@db4991967c45c6f72133dff0bb80b0a492960fc1`
+**Related:** [ADR-039](ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md), [ADR-040](ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md), repository `AGENTS.md` and Ruflo ADR-322A/324/325 policy
+
+## Context
+
+The requested work combines a user interface redesign, ecosystem integration, security validation and optimization. A polished screenshot is insufficient evidence for the integration; passing library tests is insufficient evidence for the interface; a published package version is insufficient evidence for the deployed web application.
+
+The repository guide assigns coordination and policy decisions to Ruflo and execution to Codex workers. It requires isolated worktrees, scoped ownership, constrained delegation, source bound evidence and a separately authorized release gate. MetaHarness evaluation must not silently promote a candidate or expand the safety envelope.
+
+## Decision
+
+Use a bounded SPARC implementation loop with explicit source identities, predeclared acceptance conditions, independent scopes and an evidence receipt for the final candidate. Optimize measured bottlenecks only. Preserve all failed and unmeasured gates in the final report.
+
+The work may create reviewable source, tests and ADRs. It must not publish the website, merge a release, install remote adapters, provision ruOS resources or promote a candidate without separate authorization. A local commit and review branch do not constitute deployment.
+
+## Inputs, outputs and ownership
+
+| Workstream | Inputs | Outputs | Assumptions and boundary |
+| --- | --- | --- | --- |
+| UI and mission flow | Baseline SvelteKit application, supplied archive, user objective | Workspace, entry points, search and draft interaction | No automatic mission execution |
+| Runtime observation | Existing admin auth and fixed operator endpoint configuration | Bounded status API and focused tests | No arbitrary destinations, arguments or consequential tools |
+| Source delta and bridge | Git history, current tools and bridge groups | Source inventory and restricted operational exposure where implemented | Source history does not prove production revision |
+| Architecture review | Source evidence and proposed implementation | ADRs, gap analysis, risks and acceptance matrix | Documentation does not assert unexecuted tests passed |
+| Integration and verification | Scoped commits and actual runtime | Candidate evidence, corrections and review handoff | Only the coordinator integrates workstreams |
+
+Each writer owns an isolated worktree and exact files. When a tracked collaboration harness exists, acquire the relevant session and resource leases before edits and release them at handoff. A lease coordinates work; it does not grant an action capability. Where no runnable lease harness is present, explicit scoped ownership and isolated worktrees remain mandatory.
+
+## SPARC gates
+
+### 1. Specification
+
+Freeze the tasks and safety invariants before optimizing:
+
+1. Users can identify a useful task, draft a mission, find a tool and return to chat.
+2. Missing integrations are truthful and do not break the local experience.
+3. Runtime discovery is admin only, finite and restricted to documented status calls.
+4. Operator secrets remain server side.
+5. No new path executes an autonomous mission or promotes code without the existing authority checks.
+6. Normal chat, navigation, model selection and settings continue working.
+
+### 2. Pseudocode
+
+```text
+record immutable baseline and environment
+recall relevant Ruflo memory and inspect current source
+assign isolated scopes and acceptance conditions
+
+for each candidate iteration within the agreed scope:
+    implement the smallest change addressing an observed gap
+    run focused functional and failure checks
+    inspect desktop and mobile behavior
+    measure only the relevant performance dimensions
+    compare with the same baseline, fixture and environment
+    if a hard invariant fails:
+        repair or revert before continuing
+    if a metric is unmeasured:
+        record unknown rather than invent improvement
+    retain source identity, outputs and failure evidence
+
+integrate reviewed scopes
+run the necessary combined regression checks
+bind evidence to the final immutable candidate
+handoff reviewable source and unresolved risks
+do not infer deployment or promotion authorization
+```
+
+### 3. Architecture
+
+Ruflo records coordination and policy context. Codex workers perform edits and execute validation. MetaHarness patterns structure evaluation, candidate comparison and recovery. Autogenous's bounded mutation and conjunctive promotion rules constrain any future learned tuning. The UI presents observations without becoming the release authority.
+
+Do not claim the standalone MetaHarness or Autogenous runtime ran unless command outputs or signed receipts demonstrate that invocation. A deterministic local validation harness is useful but must be named accurately. Root coordination may use an initialized local memory store when prior memory is absent; absence of historical memory is a disclosed input condition, not a failed implementation.
+
+### 4. Refinement
+
+Perform focused validation first, then broaden only to resolve a remaining concrete risk or required repository gate. Record baseline failures separately from newly introduced failures. An unavailable package registry, browser, service credential or remote endpoint must be reported with the exact affected check rather than converted into a pass.
+
+Use before and after screenshots for responsive behavior, not for backend verification. Use API tests and observed transport logs for the runtime boundary. Use actual production build output for bundle measurements. Do not import benchmark numbers from unrelated upstream packages into this UI's claims.
+
+### 5. Completion
+
+The completion artifact is an integrated source commit or immutable source snapshot plus reviewable evidence. An ADR remains Proposed until the responsible reviewer accepts the implementation and its evidence. The final handoff states what changed, what ran, what remains unverified and what release action would require authorization.
+
+## Measurement plan
+
+Targets below are candidate acceptance criteria. They are not measured results.
+
+| Measure | Baseline procedure | Candidate criterion |
+| --- | --- | --- |
+| Capability discovery | Open baseline landing page and count actions to tool inventory | Workspace provides a visible route and local search without a provider call |
+| Mission drafting | Attempt the same objective in the baseline | Objective, constraints and acceptance condition can be prepared before submission |
+| Mobile usability | Capture at 390 by 844 CSS pixels using the same browser | No horizontal overflow; primary controls usable; text readable; nav accessible |
+| Keyboard usability | Follow a fixed tab sequence | All primary actions reachable; focus visible; no new trap |
+| Status isolation | One healthy fixture and one failing fixture | Healthy result survives; failed result does not become zero or healthy |
+| Authorization | Guest and regular user requests | 401 or 403 before outbound activity |
+| Runtime resource budget | Slow, oversized and paginated fixtures | Every request stays within ADR-040 constants and releases resources |
+| Secret boundary | Token canaries in server config and malicious error payloads | Canaries absent from response, browser bundle and user visible logs |
+| Browser JavaScript | Production route chunks from baseline and candidate | Record added bytes; justify required dependencies; no Node runtime imports |
+| Status latency | Repeated fixture probes under the same environment | Report median and p95 with sample count; comply with timeout bound |
+| Chat regression | Existing conversation, model selection and submission tasks | No regression attributable to the candidate |
+
+For latency comparisons, distinguish cold process startup, warm handler cost and upstream service delay. A reasonable local fixture sample is 20 or more completed probes, but a small sample must not be described as a production p99 guarantee. For any percent improvement, publish both raw baseline and candidate values, the formula and the environment. If baseline measurement is unavailable, report only the observed candidate and label comparison unavailable.
+
+Do not tune the suite against the final candidate until it passes. Keep the critical fixtures and gates fixed across iterations. Any deliberate change to a gate requires a recorded reason and rerunning both baseline and candidate where comparison remains meaningful.
+
+## Evidence receipt
+
+The final evidence record should identify:
+
+```json
+{
+  "schemaVersion": 1,
+  "baselineCommit": "db4991967c45c6f72133dff0bb80b0a492960fc1",
+  "candidateCommit": "to be populated after integration",
+  "sourceSnapshotDigest": "required if candidate is not a clean commit",
+  "environment": {
+    "runtimeVersion": "observed value",
+    "packageLockDigest": "observed value",
+    "browserVersion": "observed value or unavailable"
+  },
+  "checks": [],
+  "measurements": [],
+  "unverified": [],
+  "deployment": { "performed": false, "authorizationRequired": true }
+}
+```
+
+This is a schema example, not an executed receipt. Each check records command or procedure, scope, exit status, time, artifact identity and evidence path. Credentials and raw private prompts are excluded. A source hash identifies content; it does not establish signer trust or approval.
+
+## Failure modes and recovery
+
+| Failure | Consequence | Fix path |
+| --- | --- | --- |
+| Stale source or deployment assumption | Wrong claims about what changed since publication | Record source history separately and obtain actual deployment build identity before release |
+| General status multiplexer receives user arguments | Mutation through an observation endpoint | Immutable call allowlist and negative argument tests |
+| Tool list or remote stream is unbounded | Server resource exhaustion | Byte, request, page and time caps with cancellation |
+| Optimizer changes tests or authority | Apparent improvement with weaker guarantees | Freeze protected paths, policies and evaluation fixtures |
+| Candidate benchmark uses a different environment | Misleading performance comparison | Same environment or clearly separated incomparable observations |
+| UI shows unsigned input as verified evidence | False assurance | Separate received, parsed, signed and trust verified states |
+| Worktree collisions | Lost edits or invalid candidate identity | Isolated writers and exact scoped handoff |
+| Release inferred from task completion | Unreviewed production changes | Explicit final release authorization gate |
+
+Rollback is a source revert to the last reviewed commit, with operator integration configuration disabled independently if needed. No UI rollout should rewrite conversation storage. A future operational promotion must retain an independently verifiable rollback target; this implementation loop does not execute that promotion.
+
+## Acceptance test
+
+From the final source identity, run the fixed guest, nonadministrator, missing endpoint, malicious payload and slow endpoint fixtures, then complete the mission drafting task on a narrow viewport. The result is acceptable only when the authority boundaries remain intact and every reported metric can be traced to a recorded observation. Publication is a separate decision.

--- a/ruflo/src/ruvocal/docs/adr/ADR-042-BOUNDED-OPERATIONS-TOOLS.md
+++ b/ruflo/src/ruvocal/docs/adr/ADR-042-BOUNDED-OPERATIONS-TOOLS.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-05
 
-Status: Accepted for implementation; deployment remains an operator action.
+Status: Proposed. Implemented on the review branch; reviewer acceptance and deployment remain pending.
 
 ## Context
 

--- a/ruflo/src/ruvocal/docs/adr/ADR-042-BOUNDED-OPERATIONS-TOOLS.md
+++ b/ruflo/src/ruvocal/docs/adr/ADR-042-BOUNDED-OPERATIONS-TOOLS.md
@@ -1,0 +1,103 @@
+# ADR 042: Bounded operations tools for the Ruflo workspace
+
+Date: 2026-09-05
+
+Status: Accepted for implementation; deployment remains an operator action.
+
+## Context
+
+Source baseline `db4991967c45c6f72133dff0bb80b0a492960fc1` provides current
+runtime, managed agent, policy, and MetaHarness inspection tools. The RuVocal
+bridge selects tools by family prefixes, which omit these additions. Adding a
+`metaharness_` or `policy_` prefix would also expose evaluation, promotion,
+approval, and budget mutations. Tool discovery alone must not expand authority.
+
+The published runtime version is v3.38.21. This source baseline is not evidence
+of which revision currently serves flo.ruv.io.
+
+## Decision
+
+Add an `operations` bridge group enabled only when
+`MCP_GROUP_OPERATIONS=true`. Its Docker default is `false`. Existing deployments
+retain their existing enabled groups.
+
+| Bridge name | Upstream name | Accepted arguments |
+|---|---|---|
+| `ruflo__mcp_status` | `mcp_status` | Empty object |
+| `ruflo__managed_agent_list` | `managed_agent_list` | Optional integer `limit`, 1 to 200 |
+| `ruflo__managed_agent_status` | `managed_agent_status` | Required nonempty `sessionId`, at most 256 characters |
+| `ruflo__autopilot_status` | `autopilot_status` | Empty object |
+| `ruflo__policy_status` | `policy_status` | Empty object |
+| `ruflo__ruvllm_status` | `ruvllm_status` | Empty object |
+| `ruflo__metaharness_flywheel_status` | `metaharness_flywheel` | Empty object; bridge supplies only `operation: "status"` |
+
+The group uses `exactNames`, never a wildcard or family prefix. Its tools appear
+only when discovered on the Ruflo backend. The bridge synthesizes the flywheel
+status alias only after discovering the underlying `metaharness_flywheel` tool.
+An upstream tool that happens to use the alias name cannot replace this wrapper.
+
+The wrapper cannot accept `operation`, `projectRoot`, key paths, approval IDs,
+confirmation, or evaluation settings. Unknown arguments are rejected before
+dispatch. It reads only the backend's existing current project.
+
+Every executor path checks the current visible tool list. Group endpoints also
+require membership of that specific group. Thus a client cannot bypass the
+operations opt-in through `/mcp`, another group endpoint, or chat autopilot.
+Backend argument validation is in this common executor, not only the discovery
+schema. Errors set MCP `isError` and include a structured code.
+
+Existing groups retain their selection rules. A selector omitted entirely keeps
+the existing wildcard behavior for existing dedicated backends; an empty
+`exactNames` or `prefixes` array never means wildcard. Disconnected backends stop
+advertising cached tools.
+
+## Runtime integration
+
+The workspace discovers `/mcp/operations` via authenticated `/mcp-servers`, or
+uses a configured catch-all `/mcp` endpoint. `/groups` reports enabled state and
+actual tool count. Consumers must interpret nested MCP text results and preserve
+`isError`, `degraded`, and `exitCode`. Tool availability does not prove healthy
+runtime state or successful work.
+
+`system_status` remains in the existing devtools group. `policy_status` reports
+the actual mode (`legacy`, `observe`, or `enforce`) and ledger verification.
+The MetaHarness status result includes state and ledger verification; it does
+not run an evaluation or promote anything. Managed agent inspection can make
+authenticated upstream reads using the backend's configured credentials.
+
+The bridge bearer credential remains a server deployment credential. This
+change does not create per-user authorization or expose it to the browser.
+Multi-tenant deployment still requires correctly scoped backend identities.
+
+## Verification
+
+Run from `mcp-bridge` after installing its dependencies:
+
+```sh
+node --check index.js
+npm test
+```
+
+The Node tests start real local HTTP bridge processes with a deterministic fake
+stdio backend and no external provider credentials. They verify default denial,
+exact opt-in discovery, catch-all and group endpoints, cross-group denial,
+lookalike names, absent upstream capability, fixed wrapper parameters, and
+managed-agent input bounds. Rejected calls must leave the backend call log empty.
+Successful wrapper calls must log exactly `metaharness_flywheel` with
+`{"operation":"status"}`.
+
+These tests establish bridge routing and authority boundaries. They do not
+claim a live Ruflo deployment, managed cloud session, or production evaluation.
+
+## Rollback
+
+Unset `MCP_GROUP_OPERATIONS` or set it to `false`, then restart the bridge.
+Discovery and execution of all seven operations tools are disabled together.
+No new runtime state or database migration is introduced.
+
+## References
+
+1. `mcp-bridge/operations-tools.js` and `operations-tools.test.js`.
+2. `v3/@claude-flow/cli/src/mcp-tools/metaharness-tools.ts` at the source baseline.
+3. `v3/@claude-flow/cli/src/mcp-tools/policy-tools.ts` at the source baseline.
+4. ADR 324 policy governance and ADR 322 evaluation and promotion transactions.

--- a/ruflo/src/ruvocal/docs/reviews/2026-09-05-ui-gap-analysis.md
+++ b/ruflo/src/ruvocal/docs/reviews/2026-09-05-ui-gap-analysis.md
@@ -1,0 +1,143 @@
+# Ruflo UI and ecosystem gap analysis
+
+**Date:** 2026-09-05
+**Review status:** Source analysis complete; implementation and runtime validation tracked separately
+**Implementation baseline:** `ruvnet/ruflo@db4991967c45c6f72133dff0bb80b0a492960fc1`
+**Decisions:** [ADR-039](../adr/ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md), [ADR-040](../adr/ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md), [ADR-041](../adr/ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md)
+
+## Decision
+
+Evolve the existing RuVocal chat application into a workspace with visible mission drafting, searchable capabilities and truthful runtime observations. Retain the conversation product and add a bounded administrator observation API. Integrate current Ruflo status and policy surfaces first; expose Autogenous and MetaHarness as configured capabilities with explicit evidence limits; reuse ruOS's instrument panel interaction principles.
+
+The largest gap is the distance between a sophisticated backend ecosystem and the operator's ability to discover, verify and deliberately use it. Adding package names or simulated activity would enlarge that gap. The initial implementation should make the next useful action clear and show exactly what the application has observed.
+
+This report does not attest that the candidate is deployed, that a live integration is connected, that cryptographic receipts were verified, or that the requested validation has passed. Those claims require candidate evidence under ADR-041.
+
+## Evidence scope and chronology
+
+| Observation | Evidence | Implication |
+| --- | --- | --- |
+| Current source baseline | `db4991967c45c6f72133dff0bb80b0a492960fc1` | Immutable starting point for the implementation |
+| GitHub release v3.38.21 | Published 2026-09-02 at 13:40:40 UTC | A Ruflo release record, not evidence of the web deployment revision |
+| Latest inspected RuVocal path change | `40affb83fe18d35e5c290ff8a4aba425baba6ac0`, 2026-08-13 | Chat source has changes later than the older goal UI |
+| Goal UI path history | `e58154a4267d406011f2d4ef63eee15a2aa129ef`, May 1 rebrand; `a10a13e623a1f7d752e95c189e07cd28b4cacfce`, May 3 fixes; `f8f4cd4bc754aeacb34a6bf11549fc7a81174e37`, May 5 environment removal | An alternate UI exists, but its history is not the target chat deployment history |
+| Supplied web archive | User supplied visual capture | Useful visual context, without source or runtime attestation |
+
+The user referred to changes since the last publication. The actual production build identity remains unverified. The correct comparison is therefore an explicitly recorded source baseline plus observed visual context until a deployment manifest, image digest or running build identifier closes that gap. A draft release or package tag cannot substitute for that evidence.
+
+The v3.38.21 release fixes MCP HTTP memory persistence after restart. The same release notes also disclose a monorepo dependency installation gap involving an unpublished standalone `@claude-flow/mcp` version. Do not silently change dependency provenance or label a blocked install a product test failure; record the exact affected environment and use the scoped application's reproducible lockfile where available. [Release record](https://github.com/ruvnet/ruflo/releases/tag/v3.38.21).
+
+## Source findings
+
+### The landing page leaves useful capability undiscovered
+
+The baseline `ChatIntroduction.svelte` renders the brand and animated dots. It deliberately references the model and message callback only to satisfy linting while the richer introduction blocks remain commented out. An operator who does not already know Ruflo's tools receives little guidance on what to ask, how to constrain a mission or how to verify available integrations. [Pinned component](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/lib/components/chat/ChatIntroduction.svelte).
+
+The proposed improvement is a compact task oriented introduction with an obvious workspace route and mission examples. Mission drafts should expose objective, constraints and acceptance conditions without granting execution authority. The business hypothesis is shorter time to a useful first request; it must be tested through a fixed task, not claimed as a measured conversion improvement.
+
+### Conversation navigation is a useful base, but not an operations console
+
+The existing navigation groups conversations by recency and provides MCP management through a modal. Keep those behaviors. Add a clear workspace entry point and local capability search instead of forcing operational information into an increasingly dense modal. A dedicated route also allows independent empty, failed and restricted states. [Pinned navigation](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/lib/components/NavMenu.svelte).
+
+### Configuration and capability availability are currently easy to confuse
+
+`/api/mcp/servers` returns configured server metadata with status unset; health is determined separately. The existing health route accepts a URL, attempts Streamable HTTP and SSE, and lists tools. This establishes a useful general MCP foundation but does not provide the smaller operator controlled runtime boundary needed for an infrastructure console. [Inventory route](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/routes/api/mcp/servers/%2Bserver.ts), [health route](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/ruflo/src/ruvocal/src/routes/api/mcp/health/%2Bserver.ts).
+
+Use a separate administrator GET with fixed server destinations, bounded protocol work and a normalized DTO. Distinguish configured, reachable, advertised, authorized and outcome verified. The observation API must not inherit arbitrary browser headers or generic tool invocation arguments.
+
+### The actual Ruflo status surface is richer than a tool count
+
+Current source registers `system_status`, `policy_status` and `metaharness_flywheel`. The policy status returns mode, version, counts and ledger verification information. The flywheel's `status` branch reads transaction state and ledger without running evaluation or promotion. These exact registered tools can support useful bounded observations with fixed arguments.
+
+There are limits even within those responses. `system_status` uses live process uptime, but several component health entries explicitly remain unknown. Do not turn the response's top level status into an assertion that memory, neural services and MCP are all healthy. The flywheel tool is a multiplexer whose other operations are consequential; only the exact `status` branch belongs in this observation API. [System tools](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/v3/%40claude-flow/cli/src/mcp-tools/system-tools.ts), [policy tools](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/v3/%40claude-flow/cli/src/mcp-tools/policy-tools.ts), [flywheel tools](https://github.com/ruvnet/ruflo/blob/db4991967c45c6f72133dff0bb80b0a492960fc1/v3/%40claude-flow/cli/src/mcp-tools/metaharness-tools.ts).
+
+## Ecosystem integration assessment
+
+| Component | Value to this UI | Verified seam | Initial scope | Later requirement |
+| --- | --- | --- | --- | --- |
+| Ruflo | Runtime and policy visibility | Registered status and policy tools | Exact status calls with immutable arguments | Action specific capability checks for mutations |
+| MetaHarness | Candidate comparison, budgets and evidence | Ruflo flywheel status; AVO and router SDKs | Observe explicitly configured runtime; identify source | Dedicated artifact bound run and receipt adapter |
+| Autogenous | Signed collaboration and governed improvement | radio-moe SDK and `@metaharness/autogenous` adapter | Discover operator deployed adapter; no invented health API | Real benchmark runner and trusted receipt verification |
+| ruOS | Infrastructure health and coherent instrument panel design | Fixed authenticated health route; Svelte shell | Rendezvous health only | Tenant scoped fleet adapter and separate action authorization |
+
+### MetaHarness
+
+Pinned at `42f568b7297c59065ea562247937bb25cd353a6a`, AVO 0.2.0 exports versioned contracts for resource budgets, candidates, evaluation results, action receipts and checkpoints. `EvaluationBinding` binds a result to a branch, workspace digest, state hash and action sequence. Those are useful foundations for a future implementation loop view that can explain what was checked and why a candidate was rejected. Security policy and capability expansion are not evolvable surfaces. [AVO types](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/avo/src/types.ts).
+
+Router 0.4.0 returns a model ID, predicted quality, cost per million tokens and `metBar`. Its fallback can choose the best prediction when no candidate meets the quality threshold. That fallback should be shown as a threshold miss, not success. Historical cost and quality comparisons require the deployment's own labeled data. [Router source](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/router/src/index.ts).
+
+AgentRadio is a deterministic local bus with logical sequence ordering, threads and mentions. It is not a network service. Importing that package does not connect independent hosts or create a durable audit store. [Bus implementation](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/radio/src/bus.ts).
+
+### Autogenous
+
+Pinned at `7bf327a9754ce798364dbee8b2825af42a421fd4`, radio-moe 0.3.1 provides signed frames, deterministic mixture snapshots, lineage aware support, action gates, outcome verification and a bounded evolution loop. Its Node crypto, transport and subprocess exports must remain outside the browser bundle. [Package manifest](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/package.json), [exports](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/src/index.ts).
+
+The current mutation surface has five active numeric levers: `sameProvider`, `sameArch`, `sameSize`, `sourceJaccard`, and `quorumThreshold`. Weights are bounded from 0 to 0.8; quorum from 1.5 to 4. Promotion requires separation improvement of at least 0.02, all hard gates, authorization and reversibility. `sameAccuracyBand` stays frozen until its own evaluation exists. These are code constraints, not claims of production accuracy. [Evolution source](https://github.com/ruvnet/autogenous/blob/7bf327a9754ce798364dbee8b2825af42a421fd4/packages/radio-moe/src/mesh-evolve.ts).
+
+The latest concrete integration is `@metaharness/autogenous` 0.1.0 in the MetaHarness repository. It supplies a bounded proposer, a domain promotion rule and an evaluator seam that must call the real radio-moe benchmark. It does not duplicate the benchmark or create a hosted service. Its promotion gate retains correlated and independent quality checks, cost nonregression and every blocking reason. This is the appropriate future optimization integration seam. [Adapter documentation](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/autogenous/README.md), [evaluator seam](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/autogenous/src/evaluator.ts), [domain gate](https://github.com/ruvnet/metaharness/blob/42f568b7297c59065ea562247937bb25cd353a6a/packages/autogenous/src/gate.ts).
+
+### ruOS
+
+Pinned at `6a9be2514a20c63e570aff219944de9c38184c55`, ruOS Control is a Svelte SPA with desktop sidebar, mobile bottom navigation, instrument panels and independent settled requests. It is a strong design reference. Borrow its task grouping and explicit unavailable states while improving its smallest text and preserving Ruflo identity. [Shell](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/control/src/App.svelte), [Fleet panel](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/control/src/lib/panels/FleetPanel.svelte).
+
+The exact health endpoint returns `{ok, services}` for `rustdesk-hbbs` and `rustdesk-hbbr`. It does not prove that a desktop can be opened or that every ruOS capability is functioning. Fleet and brain APIs have tenant and operator restrictions that should not be bypassed by an aggregated UI. [Health producer](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/service/src/serve/health.rs), [API decision](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/docs/adr/ADR-008-fleet-api-and-mcp.md).
+
+ruOS ADR-011 describes MetaHarness as phase 2 and Autogenous as phase 3. Those are planned integrations rather than evidence that its current dashboard runs them. [ADR-011](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/docs/adr/ADR-011-ruos-control-dashboard.md).
+
+## Contradictions and claim controls
+
+| Observed contradiction | Resolution |
+| --- | --- |
+| radio-moe API documentation describes 0.1.0 source exports while package manifest is 0.3.1 with compiled exports | Pin package manifest and implementation; treat API prose as potentially stale |
+| ruOS client comments call Brain routes pending while the current server mounts and tests them | Prefer implemented routes; separately verify deployed availability |
+| A tool can be registered without being configured, healthy or authorized | Keep inventory, observation and authority separate |
+| Ruflo release history and UI path history have different dates | Do not identify a production web version from a package tag |
+| A valid signature proves a signed artifact, not an authorized or independent producer | Apply an explicit trust policy before showing verified outcome |
+| Existing chat autonomy and future governed evolution have different execution boundaries | Do not imply the new observation UI retroactively secures all existing execution |
+
+## Alternatives and tradeoffs
+
+Scores use 1 as weakest and 5 as strongest. They are engineering judgments for this scope, not measured product outcomes. Lower migration risk receives a higher score.
+
+| Option | Immediate user value | Source fit | Low migration risk | Truthful integration | Total |
+| --- | --- | --- | --- | --- | --- |
+| Extend current RuVocal with workspace and bounded observations | 5 | 5 | 5 | 5 | 20 |
+| Replace chat with the older goal UI | 3 | 2 | 2 | 3 | 10 |
+| Build a new ruOS style shell with all runtimes embedded | 3 | 2 | 1 | 2 | 8 |
+
+The first option preserves authentication, conversations, model access and existing tool settings while adding useful operator tasks. It also keeps the first release's runtime authority narrow. Its cost is a staged integration: richer Autogenous and AVO evidence requires later adapters. That limitation is preferable to presenting a package import as an operational connection.
+
+## Implementation sequence
+
+1. Record source and visual baseline and the unresolved deployment identity.
+2. Add workspace navigation, mission drafting, task examples and tool search.
+3. Add the administrator runtime API with fixed endpoints, bounded discovery and exact status calls.
+4. Connect safe summarized observations and show missing, degraded and unreachable states independently.
+5. Apply responsive, keyboard, reduced motion and empty state corrections.
+6. Run focused failure and regression checks; measure only what can be reproduced.
+7. Integrate scoped commits and bind the final evidence to the candidate identity.
+8. Provide the review handoff. Publication and operational promotion remain separate actions.
+
+The current runtime design uses `GET /api/workspace` with a 5 second whole integration deadline, 256 KiB per decoded response, 1 MiB total per integration, 12 requests, 4 tool pages and 1,024 tool entries. These are proposed implementation limits, not benchmark results. A larger or more complex adapter should be justified by an observed requirement rather than enabled speculatively.
+
+## Acceptance matrix
+
+| Scenario | Required observation |
+| --- | --- |
+| No integrations configured | Useful local workspace; not configured states; zero outbound probes |
+| Guest or regular user runtime request | Denial before any upstream request |
+| One healthy and one failing integration | Independent states; no global blank screen |
+| A remote tool description contains markup or instructions | Escaped text; no execution, credential access or policy effect |
+| Tool registry includes promotion or shell tools | Discovery may display them; observation path never invokes them |
+| Flywheel status is registered | Only fixed status arguments are sent |
+| Slow, oversized or repeated cursor response | Cancellation at defined bounds; safe normalized failure |
+| ruOS reports `ok: false` | Degraded rendezvous health, not a claim that the whole fleet is offline |
+| Mission example selected | Editable draft; no provider completion or mission execution until submission |
+| Phone viewport and keyboard | Reachable controls, readable content, no horizontal overflow or focus trap |
+| Final candidate evidence | Source identity, executed commands, results and limitations are reviewable |
+
+## Remaining uncertainty and next action
+
+The biggest uncertainty is the actual deployed UI and runtime configuration. Obtain the running web build identifier and the operator's intended integration endpoints before any publication decision. Until then, compare source to source and keep live connection claims conditional on observed responses.
+
+The immediate next action is to integrate and validate the bounded workspace candidate under ADR-041. Accept it only when a fresh session with no integrations can complete the mission drafting task while the runtime API denies unauthorized callers before any network activity.

--- a/ruflo/src/ruvocal/docs/reviews/2026-09-05-ui-gap-analysis.md
+++ b/ruflo/src/ruvocal/docs/reviews/2026-09-05-ui-gap-analysis.md
@@ -5,6 +5,8 @@
 **Implementation baseline:** `ruvnet/ruflo@db4991967c45c6f72133dff0bb80b0a492960fc1`
 **Decisions:** [ADR-039](../adr/ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md), [ADR-040](../adr/ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md), [ADR-041](../adr/ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md)
 
+**Implementation evidence:** [Validation report and remaining release gates](2026-09-05-workspace-validation.md).
+
 ## Decision
 
 Evolve the existing RuVocal chat application into a workspace with visible mission drafting, searchable capabilities and truthful runtime observations. Retain the conversation product and add a bounded administrator observation API. Integrate current Ruflo status and policy surfaces first; expose Autogenous and MetaHarness as configured capabilities with explicit evidence limits; reuse ruOS's instrument panel interaction principles.

--- a/ruflo/src/ruvocal/docs/reviews/2026-09-05-workspace-receipt.json
+++ b/ruflo/src/ruvocal/docs/reviews/2026-09-05-workspace-receipt.json
@@ -1,0 +1,137 @@
+{
+  "schemaVersion": 1,
+  "baselineCommit": "db4991967c45c6f72133dff0bb80b0a492960fc1",
+  "candidateCommit": "a03d85c2c11da6ed9bfd5a7cb5bde0ebae62d94f",
+  "candidateRepositoryTree": "aa608c5457ab58310a201669ed9598a05f0eecbb",
+  "candidateApplicationTree": "a3a835c0e017d2d802df3f2c4dab028891771aaf",
+  "localValidationCommit": "339efed870306d5da0e5c98364088504e2d47b0e",
+  "sourceIdentityVerifiedBy": "Local git tree equals GitHub create_tree SHA",
+  "environment": {
+    "os": "Linux",
+    "node": "24.19.0",
+    "npm": "11.9.0",
+    "dependencies": "unchanged application package-lock.json"
+  },
+  "checks": [
+    {
+      "name": "workspace_and_regressions",
+      "command": "npm run test:workspace -- src/lib/server/database/__tests__/rvf.spec.ts src/lib/server/mcp/clientPool.spec.ts",
+      "workingDirectory": "ruflo/src/ruvocal",
+      "exitCode": 0,
+      "result": {
+        "testFiles": 8,
+        "passed": 163
+      },
+      "completedAtUTC": "2026-09-05T03:28:40.567788+00:00",
+      "sessionLogSha256": "8556399ff0565652b3769b9ce477e33196f5645e2edfdd50a4db05b73165c6f3"
+    },
+    {
+      "name": "bridge",
+      "command": "npm test --prefix mcp-bridge",
+      "workingDirectory": "ruflo/src/ruvocal",
+      "exitCode": 0,
+      "result": {
+        "passed": 6
+      },
+      "completedAtUTC": "2026-09-05T03:26:02.036246+00:00",
+      "sessionLogSha256": "f2404b51b3ddb35878bcb86f584300a4687a5a9f1a465e8a6c481af2087d4eb6"
+    },
+    {
+      "name": "build",
+      "command": "npm run build",
+      "workingDirectory": "ruflo/src/ruvocal",
+      "exitCode": 0,
+      "result": {
+        "adapter": "node",
+        "passed": true
+      },
+      "completedAtUTC": "2026-09-05T03:29:49.066630+00:00",
+      "sessionLogSha256": "2af83f0af473d06fd3221274d39d9b2c0e9c1ab7ca58a6af8c936cb1554aae2f"
+    },
+    {
+      "name": "built_http",
+      "command": "npm run test:workspace:smoke",
+      "workingDirectory": "ruflo/src/ruvocal",
+      "exitCode": 0,
+      "result": {
+        "passed": 6,
+        "fixture": "local model list only",
+        "liveIntegrationsTested": false
+      },
+      "completedAtUTC": "2026-09-05T03:29:50.801357+00:00",
+      "sessionLogSha256": "b578620ae455905bcfff0a2b45f88e05558681c54519c64cb707850fb0ecde51"
+    },
+    {
+      "name": "new_file_lint",
+      "command": "ESLint on all 24 added .ts, .svelte, .js and .mjs files",
+      "workingDirectory": "ruflo/src/ruvocal",
+      "exitCode": 0,
+      "result": {
+        "files": 24,
+        "passed": true
+      },
+      "completedAtUTC": "2026-09-05T03:29:13.484525+00:00",
+      "sessionLogSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "full_types",
+      "command": "npm run check",
+      "workingDirectory": "ruflo/src/ruvocal",
+      "exitCode": 1,
+      "result": {
+        "errors": 199,
+        "warnings": 14,
+        "files": 51,
+        "baselineErrors": 199,
+        "baselineWarnings": 14,
+        "introducedDiagnostics": 0
+      },
+      "completedAtUTC": "2026-09-05T03:29:24.896779+00:00",
+      "sessionLogSha256": "b741a7cdaf927893d33c7aa0cb8efe43d92db8e47fe616c1b29a5a8f5793e152"
+    }
+  ],
+  "baselineDiagnosticComparison": {
+    "method": "Sorted file path and message, excluding line and column positions",
+    "diagnostics": 213,
+    "identical": true,
+    "normalizedSha256": "9580285ebd3d9d76dd115bd5631b6e2555c5a95b2a494e6430602c4037c7c889"
+  },
+  "measurements": [
+    {
+      "name": "static shared layout JavaScript gzip bytes",
+      "baseline": 102208,
+      "initialCandidate": 126586,
+      "candidate": 103495,
+      "method": "Sum individually compressed unique JS files reachable by manifest static imports from /nodes/0.js; Python gzip.compress defaults"
+    },
+    {
+      "name": "all emitted client JavaScript gzip bytes",
+      "baseline": 634786,
+      "candidate": 651666,
+      "method": "Sum Python gzip.compress lengths of every emitted client .js file"
+    }
+  ],
+  "unverified": [
+    "Actual production source revision",
+    "Live configured runtimes and model inference",
+    "Browser rendering, hydration, keyboard and narrow viewport acceptance",
+    "Full application type check release gate",
+    "Remote Node 22 CI execution",
+    "Autogenous receipt trust and live evolution",
+    "MetaHarness live evaluation or promotion",
+    "ruOS fleet health beyond the rendezvous service"
+  ],
+  "toolUse": {
+    "rufloCli": "3.25.6",
+    "coordination": "bounded hierarchical swarm; hybrid memory initialized and verified",
+    "metaharnessCliStatus": "unsupported flywheel subcommand in installed CLI",
+    "runtimeContracts": "pinned source and installed MCP SDK fixtures",
+    "optimizerBenchmark": "local bundle comparison; no autonomous runtime evaluation"
+  },
+  "deployment": {
+    "performed": false,
+    "authorizationRequired": true
+  },
+  "evidenceReport": "2026-09-05-workspace-validation.md",
+  "receiptTrust": "Unsigned local validation record; hashes do not establish authorization or signer trust"
+}

--- a/ruflo/src/ruvocal/docs/reviews/2026-09-05-workspace-validation.md
+++ b/ruflo/src/ruvocal/docs/reviews/2026-09-05-workspace-validation.md
@@ -1,0 +1,89 @@
+# Ruflo workspace implementation and validation
+
+Date: 2026-09-05
+
+Status: Implemented for review. Build and scoped acceptance pass. Production publication and operational promotion have not been performed.
+
+## Source identity
+
+| Item | Immutable identity |
+| --- | --- |
+| Source baseline | `db4991967c45c6f72133dff0bb80b0a492960fc1` |
+| Candidate code commit on GitHub | `a03d85c2c11da6ed9bfd5a7cb5bde0ebae62d94f` |
+| Candidate repository tree | `aa608c5457ab58310a201669ed9598a05f0eecbb` |
+| Candidate application tree | `a3a835c0e017d2d802df3f2c4dab028891771aaf` |
+| Local validation commit | `339efed870306d5da0e5c98364088504e2d47b0e` |
+
+The local and GitHub code commits have identical repository trees. Their commit identities differ because the GitHub connector created the review commit. This report and its [machine-readable receipt](2026-09-05-workspace-receipt.json) are a subsequent documentation change. The actual revision serving flo.ruv.io remains unknown, so the comparison is against source, not an attestation of changes since the deployed release.
+
+The [gap analysis](2026-09-05-ui-gap-analysis.md) records the pinned Ruflo, Autogenous, MetaHarness and ruOS source review. [ADR-039](../adr/ADR-039-WORKSPACE-CAPABILITY-EVIDENCE.md), [ADR-040](../adr/ADR-040-GOVERNED-RUNTIME-INTEGRATIONS.md), [ADR-041](../adr/ADR-041-IMPLEMENTATION-OPTIMIZATION-LOOP.md) and [ADR-042](../adr/ADR-042-BOUNDED-OPERATIONS-TOOLS.md) define the implementation, authority boundaries and rollback. These decisions do not approve deployment.
+
+## Delivered behavior
+
+The existing chat application now has a workspace with an objective composer, bounded draft iteration instructions, recent conversations, searchable tool schemas, runtime observations and keyboard command search. Chat onboarding offers editable task examples. Responsive styles support the existing light and dark themes, reduced motion preferences and narrow screens. Mission and tool drafts transfer through the existing local input store and require deliberate submission. Even a 4,000 character Unicode objective stays out of the URL.
+
+Tool selection and successful discovery are separate states. Unchecked or failed inventories display as unavailable. Base MCP discovery resolves the deployment's private endpoint and headers from an exact server identity; browser requests cannot override them. Existing personal connection validation remains in place.
+
+The administrator runtime API observes only privately configured endpoints. Ruflo and MetaHarness use exact discovered status calls; the bridge adds seven operations tools behind an opt-in group and supplies immutable flywheel status arguments. The UI identifies observations obtained through the Ruflo fallback. ruOS observations are limited to rendezvous service health. Autogenous has a documented operator adapter seam because its inspected upstream SDK does not provide the required HTTP or MCP status service. This change does not install such an adapter or verify signed evolution receipts.
+
+Observation requests have fixed time, response size, request count, pagination and tool count limits. The API rejects guests, regular users, cross-origin requests and query overrides before upstream work. Nested MCP envelopes preserve failure signals; late responses cannot alter a timed-out observation. Availability never grants execution or promotion authority.
+
+## Executed validation
+
+Environment: Linux, Node `24.19.0`, npm `11.9.0`, dependencies installed from the unchanged application lockfile. The new scoped GitHub Actions workflow uses Node 22, following existing repository workflows; that remote execution is not part of these local results.
+
+| Check | Result | Scope and limit |
+| --- | --- | --- |
+| Workspace Vitest suite | 108 passed | Draft constraints and Unicode handoff; server rendering and unknown inventories; runtime authorization, exact calls, SDK JSON/SSE transport, nested errors, deadlines and private health targets |
+| Existing regression fixtures | 55 passed | RVF database and MCP client pool |
+| Bridge Node tests | 6 passed | Real local HTTP bridge with fake stdio backend; default denial, exact discovery, fixed arguments and cross-group denial |
+| Production build | Passed | Adapter Node output, without production provider credentials |
+| Built application HTTP smoke | 6 passed | Workspace overview, tools, runtimes, chat, models and denied guest runtime API; local model-list fixture only |
+| ESLint on 24 new source and test files | Passed | Does not certify the entire legacy application's lint state |
+| Full application type check | Failed with existing baseline | 199 errors and 14 warnings in 51 files on both baseline and candidate; normalized diagnostic paths and messages are identical, excluding shifted line positions |
+| Ruflo security scan | No signals in selected scope | Pinned CLI scan of the new server workspace directory; not a full application security assessment |
+| Browser interaction and visual review | Not completed | Advertised cloud browser could not reach the local preview; no screenshot, focus, hydration or viewport assurance is claimed |
+| Live production runtime or model calls | Not performed | Fixtures do not establish deployed connectivity, signer trust or production performance |
+
+The total is **169 passing tests plus six built HTTP checks**. The failed full type check remains release debt. No test, type rule or authorization requirement was weakened to obtain the scoped passes.
+
+The new `.github/workflows/ruvocal-workspace.yml` reruns scoped contracts, existing storage regressions, bridge tests, the offline build and built HTTP smoke when this application changes. It does not deploy, merge or certify the full type check.
+
+## Measured optimization loop
+
+The first integrated candidate eagerly imported the command palette into the shared layout. The final candidate loads it on demand. Both builds used the same installed dependencies and host. The unchanged baseline needed a local model-list fixture during build analysis; the candidate moves provider discovery to actual server startup so build analysis works offline.
+
+| Build | Shared layout dependency JS, gzip bytes | All client JS, gzip bytes |
+| --- | ---: | ---: |
+| Source baseline | 102,208 | 634,786 |
+| Initial candidate, eager command palette | 126,586 | Not used for comparison |
+| Final candidate, lazy command palette | 103,495 | 651,666 |
+
+The final layout is 23,091 compressed bytes smaller than the initial candidate, an 18.2% reduction. It is 1,287 bytes above baseline, about 1.3%. All client JavaScript grows by 16,880 bytes, about 2.7%, including the new workspace functionality.
+
+Method: read `.svelte-kit/output/client/.vite/manifest.json`, start at the entry ending in `/nodes/0.js`, recursively follow static `imports`, deduplicate emitted JavaScript files and sum their individual Python `gzip.compress` lengths. Dynamic imports are excluded from the shared layout graph. The all-client measure sums every emitted `.js` file. These are reproducible bundle size proxies, not measured page latency, network transfer, usability, model quality or MetaHarness evaluation scores.
+
+Ruflo CLI `3.25.6` recorded a bounded hierarchical swarm and initialized verified hybrid memory. Source research and implementation ran in separate Codex worktrees. That installed CLI did not support `metaharness flywheel status`; the attempted command returned an unknown subcommand error. The observer implementation instead follows the pinned current source API and is tested with actual MCP SDK transports and deterministic fixtures. No live Autogenous evolution, MetaHarness candidate evaluation or ruOS optimization run is claimed.
+
+Review iterations also corrected nested error propagation, detached work after deadlines, deployment connection resolution, draft URL exposure and unknown inventory display. These are implementation improvements verified by their targeted failure fixtures, not claims of autonomous production optimization.
+
+## Reproduction and release gate
+
+From `ruflo/src/ruvocal`:
+
+```sh
+npm ci
+npm run test:workspace -- src/lib/server/database/__tests__/rvf.spec.ts src/lib/server/mcp/clientPool.spec.ts
+npm test --prefix mcp-bridge
+npm run build
+npm run test:workspace:smoke
+npm run check
+```
+
+The last command currently fails with the documented baseline diagnostics. Configure actual deployment connections using [workspace configuration](../source/configuration/workspace.md). Do not substitute fixture observations for deployment acceptance.
+
+Before release, obtain the running production build identity, complete narrow-screen and keyboard/browser acceptance, confirm chat and conversation streaming with the intended model, verify the scoped CI execution, resolve or explicitly accept existing type debt through normal review, and observe the intended live connections with correctly scoped administrator credentials. Autogenous receipt verification and richer evaluation/fleet control require separate adapter work and authority review. This workspace does not promote candidates or change runtime budgets.
+
+Rollback uses a source revert to the reviewed baseline. The operations group can also be disabled independently with `MCP_GROUP_OPERATIONS=false`. No conversation storage migration is introduced.
+
+Acceptance test: a fresh session can draft an objective, inspect an actual discovered schema and distinguish unconfigured, failed and observed connections; an unauthorized request reaches no runtime endpoint; a mission remains an editable chat draft until submitted.

--- a/ruflo/src/ruvocal/docs/source/configuration/workspace.md
+++ b/ruflo/src/ruvocal/docs/source/configuration/workspace.md
@@ -1,0 +1,160 @@
+# Workspace runtime observations
+
+The workspace reads bounded operational evidence through `GET /api/workspace`.
+Access requires the existing Chat UI administrator session. Ordinary sessions
+receive HTTP 403. Requests without a session receive HTTP 401. Runtime observation
+is separate from enabling chat tools: registering a tool does not prove that its
+runtime is healthy or that a user may execute it.
+
+## Deployment configuration
+
+Set private environment variables on the Chat UI server. They are not public
+browser settings and are not accepted in request parameters.
+
+| Variable                        | Meaning                                                                                                               |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `WORKSPACE_RUFLO_MCP_URL`       | Exact deployed Ruflo Streamable HTTP MCP endpoint                                                                     |
+| `WORKSPACE_RUFLO_TOKEN`         | Optional service bearer token for that endpoint                                                                       |
+| `WORKSPACE_METAHARNESS_MCP_URL` | Optional separate MCP endpoint exposing the verified Ruflo MetaHarness status tool                                    |
+| `WORKSPACE_METAHARNESS_TOKEN`   | Optional bearer token for the separate endpoint                                                                       |
+| `WORKSPACE_AUTOGENOUS_MCP_URL`  | Optional operator supplied Autogenous MCP adapter; upstream currently provides a library rather than a status service |
+| `WORKSPACE_AUTOGENOUS_TOKEN`    | Optional bearer token for that adapter                                                                                |
+| `WORKSPACE_RUOS_BASE_URL`       | Deployed ruOS service origin, optionally including a reverse proxy path prefix                                        |
+| `WORKSPACE_RUOS_TOKEN`          | ruOS static token or Cognitum JWT used as a bearer token                                                              |
+
+When a separate MetaHarness endpoint is absent, observation uses the explicitly
+configured Ruflo endpoint and Ruflo token. This works because Ruflo registers
+`metaharness_flywheel`; it does not imply a separately deployed MetaHarness server.
+Without the fixed status tool, that panel reports degraded discovery.
+
+Example local deployment using the scoped bridge operations group:
+
+```ini
+# Set on the MCP bridge to expose the bounded status group.
+MCP_GROUP_OPERATIONS=true
+
+# Set on the Chat UI server. Replace the example host with your deployed bridge.
+WORKSPACE_RUFLO_MCP_URL=http://mcp-bridge:3001/mcp/operations
+```
+
+Use HTTPS across hosts or untrusted networks. Supply credentials through the
+private token variables. URLs containing credentials, query strings or fragments
+are rejected. There is no implicit connection to a production host, localhost,
+user configured chat MCP server, or arbitrary URL. Existing `MCP_SERVERS` entries
+are not automatically promoted into administrative workspace sources.
+
+## What is observed
+
+The MCP adapter uses the installed MCP SDK to initialize and enumerate registered
+tools. It supports JSON and SSE responses to Streamable HTTP POST requests. It
+does not open a persistent background subscription or fall back to legacy SSE
+endpoints. Exact fixed read calls are made only when discovered:
+
+| Integration        | Accepted tool                             | Fixed arguments             |
+| ------------------ | ----------------------------------------- | --------------------------- |
+| Ruflo              | `system_status` or `ruflo__system_status` | `{ "verbose": false }`      |
+| Ruflo              | `policy_status` or `ruflo__policy_status` | `{}`                        |
+| MetaHarness        | `metaharness_flywheel`                    | `{ "operation": "status" }` |
+| MetaHarness bridge | `ruflo__metaharness_flywheel_status`      | `{}`                        |
+| Autogenous adapter | `tools/list` discovery only               | No tool execution           |
+
+The bridge operations group includes policy and flywheel status. System status
+requires a configured endpoint that also exposes the devtools group. A source
+without a supported status tool stays clearly labeled as discovery only. No
+candidate run, promotion, reset, arbitrary command, arbitrary tool call, or user
+supplied argument is accepted by the workspace adapter. The upstream runtime may
+maintain its own protocol sessions or status bookkeeping; no change to its
+policy, workload, champion, or safety envelope is requested.
+
+Ruflo output contains reported system state and process uptime, policy mode,
+policy rule/receipt counts, and policy ledger validity when exposed. The source's
+own unknown component health is not upgraded into a healthy claim. MetaHarness
+output contains promotion ledger validity, commit count, serving epoch, and
+receipt count. `success: false`, `degraded: true`, and invalid ledgers remain
+degraded. A valid ledger does not prove evaluation quality, promotion authority,
+or that a champion is currently serving.
+
+The bridge may wrap its stdio MCP response inside a second HTTP MCP text
+envelope. Observation unwraps at most three envelopes and checks `isError`,
+`success`, `degraded`, and `exitCode` at every layer. A failure at any layer is
+never overridden by a successful inner payload. If both text and structured
+representations are provided, both must be valid and agree. Excess nesting or
+contradictory representations report degraded status.
+
+ruOS observation uses the actual `GET /api/v1/server/health` contract:
+
+```json
+{
+	"ok": true,
+	"services": {
+		"rustdesk-hbbs": "active",
+		"rustdesk-hbbr": "active"
+	}
+}
+```
+
+It reports only rendezvous service health. Both services must report `active` and
+`ok` must be true for availability. This does not measure workstation CPU, fleet
+readiness, or desktop connectivity. Upstream service errors are never forwarded.
+The implementation is bound to the [ruOS health producer at the inspected source
+revision](https://github.com/cognitum-one/ruos-desktop/blob/6a9be2514a20c63e570aff219944de9c38184c55/service/src/serve/health.rs).
+
+## Response contract and limits
+
+`WorkspaceSnapshot` in `src/lib/types/Workspace.ts` contains `schemaVersion: 1`,
+an observation completion timestamp, and four integrations in the order Ruflo,
+MetaHarness, Autogenous, ruOS. Each integration exposes:
+
+1. `id`, `name`, `state`, and a static normalized `summary`.
+2. `checkedAt` and `latencyMs`, both null if no network observation was attempted.
+3. `toolCount` only after a complete bounded MCP inventory was validated.
+4. An explicit allowlist of numeric or fixed enumeration `metrics`.
+5. `source.kind`, `source.label`, `source.configuredBy`, and `source.discoveryOnly`.
+
+| State            | Meaning                                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `not_configured` | No deployment endpoint is set; no network request occurs                                                                                 |
+| `available`      | The declared observation succeeded; discovery alone never establishes operational readiness                                              |
+| `degraded`       | Invalid configuration, unsuccessful HTTP response, unsupported/malformed/oversized result, rejected credentials, or reported degradation |
+| `unreachable`    | Network failure or the observation deadline elapsed                                                                                      |
+
+Each source has one five second deadline covering initialization, listing, status
+calls and response reads. Sources run concurrently. Each decoded response is
+limited to 256 KiB, the total per integration to 1 MiB, requests to twelve, pages
+to four, and tools to 1,024. Duplicate names and repeated cursors invalidate the
+inventory. A limit produces degraded output rather than a misleading complete
+count. Prefer a scoped MCP endpoint for a large registry.
+
+Only a completed observation is committed to the returned snapshot. Late
+responses are cancelled after the deadline, and a late reader cannot change a
+previously returned timeout result. Protocol cleanup does not extend the deadline.
+
+Redirects are rejected without a second request. Outbound requests use only the
+configured service credentials; browser cookies and user tokens are not forwarded.
+The response never contains raw URLs, upstream error text, prompts, tool
+descriptions, credential values, machine identifiers, ledger hashes, or policy
+documents. Responses use `Cache-Control: private, no-store`; cross origin browser
+requests and all query parameters are rejected before contacting a runtime.
+
+The deployment operator owns endpoint selection and network access. This adapter
+is not a tenant shared proxy. Use ordinary service egress controls to restrict
+the operator configured destinations. Workspace status is an observation, not
+authorization for subsequent actions.
+
+## Acceptance checks
+
+```bash
+npx vitest run src/lib/server/workspace --project server
+```
+
+Tests exercise the installed MCP client against protocol fixtures, JSON and SSE
+responses, fixed read calls, missing configuration, timeout and cancellation,
+decoded response bounds, malformed and duplicate inventory, failed status tools,
+redaction, redirect and credential handling, ruOS service health, and HTTP 401/403
+before observation. They do not claim a deployed production runtime was tested.
+
+For deployment acceptance, sign in as an administrator, configure the scoped
+bridge endpoint, and verify that changing the real policy status changes the
+observed policy mode. Disconnect the endpoint and confirm the next refresh shows
+unreachable with empty operational metrics. Sign in as an ordinary user and
+confirm `/api/workspace` returns 403 without issuing a runtime request.

--- a/ruflo/src/ruvocal/mcp-bridge/Dockerfile
+++ b/ruflo/src/ruvocal/mcp-bridge/Dockerfile
@@ -16,6 +16,7 @@ RUN npm install -g gemini-mcp-server || true
 RUN npm install -g @openai/codex || true
 
 COPY index.js ./
+COPY operations-tools.js ./
 COPY mcp-stdio-kernel.js ./
 
 # Create writable directories for MCP backends (ruflo, ruvector, agentic-flow)
@@ -43,5 +44,6 @@ ENV MCP_GROUP_AGENTIC_FLOW=false
 ENV MCP_GROUP_CLAUDE_CODE=false
 ENV MCP_GROUP_GEMINI=false
 ENV MCP_GROUP_CODEX=false
+ENV MCP_GROUP_OPERATIONS=false
 
 CMD ["node", "index.js"]

--- a/ruflo/src/ruvocal/mcp-bridge/index.js
+++ b/ruflo/src/ruvocal/mcp-bridge/index.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { spawn } from "child_process";
 import { randomUUID, timingSafeEqual } from "crypto";
+import { createOperationsGroup, toolMatchesGroup, projectBackendTools, backendInvocation } from "./operations-tools.js";
 
 // =============================================================================
 // CONFIGURATION
@@ -21,6 +22,8 @@ const BIND_HOST = process.env.MCP_BIND_HOST || "127.0.0.1";
 // Each group can be toggled via env var. The AI sees only enabled tools.
 
 const TOOL_GROUPS = {
+  // ADR-042: explicit read-only additions; never expose a metaharness_ wildcard.
+  operations: createOperationsGroup(),
   // --- Core (always on, built-in) ---
   core: {
     enabled: true, // cannot be disabled
@@ -258,7 +261,7 @@ class StdioMcpClient {
 
 const BACKEND_DEFS = [
   { name: "ruvector",       command: "npx", args: ["-y", "ruvector", "mcp", "start"],   groups: ["intelligence"] },
-  { name: "ruflo",          command: "npx", args: ["-y", "ruflo", "mcp", "start"],      groups: ["agents", "memory", "devtools", "security", "browser", "neural"] },
+  { name: "ruflo",          command: "npx", args: ["-y", "ruflo", "mcp", "start"],      groups: ["agents", "memory", "devtools", "security", "browser", "neural", "operations"] },
   { name: "agentic-flow",   command: "npx", args: ["-y", "agentic-flow@alpha", "mcp", "start"], groups: ["agentic-flow"] },
   { name: "claude",         command: "claude", args: ["mcp", "serve"],                  groups: ["claude-code"] },
   { name: "gemini-mcp",     command: "npx", args: ["-y", "gemini-mcp-server"],          groups: ["gemini"] },
@@ -279,19 +282,15 @@ function filterToolsByGroups(tools, backendName) {
 
   if (enabledGroups.length === 0) return [];
 
-  // If any enabled group has no prefixes defined, include all tools from that backend
-  const hasWildcard = enabledGroups.some(([, g]) => !g.prefixes);
-  if (hasWildcard) return tools;
-
-  const enabledPrefixes = enabledGroups.flatMap(([, g]) => g.prefixes || []);
-  return tools.filter(t => enabledPrefixes.some(p => t._originalName.startsWith(p)));
+  return tools.filter(tool => enabledGroups.some(([, group]) => toolMatchesGroup(tool, group)));
 }
 
 // Get the final filtered tool list with namespaced names
 function getActiveTools() {
   const filtered = [];
   for (const [backendName, client] of mcpBackends) {
-    const accepted = filterToolsByGroups(client.tools, backendName);
+    if (!client.ready) continue;
+    const accepted = filterToolsByGroups(projectBackendTools(client.tools, backendName), backendName);
     for (const t of accepted) {
       filtered.push({ ...t, name: `${backendName}__${t._originalName}` });
     }
@@ -391,7 +390,7 @@ You have access to ${BUILTIN_TOOLS.length + externalTools.length} tools organize
 
 ## Active Groups
 ${activeGroups.map(([name, g]) => {
-  const count = name === "core" ? BUILTIN_TOOLS.length : externalTools.filter(t => t.name.startsWith(g.source + "__")).length;
+  const count = getToolsForGroup(name).length;
   return `- **${name}** (${count} tools) — ${g.description}`;
 }).join("\n")}
 
@@ -419,11 +418,7 @@ ${inactiveGroups.map(([name, g]) => `- **${name}** — ${g.description}`).join("
   if (topic === "groups") {
     const groupList = Object.entries(TOOL_GROUPS).map(([name, g]) => {
       const status = g.enabled ? "ACTIVE" : "INACTIVE";
-      const toolCount = name === "core" ? BUILTIN_TOOLS.length :
-        externalTools.filter(t => {
-          const backend = t._backend;
-          return g.source === backend && (!g.prefixes || g.prefixes.some(p => t._originalName.startsWith(p)));
-        }).length;
+      const toolCount = getToolsForGroup(name).length;
       return `| ${name} | ${status} | ${toolCount} | ${g.description} |`;
     });
 
@@ -957,7 +952,14 @@ function isTerminalTool(name) {
 }
 const MCP_ENABLE_TERMINAL = process.env.MCP_ENABLE_TERMINAL === "true";
 
-async function executeTool(name, args) {
+async function executeTool(name, args, groupName) {
+  // The same visibility gate covers group endpoints, catch-all calls, and autopilot.
+  const visible = groupName === undefined
+    ? [...BUILTIN_TOOLS, ...getActiveTools()]
+    : getToolsForGroup(groupName);
+  if (!visible.some(tool => tool.name === name)) {
+    return { error: `Tool "${name}" is not available on this endpoint`, code: "TOOL_NOT_ALLOWED" };
+  }
   // Deny dangerous tools unless the operator explicitly opted in.
   // Enforced on every path (not just autopilot) — root cause of ADR-166 V2/V3.
   if (isTerminalTool(name) && !MCP_ENABLE_TERMINAL) {
@@ -1006,7 +1008,15 @@ async function executeTool(name, args) {
       const extTool = activeTools.find(t => t.name === name);
       if (extTool) {
         const backend = mcpBackends.get(extTool._backend);
-        if (backend) return backend.callTool(extTool._originalName, args);
+        if (backend) {
+          let invocation;
+          try {
+            invocation = backendInvocation(extTool, args);
+          } catch (error) {
+            return { error: error.message, code: "INVALID_TOOL_ARGUMENTS" };
+          }
+          return backend.callTool(invocation.name, invocation.arguments);
+        }
         return { error: `Backend ${extTool._backend} not available` };
       }
       return { error: `Unknown tool: ${name}. Call 'guidance' with topic='groups' to see available tools.` };
@@ -1025,17 +1035,12 @@ function getToolsForGroup(groupName) {
   if (groupName === "core") return BUILTIN_TOOLS;
 
   const allActive = getActiveTools();
-  if (!group.prefixes) {
-    // No prefix filter — return all tools from this backend
-    return allActive.filter(t => t._backend === group.source);
-  }
-  return allActive.filter(t =>
-    t._backend === group.source && group.prefixes.some(p => t._originalName.startsWith(p))
-  );
+  return allActive.filter(tool => toolMatchesGroup(tool, group));
 }
 
 // Group display names for the Chat UI
 const GROUP_DISPLAY_NAMES = {
+  operations: "Operations & Governance",
   core: "Core Tools",
   intelligence: "Intelligence & Learning",
   agents: "Agents & Orchestration",
@@ -1129,10 +1134,11 @@ function createMcpHandler(groupName) {
         }
         case "tools/call": {
           const { name, arguments: toolArgs } = params;
-          const result = await executeTool(name, toolArgs || {});
+          const result = await executeTool(name, toolArgs ?? {}, groupName);
           return res.json({
             jsonrpc: "2.0", id,
             result: {
+              isError: Boolean(result?.error || result?.isError),
               content: [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result, null, 2) }],
             },
           });
@@ -1188,10 +1194,11 @@ app.post("/mcp", async (req, res) => {
       }
       case "tools/call": {
         const { name, arguments: toolArgs } = params;
-        const result = await executeTool(name, toolArgs || {});
+        const result = await executeTool(name, toolArgs ?? {});
         return res.json({
           jsonrpc: "2.0", id,
           result: {
+            isError: Boolean(result?.error || result?.isError),
             content: [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result, null, 2) }],
           },
         });
@@ -1935,15 +1942,9 @@ app.get("/health", (_, res) => {
 
 // GET /groups — list tool groups and their status
 app.get("/groups", (_, res) => {
-  const activeTools = getActiveTools();
   const result = {};
   for (const [name, g] of Object.entries(TOOL_GROUPS)) {
-    const tools = name === "core" ? BUILTIN_TOOLS :
-      activeTools.filter(t => {
-        if (g.source !== t._backend) return false;
-        if (!g.prefixes) return true;
-        return g.prefixes.some(p => t._originalName.startsWith(p));
-      });
+    const tools = getToolsForGroup(name);
     result[name] = {
       enabled: g.enabled,
       description: g.description,
@@ -1967,8 +1968,8 @@ async function main() {
     );
     process.exit(1);
   }
-  app.listen(PORT, BIND_HOST, () => {
-    console.log(`MCP Bridge v2.0.0 on port ${PORT} (${BIND_HOST})`);
+  const server = app.listen(PORT, BIND_HOST, () => {
+    console.log(`MCP Bridge v2.0.0 on port ${server.address().port} (${BIND_HOST})`);
     const enabled = Object.entries(TOOL_GROUPS).filter(([, g]) => g.enabled).map(([n]) => n);
     console.log(`Active groups: ${enabled.join(", ")}`);
     // ADR-166 §6 — startup posture banner (helps operators see the security state at boot)

--- a/ruflo/src/ruvocal/mcp-bridge/operations-tools.js
+++ b/ruflo/src/ruvocal/mcp-bridge/operations-tools.js
@@ -1,0 +1,97 @@
+/** ADR-042: opt-in, exact-name inspection surface. No mutation family prefixes. */
+export const OPERATIONS_TOOL_NAMES = Object.freeze([
+  "mcp_status",
+  "managed_agent_list",
+  "managed_agent_status",
+  "autopilot_status",
+  "policy_status",
+  "ruvllm_status",
+  "metaharness_flywheel_status",
+]);
+
+export function createOperationsGroup(env = process.env) {
+  return {
+    enabled: env.MCP_GROUP_OPERATIONS === "true",
+    description: "Read-only runtime, managed-agent, policy, and evolution status",
+    source: "ruflo",
+    exactNames: OPERATIONS_TOOL_NAMES,
+  };
+}
+
+/** A missing selector retains legacy wildcard behavior; an empty selector does not. */
+export function toolMatchesGroup(tool, group) {
+  if (!group?.enabled || tool._backend !== group.source) return false;
+  if (group.exactNames?.includes(tool._originalName)) return true;
+  if (group.prefixes?.some(prefix => tool._originalName.startsWith(prefix))) return true;
+  return group.exactNames === undefined && group.prefixes === undefined;
+}
+
+const EMPTY_INPUT = { type: "object", properties: {}, additionalProperties: false };
+
+function operationSchema(name) {
+  if (name === "managed_agent_list") {
+    return {
+      type: "object",
+      properties: { limit: { type: "integer", minimum: 1, maximum: 200 } },
+      additionalProperties: false,
+    };
+  }
+  if (name === "managed_agent_status") {
+    return {
+      type: "object",
+      properties: { sessionId: { type: "string", minLength: 1, maxLength: 256 } },
+      required: ["sessionId"],
+      additionalProperties: false,
+    };
+  }
+  return { ...EMPTY_INPUT };
+}
+
+/** Only synthesize the wrapper when the real upstream tool was discovered. */
+export function projectBackendTools(tools, backendName) {
+  if (backendName !== "ruflo") return tools;
+  const projected = tools
+    .filter(tool => tool._originalName !== "metaharness_flywheel_status")
+    .map(tool => OPERATIONS_TOOL_NAMES.includes(tool._originalName)
+      ? { ...tool, inputSchema: operationSchema(tool._originalName) }
+      : tool);
+  if (tools.some(tool => tool._originalName === "metaharness_flywheel")) {
+    projected.push({
+      name: "metaharness_flywheel_status",
+      _originalName: "metaharness_flywheel_status",
+      _backend: "ruflo",
+      description: "Inspect the current project's MetaHarness evolution state and receipt-ledger integrity. Accepts no arguments; never runs or promotes a candidate.",
+      inputSchema: operationSchema("metaharness_flywheel_status"),
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    });
+  }
+  return projected;
+}
+
+/** Revalidate in the common executor; discovery schemas alone are not authorization. */
+export function backendInvocation(tool, args) {
+  const name = tool._originalName;
+  if (tool._backend !== "ruflo" || !OPERATIONS_TOOL_NAMES.includes(name)) {
+    return { name, arguments: args };
+  }
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    throw new Error("Operations tool arguments must be an object");
+  }
+  const allowed = name === "managed_agent_list" ? ["limit"]
+    : name === "managed_agent_status" ? ["sessionId"] : [];
+  if (Object.keys(args).some(key => !allowed.includes(key))) {
+    throw new Error("Unsupported operations tool argument");
+  }
+  if (name === "managed_agent_list" && args.limit !== undefined &&
+      (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 200)) {
+    throw new Error("limit must be an integer from 1 to 200");
+  }
+  if (name === "managed_agent_status" &&
+      (typeof args.sessionId !== "string" || !args.sessionId.trim() || args.sessionId.length > 256)) {
+    throw new Error("sessionId must be a nonempty string of at most 256 characters");
+  }
+  if (name === "metaharness_flywheel_status") {
+    return { name: "metaharness_flywheel", arguments: { operation: "status" } };
+  }
+  return { name, arguments: { ...args } };
+}

--- a/ruflo/src/ruvocal/mcp-bridge/operations-tools.test.js
+++ b/ruflo/src/ruvocal/mcp-bridge/operations-tools.test.js
@@ -1,0 +1,175 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, writeFile, chmod, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { OPERATIONS_TOOL_NAMES, createOperationsGroup, toolMatchesGroup, projectBackendTools, backendInvocation } from "./operations-tools.js";
+
+const bridgeRoot = dirname(fileURLToPath(import.meta.url));
+const fixtureNames = [
+  ...OPERATIONS_TOOL_NAMES.filter(name => name !== "metaharness_flywheel_status"),
+  "metaharness_flywheel", "metaharness_evolve", "policy_approve", "managed_agent_terminate",
+  "autopilot_enable", "ruvllm_generate", "mcp_status_evil", "agent_list",
+];
+const fixtureTools = fixtureNames.map(name => ({
+  name, _originalName: name, _backend: "ruflo", inputSchema: { type: "object" },
+}));
+
+test("operations require the exact operator opt-in and match only seven names", () => {
+  const projected = projectBackendTools(fixtureTools, "ruflo");
+  for (const value of [undefined, "false", "1", "TRUE", "true "]) {
+    assert.equal(projected.filter(tool => toolMatchesGroup(tool, createOperationsGroup({ MCP_GROUP_OPERATIONS: value }))).length, 0);
+  }
+  const group = createOperationsGroup({ MCP_GROUP_OPERATIONS: "true" });
+  assert.deepEqual(projected.filter(tool => toolMatchesGroup(tool, group)).map(tool => tool._originalName).sort(), [...OPERATIONS_TOOL_NAMES].sort());
+  assert.equal(toolMatchesGroup({ ...projected[0], _backend: "untrusted" }, group), false);
+});
+
+test("exact-name selection never becomes wildcard and preserves legacy prefixes", () => {
+  const tool = fixtureTools[0];
+  assert.equal(toolMatchesGroup(tool, { enabled: true, source: "ruflo", exactNames: [] }), false);
+  assert.equal(toolMatchesGroup(tool, { enabled: true, source: "ruflo", prefixes: [] }), false);
+  assert.equal(toolMatchesGroup(tool, { enabled: true, source: "ruflo" }), true);
+  assert.equal(toolMatchesGroup(tool, { enabled: true, source: "ruflo", prefixes: ["mcp_"] }), true);
+});
+
+test("flywheel wrapper requires upstream discovery and ignores forged alias metadata", () => {
+  assert.equal(projectBackendTools([], "ruflo").length, 0);
+  assert.equal(projectBackendTools([{ ...fixtureTools[0], _originalName: "metaharness_flywheel_status" }], "ruflo").length, 0);
+  const alias = projectBackendTools(fixtureTools, "ruflo").find(tool => tool._originalName === "metaharness_flywheel_status");
+  assert.deepEqual(alias.inputSchema, { type: "object", properties: {}, additionalProperties: false });
+  assert.deepEqual(backendInvocation(alias, {}), { name: "metaharness_flywheel", arguments: { operation: "status" } });
+  for (const args of [null, [], "status", { operation: "status" }, { operation: "run" }, { operation: "promote", confirm: true }, { projectRoot: "/tmp/other" }, { publicKeyPath: "key.pem" }, { approvalIds: ["approval"] }]) {
+    assert.throws(() => backendInvocation(alias, args));
+  }
+});
+
+test("other operations retain bounded read inputs", () => {
+  const tool = name => fixtureTools.find(item => item._originalName === name);
+  assert.deepEqual(backendInvocation(tool("managed_agent_list"), { limit: 20 }).arguments, { limit: 20 });
+  for (const limit of [0, 201, 1.2, Infinity, "10"]) assert.throws(() => backendInvocation(tool("managed_agent_list"), { limit }));
+  assert.deepEqual(backendInvocation(tool("managed_agent_status"), { sessionId: "session_1" }).arguments, { sessionId: "session_1" });
+  for (const args of [{}, { sessionId: " " }, { sessionId: "x".repeat(257) }, { sessionId: "session_1", terminate: true }]) assert.throws(() => backendInvocation(tool("managed_agent_status"), args));
+  for (const name of ["mcp_status", "autopilot_status", "policy_status", "ruvllm_status"]) {
+    assert.throws(() => backendInvocation(tool(name), { operation: "run" }));
+    assert.deepEqual(backendInvocation(tool(name), {}).arguments, {});
+  }
+});
+
+async function startFixture(t, operationsEnabled) {
+  const directory = await mkdtemp(join(tmpdir(), "ruflo-operations-test-"));
+  const command = join(directory, "npx");
+  const logPath = join(directory, "calls.jsonl");
+  const script = `#!${process.execPath}
+const { createInterface } = require('node:readline');
+const { appendFileSync } = require('node:fs');
+const names = ${JSON.stringify(fixtureNames)};
+createInterface({input:process.stdin}).on('line', line => {
+  const m = JSON.parse(line);
+  if (!m.id) return;
+  let result = {};
+  if (m.method === 'initialize') result = {protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'fixture',version:'1'}};
+  if (m.method === 'tools/list') result = {tools:names.map(name=>({name,inputSchema:{type:'object'}}))};
+  if (m.method === 'tools/call') {
+    appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(m.params)+'\\n');
+    result = {observed:m.params};
+  }
+  process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:m.id,result})+'\\n');
+});
+`;
+  await writeFile(command, script);
+  await chmod(command, 0o755);
+  const env = {
+    PATH: `${directory}:${process.env.PATH}`,
+    PORT: "0", MCP_BIND_HOST: "127.0.0.1", MCP_AUTH_TOKEN: "local-test-token",
+    MCP_GROUP_OPERATIONS: operationsEnabled ? "true" : "false",
+  };
+  for (const group of ["INTELLIGENCE", "AGENTS", "MEMORY", "DEVTOOLS", "SECURITY", "BROWSER", "NEURAL", "AGENTIC_FLOW", "CLAUDE_CODE", "GEMINI", "CODEX"]) env[`MCP_GROUP_${group}`] = "false";
+  const child = spawn(process.execPath, [join(bridgeRoot, "index.js")], { cwd: directory, env, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  child.stdout.on("data", bytes => { output += bytes; });
+  child.stderr.on("data", bytes => { output += bytes; });
+  t.after(async () => {
+    if (child.exitCode === null) {
+      const exited = once(child, "exit");
+      child.kill("SIGTERM");
+      await exited;
+    }
+    await rm(directory, { recursive: true, force: true });
+  });
+  const until = Date.now() + 10_000;
+  let port;
+  while (Date.now() < until) {
+    if (child.exitCode !== null) throw new Error(`Bridge exited: ${output}`);
+    port = /on port (\d+)/.exec(output)?.[1];
+    if (port && (!operationsEnabled || output.includes("tools loaded"))) break;
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  assert.ok(port, `Bridge did not listen: ${output}`);
+  if (operationsEnabled) assert.match(output, /tools loaded/);
+  const request = async (path, body) => {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: body ? "POST" : "GET",
+      headers: { Authorization: "Bearer local-test-token", "Content-Type": "application/json" },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.json();
+  };
+  return {
+    request,
+    rpc: (path, method, params = {}) => request(path, { jsonrpc: "2.0", id: 1, method, params }),
+    calls: async () => {
+      try { return (await readFile(logPath, "utf8")).trim().split("\n").filter(Boolean).map(JSON.parse); }
+      catch (error) { if (error.code === "ENOENT") return []; throw error; }
+    },
+  };
+}
+
+test("HTTP endpoints hide operations by default and reject direct calls", { timeout: 15000 }, async t => {
+  const bridge = await startFixture(t, false);
+  assert.equal((await bridge.request("/groups")).operations.enabled, false);
+  assert.equal((await bridge.request("/mcp-servers")).some(server => server.group === "operations"), false);
+  assert.deepEqual((await bridge.rpc("/mcp/operations", "tools/list")).result.tools, []);
+  assert.equal((await bridge.rpc("/mcp", "tools/list")).result.tools.some(tool => tool.name.startsWith("ruflo__")), false);
+  for (const endpoint of ["/mcp", "/mcp/operations", "/mcp/core"]) {
+    const result = await bridge.rpc(endpoint, "tools/call", { name: "ruflo__policy_status", arguments: {} });
+    assert.equal(result.result.isError, true);
+    assert.equal(JSON.parse(result.result.content[0].text).code, "TOOL_NOT_ALLOWED");
+  }
+  assert.deepEqual(await bridge.calls(), []);
+});
+
+test("HTTP discovery and execution expose only bounded read operations", { timeout: 15000 }, async t => {
+  const bridge = await startFixture(t, true);
+  const tools = (await bridge.rpc("/mcp/operations", "tools/list")).result.tools;
+  assert.deepEqual(tools.map(tool => tool.name).sort(), OPERATIONS_TOOL_NAMES.map(name => `ruflo__${name}`).sort());
+  assert.equal((await bridge.request("/groups")).operations.tools, 7);
+  assert.equal((await bridge.request("/mcp-servers")).find(server => server.group === "operations").tools, 7);
+  assert.equal((await bridge.rpc("/mcp", "tools/list")).result.tools.filter(tool => tool.name.startsWith("ruflo__")).length, 7);
+  for (const endpoint of ["/mcp", "/mcp/operations"]) {
+    for (const name of ["ruflo__metaharness_flywheel", "ruflo__metaharness_evolve", "ruflo__policy_approve", "ruflo__managed_agent_terminate", "ruflo__autopilot_enable", "ruflo__mcp_status_evil", "metaharness_flywheel_status"]) {
+      const result = await bridge.rpc(endpoint, "tools/call", { name, arguments: { operation: "run" } });
+      assert.equal(result.result.isError, true, name);
+    }
+    for (const args of [{ operation: "run" }, { operation: "promote", confirm: true }, { projectRoot: "/tmp/other" }, []]) {
+      const result = await bridge.rpc(endpoint, "tools/call", { name: "ruflo__metaharness_flywheel_status", arguments: args });
+      assert.equal(JSON.parse(result.result.content[0].text).code, "INVALID_TOOL_ARGUMENTS");
+    }
+  }
+  const outsideGroup = await bridge.rpc("/mcp/core", "tools/call", { name: "ruflo__policy_status", arguments: {} });
+  assert.equal(outsideGroup.result.isError, true);
+  assert.deepEqual(await bridge.calls(), []);
+  for (const endpoint of ["/mcp", "/mcp/operations"]) {
+    const result = await bridge.rpc(endpoint, "tools/call", { name: "ruflo__metaharness_flywheel_status", arguments: {} });
+    assert.equal(result.result.isError, false);
+    assert.deepEqual(JSON.parse(result.result.content[0].text).observed, { name: "metaharness_flywheel", arguments: { operation: "status" } });
+  }
+  assert.deepEqual(await bridge.calls(), [
+    { name: "metaharness_flywheel", arguments: { operation: "status" } },
+    { name: "metaharness_flywheel", arguments: { operation: "status" } },
+  ]);
+});

--- a/ruflo/src/ruvocal/mcp-bridge/package.json
+++ b/ruflo/src/ruvocal/mcp-bridge/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "node --watch index.js"
+    "dev": "node --watch index.js",
+    "test": "node --test operations-tools.test.js"
   },
   "dependencies": {
     "express": "^4.21.0"

--- a/ruflo/src/ruvocal/mcp-bridge/test-harness.js
+++ b/ruflo/src/ruvocal/mcp-bridge/test-harness.js
@@ -100,10 +100,11 @@ async function testHealth() {
 async function testGroups() {
   console.log("\n── Groups Endpoint ──");
 
-  await test("GET /groups returns all 12 groups", async () => {
+  await test("GET /groups returns all 13 groups", async () => {
     const { data } = await fetchJSON("/groups");
     const names = Object.keys(data);
-    assert(names.length === 12, `got ${names.length} groups`);
+    assert(names.length === 13, `got ${names.length} groups`);
+    assert(names.includes("operations"), "missing operations");
     assert(names.includes("core"), "missing core");
     assert(names.includes("agents"), "missing agents");
     assert(names.includes("browser"), "missing browser");

--- a/ruflo/src/ruvocal/package.json
+++ b/ruflo/src/ruvocal/package.json
@@ -16,7 +16,9 @@
 		"updateLocalEnv": "vite-node --options.transformMode.ssr='/.*/' scripts/updateLocalEnv.ts",
 		"populate": "vite-node --options.transformMode.ssr='/.*/' scripts/populate.ts",
 		"config": "vite-node --options.transformMode.ssr='/.*/' scripts/config.ts",
-		"prepare": "husky"
+		"prepare": "husky",
+		"test:workspace": "vitest run src/lib/utils/workspace.spec.ts src/lib/utils/openWorkspaceDraft.spec.ts src/lib/components/workspace/workspace.ssr.test.ts src/lib/server/workspace src/lib/server/mcp/resolveHealthTarget.spec.ts",
+		"test:workspace:smoke": "node scripts/workspace-smoke.mjs"
 	},
 	"devDependencies": {
 		"@faker-js/faker": "^8.4.1",

--- a/ruflo/src/ruvocal/scripts/setups/vitest-setup-server.ts
+++ b/ruflo/src/ruvocal/scripts/setups/vitest-setup-server.ts
@@ -8,7 +8,7 @@ const envPath = resolve(__dirname, "../../.env");
 dotenv.config({ path: envPath });
 
 // Read the .env file content
-const envContent = fs.readFileSync(envPath, "utf-8");
+const envContent = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : "";
 
 // Parse the .env content
 const envVars = dotenv.parse(envContent);

--- a/ruflo/src/ruvocal/scripts/workspace-smoke.mjs
+++ b/ruflo/src/ruvocal/scripts/workspace-smoke.mjs
@@ -1,0 +1,98 @@
+/** Local deterministic HTTP acceptance test. Never contacts a production model or runtime. */
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import assert from "node:assert/strict";
+
+const fixture = http.createServer((request, response) => {
+	response.setHeader("Content-Type", "application/json");
+	if (request.url === "/v1/models") {
+		response.end(
+			JSON.stringify({
+				data: [
+					{ id: "validation-fixture", description: "Local acceptance fixture. No inference." },
+				],
+			})
+		);
+	} else {
+		response.writeHead(503);
+		response.end(JSON.stringify({ error: "No inference in acceptance fixtures" }));
+	}
+});
+fixture.listen(0, "127.0.0.1");
+await once(fixture, "listening");
+const modelPort = fixture.address().port;
+const reserve = http.createServer();
+reserve.listen(0, "127.0.0.1");
+await once(reserve, "listening");
+const appPort = reserve.address().port;
+await new Promise((resolve) => reserve.close(resolve));
+const origin = `http://127.0.0.1:${appPort}`;
+// Use a minimal environment: do not inherit operator/provider credentials or runtime URLs.
+const app = spawn(process.execPath, ["build/index.js"], {
+	env: {
+		PATH: process.env.PATH,
+		NODE_ENV: "production",
+		HOST: "127.0.0.1",
+		PORT: String(appPort),
+		ORIGIN: origin,
+		OPENAI_BASE_URL: `http://127.0.0.1:${modelPort}/v1`,
+		COOKIE_NAME: "workspace-smoke",
+		PUBLIC_APP_NAME: "RuFlo",
+		PUBLIC_APP_ASSETS: "chatui",
+		ALLOW_INSECURE_COOKIES: "true",
+		RVF_DB_PATH: `/tmp/ruflo-workspace-smoke-${process.pid}`,
+	},
+	stdio: ["ignore", "pipe", "pipe"],
+});
+let output = "";
+app.stdout.on("data", (chunk) => {
+	output = (output + chunk).slice(-12000);
+});
+app.stderr.on("data", (chunk) => {
+	output = (output + chunk).slice(-12000);
+});
+let checks = 0;
+try {
+	const deadline = Date.now() + 20000;
+	for (;;) {
+		if (app.exitCode !== null) throw new Error(`App exited ${app.exitCode}: ${output}`);
+		try {
+			const response = await fetch(`${origin}/healthcheck`);
+			if (response.ok) break;
+		} catch {}
+		if (Date.now() > deadline) throw new Error(`App did not become ready: ${output}`);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	for (const [route, marker] of [
+		["/workspace", "Intent into action."],
+		["/workspace?view=tools", "Find the right tool."],
+		["/workspace?view=runtimes", "Every connection has evidence."],
+		["/", "What will you build next?"],
+		["/models", "validation-fixture"],
+	]) {
+		const response = await fetch(origin + route);
+		const html = await response.text();
+		assert.equal(response.status, 200, `${route}: ${html.slice(0, 300)}`);
+		assert.ok(html.includes(marker), `${route}: missing ${marker}`);
+		checks++;
+	}
+	const denied = await fetch(`${origin}/api/workspace`);
+	assert.ok([401, 403].includes(denied.status));
+	checks++;
+	console.log(
+		JSON.stringify({
+			suite: "workspace-http-smoke",
+			checks,
+			passed: true,
+			fixture: "local model list only",
+			liveIntegrationsTested: false,
+		})
+	);
+} finally {
+	app.kill("SIGTERM");
+	await Promise.race([once(app, "exit"), new Promise((resolve) => setTimeout(resolve, 2000))]);
+	if (app.exitCode === null) app.kill("SIGKILL");
+	fixture.closeAllConnections();
+	await new Promise((resolve) => fixture.close(resolve));
+}

--- a/ruflo/src/ruvocal/src/lib/components/NavMenu.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/NavMenu.svelte
@@ -33,6 +33,7 @@
 	import IconPro from "$lib/components/icons/IconPro.svelte";
 	import MCPServerManager from "./mcp/MCPServerManager.svelte";
 	import RufloHelpModal from "./RufloHelpModal.svelte";
+	import WorkspaceNav from "./workspace/WorkspaceNav.svelte";
 
 	const publicConfig = usePublicConfig();
 	const client = useAPIClient();
@@ -160,6 +161,7 @@
 <div
 	class="scrollbar-custom flex touch-pan-y flex-col gap-1 overflow-y-auto rounded-r-xl border border-l-0 border-gray-100 from-gray-50 px-3 pb-3 pt-2 text-[.9rem] dark:border-transparent dark:from-gray-800/30 max-sm:bg-gradient-to-t md:bg-gradient-to-l"
 >
+	<WorkspaceNav />
 	<div class="flex flex-col gap-0.5">
 		{#each Object.entries(groupedConversations) as [group, convs]}
 			{#if convs.length}

--- a/ruflo/src/ruvocal/src/lib/components/WelcomeModal.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/WelcomeModal.svelte
@@ -1,46 +1,78 @@
 <script lang="ts">
 	import Modal from "$lib/components/Modal.svelte";
-	import RuFloUniverse from "$lib/components/RuFloUniverse.svelte";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
-
+	import IconLayers from "~icons/lucide/layers";
 	const publicConfig = usePublicConfig();
-
-	interface Props {
-		close: () => void;
-	}
-
-	let { close }: Props = $props();
+	let { close }: { close: () => void } = $props();
 </script>
 
-<Modal closeOnBackdrop={false} onclose={close} width="!max-w-[420px] !m-4">
-	<div
-		class="flex w-full flex-col gap-8 bg-white bg-gradient-to-b to-transparent px-6 pb-7 dark:bg-black dark:from-white/10 dark:to-white/5"
-	>
-		<div class="relative -mx-6 h-48 select-none overflow-hidden">
-			<RuFloUniverse width={420} height={192} />
-			<div
-				class="absolute bottom-3 right-3 rounded-lg border border-indigo-500/30 bg-indigo-500/20 px-2 py-0.5 text-sm font-semibold text-indigo-400"
-			>
-				MCP Tools
-			</div>
-		</div>
-
-		<div class="text-gray-700 dark:text-gray-200">
-			<p class="text-[15px] leading-relaxed">
-				Welcome to <strong>{publicConfig.PUBLIC_APP_NAME}</strong>, your intelligent workflow
-				automation assistant.
-			</p>
-			<p class="mt-3 text-[15px] leading-relaxed">
-				Powered by AI models with MCP tool integration for search, analysis, and workflow
-				execution.
-			</p>
-		</div>
-
-		<button
-			class="k w-full rounded-xl bg-indigo-600 px-5 py-2.5 text-base font-medium text-white hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600"
-			onclick={close}
-		>
-			Start chatting
-		</button>
+<Modal closeOnBackdrop={false} onclose={close} width="!max-w-[440px] !m-4">
+	<div class="welcome-workspace">
+		<div class="welcome-symbol"><IconLayers /></div>
+		<p class="welcome-label">YOUR AGENT WORKSPACE</p>
+		<h1>Welcome to {publicConfig.PUBLIC_APP_NAME || "RuFlo"}.</h1>
+		<p>
+			Chat with your models, discover MCP tools, and shape a mission with clear acceptance tests.
+		</p>
+		<p class="welcome-detail">
+			The workspace shows observed connections. Runtime actions still require the permissions
+			configured by your operator.
+		</p>
+		<button onclick={close}>Open RuFlo</button>
 	</div>
 </Modal>
+
+<style>
+	.welcome-workspace {
+		padding: 2rem;
+		color: var(--ws-text);
+		background: var(--ws-panel);
+	}
+	.welcome-symbol {
+		width: 48px;
+		height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--ws-accent-text);
+		border-radius: 0.8rem;
+		background: var(--ws-accent-soft);
+		margin-bottom: 1.75rem;
+	}
+	.welcome-label {
+		font-size: 0.75rem;
+		letter-spacing: 0.12em;
+		color: var(--ws-accent-text);
+		font-weight: 600;
+		margin-bottom: 0.6rem;
+	}
+	h1 {
+		font-size: 1.8rem;
+		font-weight: 600;
+		letter-spacing: -0.04em;
+		line-height: 1.15;
+		margin-bottom: 1rem;
+	}
+	p {
+		font-size: 1rem;
+		line-height: 1.7;
+		color: var(--ws-muted);
+	}
+	.welcome-detail {
+		font-size: 0.875rem;
+		margin-top: 1rem;
+	}
+	button {
+		width: 100%;
+		min-height: 48px;
+		background: var(--ws-accent);
+		color: #06261e;
+		border-radius: 0.6rem;
+		margin-top: 1.5rem;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+	:global(:root:not(.dark)) button {
+		color: #fff;
+	}
+</style>

--- a/ruflo/src/ruvocal/src/lib/components/chat/ChatIntroduction.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/chat/ChatIntroduction.svelte
@@ -1,123 +1,172 @@
 <script lang="ts">
-	import Logo from "$lib/components/icons/Logo.svelte";
+	import { base } from "$app/paths";
 	import type { Model } from "$lib/types/Model";
 	import { usePublicConfig } from "$lib/utils/PublicConfig.svelte";
-
+	import { missionPresets } from "$lib/utils/workspace";
+	import IconArrow from "~icons/lucide/arrow-up-right";
+	import IconSparkles from "~icons/lucide/sparkles";
 	const publicConfig = usePublicConfig();
-
 	interface Props {
 		currentModel: Model;
 		onmessage?: (content: string) => void;
 	}
-
-	let { currentModel: _currentModel, onmessage }: Props = $props();
-
-	$effect(() => {
-		// referenced to appease linter while UI blocks are commented out
-		void _currentModel;
-		void onmessage;
-	});
+	let { currentModel, onmessage }: Props = $props();
 </script>
 
-<div class="my-auto grid items-center justify-center gap-8 text-center">
-	<div
-		class="relative flex -translate-y-16 select-none items-center rounded-xl text-3xl font-semibold md:-translate-y-12 md:text-5xl"
-	>
-		<Logo classNames="size-12 md:size-20 mr-0.5" />
-		{publicConfig.PUBLIC_APP_NAME}
-		<!-- Quantum dots floating over "lo" -->
-		<span class="pointer-events-none absolute right-[-4px] top-[-2px] flex gap-[4px] md:right-[-6px] md:top-[-4px] md:gap-[5px]">
-			<span class="quantum-dot qd1"></span>
-			<span class="quantum-dot qd2"></span>
-			<span class="quantum-dot qd3"></span>
-		</span>
+<section class="chat-launch">
+	<div class="launch-label">
+		<span class="launch-mark"><IconSparkles /></span>{publicConfig.PUBLIC_APP_NAME || "RuFlo"}<span
+			class="launch-separator">/</span
+		>Chat
 	</div>
-	<!-- <div class="lg:col-span-1">
-		<div>
-			<div class="mb-3 flex items-center text-2xl font-semibold">
-				<Logo classNames="mr-1 flex-none" />
-				{publicConfig.PUBLIC_APP_NAME}
-				<div
-					class="ml-3 flex h-6 items-center rounded-lg border border-gray-100 bg-gray-50 px-2 text-base text-gray-400 dark:border-gray-700/60 dark:bg-gray-800"
-				>
-					{publicConfig.PUBLIC_VERSION}
-				</div>
-			</div>
-			<p class="text-base text-gray-600 dark:text-gray-400">
-				{publicConfig.PUBLIC_APP_DESCRIPTION ||
-					"Making the community's best AI chat models available to everyone."}
-			</p>
-		</div>
-	</div>
-	<div class="lg:col-span-2 lg:pl-24">
-		{#each JSON5.parse(publicConfig.PUBLIC_ANNOUNCEMENT_BANNERS || "[]") as banner}
-			<AnnouncementBanner classNames="mb-4" title={banner.title}>
-				<a
-					target={banner.external ? "_blank" : "_self"}
-					href={banner.linkHref}
-					class="mr-2 flex items-center underline hover:no-underline">{banner.linkTitle}</a
-				>
-			</AnnouncementBanner>
+	<h1>What will you build next?</h1>
+	<p>Think it through. Bring your tools. Turn a clear goal into a verifiable result.</p>
+	<div class="launch-presets">
+		{#each missionPresets as preset}
+			<button onclick={() => onmessage?.(preset.objective)}
+				><strong>{preset.title}</strong><span>{preset.detail}</span><IconArrow /></button
+			>
 		{/each}
-		<div class="overflow-hidden rounded-xl border dark:border-gray-800">
-			<div class="flex p-3">
-				<div>
-					<div class="text-sm text-gray-600 dark:text-gray-400">Current Model</div>
-					<div class="flex items-center gap-1.5 font-semibold max-sm:text-smd">
-						{#if currentModel.logoUrl}
-							<img
-								class="aspect-square size-4 rounded border bg-white dark:border-gray-700"
-								src={currentModel.logoUrl}
-								alt=""
-							/>
-						{:else}
-							<div
-								class="size-4 rounded border border-transparent bg-gray-300 dark:bg-gray-800"
-							></div>
-						{/if}
-						{currentModel.displayName}
-					</div>
-				</div>
-				<a
-					href="{base}/settings/{currentModel.id}"
-					aria-label="Settings"
-					class="btn ml-auto flex h-7 w-7 self-start rounded-full bg-gray-100 p-1 text-xs hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-600"
-					><IconGear /></a
-				>
-			</div>
-			<ModelCardMetadata variant="dark" model={currentModel} />
-		</div>
 	</div>
-	<div class="h-40 sm:h-24"></div> -->
-</div>
+	<div class="launch-footer">
+		<span>Model: {currentModel.displayName || currentModel.name}</span><a href={`${base}/workspace`}
+			>Open workspace <IconArrow /></a
+		>
+	</div>
+</section>
 
 <style>
-	.quantum-dot {
-		display: block;
-		width: 5px;
-		height: 5px;
-		border-radius: 50%;
+	.chat-launch {
+		margin: auto 0;
+		padding: 2rem 0 15rem;
+		width: 100%;
+		text-align: left;
+		color: var(--ws-text);
 	}
-	@media (min-width: 768px) {
-		.quantum-dot {
-			width: 7px;
-			height: 7px;
+	.launch-label {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+		font-size: 0.875rem;
+		color: var(--ws-muted);
+		margin-bottom: 1.75rem;
+	}
+	.launch-mark {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 34px;
+		width: 34px;
+		background: var(--ws-accent-soft);
+		border-radius: 0.6rem;
+		color: var(--ws-accent-text);
+	}
+	.launch-mark :global(svg) {
+		width: 18px;
+		height: 18px;
+	}
+	.launch-separator {
+		color: var(--ws-border);
+	}
+	h1 {
+		font-size: clamp(1.8rem, 3.2vw, 3rem);
+		font-weight: 550;
+		letter-spacing: -0.045em;
+		line-height: 1.15;
+		margin: 0 0 1rem;
+	}
+	.chat-launch > p {
+		color: var(--ws-muted);
+		font-size: 1rem;
+		line-height: 1.7;
+		max-width: 480px;
+	}
+	.launch-presets {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 0.75rem;
+		margin: 1.8rem 0;
+	}
+	.launch-presets button {
+		position: relative;
+		display: grid;
+		gap: 0.6rem;
+		padding: 1.1rem;
+		border: 1px solid var(--ws-border);
+		background: var(--ws-panel);
+		border-radius: 0.75rem;
+		text-align: left;
+		transition:
+			border-color 0.15s,
+			transform 0.15s;
+	}
+	.launch-presets button:hover {
+		border-color: var(--ws-accent);
+		transform: translateY(-2px);
+	}
+	.launch-presets button:focus-visible {
+		outline: 2px solid var(--ws-accent);
+		outline-offset: 3px;
+	}
+	.launch-presets strong {
+		font-size: 0.875rem;
+		font-weight: 600;
+		padding-right: 0.75rem;
+	}
+	.launch-presets span {
+		font-size: 0.875rem;
+		color: var(--ws-muted);
+		line-height: 1.5;
+	}
+	.launch-presets :global(svg) {
+		position: absolute;
+		top: 0.8rem;
+		right: 0.7rem;
+		width: 14px;
+		height: 14px;
+		color: var(--ws-muted);
+	}
+	.launch-footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		font-size: 0.875rem;
+		color: var(--ws-muted);
+	}
+	.launch-footer a {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		color: var(--ws-accent-text);
+		white-space: nowrap;
+	}
+	.launch-footer :global(svg) {
+		width: 16px;
+	}
+	@media (max-width: 640px) {
+		.chat-launch {
+			padding-top: 0.5rem;
+		}
+		.launch-label {
+			margin-bottom: 1.3rem;
+		}
+		.launch-presets {
+			grid-template-columns: 1fr;
+			gap: 0.5rem;
+			margin: 1.3rem 0;
+		}
+		.launch-presets button {
+			padding: 0.85rem 1rem;
+			gap: 0.3rem;
+		}
+		.launch-footer {
+			flex-wrap: wrap;
 		}
 	}
-	.qd1 {
-		background: #3b82f6;
-		animation: qdot 2.2s ease-in-out infinite;
-	}
-	.qd2 {
-		background: #818cf8;
-		animation: qdot 2.2s ease-in-out infinite 0.35s;
-	}
-	.qd3 {
-		background: #06b6d4;
-		animation: qdot 2.2s ease-in-out infinite 0.7s;
-	}
-	@keyframes qdot {
-		0%, 100% { transform: translateY(0); opacity: 0.4; }
-		50% { transform: translateY(-5px); opacity: 1; }
+	@media (prefers-reduced-motion: reduce) {
+		.launch-presets button {
+			transition: none;
+		}
 	}
 </style>

--- a/ruflo/src/ruvocal/src/lib/components/chat/ChatWindow.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/chat/ChatWindow.svelte
@@ -668,7 +668,7 @@
 				<ChatIntroduction
 					{currentModel}
 					onmessage={(content) => {
-						onmessage?.(content);
+						draft = content;
 					}}
 				/>
 			{/if}

--- a/ruflo/src/ruvocal/src/lib/components/workspace/CommandPalette.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/workspace/CommandPalette.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import { base } from "$app/paths";
+	import { Dialog } from "bits-ui";
+	import IconSearch from "~icons/lucide/search";
+	let { open = $bindable(false) }: { open?: boolean } = $props();
+	let query = $state("");
+	const commands = [
+		{
+			title: "Open workspace",
+			detail: "Draft a mission and resume work",
+			href: `${base}/workspace`,
+		},
+		{ title: "New chat", detail: "Chat with a configured model", href: `${base}/` },
+		{
+			title: "Explore tools",
+			detail: "Search discovered MCP capabilities",
+			href: `${base}/workspace?view=tools`,
+		},
+		{
+			title: "Runtime & learning",
+			detail: "Inspect integrations and evaluation gates",
+			href: `${base}/workspace?view=runtimes`,
+		},
+		{ title: "Choose a model", detail: "Available models and settings", href: `${base}/models` },
+		{
+			title: "Application settings",
+			detail: "Preferences and configuration",
+			href: `${base}/settings/application`,
+		},
+	];
+	const filtered = $derived(
+		commands.filter((command) =>
+			`${command.title} ${command.detail}`.toLowerCase().includes(query.trim().toLowerCase())
+		)
+	);
+	$effect(() => {
+		if (open) query = "";
+	});
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Portal>
+		<Dialog.Overlay class="command-overlay" />
+		<Dialog.Content class="command-dialog">
+			<Dialog.Title class="command-title">Go to</Dialog.Title>
+			<Dialog.Description class="sr-only"
+				>Search workspace destinations. Tab to a result and press Enter to open it.</Dialog.Description
+			>
+			<div class="command-input">
+				<IconSearch /><input
+					aria-label="Search commands"
+					placeholder="Search commands…"
+					bind:value={query}
+				/>
+			</div>
+			<div class="command-results">
+				{#each filtered as command}
+					<a href={command.href} onclick={() => (open = false)}
+						><strong>{command.title}</strong><span>{command.detail}</span></a
+					>
+				{:else}<p>No matching commands.</p>{/each}
+			</div>
+			<Dialog.Close class="command-close">Close <kbd>Esc</kbd></Dialog.Close>
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>
+
+<style>
+	:global(.command-overlay) {
+		position: fixed;
+		inset: 0;
+		z-index: 70;
+		background: #020617b3;
+		backdrop-filter: blur(6px);
+	}
+	:global(.command-dialog) {
+		position: fixed;
+		z-index: 71;
+		top: 15%;
+		left: 50%;
+		transform: translateX(-50%);
+		width: min(560px, calc(100vw - 2rem));
+		max-height: 75dvh;
+		overflow-y: auto;
+		border: 1px solid var(--ws-border);
+		border-radius: 1rem;
+		background: var(--ws-panel);
+		color: var(--ws-text);
+		padding: 1.25rem;
+		box-shadow: 0 30px 90px #0005;
+	}
+	:global(.command-title) {
+		font-size: 1.2rem;
+		font-weight: 650;
+		margin-bottom: 1rem;
+	}
+	.command-input {
+		display: flex;
+		gap: 0.75rem;
+		align-items: center;
+		padding: 0.8rem;
+		border: 1px solid var(--ws-border);
+		border-radius: 0.6rem;
+	}
+	.command-input input {
+		width: 100%;
+		background: transparent;
+		font-size: 1rem;
+		outline: none;
+	}
+	.command-results {
+		display: grid;
+		gap: 0.25rem;
+		margin: 0.75rem 0;
+	}
+	.command-results a {
+		display: grid;
+		gap: 0.25rem;
+		padding: 0.8rem;
+		border-radius: 0.6rem;
+	}
+	.command-results a:hover,
+	.command-results a:focus-visible {
+		background: var(--ws-accent-soft);
+	}
+	.command-results strong {
+		font-size: 0.95rem;
+	}
+	.command-results span,
+	.command-results p {
+		font-size: 0.875rem;
+		color: var(--ws-muted);
+	}
+	:global(.command-close) {
+		display: flex;
+		width: 100%;
+		justify-content: space-between;
+		font-size: 0.875rem;
+		color: var(--ws-muted);
+		padding: 0.5rem;
+	}
+</style>

--- a/ruflo/src/ruvocal/src/lib/components/workspace/RuntimePanel.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/workspace/RuntimePanel.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import { base } from "$app/paths";
+	import { onMount } from "svelte";
+	import type { WorkspaceSnapshot } from "$lib/types/Workspace";
+	import IconActivity from "~icons/lucide/activity";
+	let snapshot: WorkspaceSnapshot | null = $state(null);
+	let loading = $state(false);
+	let message = $state("");
+	let stale = $state(false);
+	let controller: AbortController | null = null;
+	const catalog = [
+		{
+			id: "ruflo",
+			name: "Ruflo",
+			role: "Coordination",
+			description: "Runtime and policy status from configured MCP tools.",
+			tag: "MCP",
+			href: "https://github.com/ruvnet/ruflo",
+		},
+		{
+			id: "metaharness",
+			name: "MetaHarness",
+			role: "Evaluation",
+			description: "Bounded optimization status. Promotion remains a separate authorized action.",
+			tag: "MCP",
+			href: "https://github.com/ruvnet/metaharness",
+		},
+		{
+			id: "autogenous",
+			name: "Autogenous",
+			role: "Collaboration",
+			description:
+				"Signed collaboration and evolution receipts. Requires an operator supplied MCP adapter.",
+			tag: "ADAPTER",
+			href: "https://github.com/ruvnet/autogenous",
+		},
+		{
+			id: "ruos",
+			name: "ruOS",
+			role: "Compute",
+			description: "Server health through a private, authenticated deployment connection.",
+			tag: "HTTP",
+			href: "https://github.com/cognitum-one/ruos-desktop",
+		},
+	];
+	const labels = {
+		not_configured: "Not configured",
+		available: "Available",
+		degraded: "Degraded",
+		unreachable: "Unreachable",
+	};
+	async function refresh() {
+		if (loading) return;
+		controller = new AbortController();
+		const deadline = setTimeout(() => controller?.abort(), 8000);
+		loading = true;
+		message = "";
+		try {
+			const response = await fetch(`${base}/api/workspace`, {
+				signal: controller.signal,
+				cache: "no-store",
+			});
+			if (!response.ok) {
+				if (response.status === 401 || response.status === 403) {
+					snapshot = null;
+					throw new Error(
+						"Runtime status requires an administrator session. Chat and your personal tools remain available."
+					);
+				}
+				throw new Error("Runtime status is unavailable. Retry to get a fresh observation.");
+			}
+			const result: WorkspaceSnapshot = await response.json();
+			if (result.schemaVersion !== 1 || !Array.isArray(result.integrations))
+				throw new Error("The runtime response has an unsupported format.");
+			snapshot = result;
+			stale = false;
+		} catch (error) {
+			stale = snapshot !== null;
+			message =
+				error instanceof Error && error.name !== "AbortError"
+					? error.message
+					: "The status request timed out. Retry when the connection is available.";
+		} finally {
+			clearTimeout(deadline);
+			loading = false;
+		}
+	}
+	onMount(() => {
+		void refresh();
+		return () => controller?.abort();
+	});
+</script>
+
+<div class="ws-section-heading">
+	<div>
+		<p class="ws-eyebrow">RUNTIME & LEARNING</p>
+		<h2>Every connection has evidence.</h2>
+		<p>Refresh on demand. Availability is an observation, not execution authority.</p>
+	</div>
+	<button class="ws-button" disabled={loading} onclick={refresh}
+		><IconActivity />{loading ? "Checking…" : "Refresh status"}</button
+	>
+</div>
+{#if message}<div class="ws-notice" role="status">{message}</div>{/if}
+{#if snapshot}<p class="ws-result-count">
+		{stale ? "Stale observation" : "Observed"} · {new Date(snapshot.checkedAt).toLocaleString()}
+	</p>{/if}
+<div class="ws-runtime-grid">
+	{#each catalog as entry}
+		{@const integration = snapshot?.integrations.find((item) => item.id === entry.id)}
+		<article class="ws-runtime">
+			<div class="ws-row">
+				<span class="ws-eyebrow">{entry.role}</span><span
+					class="ws-badge"
+					class:ws-good={!stale && integration?.state === "available"}
+					>{stale
+						? "Stale"
+						: integration
+							? labels[integration.state]
+							: loading
+								? "Checking"
+								: "Not checked"}</span
+				>
+			</div>
+			<h3>{entry.name}<span>{entry.tag}</span></h3>
+			<p>{integration?.summary || entry.description}</p>
+			{#if integration && integration.state !== "not_configured"}
+				<p class="ws-fine">
+					{integration.source.label}{entry.id === "metaharness" &&
+					integration.source.configuredBy === "WORKSPACE_RUFLO_MCP_URL"
+						? " · via the configured Ruflo endpoint"
+						: ""}
+				</p>
+			{/if}
+			{#if integration?.source.discoveryOnly}<p class="ws-fine">
+					Tool discovery only. Runtime health has not been verified.
+				</p>{/if}
+			{#if integration && integration.metrics.length > 0}<dl class="ws-runtime-metrics">
+					{#each integration.metrics as metric}<div>
+							<dt>{metric.label}</dt>
+							<dd>{metric.value}</dd>
+						</div>{/each}
+				</dl>{/if}
+			<div class="ws-runtime-footer">
+				<a href={entry.href} target="_blank" rel="noopener noreferrer">Source ↗</a><span
+					>{integration?.latencyMs != null
+						? `${integration.latencyMs} ms observation`
+						: "No observation yet"}</span
+				>
+			</div>
+		</article>
+	{/each}
+</div>
+<section class="ws-panel ws-gates">
+	<div>
+		<p class="ws-eyebrow">PROMOTION CONTRACT</p>
+		<h3>Better. Safe. Authorized. Reversible.</h3>
+		<p>
+			Autogenous candidates must pass all four gates. MetaHarness evaluation does not grant
+			promotion authority. No candidate has been evaluated by this workspace.
+		</p>
+	</div>
+	<div class="ws-gate-list">
+		{#each ["Measured improvement", "Safety & regression checks", "Policy authorization", "Verified rollback"] as gate}<div
+			>
+				<span>{gate}</span><span class="ws-badge">Not evaluated</span>
+			</div>{/each}
+	</div>
+</section>

--- a/ruflo/src/ruvocal/src/lib/components/workspace/ToolExplorer.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/workspace/ToolExplorer.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { openWorkspaceDraft } from "$lib/utils/openWorkspaceDraft";
+	import { error as chatError } from "$lib/stores/errors";
+	import {
+		allMcpServers,
+		selectedServerIds,
+		healthCheckServer,
+		toggleServer,
+	} from "$lib/stores/mcpServers";
+	import { discoveredTools } from "$lib/utils/workspace";
+	import MCPServerManager from "$lib/components/mcp/MCPServerManager.svelte";
+	import IconSearch from "~icons/lucide/search";
+	let query = $state("");
+	let family = $state("All");
+	let serverId = $state("all");
+	let limit = $state(30);
+	let managerOpen = $state(false);
+	let checking = $state<string | null>(null);
+	const tools = $derived(discoveredTools($allMcpServers, $selectedServerIds));
+	const families = ["All", "Agents", "Memory", "Learning", "Governance", "Tools"];
+	const filtered = $derived(
+		tools.filter(
+			(tool) =>
+				(family === "All" || tool.family === family) &&
+				(serverId === "all" || tool.serverId === serverId) &&
+				`${tool.name} ${tool.description ?? ""} ${tool.serverName}`
+					.toLowerCase()
+					.includes(query.trim().toLowerCase())
+		)
+	);
+	$effect(() => {
+		void query;
+		void family;
+		void serverId;
+		limit = 30;
+	});
+	async function check(id: string) {
+		if (checking) return;
+		const server = $allMcpServers.find((entry) => entry.id === id);
+		if (!server) return;
+		checking = id;
+		try {
+			await healthCheckServer(server);
+		} finally {
+			checking = null;
+		}
+	}
+</script>
+
+<div class="ws-section-heading">
+	<div>
+		<p class="ws-eyebrow">CAPABILITIES</p>
+		<h2>Find the right tool.</h2>
+		<p>Search up to 1,024 schemas per server. Check a connection to update its inventory.</p>
+	</div>
+	<button class="ws-button" onclick={() => (managerOpen = true)}>Manage servers</button>
+</div>
+<div class="ws-server-grid">
+	{#each $allMcpServers as server (server.id)}
+		<div class="ws-server">
+			<div class="ws-row">
+				<strong>{server.name}</strong><span
+					class="ws-badge"
+					class:ws-good={server.status === "connected"}
+					>{server.status === "connected"
+						? "Discovered"
+						: server.status === "error"
+							? "Unavailable"
+							: server.status === "connecting"
+								? "Checking"
+								: "Not checked"}</span
+				>
+			</div>
+			<p>
+				{server.type === "wasm"
+					? "Browser WASM"
+					: server.type === "base"
+						? "Deployment connection"
+						: "Personal connection"} · {server.status === "connected"
+					? `${server.tools?.length ?? 0} discovered tools`
+					: "Inventory unavailable"}
+			</p>
+			<div class="ws-row">
+				<button class="ws-link-button" disabled={checking !== null} onclick={() => check(server.id)}
+					>{checking === server.id ? "Checking…" : "Check connection"}</button
+				><button
+					class="ws-toggle"
+					aria-pressed={$selectedServerIds.has(server.id)}
+					onclick={() => toggleServer(server.id)}
+					>{$selectedServerIds.has(server.id) ? "Selected for chat" : "Select for chat"}</button
+				>
+			</div>
+		</div>
+	{/each}
+</div>
+<div class="ws-toolbar">
+	<div class="ws-search">
+		<IconSearch /><input
+			aria-label="Search discovered tools"
+			placeholder="Search tools, descriptions, or servers…"
+			bind:value={query}
+		/>
+	</div>
+	<select aria-label="Filter by server" bind:value={serverId}
+		><option value="all">All servers</option>{#each $allMcpServers as server}<option
+				value={server.id}>{server.name}</option
+			>{/each}</select
+	>
+</div>
+<div class="ws-filters" aria-label="Tool categories">
+	{#each families as item}<button
+			class:chosen={family === item}
+			aria-pressed={family === item}
+			onclick={() => (family = item)}>{item}</button
+		>{/each}
+</div>
+<p class="ws-result-count" aria-live="polite">
+	{filtered.length} matching tools · showing {Math.min(limit, filtered.length)}
+</p>
+<div class="ws-tool-list">
+	{#each filtered.slice(0, limit) as tool (tool.id)}
+		<details class="ws-tool">
+			<summary
+				><span class="ws-tool-name"
+					><strong>{tool.name}</strong><span>{tool.serverName} · {tool.family}</span></span
+				><span class="ws-badge"
+					>{tool.connected
+						? tool.selected
+							? "Selected"
+							: "Not selected"
+						: "Connection unavailable"}</span
+				></summary
+			>
+			<div class="ws-tool-detail">
+				<p>{tool.description || "No description provided by this server."}</p>
+				<h3>Input schema</h3>
+				<pre>{JSON.stringify(tool.inputSchema ?? {}, null, 2)}</pre>
+				<button
+					class="ws-button"
+					onclick={() =>
+						openWorkspaceDraft(
+							`Inspect the discovered tool ${tool.name} from ${tool.serverName}. Explain its inputs and risks and draft a use plan. Do not execute it yet.`
+						).catch(() => chatError.set("Could not open the tool request draft."))}
+					>Draft a tool request</button
+				>
+			</div>
+		</details>
+	{:else}
+		<div class="ws-empty">
+			<strong
+				>{tools.length ? "No tools match your filters." : "No tool schemas discovered yet."}</strong
+			>
+			<p>
+				{tools.length
+					? "Try another name or category."
+					: "Check an available server above, or configure a connection."}
+			</p>
+		</div>
+	{/each}
+</div>
+{#if filtered.length > limit}<button class="ws-button ws-load-more" onclick={() => (limit += 30)}
+		>Show 30 more</button
+	>{/if}
+{#if managerOpen}<MCPServerManager onclose={() => (managerOpen = false)} />{/if}

--- a/ruflo/src/ruvocal/src/lib/components/workspace/WorkspaceCommands.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/workspace/WorkspaceCommands.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import type { Component } from "svelte";
+	import { error } from "$lib/stores/errors";
+	let Palette: Component<{ open?: boolean }> | null = $state(null);
+	let open = $state(false);
+	let loading = false;
+	async function toggle() {
+		if (loading || document.getElementById("app")?.hasAttribute("inert")) return;
+		if (!Palette) {
+			loading = true;
+			try {
+				Palette = (await import("./CommandPalette.svelte")).default;
+			} catch {
+				error.set("Command search could not load. Use the workspace navigation.");
+				return;
+			} finally {
+				loading = false;
+			}
+		}
+		open = !open;
+	}
+	onMount(() => {
+		const keyboard = (event: KeyboardEvent) => {
+			if (
+				(event.ctrlKey || event.metaKey) &&
+				event.key.toLowerCase() === "k" &&
+				!event.isComposing
+			) {
+				if (document.getElementById("app")?.hasAttribute("inert")) return;
+				event.preventDefault();
+				void toggle();
+			}
+		};
+		const requested = () => {
+			void toggle();
+		};
+		window.addEventListener("keydown", keyboard);
+		window.addEventListener("ruflo:commands", requested);
+		return () => {
+			window.removeEventListener("keydown", keyboard);
+			window.removeEventListener("ruflo:commands", requested);
+		};
+	});
+</script>
+
+{#if Palette}<Palette bind:open />{/if}

--- a/ruflo/src/ruvocal/src/lib/components/workspace/WorkspaceNav.svelte
+++ b/ruflo/src/ruvocal/src/lib/components/workspace/WorkspaceNav.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { base } from "$app/paths";
+	import { page } from "$app/state";
+	import IconWorkspace from "~icons/lucide/layout-dashboard";
+	import IconTools from "~icons/lucide/blocks";
+	import IconActivity from "~icons/lucide/activity";
+	import IconResearch from "~icons/lucide/telescope";
+	const items = [
+		{ label: "Workspace", href: `${base}/workspace`, view: "overview", icon: IconWorkspace },
+		{
+			label: "Tool explorer",
+			href: `${base}/workspace?view=tools`,
+			view: "tools",
+			icon: IconTools,
+		},
+		{
+			label: "Runtime & learning",
+			href: `${base}/workspace?view=runtimes`,
+			view: "runtimes",
+			icon: IconActivity,
+		},
+	];
+</script>
+
+<div class="workspace-nav" aria-label="Workspace navigation">
+	{#each items as item}
+		{@const selected =
+			page.url.pathname === `${base}/workspace` &&
+			(page.url.searchParams.get("view") || "overview") === item.view}
+		<a href={item.href} aria-current={selected ? "page" : undefined} class:current={selected}>
+			<item.icon /> <span>{item.label}</span>
+		</a>
+	{/each}
+	<a href="https://goal.ruv.io/" target="_blank" rel="noopener noreferrer"
+		><IconResearch /><span>Research planner</span><span
+			class="external"
+			aria-label="opens in a new tab">↗</span
+		></a
+	>
+</div>
+
+<style>
+	.workspace-nav {
+		display: grid;
+		gap: 0.25rem;
+		padding-bottom: 1rem;
+		margin-bottom: 0.25rem;
+		border-bottom: 1px solid var(--ws-border);
+	}
+	a {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		min-height: 44px;
+		border-radius: 0.65rem;
+		padding: 0.65rem 0.75rem;
+		font-size: 0.875rem;
+		color: var(--ws-muted);
+		transition: background 0.15s;
+	}
+	a:hover {
+		background: var(--ws-hover);
+		color: var(--ws-text);
+	}
+	a.current {
+		color: var(--ws-accent-text);
+		background: var(--ws-accent-soft);
+		font-weight: 600;
+	}
+	a :global(svg) {
+		width: 18px;
+		height: 18px;
+		flex-shrink: 0;
+	}
+	.external {
+		margin-left: auto;
+	}
+</style>

--- a/ruflo/src/ruvocal/src/lib/components/workspace/workspace.ssr.test.ts
+++ b/ruflo/src/ruvocal/src/lib/components/workspace/workspace.ssr.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render } from "svelte/server";
+import { writable, type Writable } from "svelte/store";
+import type { MCPServer } from "$lib/types/Tool";
+import { allMcpServers } from "$lib/stores/mcpServers";
+vi.mock("$app/paths", () => ({ base: "/flo" }));
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+vi.mock("$app/state", () => ({ page: { url: new URL("http://example.test/flo/workspace") } }));
+vi.mock("$lib/stores/mcpServers", () => ({
+	allMcpServers: writable([]),
+	selectedServerIds: writable(new Set()),
+	enabledServersCount: writable(0),
+	toggleServer: vi.fn(),
+	healthCheckServer: vi.fn(),
+	addCustomServer: vi.fn(),
+	refreshMcpServers: vi.fn(),
+}));
+import Workspace from "../../../routes/workspace/+page.svelte";
+import RuntimePanel from "./RuntimePanel.svelte";
+import ToolExplorer from "./ToolExplorer.svelte";
+
+const mockServers = allMcpServers as Writable<MCPServer[]>;
+afterEach(() => mockServers.set([]));
+
+describe("workspace server rendering", () => {
+	it("works with no models, tools, or conversations and offers no fake runtime counts", () => {
+		const { body } = render(Workspace, {
+			props: { data: { models: [], conversations: [] } } as never,
+		});
+		expect(body).toContain("Intent into action.");
+		expect(body).toContain("Configure a model before drafting");
+		expect(body).toContain("No mission is running.");
+		expect(body).toContain('href="/flo/models"');
+		expect(body).not.toContain("NaN");
+	});
+	it("renders integrations as unchecked until observed", () => {
+		const { body } = render(RuntimePanel);
+		expect(body.match(/Not checked/g) || []).toHaveLength(4);
+		expect(body).toContain("Requires an operator supplied MCP adapter");
+		expect(body).toContain("Not evaluated");
+		expect(body).not.toContain("ws-good");
+	});
+	it("distinguishes an unknown inventory from a successfully discovered empty inventory", () => {
+		mockServers.set(
+			(["disconnected", "connecting", "error", "connected"] as const).map((status) => ({
+				id: status,
+				name: status,
+				url: "https://example.test/mcp",
+				type: "custom",
+				status,
+				isLocked: false,
+				tools: [],
+			}))
+		);
+		const { body } = render(ToolExplorer);
+		expect(body.match(/Inventory unavailable/g) || []).toHaveLength(3);
+		expect(body.match(/0 discovered tools/g) || []).toHaveLength(1);
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/server/mcp/resolveHealthTarget.spec.ts
+++ b/ruflo/src/ruvocal/src/lib/server/mcp/resolveHealthTarget.spec.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveHealthTarget } from "./resolveHealthTarget";
+
+const privateServers = JSON.stringify([
+	{
+		name: "Ruflo",
+		url: "http://192.168.1.20:3001/mcp/operations",
+		headers: { Authorization: "Bearer deployment-test-secret" },
+	},
+]);
+
+describe("health target authority", () => {
+	it("resolves exact deployment identity and private credentials without browser copies", () => {
+		expect(resolveHealthTarget({ serverId: "base-Ruflo" }, privateServers)).toEqual({
+			url: "http://192.168.1.20:3001/mcp/operations",
+			headers: [{ key: "Authorization", value: "Bearer deployment-test-secret" }],
+			configured: true,
+		});
+	});
+	it.each([
+		{ serverId: "base-missing" },
+		{ serverId: "Ruflo" },
+		{ serverId: 1 },
+		{ serverId: "base-Ruflo", url: "https://attacker.example/mcp" },
+		{ serverId: "base-Ruflo", url: "http://192.168.1.20:3001/mcp/operations" },
+		{ serverId: "base-Ruflo", headers: [] },
+		{ serverId: "base-Ruflo", headers: [{ key: "Authorization", value: "Bearer replacement" }] },
+	])("rejects unknown identities and every configured target override: %j", (body) => {
+		expect(() => resolveHealthTarget(body, privateServers)).toThrow();
+	});
+	it("rejects duplicate configured identities", () => {
+		const duplicate = JSON.stringify([
+			...JSON.parse(privateServers),
+			...JSON.parse(privateServers),
+		]);
+		expect(() => resolveHealthTarget({ serverId: "base-Ruflo" }, duplicate)).toThrow(/ambiguous/);
+	});
+	it.each([
+		"file:///etc/passwd",
+		"https://user:password@example.test/mcp",
+		"http://host/mcp#fragment",
+	])("rejects invalid configured targets: %s", (url) => {
+		expect(() =>
+			resolveHealthTarget({ serverId: "base-Ruflo" }, JSON.stringify([{ name: "Ruflo", url }]))
+		).toThrow(/configuration/);
+	});
+	it("preserves HTTPS custom credentials without borrowing deployment headers", () => {
+		const headers = [{ key: "X-Personal-Key", value: "personal-key" }];
+		expect(
+			resolveHealthTarget({ url: "https://example.test/mcp", headers }, privateServers)
+		).toEqual({
+			url: "https://example.test/mcp",
+			headers,
+			configured: false,
+		});
+	});
+	it.each(["http://example.test/mcp", "https://169.254.169.254/mcp", "file:///etc/passwd"])(
+		"preserves custom URL validation: %s",
+		(url) => {
+			expect(() => resolveHealthTarget({ url }, privateServers)).toThrow(/unsafe/);
+		}
+	);
+	it("preserves the existing custom loopback exception", () => {
+		expect(
+			resolveHealthTarget({ url: "http://localhost:3001/mcp" }, privateServers).configured
+		).toBe(false);
+	});
+});
+
+const mocks = vi.hoisted(() => ({
+	connect: vi.fn(),
+	listTools: vi.fn(),
+	close: vi.fn(),
+	transports: vi.fn(),
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: class {
+		connect = mocks.connect;
+		listTools = mocks.listTools;
+		close = mocks.close;
+	},
+}));
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+	StreamableHTTPClientTransport: class {
+		constructor(url: URL, options: unknown) {
+			mocks.transports(url, options);
+		}
+	},
+}));
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+	SSEClientTransport: class {
+		constructor(url: URL, options: unknown) {
+			mocks.transports(url, options);
+		}
+	},
+}));
+vi.mock("$lib/server/config", () => ({
+	config: {
+		MCP_SERVERS: JSON.stringify([
+			{
+				name: "Ruflo",
+				url: "http://192.168.1.20:3001/mcp/operations",
+				headers: { Authorization: "Bearer deployment-test-secret" },
+			},
+		]),
+		EXA_API_KEY: "",
+		MCP_FORWARD_HF_USER_TOKEN: "false",
+	},
+}));
+vi.mock("$lib/server/logger", () => ({ logger: mocks.logger }));
+import { POST } from "../../../routes/api/mcp/health/+server";
+
+async function probe(body: unknown) {
+	return POST({
+		request: new Request("https://ui.test/api/mcp/health", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}),
+		locals: {},
+	} as Parameters<typeof POST>[0]);
+}
+
+describe("configured health route", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.connect.mockResolvedValue(undefined);
+		mocks.close.mockResolvedValue(undefined);
+		mocks.listTools.mockResolvedValue({
+			tools: [{ name: "ruflo__policy_status", inputSchema: { type: "object" } }],
+		});
+	});
+	it("uses the deployment credential on the server and never returns it", async () => {
+		const response = await probe({ serverId: "base-Ruflo" });
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			ready: true,
+			authRequired: false,
+			tools: [{ name: "ruflo__policy_status", inputSchema: { type: "object" } }],
+		});
+		const [url, options] = mocks.transports.mock.calls[0];
+		expect(url.toString()).toBe("http://192.168.1.20:3001/mcp/operations");
+		expect(options.requestInit.headers.Authorization).toBe("Bearer deployment-test-secret");
+		expect(options.requestInit.redirect).toBe("error");
+	});
+	it.each([
+		{ serverId: "base-missing" },
+		{ serverId: "base-Ruflo", url: "https://attacker.test/mcp" },
+		{ serverId: "base-Ruflo", headers: [{ key: "Host", value: "attacker.test" }] },
+		{ url: "http://example.test/mcp" },
+	])("rejects invalid targets before any connection: %j", async (body) => {
+		const response = await probe(body);
+		expect(response.status).toBe(400);
+		expect(mocks.connect).not.toHaveBeenCalled();
+		expect(mocks.transports).not.toHaveBeenCalled();
+	});
+	it("uses only personal headers for a custom HTTPS endpoint", async () => {
+		const response = await probe({
+			url: "https://example.test/mcp",
+			headers: [{ key: "X-Personal-Key", value: "mine" }],
+		});
+		expect(response.status).toBe(200);
+		const [, options] = mocks.transports.mock.calls[0];
+		expect(options.requestInit.headers["X-Personal-Key"]).toBe("mine");
+		expect(options.requestInit.headers.Authorization).toBeUndefined();
+	});
+	it("pins HTTP and SSE fetches to the configured origin without redirects", async () => {
+		mocks.connect.mockRejectedValueOnce(new Error("Try legacy SSE"));
+		const response = await probe({ serverId: "base-Ruflo" });
+		expect(response.status).toBe(200);
+		expect(mocks.transports).toHaveBeenCalledTimes(2);
+		const outbound = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
+		try {
+			for (const [, options] of mocks.transports.mock.calls) {
+				await expect(options.fetch("https://attacker.test/mcp", {})).rejects.toThrow(/origin/);
+				expect(outbound).not.toHaveBeenCalled();
+				await options.fetch("http://192.168.1.20:3001/messages", { redirect: "follow" });
+				expect(outbound.mock.calls[0][1]?.redirect).toBe("error");
+				outbound.mockClear();
+			}
+		} finally {
+			outbound.mockRestore();
+		}
+	});
+	it("redacts credential-bearing upstream failures from responses and logs", async () => {
+		mocks.connect.mockRejectedValue(new Error("401 deployment-test-secret"));
+		const response = await probe({ serverId: "base-Ruflo" });
+		expect(response.status).toBe(503);
+		const text = await response.text();
+		expect(text).not.toContain("deployment-test-secret");
+		expect(JSON.parse(text).authRequired).toBe(true);
+		for (const logger of Object.values(mocks.logger))
+			expect(JSON.stringify(logger.mock.calls)).not.toContain("deployment-test-secret");
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/server/mcp/resolveHealthTarget.ts
+++ b/ruflo/src/ruvocal/src/lib/server/mcp/resolveHealthTarget.ts
@@ -1,0 +1,83 @@
+import type { KeyValuePair } from "$lib/types/Tool";
+import { isValidUrl } from "$lib/server/urlSafety";
+
+export class HealthTargetError extends Error {}
+
+interface HealthTarget {
+	url: string;
+	headers?: KeyValuePair[];
+	configured: boolean;
+}
+
+/** The browser identifies a deployment connection; its credentials never make a round trip. */
+export function resolveHealthTarget(body: unknown, configuredServers: string): HealthTarget {
+	if (!body || typeof body !== "object" || Array.isArray(body))
+		throw new HealthTargetError("Invalid health check request");
+	const request = body as Record<string, unknown>;
+	if (Object.hasOwn(request, "serverId")) {
+		if (Object.keys(request).some((key) => key !== "serverId"))
+			throw new HealthTargetError("Configured health checks accept only serverId");
+		if (typeof request.serverId !== "string" || !request.serverId.startsWith("base-"))
+			throw new HealthTargetError("Unknown configured MCP server");
+		let entries: unknown;
+		try {
+			entries = JSON.parse(configuredServers || "[]");
+		} catch {
+			throw new HealthTargetError("Invalid MCP server configuration");
+		}
+		if (!Array.isArray(entries)) throw new HealthTargetError("Invalid MCP server configuration");
+		const matches = entries.filter(
+			(entry): entry is Record<string, unknown> =>
+				entry !== null &&
+				typeof entry === "object" &&
+				!Array.isArray(entry) &&
+				typeof entry.name === "string" &&
+				`base-${entry.name}` === request.serverId
+		);
+		if (matches.length !== 1)
+			throw new HealthTargetError("Unknown or ambiguous configured MCP server");
+		const server = matches[0];
+		if (typeof server.url !== "string")
+			throw new HealthTargetError("Invalid MCP server configuration");
+		try {
+			const url = new URL(server.url);
+			// Private HTTP is allowed only through this exact, operator-configured target.
+			if (!["https:", "http:"].includes(url.protocol) || url.username || url.password || url.hash)
+				throw new Error();
+		} catch {
+			throw new HealthTargetError("Invalid MCP server configuration");
+		}
+		let headers: KeyValuePair[] | undefined;
+		if (server.headers !== undefined) {
+			if (!server.headers || typeof server.headers !== "object" || Array.isArray(server.headers))
+				throw new HealthTargetError("Invalid MCP server configuration");
+			headers = Object.entries(server.headers).map(([key, value]) => {
+				if (typeof value !== "string")
+					throw new HealthTargetError("Invalid MCP server configuration");
+				return { key, value };
+			});
+		}
+		return { url: server.url, headers, configured: true };
+	}
+	if (typeof request.url !== "string" || !request.url)
+		throw new HealthTargetError("URL is required");
+	// Preserve the existing custom-server protocol/IP validation, including local exceptions.
+	if (!isValidUrl(request.url)) throw new HealthTargetError("Invalid or unsafe MCP URL");
+	if (
+		request.headers !== undefined &&
+		(!Array.isArray(request.headers) ||
+			request.headers.some(
+				(header) =>
+					!header ||
+					typeof header !== "object" ||
+					typeof header.key !== "string" ||
+					typeof header.value !== "string"
+			))
+	)
+		throw new HealthTargetError("Invalid custom MCP headers");
+	return {
+		url: request.url,
+		headers: request.headers as KeyValuePair[] | undefined,
+		configured: false,
+	};
+}

--- a/ruflo/src/ruvocal/src/lib/server/models.ts
+++ b/ruflo/src/ruvocal/src/lib/server/models.ts
@@ -1,4 +1,5 @@
 import { config } from "$lib/server/config";
+import { building } from "$app/environment";
 import type { ChatTemplateInput } from "$lib/types/Template";
 import { z } from "zod";
 import endpoints, { endpointSchema, type Endpoint } from "./endpoints/endpoints";
@@ -491,7 +492,8 @@ const rebuildModels = async (): Promise<ModelsRefreshSummary> => {
 	return applyModelState(newModels, startedAt);
 };
 
-await rebuildModels();
+// Build analysis imports server modules; provider discovery belongs to server startup.
+if (!building) await rebuildModels();
 
 export const refreshModels = async (): Promise<ModelsRefreshSummary> => {
 	if (inflightRefresh) {

--- a/ruflo/src/ruvocal/src/lib/server/workspace/config.ts
+++ b/ruflo/src/ruvocal/src/lib/server/workspace/config.ts
@@ -1,0 +1,75 @@
+import type { WorkspaceIntegration } from "$lib/types/Workspace";
+
+export type WorkspaceEnvironment = Record<string, string | undefined>;
+
+export interface IntegrationConfig {
+	base: WorkspaceIntegration;
+	url?: URL;
+	token?: string;
+}
+
+const DEFINITIONS = [
+	{ id: "ruflo", name: "Ruflo", key: "WORKSPACE_RUFLO_MCP_URL", kind: "mcp" },
+	{ id: "metaharness", name: "MetaHarness", key: "WORKSPACE_METAHARNESS_MCP_URL", kind: "mcp" },
+	{ id: "autogenous", name: "Autogenous", key: "WORKSPACE_AUTOGENOUS_MCP_URL", kind: "mcp" },
+	{ id: "ruos", name: "ruOS", key: "WORKSPACE_RUOS_BASE_URL", kind: "http" },
+] as const;
+
+/** Deployment configuration is the only source of endpoints and credentials. */
+export function readWorkspaceConfig(env: WorkspaceEnvironment): IntegrationConfig[] {
+	return DEFINITIONS.map(({ id, name, key, kind }) => {
+		// Ruflo exposes MetaHarness's actual flywheel status tool through its MCP registry.
+		const configuredBy =
+			id === "metaharness" && !env[key] && env.WORKSPACE_RUFLO_MCP_URL
+				? "WORKSPACE_RUFLO_MCP_URL"
+				: key;
+		const raw = env[configuredBy]?.trim();
+		const tokenKey = configuredBy.replace(/_(MCP_URL|BASE_URL)$/, "_TOKEN");
+		const token = env[tokenKey]?.trim();
+		const base: WorkspaceIntegration = {
+			id,
+			name,
+			state: "not_configured",
+			summary:
+				id === "autogenous"
+					? "No Autogenous adapter configured. Upstream provides a library, not a status service."
+					: "Configure a server endpoint to observe this integration.",
+			checkedAt: null,
+			latencyMs: null,
+			metrics: [],
+			source: {
+				kind,
+				label: kind === "mcp" ? "MCP tool discovery" : "ruOS rendezvous service health",
+				configuredBy,
+				discoveryOnly: kind === "mcp",
+			},
+		};
+		if (!raw) return { base };
+		try {
+			const url = new URL(raw);
+			if (
+				raw.length > 2048 ||
+				!["https:", "http:"].includes(url.protocol) ||
+				url.username ||
+				url.password ||
+				url.search ||
+				url.hash ||
+				(token && (token.length > 8192 || /[^\x21-\x7e]/.test(token)))
+			) {
+				throw new Error("Invalid deployment configuration");
+			}
+			if (id === "ruos") {
+				url.pathname = `${url.pathname.replace(/\/$/, "")}/api/v1/server/health`;
+			}
+			return { base, url, token };
+		} catch {
+			return {
+				base: {
+					...base,
+					state: "degraded",
+					summary: "Invalid server configuration. Review the private deployment settings.",
+				},
+			};
+		}
+	});
+}

--- a/ruflo/src/ruvocal/src/lib/server/workspace/normalize.ts
+++ b/ruflo/src/ruvocal/src/lib/server/workspace/normalize.ts
@@ -1,0 +1,150 @@
+import type { WorkspaceIntegration } from "$lib/types/Workspace";
+import { isDeepStrictEqual } from "node:util";
+import { ProbeError } from "./transport";
+
+export function record(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value))
+		throw new ProbeError("malformed");
+	return value as Record<string, unknown>;
+}
+
+function count(value: unknown): number {
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0 || value > 1e12) {
+		throw new ProbeError("malformed");
+	}
+	return value;
+}
+
+function bool(value: unknown): boolean {
+	if (typeof value !== "boolean") throw new ProbeError("malformed");
+	return value;
+}
+
+function assertStatusMetadata(result: Record<string, unknown>): void {
+	for (const key of ["isError", "success", "degraded"]) {
+		if (result[key] !== undefined && typeof result[key] !== "boolean")
+			throw new ProbeError("malformed");
+	}
+	if (
+		result.exitCode !== undefined &&
+		(typeof result.exitCode !== "number" || !Number.isSafeInteger(result.exitCode))
+	)
+		throw new ProbeError("malformed");
+	if (
+		result.isError === true ||
+		result.success === false ||
+		result.degraded === true ||
+		(result.exitCode !== undefined && result.exitCode !== 0)
+	)
+		throw new ProbeError("runtime");
+}
+
+/**
+ * The HTTP bridge can wrap the stdio tool result in a second MCP text envelope.
+ * Unwrap at most three envelopes, retaining failure semantics at EVERY layer.
+ * Check both representations when present so structured content cannot conceal
+ * an error in nested text, or vice versa. Arbitrary prose is never status data.
+ */
+function unwrapToolData(value: unknown, envelopesRemaining: number): Record<string, unknown> {
+	const result = record(value);
+	assertStatusMetadata(result);
+	const hasStructured = result.structuredContent !== undefined;
+	const hasContent = result.content !== undefined;
+	if (!hasStructured && !hasContent) return result;
+	if (envelopesRemaining === 0) throw new ProbeError("malformed");
+	let textData: Record<string, unknown> | undefined;
+	if (hasContent) {
+		if (!Array.isArray(result.content) || result.content.length !== 1)
+			throw new ProbeError("malformed");
+		const content = record(result.content[0]);
+		if (content.type !== "text" || typeof content.text !== "string")
+			throw new ProbeError("malformed");
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(content.text);
+		} catch {
+			throw new ProbeError("malformed");
+		}
+		textData = unwrapToolData(parsed, envelopesRemaining - 1);
+	}
+	if (hasStructured) {
+		const structuredData = unwrapToolData(result.structuredContent, envelopesRemaining - 1);
+		// Ambiguous representations must not choose whichever happens to look healthy.
+		if (textData && !isDeepStrictEqual(textData, structuredData)) throw new ProbeError("malformed");
+		return structuredData;
+	}
+	return record(textData);
+}
+
+export function toolData(value: unknown): Record<string, unknown> {
+	return unwrapToolData(value, 3);
+}
+
+export function normalizeSystem(data: Record<string, unknown>, integration: WorkspaceIntegration) {
+	if (!["healthy", "degraded", "unhealthy"].includes(String(data.status)))
+		throw new ProbeError("malformed");
+	if (data.status !== "healthy" || data.success === false || data.degraded === true)
+		integration.state = "degraded";
+	integration.metrics.push(
+		{ label: "Reported system state", value: String(data.status) },
+		{ label: "Process uptime seconds", value: Math.floor(count(data.uptime) / 1000) }
+	);
+}
+
+export function normalizePolicy(data: Record<string, unknown>, integration: WorkspaceIntegration) {
+	if (!["legacy", "observe", "enforce"].includes(String(data.mode)))
+		throw new ProbeError("malformed");
+	const counts = record(data.counts);
+	const ledgerValid = bool(record(data.ledger).valid);
+	if (!ledgerValid || data.success === false || data.degraded === true)
+		integration.state = "degraded";
+	integration.metrics.push(
+		{ label: "Policy mode", value: String(data.mode) },
+		{ label: "Policy rules", value: count(counts.rules) },
+		{ label: "Policy receipts", value: count(counts.receipts) },
+		{ label: "Policy ledger", value: ledgerValid ? "Valid" : "Invalid" }
+	);
+}
+
+export function normalizeFlywheel(
+	data: Record<string, unknown>,
+	integration: WorkspaceIntegration
+) {
+	if (!bool(data.success) || bool(data.degraded)) {
+		integration.state = "degraded";
+		integration.summary = "The MetaHarness status tool reported a failure or degraded integration.";
+		return;
+	}
+	const payload = record(data.data);
+	const state = record(payload.state);
+	const ledger = record(payload.ledger);
+	const valid = bool(ledger.valid);
+	if (!valid) integration.state = "degraded";
+	integration.metrics.push(
+		{ label: "Promotion ledger", value: valid ? "Valid" : "Invalid" },
+		{ label: "Promotion commits", value: count(ledger.commits) },
+		{ label: "Serving epoch", value: count(state.servingEpoch) },
+		{ label: "Recorded receipts", value: Object.keys(record(state.receiptStates)).length }
+	);
+	integration.summary = valid
+		? "Flywheel state observed. Ledger integrity does not establish candidate quality or promotion authority."
+		: "The flywheel reported an invalid promotion ledger.";
+}
+
+/** This endpoint reports the two rendezvous services, not fleet or desktop health. */
+export function normalizeRuos(value: unknown, integration: WorkspaceIntegration) {
+	const data = record(value);
+	const ok = bool(data.ok);
+	const services = record(data.services);
+	const units = ["rustdesk-hbbs", "rustdesk-hbbr"];
+	for (const unit of units) {
+		if (typeof services[unit] !== "string") throw new ProbeError("malformed");
+	}
+	const active = units.filter((unit) => services[unit] === "active").length;
+	integration.state = ok && active === units.length ? "available" : "degraded";
+	integration.summary =
+		integration.state === "available"
+			? "Both ruOS rendezvous services report active. Fleet and desktop readiness are not measured."
+			: "One or more ruOS rendezvous services are not confirmed active.";
+	integration.metrics.push({ label: "Active rendezvous services", value: active });
+}

--- a/ruflo/src/ruvocal/src/lib/server/workspace/route.spec.ts
+++ b/ruflo/src/ruvocal/src/lib/server/workspace/route.spec.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createWorkspaceSnapshot } = vi.hoisted(() => ({ createWorkspaceSnapshot: vi.fn() }));
+vi.mock("./snapshot", () => ({ createWorkspaceSnapshot }));
+
+import { GET } from "../../../routes/api/workspace/+server";
+
+function event(
+	options: { session?: boolean; admin?: boolean; headers?: HeadersInit; query?: string } = {}
+) {
+	const url = new URL(`https://ruflo.example.test/api/workspace${options.query ?? ""}`);
+	return {
+		url,
+		request: new Request(url, { headers: options.headers }),
+		locals: {
+			sessionId: options.session === false ? "" : "session",
+			isAdmin: options.admin ?? false,
+		},
+	} as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+	createWorkspaceSnapshot.mockReset();
+	createWorkspaceSnapshot.mockResolvedValue({
+		schemaVersion: 1,
+		checkedAt: "2026-09-05T12:00:00.000Z",
+		integrations: [],
+	});
+});
+
+describe("GET /api/workspace", () => {
+	it("rejects a missing session with 401 before reading runtime state", async () => {
+		await expect(GET(event({ session: false }))).rejects.toMatchObject({ status: 401 });
+		expect(createWorkspaceSnapshot).not.toHaveBeenCalled();
+	});
+
+	it("rejects an ordinary signed-in user with 403 before reading runtime state", async () => {
+		await expect(GET(event())).rejects.toMatchObject({ status: 403 });
+		expect(createWorkspaceSnapshot).not.toHaveBeenCalled();
+	});
+
+	it.each<Record<string, string>>([
+		{ origin: "https://attacker.example.test" },
+		{ "sec-fetch-site": "cross-site" },
+		{ "sec-fetch-site": "same-site" },
+	])("rejects cross-origin admin requests", async (headers) => {
+		await expect(GET(event({ admin: true, headers }))).rejects.toMatchObject({ status: 403 });
+		expect(createWorkspaceSnapshot).not.toHaveBeenCalled();
+	});
+
+	it("does not permit user supplied endpoint or tool arguments", async () => {
+		await expect(
+			GET(event({ admin: true, query: "?url=http://metadata.internal&operation=promote" }))
+		).rejects.toMatchObject({ status: 400 });
+		expect(createWorkspaceSnapshot).not.toHaveBeenCalled();
+	});
+
+	it("returns same-origin admin observations without allowing shared caching", async () => {
+		const response = await GET(
+			event({
+				admin: true,
+				headers: { origin: "https://ruflo.example.test", "sec-fetch-site": "same-origin" },
+			})
+		);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("cache-control")).toBe("private, no-store");
+		expect(response.headers.get("access-control-allow-origin")).toBeNull();
+		expect(await response.json()).toMatchObject({ schemaVersion: 1 });
+		expect(createWorkspaceSnapshot).toHaveBeenCalledTimes(1);
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/server/workspace/snapshot.spec.ts
+++ b/ruflo/src/ruvocal/src/lib/server/workspace/snapshot.spec.ts
@@ -1,0 +1,524 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createWorkspaceSnapshot } from "./snapshot";
+import {
+	createBoundedTransport,
+	WORKSPACE_RESPONSE_BYTES,
+	WORKSPACE_TIMEOUT_MS,
+} from "./transport";
+
+const RUFLO_URL = "https://runtime.example.test/mcp";
+const RUOS_URL = "https://desktop.example.test";
+const system = { status: "healthy", uptime: 42_000, components: { memory: { status: "unknown" } } };
+const policy = { mode: "enforce", counts: { rules: 4, receipts: 9 }, ledger: { valid: true } };
+const flywheel = {
+	success: true,
+	degraded: false,
+	data: {
+		state: { servingEpoch: 2, receiptStates: { receipt1: "evaluated" } },
+		ledger: { valid: true, commits: 2 },
+	},
+};
+
+function envelope(value: unknown, metadata: Record<string, unknown> = {}) {
+	return { content: [{ type: "text", text: JSON.stringify(value) }], ...metadata };
+}
+
+function mcpFixture(
+	names: string[] = ["system_status", "policy_status", "metaharness_flywheel"],
+	options: {
+		status?: Record<string, unknown>;
+		list?: unknown;
+		sse?: boolean;
+		toolResult?: unknown;
+		additionalEnvelopes?: number;
+	} = {}
+) {
+	const messages: Record<string, unknown>[] = [];
+	const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+		const message = JSON.parse(String(init?.body));
+		messages.push(message);
+		if (message.method === "notifications/initialized") return new Response(null, { status: 202 });
+		let result: unknown;
+		if (message.method === "initialize") {
+			result = {
+				protocolVersion: message.params.protocolVersion,
+				capabilities: { tools: {} },
+				serverInfo: { name: "fixture", version: "1.0.0" },
+			};
+		} else if (message.method === "tools/list") {
+			result = options.list ?? {
+				tools: names.map((name) => ({ name, inputSchema: { type: "object" } })),
+			};
+		} else if (message.method === "tools/call") {
+			const name: string = message.params.name;
+			const value =
+				options.status ??
+				(name.includes("flywheel") ? flywheel : name.includes("policy") ? policy : system);
+			result = options.toolResult ?? { content: [{ type: "text", text: JSON.stringify(value) }] };
+			for (let layer = 0; layer < (options.additionalEnvelopes ?? 0); layer += 1)
+				result = envelope(result);
+		} else {
+			throw new Error("Unexpected method");
+		}
+		const data = JSON.stringify({ jsonrpc: "2.0", id: message.id, result });
+		return options.sse
+			? new Response(`event: message\ndata: ${data}\n\n`, {
+					headers: { "Content-Type": "text/event-stream" },
+				})
+			: new Response(data, { headers: { "Content-Type": "application/json" } });
+	});
+	return { fetcher, messages };
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("workspace runtime observations", () => {
+	it("returns four honest unconfigured states without opening any connection", async () => {
+		const fetcher = vi.fn<typeof fetch>();
+		const snapshot = await createWorkspaceSnapshot({}, fetcher);
+		expect(snapshot.integrations.map((item) => item.state)).toEqual(
+			Array(4).fill("not_configured")
+		);
+		expect(
+			snapshot.integrations.every((item) => item.checkedAt === null && item.metrics.length === 0)
+		).toBe(true);
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("uses real MCP initialization, discovery and exact read calls with service credentials", async () => {
+		const { fetcher, messages } = mcpFixture();
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL, WORKSPACE_RUFLO_TOKEN: "private-fixture-token" },
+			fetcher
+		);
+		const [ruflo, metaharness, autogenous] = snapshot.integrations;
+		expect(ruflo).toMatchObject({
+			state: "available",
+			toolCount: 3,
+			source: { discoveryOnly: false },
+		});
+		expect(ruflo.metrics).toContainEqual({ label: "Process uptime seconds", value: 42 });
+		expect(ruflo.metrics).toContainEqual({ label: "Policy mode", value: "enforce" });
+		expect(metaharness).toMatchObject({
+			state: "available",
+			source: { configuredBy: "WORKSPACE_RUFLO_MCP_URL", discoveryOnly: false },
+		});
+		expect(metaharness.metrics).toContainEqual({ label: "Promotion commits", value: 2 });
+		expect(autogenous.state).toBe("not_configured");
+		const calls = messages
+			.filter((message) => message.method === "tools/call")
+			.map((message) => message.params);
+		expect(calls).toEqual(
+			expect.arrayContaining([
+				{ name: "system_status", arguments: { verbose: false } },
+				{ name: "policy_status", arguments: {} },
+				{ name: "metaharness_flywheel", arguments: { operation: "status" } },
+			])
+		);
+		expect(calls).toHaveLength(3);
+		for (const [url, init] of fetcher.mock.calls) {
+			expect(String(url)).toBe(RUFLO_URL);
+			expect(init).toMatchObject({ redirect: "manual", credentials: "omit", method: "POST" });
+			expect(new Headers(init?.headers).get("authorization")).toBe("Bearer private-fixture-token");
+		}
+		expect(JSON.stringify(snapshot)).not.toContain("private-fixture-token");
+		expect(JSON.stringify(snapshot)).not.toContain(RUFLO_URL);
+	});
+
+	it("accepts actual SSE MCP response envelopes and the fixed bridge status wrappers", async () => {
+		const { fetcher, messages } = mcpFixture(
+			["ruflo__system_status", "ruflo__policy_status", "ruflo__metaharness_flywheel_status"],
+			{ sse: true }
+		);
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL }, fetcher);
+		expect(snapshot.integrations.slice(0, 2).map((item) => item.state)).toEqual([
+			"available",
+			"available",
+		]);
+		expect(messages).toContainEqual(
+			expect.objectContaining({
+				method: "tools/call",
+				params: { name: "ruflo__metaharness_flywheel_status", arguments: {} },
+			})
+		);
+	});
+
+	it("labels discovery-only results and does not execute similarly named or arbitrary tools", async () => {
+		const { fetcher, messages } = mcpFixture([
+			"system_status_attack",
+			"metaharness_flywheel_promote",
+			"shell_execute",
+		]);
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL }, fetcher);
+		expect(snapshot.integrations[0]).toMatchObject({
+			state: "available",
+			toolCount: 3,
+			source: { discoveryOnly: true },
+		});
+		expect(snapshot.integrations[1].state).toBe("degraded");
+		expect(messages.some((message) => message.method === "tools/call")).toBe(false);
+	});
+
+	it.each([1, 2])(
+		"unwraps the real HTTP bridge plus stdio envelope shape with %s extra layers",
+		async (additionalEnvelopes) => {
+			const { fetcher } = mcpFixture(
+				["ruflo__system_status", "ruflo__policy_status", "ruflo__metaharness_flywheel_status"],
+				{ additionalEnvelopes }
+			);
+			const snapshot = await createWorkspaceSnapshot(
+				{ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL },
+				fetcher
+			);
+			expect(snapshot.integrations[0].state).toBe("available");
+			expect(snapshot.integrations[0].metrics).toContainEqual({
+				label: "Policy mode",
+				value: "enforce",
+			});
+			expect(snapshot.integrations[1].state).toBe("available");
+			expect(snapshot.integrations[1].metrics).toContainEqual({
+				label: "Promotion commits",
+				value: 2,
+			});
+		}
+	);
+
+	it("rejects more than three MCP envelopes", async () => {
+		const { fetcher } = mcpFixture(["ruflo__metaharness_flywheel_status"], {
+			additionalEnvelopes: 3,
+		});
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1]).toMatchObject({ state: "degraded", metrics: [] });
+	});
+
+	it.each([
+		envelope(envelope(flywheel), { success: false }),
+		envelope(envelope(flywheel), { degraded: true }),
+		envelope(envelope(flywheel), { exitCode: 1 }),
+		envelope(envelope(flywheel, { isError: true })),
+		envelope(envelope(flywheel, { success: false })),
+		envelope(envelope(flywheel, { degraded: true })),
+		envelope(envelope(flywheel, { exitCode: 1 })),
+		envelope(envelope({ ...flywheel, exitCode: 1 })),
+		envelope(envelope(flywheel, { isError: true }), { structuredContent: flywheel }),
+		envelope(envelope(flywheel), { structuredContent: { ...flywheel, isError: true } }),
+	])(
+		"does not mask an outer or nested failure with an apparently successful payload",
+		async (toolResult) => {
+			const { fetcher } = mcpFixture(["ruflo__metaharness_flywheel_status"], { toolResult });
+			const snapshot = await createWorkspaceSnapshot(
+				{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+				fetcher
+			);
+			expect(snapshot.integrations[1]).toMatchObject({ state: "degraded", metrics: [] });
+			expect(snapshot.integrations[1].summary).toContain("reported an error");
+		}
+	);
+
+	it("accepts matching structured and nested text status without losing explicit zero exit codes", async () => {
+		const result = { ...flywheel, exitCode: 0 };
+		const { fetcher } = mcpFixture(["ruflo__metaharness_flywheel_status"], {
+			toolResult: envelope(envelope(result, { success: true, degraded: false, exitCode: 0 }), {
+				structuredContent: result,
+				success: true,
+				degraded: false,
+				exitCode: 0,
+			}),
+		});
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1].state).toBe("available");
+	});
+
+	it("rejects contradictory status representations instead of preferring the healthy one", async () => {
+		const invalidLedger = {
+			...flywheel,
+			data: { ...flywheel.data, ledger: { valid: false, commits: 2 } },
+		};
+		const { fetcher } = mcpFixture(["ruflo__metaharness_flywheel_status"], {
+			toolResult: envelope(envelope(invalidLedger), { structuredContent: flywheel }),
+		});
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1]).toMatchObject({ state: "degraded", metrics: [] });
+	});
+
+	it.each([
+		{ success: false, degraded: false, error: "secret upstream failure" },
+		{ success: true, degraded: true, error: "secret upstream failure" },
+		{ ...flywheel, data: { ...flywheel.data, ledger: { valid: false, commits: 2 } } },
+	])("preserves failed or degraded MetaHarness status as degraded", async (status) => {
+		const { fetcher } = mcpFixture(["metaharness_flywheel"], { status });
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1].state).toBe("degraded");
+		expect(JSON.stringify(snapshot)).not.toContain("secret upstream failure");
+	});
+
+	it.each([
+		{ status: "unhealthy", uptime: 1000 },
+		{ status: "healthy", uptime: 1000, degraded: true },
+		{ status: "healthy", uptime: 1000, success: false },
+	])("does not label explicitly unhealthy system reports available", async (status) => {
+		const { fetcher } = mcpFixture(["system_status"], { status });
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL }, fetcher);
+		expect(snapshot.integrations[0].state).toBe("degraded");
+	});
+
+	it.each([
+		{ tools: "not an array" },
+		{
+			tools: [
+				{ name: "system_status", inputSchema: { type: "object" } },
+				{ name: "system_status", inputSchema: { type: "object" } },
+			],
+		},
+		{ tools: [{ name: "system_status" }] },
+		{ tools: [], nextCursor: "repeated-cursor" },
+	])("rejects malformed, duplicate and cyclic tool inventories", async (list) => {
+		const { fetcher } = mcpFixture([], { list });
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL }, fetcher);
+		expect(snapshot.integrations[0].state).toBe("degraded");
+		expect(snapshot.integrations[0].toolCount).toBeUndefined();
+	});
+
+	it("rejects an inventory over the total tool limit", async () => {
+		const { fetcher } = mcpFixture(Array.from({ length: 1025 }, (_, index) => `tool_${index}`));
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL }, fetcher);
+		expect(snapshot.integrations[0]).toMatchObject({
+			state: "degraded",
+			metrics: [],
+		});
+		expect(snapshot.integrations[0].toolCount).toBeUndefined();
+	});
+
+	it.each([
+		{ content: [{ type: "text", text: "a password rather than JSON" }] },
+		{ content: [{ type: "text", text: "[]" }] },
+		{ content: [{ type: "text", text: JSON.stringify(system) }], isError: true },
+		{ content: [{ type: "text", text: JSON.stringify({ ...system, uptime: -1 }) }] },
+	])("rejects malformed or error status payloads without emitting raw text", async (toolResult) => {
+		const { fetcher } = mcpFixture(["system_status"], { toolResult });
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL }, fetcher);
+		expect(snapshot.integrations[0]).toMatchObject({ state: "degraded", metrics: [] });
+		expect(JSON.stringify(snapshot)).not.toContain("password");
+	});
+
+	it("redacts nested credentials, upstream errors, prompts and machine identifiers by allowlisting", async () => {
+		const secret = "untrusted-secret-canary";
+		const { fetcher } = mcpFixture(["system_status"], {
+			status: {
+				...system,
+				token: secret,
+				prompt: secret,
+				endpoint: secret,
+				metrics: { authorization: secret },
+			},
+		});
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_RUFLO_MCP_URL: RUFLO_URL, WORKSPACE_RUFLO_TOKEN: secret },
+			fetcher
+		);
+		expect(snapshot.integrations[0].state).toBe("available");
+		expect(JSON.stringify(snapshot)).not.toContain(secret);
+		expect(JSON.stringify(snapshot)).not.toContain("components");
+	});
+
+	it.each([401, 403, 500])(
+		"maps upstream HTTP %s to degraded without exposing its error body",
+		async (status) => {
+			const fetcher = vi
+				.fn<typeof fetch>()
+				.mockResolvedValue(new Response("secret error body", { status }));
+			const snapshot = await createWorkspaceSnapshot(
+				{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+				fetcher
+			);
+			expect(snapshot.integrations[1].state).toBe("degraded");
+			expect(JSON.stringify(snapshot)).not.toContain("secret error body");
+		}
+	);
+
+	it("rejects redirects before a credential can be sent to their target", async () => {
+		const fetcher = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				new Response(null, { status: 302, headers: { Location: "https://attacker.example.test" } })
+			);
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL, WORKSPACE_METAHARNESS_TOKEN: "secret" },
+			fetcher
+		);
+		expect(snapshot.integrations[1].state).toBe("degraded");
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		expect(JSON.stringify(snapshot)).not.toContain("attacker");
+	});
+
+	it("classifies a connection failure as unreachable", async () => {
+		const fetcher = vi.fn<typeof fetch>().mockRejectedValue(new Error("secret endpoint refused"));
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1].state).toBe("unreachable");
+		expect(JSON.stringify(snapshot)).not.toContain("secret endpoint");
+	});
+
+	it("enforces one 5 second deadline and aborts pending I/O", async () => {
+		vi.useFakeTimers();
+		let signal: AbortSignal | null | undefined;
+		const fetcher = vi.fn<typeof fetch>((_input, init) => {
+			signal = init?.signal;
+			return new Promise(() => {});
+		});
+		const result = createWorkspaceSnapshot({ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL }, fetcher);
+		await vi.advanceTimersByTimeAsync(WORKSPACE_TIMEOUT_MS);
+		const snapshot = await result;
+		expect(snapshot.integrations[1]).toMatchObject({
+			state: "unreachable",
+			latencyMs: WORKSPACE_TIMEOUT_MS,
+		});
+		expect(signal?.aborted).toBe(true);
+	});
+
+	it("bounds decoded streaming bodies even when no content length was provided", async () => {
+		const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(new Uint8Array(WORKSPACE_RESPONSE_BYTES + 1), {
+				headers: { "Content-Type": "application/json" },
+			})
+		);
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1]).toMatchObject({ state: "degraded", metrics: [] });
+		expect(snapshot.integrations[1].summary).toContain("size");
+	});
+
+	it("keeps a returned timeout snapshot immutable when an uncooperative reader settles late", async () => {
+		vi.useFakeTimers();
+		let completeRead: (value: unknown) => void = () => {};
+		const lateRead = new Promise((resolve) => {
+			completeRead = resolve;
+		});
+		const response = new Response(null, { headers: { "Content-Type": "application/json" } });
+		response.json = () => lateRead;
+		const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response);
+		const pending = createWorkspaceSnapshot({ WORKSPACE_RUOS_BASE_URL: RUOS_URL }, fetcher);
+		await vi.advanceTimersByTimeAsync(WORKSPACE_TIMEOUT_MS);
+		const snapshot = await pending;
+		const frozen = JSON.stringify(snapshot);
+		completeRead({ ok: true, services: { "rustdesk-hbbs": "active", "rustdesk-hbbr": "active" } });
+		await vi.advanceTimersByTimeAsync(1);
+		expect(snapshot.integrations[3]).toMatchObject({ state: "unreachable", metrics: [] });
+		expect(JSON.stringify(snapshot)).toBe(frozen);
+	});
+
+	it("cancels late fetch responses without parsing them after timeout", async () => {
+		vi.useFakeTimers();
+		let completeFetch: (response: Response) => void = () => {};
+		const fetcher = vi.fn<typeof fetch>(
+			() =>
+				new Promise((resolve) => {
+					completeFetch = resolve;
+				})
+		);
+		const pending = createWorkspaceSnapshot({ WORKSPACE_RUOS_BASE_URL: RUOS_URL }, fetcher);
+		await vi.advanceTimersByTimeAsync(WORKSPACE_TIMEOUT_MS);
+		const snapshot = await pending;
+		let cancelled = false;
+		const body = new ReadableStream({
+			cancel() {
+				cancelled = true;
+			},
+		});
+		completeFetch(new Response(body, { headers: { "Content-Type": "application/json" } }));
+		await vi.advanceTimersByTimeAsync(1);
+		expect(cancelled).toBe(true);
+		expect(snapshot.integrations[3].state).toBe("unreachable");
+	});
+
+	it("does not wait for asynchronous SDK cleanup beyond the observation deadline", async () => {
+		vi.spyOn(Client.prototype, "close").mockImplementation(() => new Promise(() => {}));
+		const { fetcher } = mcpFixture(["metaharness_flywheel"]);
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_METAHARNESS_MCP_URL: RUFLO_URL },
+			fetcher
+		);
+		expect(snapshot.integrations[1].state).toBe("available");
+	});
+
+	it.each([
+		"file:///etc/passwd",
+		"https://user:secret@example.test/mcp",
+		"https://example.test/mcp?token=secret",
+		"https://example.test/mcp#secret",
+	])("rejects unsafe deployment URLs before network access", async (url) => {
+		const fetcher = vi.fn<typeof fetch>();
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_METAHARNESS_MCP_URL: url }, fetcher);
+		expect(snapshot.integrations[1]).toMatchObject({ state: "degraded", checkedAt: null });
+		expect(fetcher).not.toHaveBeenCalled();
+		expect(JSON.stringify(snapshot)).not.toContain("secret");
+	});
+
+	it("restricts SDK transport tools/call to fixed status arguments", async () => {
+		const fetcher = vi.fn<typeof fetch>();
+		const url = new URL(RUFLO_URL);
+		const transport = createBoundedTransport(url, new AbortController().signal, fetcher, true);
+		await expect(
+			transport.fetch(url, {
+				method: "POST",
+				body: JSON.stringify({
+					method: "tools/call",
+					params: { name: "metaharness_flywheel", arguments: { operation: "promote" } },
+				}),
+			})
+		).rejects.toThrow("malformed");
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("observes the concrete ruOS endpoint and keeps service failures private", async () => {
+		const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+			Response.json({
+				ok: true,
+				services: { "rustdesk-hbbs": "active", "rustdesk-hbbr": "active" },
+			})
+		);
+		const snapshot = await createWorkspaceSnapshot(
+			{ WORKSPACE_RUOS_BASE_URL: RUOS_URL, WORKSPACE_RUOS_TOKEN: "ruos-private" },
+			fetcher
+		);
+		expect(snapshot.integrations[3]).toMatchObject({
+			state: "available",
+			metrics: [{ label: "Active rendezvous services", value: 2 }],
+			source: { discoveryOnly: false },
+		});
+		expect(String(fetcher.mock.calls[0][0])).toBe(`${RUOS_URL}/api/v1/server/health`);
+		expect(JSON.stringify(snapshot)).not.toContain("ruos-private");
+	});
+
+	it("does not trust ok:true when a ruOS service is failed", async () => {
+		const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+			Response.json({
+				ok: true,
+				services: { "rustdesk-hbbs": "active", "rustdesk-hbbr": "error: private path and token" },
+			})
+		);
+		const snapshot = await createWorkspaceSnapshot({ WORKSPACE_RUOS_BASE_URL: RUOS_URL }, fetcher);
+		expect(snapshot.integrations[3].state).toBe("degraded");
+		expect(JSON.stringify(snapshot)).not.toContain("private path");
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/server/workspace/snapshot.ts
+++ b/ruflo/src/ruvocal/src/lib/server/workspace/snapshot.ts
@@ -1,0 +1,168 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { WorkspaceIntegration, WorkspaceSnapshot } from "$lib/types/Workspace";
+import { readWorkspaceConfig, type IntegrationConfig, type WorkspaceEnvironment } from "./config";
+import {
+	normalizeFlywheel,
+	normalizePolicy,
+	normalizeRuos,
+	normalizeSystem,
+	toolData,
+} from "./normalize";
+import {
+	createBoundedTransport,
+	failureSummary,
+	ProbeError,
+	READ_CALLS,
+	WORKSPACE_TIMEOUT_MS,
+} from "./transport";
+
+const MAX_PAGES = 4;
+const MAX_TOOLS = 1024;
+
+function summarizeRuflo(integration: WorkspaceIntegration): string {
+	return integration.state === "degraded"
+		? "The runtime reported a degraded system state or invalid policy ledger."
+		: "Runtime status observed. Individual component health and action authority are not established.";
+}
+
+async function observeMcp(client: Client, integration: WorkspaceIntegration, signal: AbortSignal) {
+	const names = new Set<string>();
+	const cursors = new Set<string>();
+	let cursor: string | undefined;
+	for (let page = 0; page < MAX_PAGES; page += 1) {
+		const result = await client.listTools(cursor ? { cursor } : {}, { signal });
+		for (const tool of result.tools) {
+			if (!/^[A-Za-z0-9_.:/-]{1,128}$/.test(tool.name) || names.has(tool.name))
+				throw new ProbeError("malformed");
+			names.add(tool.name);
+			if (names.size > MAX_TOOLS) throw new ProbeError("oversize");
+		}
+		cursor = result.nextCursor;
+		if (!cursor) break;
+		if (cursor.length > 2048 || cursors.has(cursor)) throw new ProbeError("malformed");
+		cursors.add(cursor);
+		if (page === MAX_PAGES - 1) throw new ProbeError("oversize");
+	}
+	integration.toolCount = names.size;
+	integration.state = "available";
+	integration.summary =
+		"MCP discovery completed. Tool execution and operational health are not verified.";
+	const call = async (name: string) =>
+		toolData(await client.callTool({ name, arguments: READ_CALLS[name] }, undefined, { signal }));
+	if (integration.id === "ruflo") {
+		const system = ["ruflo__system_status", "system_status"].find((name) => names.has(name));
+		const policy = ["ruflo__policy_status", "policy_status"].find((name) => names.has(name));
+		if (system) normalizeSystem(await call(system), integration);
+		if (policy) normalizePolicy(await call(policy), integration);
+		if (system || policy) {
+			integration.source.discoveryOnly = false;
+			integration.source.label = [system ? "system_status" : "", policy ? "policy_status" : ""]
+				.filter(Boolean)
+				.join(" + ");
+			integration.summary = summarizeRuflo(integration);
+		}
+	} else if (integration.id === "metaharness") {
+		const flywheel = ["ruflo__metaharness_flywheel_status", "metaharness_flywheel"].find((name) =>
+			names.has(name)
+		);
+		if (flywheel) {
+			integration.source.discoveryOnly = false;
+			integration.source.label = "Ruflo MetaHarness flywheel status";
+			normalizeFlywheel(await call(flywheel), integration);
+		} else {
+			integration.state = "degraded";
+			integration.summary =
+				"MCP discovery completed, but the fixed MetaHarness status tool is not exposed.";
+		}
+	}
+}
+
+async function observeIntegration(
+	config: IntegrationConfig,
+	fetcher: typeof fetch
+): Promise<WorkspaceIntegration> {
+	const integration = config.base;
+	if (!config.url) return integration;
+	// Only a completed observation is committed to the returned object. A timed
+	// out task may settle later, but it can mutate only this private draft.
+	const draft = structuredClone(integration);
+	const started = Date.now();
+	const controller = new AbortController();
+	const bounded = createBoundedTransport(
+		config.url,
+		controller.signal,
+		fetcher,
+		integration.source.kind === "mcp"
+	);
+	const headers: Record<string, string> = config.token
+		? { Authorization: `Bearer ${config.token}` }
+		: {};
+	let client: Client | undefined;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const deadline = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => {
+				controller.abort();
+				reject(new ProbeError("timeout"));
+			}, WORKSPACE_TIMEOUT_MS);
+		});
+		const observe = async () => {
+			if (integration.source.kind === "http") {
+				const response = await bounded.fetch(config.url as URL, {
+					headers: { ...headers, Accept: "application/json" },
+				});
+				if (!response.headers.get("content-type")?.includes("application/json"))
+					throw new ProbeError("malformed");
+				normalizeRuos(await response.json(), draft);
+				return;
+			}
+			client = new Client({ name: "ruflo-workspace-observer", version: "1.0.0" });
+			const transport = new StreamableHTTPClientTransport(config.url as URL, {
+				fetch: bounded.fetch,
+				requestInit: { headers },
+				reconnectionOptions: {
+					maxRetries: 0,
+					initialReconnectionDelay: 0,
+					maxReconnectionDelay: 0,
+					reconnectionDelayGrowFactor: 1,
+				},
+			});
+			await client.connect(transport, { signal: controller.signal, timeout: WORKSPACE_TIMEOUT_MS });
+			await observeMcp(client, draft, controller.signal);
+		};
+		await Promise.race([observe(), deadline]);
+		if (controller.signal.aborted) throw new ProbeError("timeout");
+		Object.assign(integration, draft);
+	} catch (error) {
+		const reason = controller.signal.aborted
+			? "timeout"
+			: (bounded.failure ??
+				(error instanceof ProbeError ? error.reason : bounded.responded ? "malformed" : "network"));
+		integration.state = reason === "timeout" || reason === "network" ? "unreachable" : "degraded";
+		integration.summary = failureSummary(reason);
+		// A failed observation never retains partial metrics as current operational evidence.
+		integration.metrics = [];
+	} finally {
+		clearTimeout(timer);
+		controller.abort();
+		// The installed SDK closes by aborting its transport synchronously. Do
+		// not let a future asynchronous cleanup extend the observation deadline.
+		void client?.close().catch(() => {});
+		integration.checkedAt = new Date().toISOString();
+		integration.latencyMs = Math.max(0, Date.now() - started);
+	}
+	return integration;
+}
+
+export async function createWorkspaceSnapshot(
+	env: WorkspaceEnvironment,
+	fetcher: typeof fetch = globalThis.fetch
+): Promise<WorkspaceSnapshot> {
+	const configs = readWorkspaceConfig(env);
+	// One failed source must not blank the remaining integrations.
+	const integrations = await Promise.all(
+		configs.map((config) => observeIntegration(config, fetcher))
+	);
+	return { schemaVersion: 1, checkedAt: new Date().toISOString(), integrations };
+}

--- a/ruflo/src/ruvocal/src/lib/server/workspace/transport.ts
+++ b/ruflo/src/ruvocal/src/lib/server/workspace/transport.ts
@@ -1,0 +1,145 @@
+export const WORKSPACE_TIMEOUT_MS = 5_000;
+export const WORKSPACE_RESPONSE_BYTES = 256 * 1024;
+const MAX_TOTAL_BYTES = 1024 * 1024;
+const MAX_REQUESTS = 12;
+
+/** Exact arguments are owned by this adapter, never by the caller or tool descriptions. */
+export const READ_CALLS: Record<string, Record<string, unknown>> = {
+	system_status: { verbose: false },
+	ruflo__system_status: { verbose: false },
+	policy_status: {},
+	ruflo__policy_status: {},
+	metaharness_flywheel: { operation: "status" },
+	ruflo__metaharness_flywheel_status: {},
+};
+
+export type ProbeFailure =
+	| "timeout"
+	| "oversize"
+	| "redirect"
+	| "credentials"
+	| "http"
+	| "malformed"
+	| "runtime";
+
+export class ProbeError extends Error {
+	constructor(public readonly reason: ProbeFailure) {
+		super(reason);
+	}
+}
+
+/** No upstream text, endpoint, credentials or errors are returned to the browser. */
+export function failureSummary(reason: ProbeFailure | "network"): string {
+	return {
+		timeout: "No complete response within the 5 second observation limit.",
+		oversize: "The response exceeded the bounded observation size.",
+		redirect: "The configured endpoint redirected. Set its final URL in deployment settings.",
+		credentials: "The runtime rejected the configured service credentials.",
+		http: "The runtime returned an unsuccessful HTTP response.",
+		malformed: "The runtime response did not match the supported status contract.",
+		runtime: "The runtime status tool reported an error, failure or degraded operation.",
+		network: "The configured runtime could not be reached.",
+	}[reason];
+}
+
+/**
+ * Fetch only one fixed endpoint. Bound decompressed body bytes, total requests and
+ * wall time; prevent credentials following redirects or arbitrary SDK requests.
+ */
+export function createBoundedTransport(
+	url: URL,
+	signal: AbortSignal,
+	fetcher: typeof fetch,
+	mcp: boolean
+) {
+	let totalBytes = 0;
+	let requests = 0;
+	let failure: ProbeFailure | undefined;
+	let responded = false;
+	const fail = (reason: ProbeFailure): never => {
+		failure = reason;
+		throw new ProbeError(reason);
+	};
+	const boundedFetch: typeof fetch = async (input, init) => {
+		const target = input instanceof Request ? input.url : input.toString();
+		if (target !== url.href || requests >= MAX_REQUESTS) fail("malformed");
+		if (signal.aborted) fail("timeout");
+		const method = init?.method ?? "GET";
+		// A snapshot does not subscribe to optional MCP background SSE events.
+		// The SDK accepts 405 here and still supports SSE responses to POST.
+		if (mcp && method === "GET") return new Response(null, { status: 405 });
+		if (method !== (mcp ? "POST" : "GET")) fail("malformed");
+		if (mcp) {
+			let message;
+			try {
+				message = JSON.parse(String(init?.body));
+			} catch {
+				fail("malformed");
+			}
+			if (
+				!["initialize", "notifications/initialized", "tools/list", "tools/call"].includes(
+					message?.method
+				)
+			) {
+				fail("malformed");
+			}
+			if (message.method === "tools/call") {
+				const name = message.params?.name;
+				if (
+					typeof name !== "string" ||
+					!Object.hasOwn(READ_CALLS, name) ||
+					JSON.stringify(message.params.arguments) !== JSON.stringify(READ_CALLS[name])
+				)
+					fail("malformed");
+			}
+		}
+		requests += 1;
+		const response = await fetcher(url, {
+			...init,
+			redirect: "manual",
+			credentials: "omit",
+			signal: init?.signal ? AbortSignal.any([signal, init.signal]) : signal,
+		});
+		// A fetch implementation must not turn a late completion into current evidence.
+		if (signal.aborted) {
+			void response.body?.cancel().catch(() => {});
+			fail("timeout");
+		}
+		responded = true;
+		if (response.status >= 300 && response.status < 400) {
+			void response.body?.cancel().catch(() => {});
+			fail("redirect");
+		}
+		if (!response.ok) {
+			void response.body?.cancel().catch(() => {});
+			fail(response.status === 401 || response.status === 403 ? "credentials" : "http");
+		}
+		if (Number(response.headers.get("content-length")) > WORKSPACE_RESPONSE_BYTES) {
+			void response.body?.cancel().catch(() => {});
+			fail("oversize");
+		}
+		if (!response.body) return response;
+		let bytes = 0;
+		const stream = response.body.pipeThrough(
+			new TransformStream<Uint8Array, Uint8Array>({
+				transform(chunk, controller) {
+					bytes += chunk.byteLength;
+					totalBytes += chunk.byteLength;
+					if (bytes > WORKSPACE_RESPONSE_BYTES || totalBytes > MAX_TOTAL_BYTES) fail("oversize");
+					controller.enqueue(chunk);
+				},
+			}),
+			{ signal }
+		);
+		return new Response(stream, { status: response.status, headers: response.headers });
+	};
+	return {
+		fetch: boundedFetch,
+		get failure() {
+			return failure;
+		},
+		get responded() {
+			return responded;
+		},
+	};
+}

--- a/ruflo/src/ruvocal/src/lib/stores/mcpServers.ts
+++ b/ruflo/src/ruvocal/src/lib/stores/mcpServers.ts
@@ -415,7 +415,11 @@ export async function healthCheckServer(
 		const response = await fetch(`${base}/api/mcp/health`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ url: server.url, headers: server.headers }),
+			body: JSON.stringify(
+				server.type === "base"
+					? { serverId: server.id }
+					: { url: server.url, headers: server.headers }
+			),
 		});
 
 		const result = await response.json();

--- a/ruflo/src/ruvocal/src/lib/types/Settings.ts
+++ b/ruflo/src/ruvocal/src/lib/types/Settings.ts
@@ -1,4 +1,5 @@
 import { defaultModel } from "$lib/server/models";
+import { building } from "$app/environment";
 import type { Timestamps } from "./Timestamps";
 import type { User } from "./User";
 
@@ -79,7 +80,7 @@ export type SettingsEditable = Omit<Settings, "welcomeModalSeenAt" | "createdAt"
 // TODO: move this to a constant file along with other constants
 export const DEFAULT_SETTINGS = {
 	shareConversationsWithModelAuthors: true,
-	activeModel: defaultModel.id,
+	activeModel: building ? "" : defaultModel.id,
 	customPrompts: {},
 	multimodalOverrides: {},
 	toolsOverrides: {},

--- a/ruflo/src/ruvocal/src/lib/types/Workspace.ts
+++ b/ruflo/src/ruvocal/src/lib/types/Workspace.ts
@@ -1,0 +1,27 @@
+export type WorkspaceIntegrationId = "ruflo" | "metaharness" | "autogenous" | "ruos";
+
+export type WorkspaceIntegrationState = "not_configured" | "available" | "degraded" | "unreachable";
+
+/** Only normalized, explicitly allowed fields cross the server boundary. */
+export interface WorkspaceIntegration {
+	id: WorkspaceIntegrationId;
+	name: string;
+	state: WorkspaceIntegrationState;
+	summary: string;
+	checkedAt: string | null;
+	latencyMs: number | null;
+	toolCount?: number;
+	metrics: { label: string; value: string | number }[];
+	source: {
+		kind: "mcp" | "http";
+		label: string;
+		configuredBy: string;
+		discoveryOnly: boolean;
+	};
+}
+
+export interface WorkspaceSnapshot {
+	schemaVersion: 1;
+	checkedAt: string;
+	integrations: WorkspaceIntegration[];
+}

--- a/ruflo/src/ruvocal/src/lib/utils/openWorkspaceDraft.spec.ts
+++ b/ruflo/src/ruvocal/src/lib/utils/openWorkspaceDraft.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+vi.mock("$app/paths", () => ({ base: "/flo" }));
+vi.mock("$app/navigation", () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
+import { goto } from "$app/navigation";
+import { pendingChatInput } from "$lib/stores/pendingChatInput";
+import { openWorkspaceDraft } from "./openWorkspaceDraft";
+import { buildMissionDraft } from "./workspace";
+
+beforeEach(() => {
+	vi.mocked(goto).mockReset().mockResolvedValue(undefined);
+	pendingChatInput.set(undefined);
+});
+describe("local draft handoff", () => {
+	it("preserves 4,000 Unicode characters without putting them in a URL", async () => {
+		const draft = buildMissionDraft("語".repeat(4000), "build", 3);
+		await openWorkspaceDraft(draft);
+		expect(goto).toHaveBeenCalledWith("/flo/");
+		expect(get(pendingChatInput)).toEqual(draft);
+	});
+	it("clears an unconsumed handoff on failed navigation", async () => {
+		vi.mocked(goto).mockRejectedValueOnce(new Error("Navigation failed"));
+		await expect(openWorkspaceDraft("local draft")).rejects.toThrow("Navigation failed");
+		expect(get(pendingChatInput)).toBeUndefined();
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/utils/openWorkspaceDraft.ts
+++ b/ruflo/src/ruvocal/src/lib/utils/openWorkspaceDraft.ts
@@ -1,0 +1,14 @@
+import { base } from "$app/paths";
+import { goto } from "$app/navigation";
+import { pendingChatInput } from "$lib/stores/pendingChatInput";
+
+/** Transfer a draft within this tab, without including user text in URLs or submitting it. */
+export async function openWorkspaceDraft(draft: string): Promise<void> {
+	pendingChatInput.set(draft);
+	try {
+		await goto(`${base}/`);
+	} catch (error) {
+		pendingChatInput.set(undefined);
+		throw error;
+	}
+}

--- a/ruflo/src/ruvocal/src/lib/utils/workspace.spec.ts
+++ b/ruflo/src/ruvocal/src/lib/utils/workspace.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { buildMissionDraft, discoveredTools, toolFamily } from "./workspace";
+import type { MCPServer } from "$lib/types/Tool";
+
+describe("mission drafts", () => {
+	it("preserves the objective and explicitly separates instructions from authority", () => {
+		const draft = buildMissionDraft("  Fix the mobile navigation  ", "build", 3);
+		expect(draft).toMatch(/^Fix the mobile navigation\n/);
+		expect(draft).toContain("Requested iteration limit: 3");
+		expect(draft).toContain("do not grant permission or enforce runtime budgets");
+		expect(draft).toContain("Do not expand authority, promote, publish or deploy");
+	});
+	it.each(["", "  ", "x".repeat(4001)])("rejects invalid objectives", (input) => {
+		expect(() => buildMissionDraft(input, "review", 1)).toThrow();
+	});
+	it.each([0, 6, 1.5, NaN, Infinity])("rejects invalid iteration limits", (input) => {
+		expect(() => buildMissionDraft("Inspect the source", "review", input)).toThrow();
+	});
+	it("keeps adversarial text as draft content without evaluating it", () => {
+		const draft = buildMissionDraft('<script>alert("x")</script>', "review", 1);
+		expect(decodeURIComponent(encodeURIComponent(draft))).toEqual(draft);
+	});
+});
+
+describe("observed capabilities", () => {
+	const server: MCPServer = {
+		id: "base-ruflo",
+		name: "Ruflo",
+		url: "https://example.test/mcp",
+		type: "base",
+		status: "connected",
+		tools: [{ name: "ruflo__policy_status" }, { name: "memory_stats" }],
+	};
+	it("does not invent schemas for a selected but undiscovered server", () => {
+		expect(discoveredTools([{ ...server, tools: undefined }], new Set([server.id]))).toEqual([]);
+	});
+	it("distinguishes selection and connection", () => {
+		const tools = discoveredTools([{ ...server, status: "error" }], new Set([server.id]));
+		expect(tools.every((tool) => tool.selected && !tool.connected)).toBe(true);
+	});
+	it("deduplicates schemas and rejects malformed names before rendering keyed rows", () => {
+		const tools = discoveredTools(
+			[
+				{
+					...server,
+					tools: [
+						{ name: "memory_stats" },
+						{ name: "memory_stats" },
+						{ name: "" },
+						{ name: 42 } as never,
+						null as never,
+					],
+				},
+			],
+			new Set()
+		);
+		expect(tools.map((tool) => tool.name)).toEqual(["memory_stats"]);
+	});
+
+	it("keeps same-named tools on separate servers distinct", () => {
+		const tools = discoveredTools([server, { ...server, id: "other" }], new Set());
+		expect(new Set(tools.map((tool) => tool.id)).size).toBe(4);
+	});
+	it.each([
+		["ruflo__metaharness_flywheel_status", "Governance"],
+		["policy_status", "Governance"],
+		["ruvector__memory_stats", "Memory"],
+		["managed_agent_list", "Agents"],
+		["hooks_intelligence_stats", "Learning"],
+	])("classifies %s by original tool name", (tool, family) => {
+		expect(toolFamily(tool)).toBe(family);
+	});
+});

--- a/ruflo/src/ruvocal/src/lib/utils/workspace.ts
+++ b/ruflo/src/ruvocal/src/lib/utils/workspace.ts
@@ -1,0 +1,89 @@
+import type { MCPServer, MCPTool } from "$lib/types/Tool";
+
+export const missionPresets = [
+	{
+		id: "build",
+		title: "Build a feature",
+		detail: "Specification, implementation, validation",
+		objective: "Implement a feature with a clear acceptance test.",
+		icon: "build",
+	},
+	{
+		id: "review",
+		title: "Review a repository",
+		detail: "Find risks and prioritize fixes",
+		objective:
+			"Review a repository. Rank confirmed defects by impact and propose the smallest verifiable fixes.",
+		icon: "review",
+	},
+	{
+		id: "optimize",
+		title: "Optimize with evidence",
+		detail: "Measure a baseline, test a candidate",
+		objective:
+			"Measure a baseline, propose a bounded improvement, and compare the candidate against the same acceptance tests.",
+		icon: "optimize",
+	},
+] as const;
+
+export type MissionKind = (typeof missionPresets)[number]["id"];
+
+/** These are instructions for a chat draft, never runtime policy or authorization. */
+export function buildMissionDraft(
+	objective: string,
+	kind: MissionKind,
+	iterations: number
+): string {
+	const trimmed = objective.trim();
+	if (!trimmed || trimmed.length > 4000)
+		throw new Error("Enter an objective of 1 to 4,000 characters.");
+	if (!missionPresets.some((preset) => preset.id === kind))
+		throw new Error("Unknown mission type.");
+	if (!Number.isInteger(iterations) || iterations < 1 || iterations > 5)
+		throw new Error("Choose 1 to 5 iterations.");
+	return `${trimmed}\n\nMission: ${kind}. Requested iteration limit: ${iterations}.\nInspect available tools and repository instructions first. State inputs, outputs, constraints and an executable acceptance test. Use Ruflo for coordination, MetaHarness for evaluation, and Autogenous where a verified adapter is available. Distinguish configured, reachable and authorized capabilities. Record architecture decisions when needed. Measure the same baseline and candidate, retain failure evidence, and stop after the requested iteration limit or a repeated failure. These instructions do not grant permission or enforce runtime budgets. Do not expand authority, promote, publish or deploy without the required approval.`;
+}
+
+export function toolFamily(name: string): string {
+	name = name.includes("__") ? name.slice(name.lastIndexOf("__") + 2) : name;
+	if (/^(metaharness_|policy_|audit_)/.test(name)) return "Governance";
+	if (/^(memory_|agentdb_|embeddings_|ruvector_)/.test(name)) return "Memory";
+	if (/^(agent_|managed_agent_|swarm_|task_|hive_|autopilot_)/.test(name)) return "Agents";
+	if (/^(hooks_|neural_|learning_|ruvllm_)/.test(name)) return "Learning";
+	return "Tools";
+}
+
+/** Only observed tool schemas enter the inventory. Selection is not health. */
+export function discoveredTools(servers: MCPServer[], selected: Set<string>) {
+	const seen = new Set<string>();
+	return servers
+		.flatMap((server) => {
+			const schemas = Array.isArray(server.tools) ? server.tools : [];
+			return schemas
+				.slice(0, 1024)
+				.filter((tool): tool is MCPTool => {
+					if (
+						!tool ||
+						typeof tool.name !== "string" ||
+						!/^[A-Za-z0-9_.:/-]{1,128}$/.test(tool.name)
+					)
+						return false;
+					const id = `${server.id}:${tool.name}`;
+					if (seen.has(id)) return false;
+					seen.add(id);
+					return true;
+				})
+				.map((tool) => ({
+					...tool,
+					description:
+						typeof tool.description === "string" ? tool.description.slice(0, 4000) : undefined,
+					id: `${server.id}:${tool.name}`,
+					serverId: server.id,
+					serverName: server.name,
+					family: toolFamily(tool.name),
+					selected: selected.has(server.id),
+					connected: server.status === "connected",
+				}));
+		})
+		.sort((a, b) => a.name.localeCompare(b.name) || a.serverId.localeCompare(b.serverId));
+}

--- a/ruflo/src/ruvocal/src/routes/+layout.svelte
+++ b/ruflo/src/ruvocal/src/routes/+layout.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import "../styles/main.css";
+	import "../styles/workspace.css";
+	import WorkspaceCommands from "$lib/components/workspace/WorkspaceCommands.svelte";
 
 	import { onDestroy, onMount, untrack } from "svelte";
 	import { goto } from "$app/navigation";
@@ -256,6 +258,7 @@
 {/if}
 
 <BackgroundGenerationPoller />
+<WorkspaceCommands />
 
 <div
 	class="fixed grid h-dvh w-screen grid-cols-1 grid-rows-[auto,1fr] overflow-hidden text-smd {!isNavCollapsed

--- a/ruflo/src/ruvocal/src/routes/api/mcp/health/+server.ts
+++ b/ruflo/src/ruvocal/src/routes/api/mcp/health/+server.ts
@@ -1,17 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { KeyValuePair } from "$lib/types/Tool";
 import { config } from "$lib/server/config";
 import { logger } from "$lib/server/logger";
 import type { RequestHandler } from "./$types";
-import { isValidUrl } from "$lib/server/urlSafety";
+import { resolveHealthTarget, HealthTargetError } from "$lib/server/mcp/resolveHealthTarget";
 import { isStrictHfMcpLogin, hasNonEmptyToken, isExaMcpServer } from "$lib/server/mcp/hf";
-
-interface HealthCheckRequest {
-	url: string;
-	headers?: KeyValuePair[];
-}
 
 interface HealthCheckResponse {
 	ready: boolean;
@@ -26,29 +20,14 @@ interface HealthCheckResponse {
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	let client: Client | undefined;
+	let configuredRequest = false;
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	let controller: AbortController | undefined;
 
 	try {
-		const body: HealthCheckRequest = await request.json();
-		const { url, headers } = body;
-
-		if (!url) {
-			return new Response(JSON.stringify({ ready: false, error: "URL is required" }), {
-				status: 400,
-				headers: { "Content-Type": "application/json" },
-			});
-		}
-
-		// URL validation handled above
-
-		if (!isValidUrl(url)) {
-			return new Response(
-				JSON.stringify({
-					ready: false,
-					error: "Invalid or unsafe URL (only HTTPS is supported)",
-				} as HealthCheckResponse),
-				{ status: 400, headers: { "Content-Type": "application/json" } }
-			);
-		}
+		const target = resolveHealthTarget(await request.json(), config.MCP_SERVERS || "[]");
+		const { url, headers } = target;
+		configuredRequest = target.configured;
 
 		// Inject Exa API key for mcp.exa.ai servers via URL param
 		let finalUrl = url;
@@ -92,27 +71,41 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		}
 
 		// Add an abort timeout to outbound requests (align with fetch-url: 30s)
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 30000);
+		controller = new AbortController();
+		timeoutId = setTimeout(() => controller?.abort(), 30000);
 		const signal = controller.signal;
 		const requestInit: RequestInit = {
 			headers: headersRecord,
 			signal,
+			...(configuredRequest ? { redirect: "error" as const } : {}),
 		};
+		// SSE's EventSource GET does not inherit requestInit.redirect. Pin every
+		// configured transport request to its deployment origin and forbid redirects.
+		const configuredFetch: typeof fetch | undefined = configuredRequest
+			? async (input, init) => {
+					const destination = new URL(input instanceof Request ? input.url : input);
+					if (destination.origin !== baseUrl.origin)
+						throw new Error("Configured MCP health target cannot change origin");
+					return fetch(input, { ...init, redirect: "error", signal });
+				}
+			: undefined;
 
 		let httpError: Error | undefined;
 		let lastError: Error | undefined;
 
 		// Try Streamable HTTP transport first
 		try {
-			logger.info({}, `[MCP Health] Trying HTTP transport for ${url}`);
+			logger.info({}, "[MCP Health] Trying HTTP transport");
 			client = new Client({
 				name: "chat-ui-health-check",
 				version: "1.0.0",
 			});
 
-			const transport = new StreamableHTTPClientTransport(baseUrl, { requestInit });
-			logger.info({}, `[MCP Health] Connecting to ${url}...`);
+			const transport = new StreamableHTTPClientTransport(baseUrl, {
+				requestInit,
+				fetch: configuredFetch,
+			});
+			logger.info({}, "[MCP Health] Connecting...");
 			await client.connect(transport);
 			logger.info({}, `[MCP Health] Connected successfully via HTTP`);
 
@@ -157,7 +150,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		} catch (error) {
 			httpError = error instanceof Error ? error : new Error(String(error));
 			lastError = httpError;
-			logger.warn(lastError.message, "Streamable HTTP failed, trying SSE transport...");
+			logger.warn(
+				configuredRequest ? "Configured MCP connection failed" : lastError.message,
+				"Streamable HTTP failed, trying SSE transport..."
+			);
 
 			// Close failed client
 			try {
@@ -168,13 +164,16 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 			// Try SSE transport
 			try {
-				logger.info({}, `[MCP Health] Trying SSE transport for ${url}`);
+				logger.info({}, "[MCP Health] Trying SSE transport");
 				client = new Client({
 					name: "chat-ui-health-check",
 					version: "1.0.0",
 				});
 
-				const sseTransport = new SSEClientTransport(baseUrl, { requestInit });
+				const sseTransport = new SSEClientTransport(baseUrl, {
+					requestInit,
+					fetch: configuredFetch,
+				});
 				logger.info({}, `[MCP Health] Connecting via SSE...`);
 				await client.connect(sseTransport);
 				logger.info({}, `[MCP Health] Connected successfully via SSE`);
@@ -227,7 +226,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 						{ cause: sseError instanceof Error ? sseError : undefined }
 					);
 				}
-				logger.error(lastError, "Both transports failed.");
+				logger.error(
+					configuredRequest ? "Configured MCP connection failed" : lastError,
+					"Both transports failed."
+				);
 			}
 		}
 
@@ -254,6 +256,11 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		} else if (errorMessage.includes("CORS")) {
 			errorMessage = `CORS error. The MCP server needs to allow requests from this origin.`;
 		}
+		if (configuredRequest) {
+			errorMessage = authRequired
+				? "The configured MCP server requires valid deployment credentials."
+				: "The configured MCP server health check failed. Review the private deployment settings.";
+		}
 
 		const res = new Response(
 			JSON.stringify({
@@ -269,7 +276,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		clearTimeout(timeoutId);
 		return res;
 	} catch (error) {
-		logger.error(error, "MCP health check failed");
+		if (error instanceof HealthTargetError) {
+			return Response.json({ ready: false, error: error.message }, { status: 400 });
+		}
+		logger.error(
+			configuredRequest ? "Configured MCP connection failed" : error,
+			"MCP health check failed"
+		);
 
 		// Clean up client if it exists
 		try {
@@ -280,7 +293,11 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		const response: HealthCheckResponse = {
 			ready: false,
-			error: error instanceof Error ? error.message : "Unknown error",
+			error: configuredRequest
+				? "The configured MCP server health check failed."
+				: error instanceof Error
+					? error.message
+					: "Unknown error",
 		};
 
 		const res = new Response(JSON.stringify(response), {
@@ -288,5 +305,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			headers: { "Content-Type": "application/json" },
 		});
 		return res;
+	} finally {
+		clearTimeout(timeoutId);
+		controller?.abort();
+		void client?.close().catch(() => {});
 	}
 };

--- a/ruflo/src/ruvocal/src/routes/api/workspace/+server.ts
+++ b/ruflo/src/ruvocal/src/routes/api/workspace/+server.ts
@@ -1,0 +1,24 @@
+import { env } from "$env/dynamic/private";
+import { error, json } from "@sveltejs/kit";
+import { requireAdmin } from "$lib/server/api/utils/requireAuth";
+import { createWorkspaceSnapshot } from "$lib/server/workspace/snapshot";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ locals, request, url }) => {
+	// Reject before reading deployment configuration or opening any outbound connection.
+	requireAdmin(locals);
+	const origin = request.headers.get("origin");
+	const site = request.headers.get("sec-fetch-site");
+	if ((origin && origin !== url.origin) || (site && !["same-origin", "none"].includes(site))) {
+		error(403, "Same origin access required");
+	}
+	if (url.search) error(400, "Workspace observation does not accept query parameters");
+	const snapshot = await createWorkspaceSnapshot(env);
+	return json(snapshot, {
+		headers: {
+			"Cache-Control": "private, no-store",
+			Vary: "Cookie, Origin, Sec-Fetch-Site",
+			"X-Content-Type-Options": "nosniff",
+		},
+	});
+};

--- a/ruflo/src/ruvocal/src/routes/workspace/+page.svelte
+++ b/ruflo/src/ruvocal/src/routes/workspace/+page.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+	import { base } from "$app/paths";
+	import { page } from "$app/state";
+	import { openWorkspaceDraft } from "$lib/utils/openWorkspaceDraft";
+	import { allMcpServers, selectedServerIds } from "$lib/stores/mcpServers";
+	import {
+		missionPresets,
+		buildMissionDraft,
+		discoveredTools,
+		type MissionKind,
+	} from "$lib/utils/workspace";
+	import ToolExplorer from "$lib/components/workspace/ToolExplorer.svelte";
+	import RuntimePanel from "$lib/components/workspace/RuntimePanel.svelte";
+	import IconArrow from "~icons/lucide/arrow-up-right";
+	import IconCommand from "~icons/lucide/command";
+	import IconLayers from "~icons/lucide/layers";
+	import IconShield from "~icons/lucide/shield-check";
+	import IconFlask from "~icons/lucide/flask-conical";
+	let { data } = $props();
+	let objective = $state("");
+	let kind = $state<MissionKind>("build");
+	let iterations = $state(3);
+	let formError = $state("");
+	let opening = $state(false);
+	const icons = { build: IconLayers, review: IconShield, optimize: IconFlask };
+	const view = $derived(
+		["tools", "runtimes"].includes(page.url.searchParams.get("view") ?? "")
+			? page.url.searchParams.get("view")
+			: "overview"
+	);
+	const tools = $derived(discoveredTools($allMcpServers, $selectedServerIds));
+	const connected = $derived(
+		$allMcpServers.filter((server) => server.status === "connected").length
+	);
+	async function draftMission(event: SubmitEvent) {
+		event.preventDefault();
+		formError = "";
+		try {
+			opening = true;
+			const draft = buildMissionDraft(objective, kind, iterations);
+			await openWorkspaceDraft(draft);
+		} catch (error) {
+			formError = error instanceof Error ? error.message : "Could not open the mission draft.";
+		} finally {
+			opening = false;
+		}
+	}
+</script>
+
+<svelte:head
+	><title>Workspace · RuFlo</title><meta
+		name="description"
+		content="Coordinate missions, discover tools, and inspect governed runtime integrations in RuFlo."
+	/></svelte:head
+>
+
+<main class="ws-workspace scrollbar-custom" id="workspace-main">
+	<header class="ws-topbar">
+		<a href={`${base}/workspace`} class="ws-wordmark"
+			>ru<span>flo</span><span class="ws-divider">/</span><span class="ws-location">Workspace</span
+			></a
+		>
+		<div class="ws-topbar-actions">
+			<button
+				class="ws-keyboard"
+				aria-label="Open command search"
+				onclick={() => window.dispatchEvent(new Event("ruflo:commands"))}><IconCommand /> K</button
+			><a class="ws-button ws-small" href={`${base}/`}>New chat <IconArrow /></a>
+		</div>
+	</header>
+	<nav class="ws-tabs" aria-label="Workspace sections">
+		{#each [{ id: "overview", label: "Overview" }, { id: "tools", label: "Tool explorer" }, { id: "runtimes", label: "Runtime & learning" }] as tab}<a
+				aria-current={view === tab.id ? "page" : undefined}
+				class:active={view === tab.id}
+				href={`${base}/workspace${tab.id === "overview" ? "" : `?view=${tab.id}`}`}>{tab.label}</a
+			>{/each}
+	</nav>
+	<div class="ws-content">
+		{#if view === "tools"}<ToolExplorer />
+		{:else if view === "runtimes"}<RuntimePanel />
+		{:else}
+			<div class="ws-intro">
+				<div>
+					<p class="ws-eyebrow">YOUR AGENT WORKSPACE</p>
+					<h1>Intent into action.</h1>
+					<p>Bring a goal. Choose the tools. Keep the evidence.</p>
+				</div>
+				<a class="ws-text-link" href={`${base}/workspace?view=runtimes`}
+					>Inspect runtime <IconArrow /></a
+				>
+			</div>
+			<div class="ws-stats">
+				<a href={`${base}/models`}
+					><span>Available models</span><strong
+						>{data.models.length.toString().padStart(2, "0")}</strong
+					><small>Configured in this deployment</small></a
+				><a href={`${base}/workspace?view=tools`}
+					><span>Discovered tools</span><strong>{tools.length.toString().padStart(2, "0")}</strong
+					><small>Observed schemas, not permissions</small></a
+				><a href={`${base}/workspace?view=tools`}
+					><span>Connections checked</span><strong
+						>{connected.toString().padStart(2, "0")}<em> / {$allMcpServers.length}</em></strong
+					><small>Successful tool discovery</small></a
+				>
+			</div>
+			<div class="ws-mission-grid">
+				<section class="ws-panel ws-mission">
+					<div class="ws-row">
+						<p class="ws-eyebrow">NEW MISSION</p>
+						<span class="ws-badge">Draft before execution</span>
+					</div>
+					<h2>What are we working on?</h2>
+					<form onsubmit={draftMission}>
+						<label class="sr-only" for="mission-objective">Mission objective</label><textarea
+							id="mission-objective"
+							required
+							maxlength={4000}
+							bind:value={objective}
+							placeholder="Describe the outcome, repository, and what success looks like…"
+							rows="4"
+						></textarea>
+						<div class="ws-mission-options">
+							<label
+								>Workflow<select bind:value={kind}
+									>{#each missionPresets as preset}<option value={preset.id}>{preset.title}</option
+										>{/each}</select
+								></label
+							><label
+								>Requested iterations<select bind:value={iterations}
+									>{#each [1, 2, 3, 4, 5] as count}<option value={count}
+											>{count} {count === 1 ? "iteration" : "iterations"}</option
+										>{/each}</select
+								></label
+							>
+						</div>
+						{#if formError}<p class="ws-form-error" role="alert">{formError}</p>{/if}
+						<div class="ws-mission-submit">
+							<p>
+								Opens an editable chat draft.<br />Runtime limits and approvals remain separate.
+							</p>
+							<button
+								class="ws-button ws-primary"
+								type="submit"
+								disabled={opening || !objective.trim() || !data.models.length}
+								>{opening ? "Opening…" : "Draft mission"}<IconArrow /></button
+							>
+						</div>
+						{#if !data.models.length}<p class="ws-form-error">
+								Configure a model before drafting a mission in chat.
+							</p>{/if}
+					</form>
+				</section>
+				<aside class="ws-loop">
+					<p class="ws-eyebrow">THE IMPLEMENTATION LOOP</p>
+					<h2>Progress you can verify.</h2>
+					<ol>
+						{#each [{ title: "Specify", detail: "Inputs, constraints, acceptance test" }, { title: "Build", detail: "Ruflo coordinates available workers" }, { title: "Evaluate", detail: "MetaHarness compares evidence" }, { title: "Review", detail: "Policy, regression, rollback gates" }] as step, index}<li
+							>
+								<span class="ws-step">0{index + 1}</span>
+								<div>
+									<strong>{step.title}</strong>
+									<p>{step.detail}</p>
+								</div>
+							</li>{/each}
+					</ol>
+					<p class="ws-loop-note">Workflow guidance. No mission is running.</p>
+				</aside>
+			</div>
+			<section class="ws-section">
+				<div class="ws-section-title">
+					<h2>Start with a clear outcome</h2>
+					<span>Choose a starting point</span>
+				</div>
+				<div class="ws-preset-grid">
+					{#each missionPresets as preset}{@const Icon = icons[preset.id]}<button
+							class="ws-preset"
+							onclick={() => {
+								kind = preset.id;
+								objective = preset.objective;
+								document.getElementById("mission-objective")?.focus();
+							}}
+							><Icon /><strong>{preset.title}</strong><span>{preset.detail}</span><IconArrow
+								class="ws-preset-arrow"
+							/></button
+						>{/each}
+				</div>
+			</section>
+			<section class="ws-section">
+				<div class="ws-section-title">
+					<h2>Continue your work</h2>
+					<a href={`${base}/`}>New conversation ↗</a>
+				</div>
+				<div class="ws-recent">
+					{#each data.conversations.slice(0, 5) as conversation}<a
+							href={`${base}/conversation/${conversation.id}`}
+							><span class="ws-conversation-icon"><IconCommand /></span><span
+								><strong>{conversation.title || "Untitled conversation"}</strong><small
+									>{new Date(conversation.updatedAt).toLocaleDateString(undefined, {
+										month: "short",
+										day: "numeric",
+									})}</small
+								></span
+							><IconArrow /></a
+						>{:else}<div class="ws-empty">
+							<strong>Your next mission starts here.</strong>
+							<p>Draft a goal above or open a new chat. Conversations will appear here.</p>
+						</div>{/each}
+				</div>
+			</section>
+			<footer class="ws-footer">
+				<span>RuFlo · Coordination with evidence</span><a
+					href="https://goal.ruv.io/"
+					target="_blank"
+					rel="noopener noreferrer">Open research planner ↗</a
+				>
+			</footer>
+		{/if}
+	</div>
+</main>

--- a/ruflo/src/ruvocal/src/styles/workspace.css
+++ b/ruflo/src/ruvocal/src/styles/workspace.css
@@ -1,0 +1,982 @@
+:root {
+	--ws-bg: #f4f7fb;
+	--ws-panel: #fff;
+	--ws-text: #142031;
+	--ws-muted: #56677c;
+	--ws-border: #dce4ed;
+	--ws-hover: #e9eff6;
+	--ws-accent: #117b7a;
+	--ws-accent-text: #086e6c;
+	--ws-accent-soft: #ddf3ed;
+	--ws-warm: #bc8426;
+	--ws-shadow: 0 8px 28px #182d4510;
+}
+:root.dark {
+	--ws-bg: #0b1018;
+	--ws-panel: #111a26;
+	--ws-text: #eaf0f8;
+	--ws-muted: #a2b0c2;
+	--ws-border: #253344;
+	--ws-hover: #1c293a;
+	--ws-accent: #62dcc6;
+	--ws-accent-text: #7fe5d0;
+	--ws-accent-soft: #173731;
+	--ws-warm: #e6bd70;
+	--ws-shadow: 0 8px 28px #0002;
+}
+.ws-workspace {
+	min-width: 0;
+	height: 100%;
+	overflow-y: auto;
+	color: var(--ws-text);
+	background: var(--ws-bg);
+	font-size: 1rem;
+}
+.ws-workspace *,
+.workspace-nav * {
+	box-sizing: border-box;
+}
+.ws-workspace :is(button, a, input, textarea, select):focus-visible,
+.workspace-nav a:focus-visible {
+	outline: 2px solid var(--ws-accent);
+	outline-offset: 4px;
+}
+.ws-workspace button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+.ws-topbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 78px;
+	padding: 1rem 2.5rem;
+	border-bottom: 1px solid var(--ws-border);
+	gap: 1rem;
+}
+.ws-wordmark {
+	display: flex;
+	align-items: center;
+	font-weight: 750;
+	font-size: 1.55rem;
+	letter-spacing: -0.06em;
+}
+.ws-wordmark > span:first-child {
+	color: var(--ws-accent-text);
+}
+.ws-wordmark .ws-divider {
+	margin: 0 1rem;
+	color: var(--ws-border);
+	font-weight: 400;
+}
+.ws-wordmark .ws-location {
+	font-size: 0.875rem;
+	font-weight: 500;
+	letter-spacing: 0;
+	color: var(--ws-muted);
+}
+.ws-topbar-actions {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+}
+.ws-keyboard {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.8rem;
+	border: 1px solid var(--ws-border);
+	padding: 0.25rem 0.5rem;
+	border-radius: 0.4rem;
+	color: var(--ws-muted);
+}
+.ws-keyboard svg {
+	width: 14px;
+	height: 14px;
+}
+.ws-tabs {
+	display: flex;
+	gap: 1.75rem;
+	border-bottom: 1px solid var(--ws-border);
+	padding: 0 2.5rem;
+	overflow-x: auto;
+}
+.ws-tabs a {
+	min-height: 52px;
+	display: flex;
+	align-items: center;
+	white-space: nowrap;
+	font-size: 0.875rem;
+	color: var(--ws-muted);
+	border-bottom: 2px solid transparent;
+}
+.ws-tabs a.active {
+	color: var(--ws-accent-text);
+	border-color: var(--ws-accent);
+}
+.ws-content {
+	max-width: 1420px;
+	margin: 0 auto;
+	padding: 2.5rem;
+}
+.ws-eyebrow {
+	color: var(--ws-accent-text);
+	font-size: 0.75rem;
+	letter-spacing: 0.13em;
+	font-weight: 650;
+	margin: 0 0 0.85rem;
+}
+.ws-intro {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+	gap: 1rem;
+	margin-bottom: 2rem;
+}
+.ws-intro h1 {
+	font-size: clamp(2rem, 3.5vw, 3.25rem);
+	line-height: 1.1;
+	letter-spacing: -0.05em;
+	font-weight: 600;
+	margin: 0 0 0.8rem;
+}
+.ws-intro p:not(.ws-eyebrow),
+.ws-section-heading p:not(.ws-eyebrow) {
+	color: var(--ws-muted);
+	line-height: 1.6;
+}
+.ws-text-link {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+	font-size: 0.875rem;
+	white-space: nowrap;
+}
+.ws-text-link svg {
+	width: 16px;
+}
+.ws-stats {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	border: 1px solid var(--ws-border);
+	border-radius: 1rem;
+	overflow: hidden;
+	background: var(--ws-panel);
+	margin-bottom: 1.5rem;
+}
+.ws-stats a {
+	padding: 1.25rem 1.5rem;
+	display: grid;
+	gap: 0.4rem;
+	transition: background 0.15s;
+}
+.ws-stats a:hover {
+	background: var(--ws-hover);
+}
+.ws-stats a + a {
+	border-left: 1px solid var(--ws-border);
+}
+.ws-stats span {
+	font-size: 0.875rem;
+	color: var(--ws-muted);
+}
+.ws-stats strong {
+	font-weight: 500;
+	font-size: 2rem;
+	font-variant-numeric: tabular-nums;
+}
+.ws-stats em {
+	font-style: normal;
+	font-size: 1rem;
+	color: var(--ws-muted);
+}
+.ws-stats small {
+	color: var(--ws-muted);
+	font-size: 0.75rem;
+}
+.ws-panel {
+	border: 1px solid var(--ws-border);
+	border-radius: 1rem;
+	background: var(--ws-panel);
+	box-shadow: var(--ws-shadow);
+}
+.ws-mission-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1.65fr) minmax(245px, 1fr);
+	gap: 1.5rem;
+}
+.ws-mission {
+	padding: 1.75rem;
+}
+.ws-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.8rem;
+	flex-wrap: wrap;
+}
+.ws-row .ws-eyebrow {
+	margin: 0;
+}
+.ws-badge {
+	display: inline-flex;
+	align-items: center;
+	width: fit-content;
+	flex-shrink: 0;
+	font-size: 0.75rem;
+	font-weight: 500;
+	padding: 0.25rem 0.5rem;
+	border: 1px solid var(--ws-border);
+	border-radius: 0.35rem;
+	color: var(--ws-muted);
+	background: var(--ws-bg);
+}
+.ws-badge.ws-good {
+	color: var(--ws-accent-text);
+	border-color: var(--ws-accent);
+	background: var(--ws-accent-soft);
+}
+.ws-mission h2 {
+	font-size: 1.4rem;
+	font-weight: 550;
+	margin: 1rem 0;
+	letter-spacing: -0.025em;
+}
+.ws-mission textarea {
+	width: 100%;
+	min-height: 140px;
+	resize: vertical;
+	background: var(--ws-bg);
+	color: var(--ws-text);
+	border: 1px solid var(--ws-border);
+	border-radius: 0.75rem;
+	padding: 1rem;
+	font-size: 1rem;
+	line-height: 1.65;
+}
+.ws-mission textarea::placeholder,
+.ws-search input::placeholder {
+	color: var(--ws-muted);
+	opacity: 0.85;
+}
+.ws-mission-options {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+	margin: 1rem 0 1.5rem;
+}
+.ws-mission-options label {
+	display: grid;
+	gap: 0.5rem;
+	font-size: 0.875rem;
+	color: var(--ws-muted);
+}
+.ws-workspace select {
+	background: var(--ws-bg);
+	color: var(--ws-text);
+	border: 1px solid var(--ws-border);
+	border-radius: 0.5rem;
+	min-height: 44px;
+	padding: 0.55rem 0.75rem;
+	font-size: 0.875rem;
+	max-width: 100%;
+}
+.ws-mission-submit {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+.ws-mission-submit p {
+	font-size: 0.75rem;
+	line-height: 1.6;
+	color: var(--ws-muted);
+}
+.ws-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.55rem;
+	min-height: 44px;
+	border-radius: 0.6rem;
+	padding: 0.6rem 1rem;
+	border: 1px solid var(--ws-border);
+	background: var(--ws-panel);
+	font-size: 0.875rem;
+	font-weight: 550;
+	white-space: nowrap;
+	transition:
+		background 0.15s,
+		border-color 0.15s;
+}
+.ws-button:hover {
+	background: var(--ws-hover);
+	border-color: var(--ws-muted);
+}
+.ws-button svg {
+	width: 17px;
+	height: 17px;
+}
+.ws-button.ws-primary {
+	background: var(--ws-accent);
+	color: #071c18;
+	border-color: var(--ws-accent);
+}
+:root:not(.dark) .ws-button.ws-primary {
+	color: #fff;
+}
+.ws-button.ws-primary:hover {
+	filter: brightness(1.08);
+}
+.ws-small {
+	padding: 0.4rem 0.75rem;
+}
+.ws-loop {
+	padding: 1.75rem;
+	border: 1px solid var(--ws-border);
+	border-radius: 1rem;
+	background: linear-gradient(145deg, var(--ws-panel), var(--ws-accent-soft));
+}
+.ws-loop .ws-eyebrow {
+	color: var(--ws-warm);
+}
+.ws-loop h2 {
+	font-size: 1.25rem;
+	font-weight: 550;
+	margin-bottom: 1.4rem;
+	letter-spacing: -0.02em;
+}
+.ws-loop ol {
+	display: grid;
+	gap: 1.3rem;
+	list-style: none;
+	padding: 0;
+}
+.ws-loop li {
+	display: flex;
+	gap: 0.85rem;
+}
+.ws-step {
+	font-size: 0.75rem;
+	display: flex;
+	flex-shrink: 0;
+	align-items: center;
+	justify-content: center;
+	height: 30px;
+	width: 30px;
+	border: 1px solid var(--ws-border);
+	border-radius: 50%;
+	color: var(--ws-muted);
+}
+.ws-loop li strong {
+	font-size: 0.875rem;
+	font-weight: 600;
+}
+.ws-loop li p {
+	color: var(--ws-muted);
+	font-size: 0.875rem;
+	margin-top: 0.2rem;
+	line-height: 1.4;
+}
+.ws-loop-note {
+	border-top: 1px solid var(--ws-border);
+	padding-top: 1rem;
+	margin-top: 1.5rem;
+	font-size: 0.75rem;
+	color: var(--ws-muted);
+}
+.ws-section {
+	margin-top: 2.25rem;
+}
+.ws-section-title {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	align-items: center;
+	margin-bottom: 1rem;
+}
+.ws-section-title h2 {
+	font-size: 1.1rem;
+	font-weight: 600;
+	letter-spacing: -0.02em;
+}
+.ws-section-title span,
+.ws-section-title a {
+	font-size: 0.875rem;
+	color: var(--ws-muted);
+}
+.ws-preset-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1rem;
+}
+.ws-preset {
+	position: relative;
+	text-align: left;
+	display: grid;
+	gap: 0.5rem;
+	background: var(--ws-panel);
+	border: 1px solid var(--ws-border);
+	border-radius: 0.75rem;
+	padding: 1.25rem;
+	transition:
+		border-color 0.15s,
+		transform 0.15s;
+}
+.ws-preset:hover {
+	border-color: var(--ws-accent);
+	transform: translateY(-2px);
+}
+.ws-preset > svg {
+	width: 21px;
+	height: 21px;
+	margin-bottom: 0.4rem;
+	color: var(--ws-accent-text);
+}
+.ws-preset strong {
+	font-size: 0.95rem;
+	font-weight: 600;
+}
+.ws-preset span {
+	font-size: 0.875rem;
+	color: var(--ws-muted);
+	line-height: 1.5;
+}
+.ws-preset .ws-preset-arrow {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	width: 16px;
+	color: var(--ws-muted);
+}
+.ws-recent {
+	border: 1px solid var(--ws-border);
+	border-radius: 0.75rem;
+	background: var(--ws-panel);
+	overflow: hidden;
+}
+.ws-recent > a {
+	display: flex;
+	gap: 1rem;
+	align-items: center;
+	padding: 1rem 1.25rem;
+}
+.ws-recent > a:hover {
+	background: var(--ws-hover);
+}
+.ws-recent > a + a {
+	border-top: 1px solid var(--ws-border);
+}
+.ws-recent > a > span:nth-child(2) {
+	display: grid;
+	gap: 0.25rem;
+	min-width: 0;
+}
+.ws-recent strong {
+	font-size: 0.875rem;
+	font-weight: 500;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
+}
+.ws-recent small {
+	font-size: 0.75rem;
+	color: var(--ws-muted);
+}
+.ws-conversation-icon {
+	display: flex;
+	padding: 0.65rem;
+	background: var(--ws-bg);
+	border-radius: 0.5rem;
+	color: var(--ws-muted);
+}
+.ws-recent svg {
+	width: 16px;
+	height: 16px;
+	flex-shrink: 0;
+}
+.ws-recent > a > svg {
+	margin-left: auto;
+}
+.ws-empty {
+	padding: 2rem;
+	text-align: center;
+	color: var(--ws-muted);
+}
+.ws-empty strong {
+	font-size: 1rem;
+	color: var(--ws-text);
+	white-space: normal;
+}
+.ws-empty p {
+	font-size: 0.875rem;
+	line-height: 1.6;
+	margin-top: 0.5rem;
+}
+.ws-footer {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	margin-top: 2rem;
+	color: var(--ws-muted);
+	font-size: 0.75rem;
+}
+.ws-section-heading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1.5rem;
+	margin-bottom: 1.5rem;
+}
+.ws-section-heading h2 {
+	font-size: clamp(1.6rem, 2.5vw, 2.3rem);
+	letter-spacing: -0.04em;
+	font-weight: 550;
+	margin-bottom: 0.6rem;
+}
+.ws-server-grid,
+.ws-runtime-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 1rem;
+	margin: 1.5rem 0;
+}
+.ws-server {
+	background: var(--ws-panel);
+	padding: 1.25rem;
+	border: 1px solid var(--ws-border);
+	border-radius: 0.75rem;
+	min-width: 0;
+}
+.ws-server strong {
+	font-size: 0.95rem;
+	overflow-wrap: anywhere;
+}
+.ws-server p {
+	color: var(--ws-muted);
+	font-size: 0.875rem;
+	margin: 0.65rem 0 1rem;
+}
+.ws-link-button,
+.ws-toggle {
+	font-size: 0.875rem;
+	min-height: 44px;
+	color: var(--ws-accent-text);
+}
+.ws-toggle {
+	padding: 0.4rem 0.65rem;
+	color: var(--ws-muted);
+	border: 1px solid var(--ws-border);
+	border-radius: 0.5rem;
+}
+.ws-toggle[aria-pressed="true"] {
+	background: var(--ws-accent-soft);
+	color: var(--ws-accent-text);
+}
+.ws-toolbar {
+	display: flex;
+	gap: 1rem;
+	align-items: center;
+	margin-top: 2rem;
+}
+.ws-search {
+	display: flex;
+	align-items: center;
+	flex: 1;
+	gap: 0.75rem;
+	min-width: 0;
+	background: var(--ws-panel);
+	padding: 0.75rem 1rem;
+	border: 1px solid var(--ws-border);
+	border-radius: 0.6rem;
+}
+.ws-search svg {
+	width: 18px;
+	flex-shrink: 0;
+	color: var(--ws-muted);
+}
+.ws-search input {
+	background: transparent;
+	width: 100%;
+	font-size: 1rem;
+	border: 0;
+	outline: none;
+}
+.ws-filters {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+	margin: 1rem 0;
+}
+.ws-filters button {
+	border: 1px solid var(--ws-border);
+	border-radius: 0.5rem;
+	padding: 0.5rem 0.8rem;
+	min-height: 40px;
+	font-size: 0.875rem;
+	color: var(--ws-muted);
+}
+.ws-filters button.chosen {
+	background: var(--ws-accent-soft);
+	border-color: var(--ws-accent);
+	color: var(--ws-accent-text);
+}
+.ws-result-count {
+	font-size: 0.75rem;
+	color: var(--ws-muted);
+	margin: 1rem 0;
+}
+.ws-tool-list {
+	display: grid;
+	gap: 0.5rem;
+}
+.ws-tool {
+	background: var(--ws-panel);
+	border: 1px solid var(--ws-border);
+	border-radius: 0.6rem;
+	overflow: hidden;
+}
+.ws-tool summary {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 1rem 1.25rem;
+	gap: 1rem;
+	cursor: pointer;
+}
+.ws-tool-name {
+	display: grid;
+	gap: 0.3rem;
+	min-width: 0;
+}
+.ws-tool-name strong {
+	font-family: ui-monospace, monospace;
+	font-size: 0.875rem;
+	overflow-wrap: anywhere;
+}
+.ws-tool-name > span {
+	font-size: 0.75rem;
+	color: var(--ws-muted);
+}
+.ws-tool-detail {
+	padding: 0 1.25rem 1.25rem;
+}
+.ws-tool-detail p {
+	font-size: 0.95rem;
+	line-height: 1.7;
+	color: var(--ws-muted);
+	overflow-wrap: anywhere;
+}
+.ws-tool-detail h3 {
+	font-size: 0.875rem;
+	font-weight: 600;
+	margin: 1rem 0 0.5rem;
+}
+.ws-tool-detail pre {
+	max-height: 280px;
+	overflow: auto;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	font-size: 0.8rem;
+	line-height: 1.6;
+	padding: 1rem;
+	background: var(--ws-bg);
+	border-radius: 0.5rem;
+	margin-bottom: 1rem;
+}
+.ws-load-more {
+	display: flex;
+	margin: 1.5rem auto;
+}
+.ws-runtime {
+	background: var(--ws-panel);
+	border: 1px solid var(--ws-border);
+	border-radius: 0.9rem;
+	padding: 1.5rem;
+	min-width: 0;
+}
+.ws-runtime h3 {
+	font-size: 1.5rem;
+	font-weight: 600;
+	letter-spacing: -0.03em;
+	margin: 1rem 0 0.7rem;
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+}
+.ws-runtime h3 span {
+	font-size: 0.65rem;
+	font-weight: 500;
+	letter-spacing: 0.06em;
+	border: 1px solid var(--ws-border);
+	border-radius: 0.25rem;
+	padding: 0.2rem 0.3rem;
+	color: var(--ws-muted);
+}
+.ws-runtime > p {
+	color: var(--ws-muted);
+	line-height: 1.6;
+	font-size: 0.95rem;
+}
+.ws-runtime .ws-fine {
+	font-size: 0.875rem;
+	margin-top: 0.8rem;
+}
+.ws-runtime-footer {
+	display: flex;
+	justify-content: space-between;
+	gap: 0.5rem;
+	font-size: 0.75rem;
+	color: var(--ws-muted);
+	border-top: 1px solid var(--ws-border);
+	padding-top: 1rem;
+	margin-top: 1.5rem;
+}
+.ws-runtime-footer a {
+	color: var(--ws-accent-text);
+}
+.ws-runtime-metrics {
+	display: grid;
+	gap: 0.5rem;
+	margin-top: 1rem;
+}
+.ws-runtime-metrics > div {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	font-size: 0.875rem;
+}
+.ws-runtime-metrics dt {
+	color: var(--ws-muted);
+}
+.ws-runtime-metrics dd {
+	font-variant-numeric: tabular-nums;
+}
+.ws-notice {
+	border: 1px solid var(--ws-border);
+	border-left: 3px solid var(--ws-warm);
+	background: var(--ws-panel);
+	padding: 1rem 1.25rem;
+	font-size: 0.875rem;
+	line-height: 1.6;
+	border-radius: 0.5rem;
+}
+.ws-gates {
+	padding: 1.75rem;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 2rem;
+	margin-top: 1.5rem;
+}
+.ws-gates h3 {
+	font-size: 1.3rem;
+	font-weight: 550;
+	margin-bottom: 0.75rem;
+	letter-spacing: -0.02em;
+}
+.ws-gates p:not(.ws-eyebrow) {
+	font-size: 0.95rem;
+	color: var(--ws-muted);
+	line-height: 1.7;
+}
+.ws-gate-list {
+	display: grid;
+	gap: 0.65rem;
+}
+.ws-gate-list > div {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.6rem;
+	font-size: 0.875rem;
+	border-bottom: 1px solid var(--ws-border);
+	padding-bottom: 0.65rem;
+}
+.ws-form-error {
+	color: #e46c74;
+	font-size: 0.875rem;
+	margin: 0.75rem 0;
+}
+@media (max-width: 1100px) {
+	.ws-content {
+		padding: 1.75rem;
+	}
+	.ws-topbar,
+	.ws-tabs {
+		padding-left: 1.75rem;
+		padding-right: 1.75rem;
+	}
+	.ws-mission-grid {
+		grid-template-columns: 1fr;
+	}
+	.ws-loop ol {
+		grid-template-columns: 1fr 1fr;
+	}
+	.ws-preset-grid {
+		gap: 0.65rem;
+	}
+	.ws-preset {
+		padding: 1rem;
+	}
+}
+@media (max-width: 640px) {
+	.ws-topbar {
+		min-height: 64px;
+		padding: 0.85rem 1rem;
+	}
+	.ws-tabs {
+		gap: 1.2rem;
+		padding: 0 1rem;
+	}
+	.ws-tabs a {
+		font-size: 0.875rem;
+	}
+	.ws-content {
+		padding: 1.5rem 1rem calc(2rem + env(safe-area-inset-bottom));
+	}
+	.ws-keyboard,
+	.ws-wordmark .ws-location,
+	.ws-wordmark .ws-divider {
+		display: none;
+	}
+	.ws-intro {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+	.ws-intro h1 {
+		font-size: 2.3rem;
+	}
+	.ws-intro > a {
+		display: none;
+	}
+	.ws-stats {
+		grid-template-columns: 1fr;
+	}
+	.ws-stats a {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		padding: 1rem 1.2rem;
+	}
+	.ws-stats a + a {
+		border-left: 0;
+		border-top: 1px solid var(--ws-border);
+	}
+	.ws-stats strong {
+		grid-column: 2;
+		grid-row: 1 / span 2;
+		align-self: center;
+		font-size: 1.75rem;
+	}
+	.ws-stats small {
+		font-size: 0.75rem;
+	}
+	.ws-mission {
+		padding: 1.2rem;
+	}
+	.ws-mission .ws-row {
+		align-items: flex-start;
+		gap: 0.6rem;
+	}
+	.ws-mission textarea {
+		min-height: 140px;
+	}
+	.ws-mission-options {
+		grid-template-columns: 1fr;
+	}
+	.ws-mission-options select {
+		font-size: 1rem;
+	}
+	.ws-mission-submit {
+		flex-direction: column-reverse;
+		align-items: stretch;
+	}
+	.ws-mission-submit p {
+		text-align: center;
+		font-size: 0.875rem;
+	}
+	.ws-loop {
+		padding: 1.2rem;
+	}
+	.ws-loop ol {
+		grid-template-columns: 1fr;
+	}
+	.ws-preset-grid,
+	.ws-server-grid,
+	.ws-runtime-grid,
+	.ws-gates {
+		grid-template-columns: 1fr;
+	}
+	.ws-preset {
+		padding: 1.25rem;
+	}
+	.ws-section-title span {
+		display: none;
+	}
+	.ws-section-title a {
+		font-size: 0.875rem;
+	}
+	.ws-footer {
+		flex-direction: column;
+		font-size: 0.875rem;
+	}
+	.ws-section-heading {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+	.ws-toolbar {
+		flex-direction: column;
+		align-items: stretch;
+	}
+	.ws-tool summary {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+	.ws-runtime {
+		padding: 1.25rem;
+	}
+	.ws-runtime-footer {
+		font-size: 0.875rem;
+		flex-wrap: wrap;
+	}
+	.ws-gates {
+		padding: 1.25rem;
+	}
+	.ws-badge {
+		font-size: 0.875rem;
+	}
+	.ws-filters button {
+		min-height: 44px;
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.ws-workspace * {
+		animation: none !important;
+		transition: none !important;
+		scroll-behavior: auto !important;
+	}
+}
+
+/* Keep the mission composer ahead of diagnostic counts on narrow screens. */
+@media (max-width: 640px) {
+	.ws-content:has(.ws-mission-grid) {
+		display: flex;
+		flex-direction: column;
+	}
+	.ws-content:has(.ws-mission-grid) > .ws-intro {
+		order: 0;
+	}
+	.ws-content:has(.ws-mission-grid) > .ws-mission-grid {
+		order: 1;
+	}
+	.ws-content:has(.ws-mission-grid) > .ws-stats {
+		order: 2;
+		margin-top: 1.5rem;
+		margin-bottom: 0;
+	}
+	.ws-content:has(.ws-mission-grid) > .ws-section {
+		order: 3;
+	}
+	.ws-content:has(.ws-mission-grid) > .ws-footer {
+		order: 4;
+	}
+}


### PR DESCRIPTION
The current chat UI hides much of Ruflo's operational capability behind chat and server management dialogs. This adds a workspace that makes mission drafting, tool discovery and runtime observations visible while preserving deliberate execution and existing conversations.

Changes:
- Refresh chat onboarding and add a responsive workspace, recent conversations, mission presets and command search.
- Explore actual discovered MCP schemas with separate selection, inventory and connection states.
- Add an administrator observation API for configured Ruflo and MetaHarness status, an Autogenous adapter seam, and ruOS rendezvous health.
- Add seven exact bridge operations behind `MCP_GROUP_OPERATIONS=true`. Fix private base-server discovery without exposing deployment credentials or accepting browser overrides.
- Bound status calls, nested responses, pagination and timeouts. Keep drafts out of URLs and require submission before execution.
- Add four ADRs, a pinned ecosystem gap analysis, a reproducible validation receipt and scoped CI.

Validation:
- 163 application tests and 6 bridge tests passed.
- Production build and 6 built HTTP checks passed with local fixtures.
- ESLint passed for all 24 new source and test files.
- Full type check retains the baseline's 199 errors and 14 warnings in 51 files. Diagnostic paths and messages are identical after excluding shifted line positions.
- Lazy command search reduced the shared layout's compressed JavaScript from 126,586 bytes in the initial candidate to 103,495 bytes. Baseline is 102,208 bytes. This is a bundle-size comparison, not a latency benchmark.

This is a draft because browser interaction/visual acceptance, live integrations, remote CI and the existing type debt remain release gates. The production deployment revision is unknown. No deployment, operational promotion, live Autogenous evolution, or MetaHarness evaluation was performed. The installed Ruflo CLI recorded coordination and memory, but its version lacks the current flywheel status subcommand; integration contracts were verified against pinned source and MCP SDK fixtures.

[Gap analysis](https://github.com/ruvnet/ruflo/blob/codex/ruflo-ui-mission-20260905/ruflo/src/ruvocal/docs/reviews/2026-09-05-ui-gap-analysis.md) · [Validation and release gates](https://github.com/ruvnet/ruflo/blob/codex/ruflo-ui-mission-20260905/ruflo/src/ruvocal/docs/reviews/2026-09-05-workspace-validation.md) · [Source-bound receipt](https://github.com/ruvnet/ruflo/blob/codex/ruflo-ui-mission-20260905/ruflo/src/ruvocal/docs/reviews/2026-09-05-workspace-receipt.json)

Acceptance: a fresh session can draft an objective and inspect discovered capabilities; unknown status remains explicit; unauthorized runtime requests make no upstream calls; a mission stays an editable draft until submitted.