### PR TITLE
fix: replace invalid example agent-type names in bundled skills (#607)

### DIFF
--- a/.claude/skills/github-multi-repo/SKILL.md
+++ b/.claude/skills/github-multi-repo/SKILL.md
@@ -90,8 +90,8 @@ mcp__claude-flow__swarm_init({
 // Execute synchronized changes across repositories
 [Parallel Multi-Repo Operations]:
   // Spawn coordination agents
-  Task("Repository Coordinator", "Coordinate changes across all repositories", "coordinator")
-  Task("Dependency Analyzer", "Analyze cross-repo dependencies", "analyst")
+  Task("Repository Coordinator", "Coordinate changes across all repositories", "multi-repo-swarm")
+  Task("Dependency Analyzer", "Analyze cross-repo dependencies", "code-analyzer")
   Task("Integration Tester", "Validate cross-repo changes", "tester")
 
   // Get matching repositories
@@ -136,8 +136,8 @@ mcp__claude-flow__swarm_init({
   mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 5 })
 
   // Spawn sync agents
-  Task("Sync Coordinator", "Coordinate version alignment", "coordinator")
-  Task("Dependency Analyzer", "Analyze dependencies", "analyst")
+  Task("Sync Coordinator", "Coordinate version alignment", "sync-coordinator")
+  Task("Dependency Analyzer", "Analyze dependencies", "code-analyzer")
   Task("Integration Tester", "Validate synchronization", "tester")
 
   // Read package states
@@ -237,8 +237,8 @@ mcp__claude-flow__swarm_init({
   mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 6 })
 
   // Spawn architecture agents
-  Task("Senior Architect", "Analyze repository structure", "architect")
-  Task("Structure Analyst", "Identify optimization opportunities", "analyst")
+  Task("Senior Architect", "Analyze repository structure", "repo-architect")
+  Task("Structure Analyst", "Identify optimization opportunities", "code-analyzer")
   Task("Performance Optimizer", "Optimize structure for scalability", "optimizer")
   Task("Best Practices Researcher", "Research architecture patterns", "researcher")
 
@@ -397,8 +397,8 @@ Part of #$TRACKING_ISSUE"
   mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 8 })
 
   // Spawn specialized agents
-  Task("Refactoring Coordinator", "Coordinate refactoring across repos", "coordinator")
-  Task("Impact Analyzer", "Analyze refactoring impact", "analyst")
+  Task("Refactoring Coordinator", "Coordinate refactoring across repos", "multi-repo-swarm")
+  Task("Impact Analyzer", "Analyze refactoring impact", "code-analyzer")
   Task("Code Transformer", "Apply refactoring changes", "coder")
   Task("Migration Guide Creator", "Create migration documentation", "documenter")
   Task("Integration Tester", "Validate refactored code", "tester")

--- a/.claude/skills/github-release-management/SKILL.md
+++ b/.claude/skills/github-release-management/SKILL.md
@@ -298,7 +298,7 @@ npx claude-flow github release-deploy \
   Task("Package A Manager", "Coordinate claude-flow package release v1.0.72", "coder")
   Task("Package B Manager", "Coordinate ruv-swarm package release v1.0.12", "coder")
   Task("Integration Tester", "Validate cross-package compatibility", "tester")
-  Task("Version Coordinator", "Align dependencies and versions", "coordinator")
+  Task("Version Coordinator", "Align dependencies and versions", "release-manager")
 
   // Update all packages simultaneously
   Write("packages/claude-flow/package.json", "[v1.0.72 content]")
@@ -380,9 +380,9 @@ npx claude-flow github multi-release \
   mcp__claude-flow__swarm_init { topology: "star", maxAgents: 6 }
 
   // Spawn repo-specific coordinators
-  Task("Frontend Release", "Release frontend v2.0.0 with API compatibility", "coordinator")
-  Task("Backend Release", "Release backend v2.1.0 with breaking changes", "coordinator")
-  Task("CLI Release", "Release CLI v1.5.0 with new commands", "coordinator")
+  Task("Frontend Release", "Release frontend v2.0.0 with API compatibility", "release-manager")
+  Task("Backend Release", "Release backend v2.1.0 with breaking changes", "release-manager")
+  Task("CLI Release", "Release CLI v1.5.0 with new commands", "release-manager")
   Task("Compatibility Checker", "Validate cross-repo compatibility", "researcher")
 
   // Coordinate version updates across repos

--- a/.claude/skills/hive-mind-advanced/SKILL.md
+++ b/.claude/skills/hive-mind-advanced/SKILL.md
@@ -228,7 +228,7 @@ npx claude-flow hive-mind spawn "Build REST API" --claude
 
 Output:
 ```javascript
-Task("Queen Coordinator", "Orchestrate REST API development...", "coordinator")
+Task("Queen Coordinator", "Orchestrate REST API development...", "queen-coordinator")
 Task("Backend Developer", "Implement Express routes...", "backend-dev")
 Task("Database Architect", "Design PostgreSQL schema...", "code-analyzer")
 Task("Test Engineer", "Create Jest test suite...", "tester")

--- a/v3/@claude-flow/cli/__tests__/skill-agent-types-607.test.ts
+++ b/v3/@claude-flow/cli/__tests__/skill-agent-types-607.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression guard for #607 ("analyst agent is never 'found'").
+ *
+ * Root cause: several bundled `.claude/skills/*.md` files contain example
+ * `Task(name, description, type)` calls using generic placeholder type
+ * strings ("coordinator", "architect", "analyst", "specialist") that do not
+ * match any agent actually registered under `.claude/agents/**\/*.md`.
+ * Claude Code's Task tool validates `subagent_type` against that live
+ * registry at runtime, so copying these examples verbatim fails with
+ * "Agent type 'X' not found."
+ *
+ * This test asserts the three affected skill files no longer contain that
+ * literal invalid-third-argument pattern. It is a narrow content guard
+ * (not a general skill/agent-registry linter) scoped to the exact
+ * occurrences fixed for #607.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const skillsRoot = path.resolve(__dirname, '../../../../.claude/skills');
+
+// Generic placeholder type strings that are never registered agent names.
+const INVALID_TYPE_PATTERN = /Task\([^)]*"(coordinator|architect|analyst|specialist)"\)/;
+
+const affectedFiles = [
+  'github-multi-repo/SKILL.md',
+  'hive-mind-advanced/SKILL.md',
+  'github-release-management/SKILL.md',
+];
+
+describe('#607 skill example agent types', () => {
+  for (const relPath of affectedFiles) {
+    it(`${relPath} has no invalid placeholder Task(...) agent types`, () => {
+      const content = readFileSync(path.join(skillsRoot, relPath), 'utf-8');
+      const match = content.match(INVALID_TYPE_PATTERN);
+      expect(match).toBeNull();
+    });
+  }
+
+  it('github-multi-repo/SKILL.md uses real registered agent names for its example agents', () => {
+    const content = readFileSync(path.join(skillsRoot, 'github-multi-repo/SKILL.md'), 'utf-8');
+    expect(content).toContain('"multi-repo-swarm"');
+    expect(content).toContain('"code-analyzer"');
+    expect(content).toContain('"sync-coordinator"');
+    expect(content).toContain('"repo-architect"');
+  });
+
+  it('hive-mind-advanced/SKILL.md uses "queen-coordinator" for its Queen example', () => {
+    const content = readFileSync(path.join(skillsRoot, 'hive-mind-advanced/SKILL.md'), 'utf-8');
+    expect(content).toContain('Task("Queen Coordinator", "Orchestrate REST API development...", "queen-coordinator")');
+  });
+
+  it('github-release-management/SKILL.md uses "release-manager" for its coordinator examples', () => {
+    const content = readFileSync(path.join(skillsRoot, 'github-release-management/SKILL.md'), 'utf-8');
+    const releaseManagerCount = (content.match(/"release-manager"/g) ?? []).length;
+    expect(releaseManagerCount).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #607 ("analyst agent is never 'found'").

Several bundled `.claude/skills/*.md` files contain example `Task(name, description, type)` calls using generic placeholder type strings (`"coordinator"`, `"architect"`, `"analyst"`, `"specialist"`) that do not match any agent actually registered under `.claude/agents/**/*.md`. Claude Code's Task tool validates `subagent_type` against that live registry at runtime, so copying these examples verbatim fails with `Agent type 'X' not found.`

This replaces the 13 affected occurrences across 3 files with real registered agent names that match each example's context:
- `github-multi-repo/SKILL.md`: `coordinator` → `multi-repo-swarm` / `sync-coordinator`, `analyst` → `code-analyzer`, `architect` → `repo-architect`
- `hive-mind-advanced/SKILL.md`: `coordinator` → `queen-coordinator`
- `github-release-management/SKILL.md`: `coordinator` → `release-manager`

## Test coverage

Added `v3/@claude-flow/cli/__tests__/skill-agent-types-607.test.ts` — a narrow regression guard asserting the three affected files no longer contain the invalid placeholder `Task(..., "coordinator"|"architect"|"analyst"|"specialist")` pattern, and that they use the correct replacement agent names. Verified locally:
- Fails (6/6) against the pre-fix file content (confirmed via `git stash`).
- Passes (6/6) against the post-fix content.
- Full `@claude-flow/cli` test suite run before/after shows no new failures (pre-existing unrelated failures are native-module/environment issues, e.g. `@ruvector/ruvllm-wasm`, not touched by this change).

## Scope

Only the 3 SKILL.md files and one new test file are touched. No CI/workflow, release/publish tooling, or agent registry files were changed.

---

Opened by the nightly triage routine — human review required before merge.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_013ck5ngNyhwAFzmN9PdaV4p

---
_Generated by [Claude Code](https://claude.ai/code/session_013ck5ngNyhwAFzmN9PdaV4p)_