### PR TITLE
test/hooks: fix two stale main-tree Test Suite failures exposed by #3203 (embedding width; hook-handler exports)

### DIFF
--- a/.claude/helpers/context-persistence-hook.mjs
+++ b/.claude/helpers/context-persistence-hook.mjs
@@ -288,7 +288,7 @@ class SQLiteBackend {
   }
 
   /**
-   * Store embedding blob for an entry (768-dim Float32Array → Buffer).
+   * Store embedding blob for an entry (Float32Array → Buffer; 384-dim ONNX today, 768-dim legacy hash blobs still readable).
    */
   storeEmbedding(id, embedding) {
     const buf = Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength);

--- a/.claude/helpers/hook-handler.cjs
+++ b/.claude/helpers/hook-handler.cjs
@@ -587,9 +587,20 @@ const handlers = {
 
 // Hooks must ALWAYS exit 0 — Claude Code treats non-zero as "hook error"
 // and skips all subsequent hooks for the event.
-process.exitCode = 0;
-main().catch((e) => {
-  try { console.log(`[WARN] Hook handler error: ${e.message}`); } catch (_) {}
-}).finally(() => {
-  process.exit(0);
-});
+//
+// Only dispatch when run directly (node hook-handler.cjs <cmd>). When
+// require()'d by a test, expose the internals instead of reading stdin and
+// calling process.exit — the 2026-06-15 fix (cb1e93e8d) added this guard and
+// the exports for tests/hook-handler-runwithtimeout.test.cjs; the 2026-07-04
+// helper sync (a5f86ad0a) dropped both, so the test died with
+// "runWithTimeout is not a function" once the Test Suite job ran again.
+if (require.main === module) {
+  process.exitCode = 0;
+  main().catch((e) => {
+    try { console.log(`[WARN] Hook handler error: ${e.message}`); } catch (_) {}
+  }).finally(() => {
+    process.exit(0);
+  });
+}
+
+module.exports = { runWithTimeout, INTELLIGENCE_TIMEOUT_MS };

--- a/tests/context-persistence-hook.test.mjs
+++ b/tests/context-persistence-hook.test.mjs
@@ -15,6 +15,7 @@ const {
   resolveBackend,
   getRuVectorConfig,
   createHashEmbedding,
+  EMBEDDING_DIM,
   hashContent,
   parseTranscript,
   extractTextContent,
@@ -292,9 +293,14 @@ describe('resolveBackend', () => {
 // ============================================================================
 
 describe('createHashEmbedding', () => {
-  it('should produce 768-dimensional embedding', () => {
+  it('should produce an EMBEDDING_DIM-dimensional embedding (384, matching the ONNX vectors it substitutes for)', () => {
+    // The hook moved to 384-dim ONNX embeddings (all-MiniLM-L6-v2) and the
+    // hash fallback defaults to the same width so blobs stay comparable; this
+    // test still said 768 (the legacy hash width) and only surfaced once the
+    // Test Suite job ran again after the ETARGET fix (#3203).
     const emb = createHashEmbedding('hello world');
-    assert.equal(emb.length, 768);
+    assert.equal(emb.length, EMBEDDING_DIM);
+    assert.equal(EMBEDDING_DIM, 384);
     assert.ok(emb instanceof Float32Array);
   });
 

--- a/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
+++ b/v3/@claude-flow/cli/.claude/helpers/helpers.manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest": {
-    "version": "3.38.20",
+    "version": "3.38.21",
     "files": {
       "auto-memory-hook.mjs": "85fe05c757421c52137c0bc8545a0896bab6b4714538c2a11d1d0835bfcc8c1c",
-      "hook-handler.cjs": "dae295fb9ae2626b89899c19a20cc911541af82b52d2eeb9b214d618b96e9a86",
+      "hook-handler.cjs": "209d9fafe10e17d1be0866727f6f9cf9ac66f9a0793f1c793a4f58319e8e4583",
       "intelligence.cjs": "30e42ed7ec4ca5a94ac54fdb1330d2d47ac5f3fdeeef207753574723a9e77b5c",
       "statusline.cjs": "4a48353b4f1566fa4379b00fd0321b6676a22b6cc91fbbd8380ac5183d619468"
     }
   },
-  "signature": "XrmLYCSWusInkReUHieYqHKPPC8/0TKovnPNWAdPvxDEhHezvy+BkkVyk7Y62HClcy7a4+PP2G4mJ1kaPLJ7Bw==",
+  "signature": "JLgMf4RwnmFyNjpOas3JNQq5BMWGRw6IRZzne3ZynGYTTFH9HnW5SLjHKm/3KD/277cp1gsW9TCU0iAF46b1Dw==",
   "algorithm": "ed25519"
 }

--- a/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
+++ b/v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs
@@ -587,9 +587,20 @@ const handlers = {
 
 // Hooks must ALWAYS exit 0 — Claude Code treats non-zero as "hook error"
 // and skips all subsequent hooks for the event.
-process.exitCode = 0;
-main().catch((e) => {
-  try { console.log(`[WARN] Hook handler error: ${e.message}`); } catch (_) {}
-}).finally(() => {
-  process.exit(0);
-});
+//
+// Only dispatch when run directly (node hook-handler.cjs <cmd>). When
+// require()'d by a test, expose the internals instead of reading stdin and
+// calling process.exit — the 2026-06-15 fix (cb1e93e8d) added this guard and
+// the exports for tests/hook-handler-runwithtimeout.test.cjs; the 2026-07-04
+// helper sync (a5f86ad0a) dropped both, so the test died with
+// "runWithTimeout is not a function" once the Test Suite job ran again.
+if (require.main === module) {
+  process.exitCode = 0;
+  main().catch((e) => {
+    try { console.log(`[WARN] Hook handler error: ${e.message}`); } catch (_) {}
+  }).finally(() => {
+    process.exit(0);
+  });
+}
+
+module.exports = { runWithTimeout, INTELLIGENCE_TIMEOUT_MS };


### PR DESCRIPTION
Two stale main-tree failures in the Test Suite job, both hidden while root `npm ci` died at `ETARGET` (fixed in #3203) and both surfacing on the first PR runs after it (#3177 run 33971855691, #3184).

**1. `tests/context-persistence-hook.test.mjs:297`** asserted `createHashEmbedding(...).length === 768`, but the hook has defaulted the hash fallback to 384 (`EMBEDDING_DIM`, the ONNX all-MiniLM-L6-v2 width) since February. The test now asserts `EMBEDDING_DIM` and pins it to 384; the "768-dim" docstring on the blob store is corrected.

**2. `tests/hook-handler-runwithtimeout.test.cjs`** failed with `runWithTimeout is not a function`. cb1e93e8d (2026-06-15) had guarded `hook-handler.cjs`'s dispatch behind `require.main === module` and exported `{ runWithTimeout, INTELLIGENCE_TIMEOUT_MS }` for that test; the 2026-07-04 helper sync (a5f86ad0a) replaced both copies with the packaged build and dropped the guard and the exports, so `require()` ran `main()` and exposed nothing. Restored identically in the repo dogfood copy and `v3/@claude-flow/cli/.claude/helpers/hook-handler.cjs`; direct invocation still prints usage and exits 0. The helpers manifest is re-signed in `prepublishOnly`, which is what `helpers-manifest-guard` asserts is wired; `scripts/smoke-helper-signing-security.mjs` passes.

**Verification (local, repo deps):** `node --test tests/hook-handler-runwithtimeout.test.cjs tests/context-persistence-hook.test.mjs` → 71 pass, 0 fail. CI at `419d6c8` is the second witness.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_019xHM4rAH4aaShb4DTr1n6s
