### PR TITLE
fix(claims): anchor MCP claims store to project cwd

### DIFF
--- a/v3/@claude-flow/cli/__tests__/claims-project-cwd-3178.test.ts
+++ b/v3/@claude-flow/cli/__tests__/claims-project-cwd-3178.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { claimsTools } from '../src/mcp-tools/claims-tools.js';
+
+describe('claims persistence uses the effective project cwd (#3178)', () => {
+  let originalCwd: string;
+  let project: string;
+  let firstCwd: string;
+  let secondCwd: string;
+
+  const call = (name: string, input: Record<string, unknown> = {}) =>
+    claimsTools.find(tool => tool.name === name)!.handler(input);
+  const claim = (issueId = '3178', claimant = 'agent:coder-1:coder') =>
+    call('claims_claim', { issueId, claimant });
+  const readStore = (root: string) =>
+    JSON.parse(readFileSync(join(root, '.claude-flow/claims/claims.json'), 'utf8'));
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    project = mkdtempSync(join(tmpdir(), 'claims-project-cwd-'));
+    firstCwd = join(project, 'packages', 'first');
+    secondCwd = join(project, 'packages', 'second', 'src');
+    mkdirSync(firstCwd, { recursive: true });
+    mkdirSync(secondCwd, { recursive: true });
+    vi.stubEnv('CLAUDE_FLOW_CWD', project);
+    process.chdir(firstCwd);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.unstubAllEnvs();
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  it('shares writes, queries, ownership checks and release across nested cwd values', async () => {
+    expect(await claim()).toMatchObject({ success: true });
+    expect(readStore(project).claims['3178']).toMatchObject({ issueId: '3178' });
+    process.chdir(secondCwd);
+    expect(await call('claims_list')).toMatchObject({ count: 1 });
+    expect(await call('claims_board')).toMatchObject({ summary: { total: 1, active: 1 } });
+    expect(await claim('3178', 'agent:coder-2:coder')).toMatchObject({ success: false });
+    expect(await call('claims_release', { issueId: '3178', claimant: 'agent:coder-2:coder' }))
+      .toMatchObject({ success: false });
+    expect(await call('claims_release', { issueId: '3178', claimant: 'agent:coder-1:coder' }))
+      .toMatchObject({ success: true });
+    process.chdir(firstCwd);
+    expect(await call('claims_list')).toMatchObject({ count: 0 });
+    expect(readStore(project).claims).toEqual({});
+    expect(existsSync(join(firstCwd, '.claude-flow'))).toBe(false);
+    expect(existsSync(join(secondCwd, '.claude-flow'))).toBe(false);
+  });
+
+  it('persists handoff and status changes in the same store', async () => {
+    expect(await claim()).toMatchObject({ success: true });
+    process.chdir(secondCwd);
+    expect(await call('claims_handoff', {
+      issueId: '3178', from: 'agent:coder-1:coder', to: 'human:alice:Alice', progress: 40,
+    })).toMatchObject({ success: true });
+    process.chdir(firstCwd);
+    expect(await call('claims_accept-handoff', { issueId: '3178', claimant: 'human:alice:Alice' }))
+      .toMatchObject({ success: true });
+    expect(await call('claims_status', { issueId: '3178', status: 'paused' }))
+      .toMatchObject({ success: true });
+    process.chdir(secondCwd);
+    expect(await call('claims_list', { status: 'paused', claimant: 'human:alice:Alice' }))
+      .toMatchObject({ count: 1 });
+    expect(readStore(project).claims['3178']).toMatchObject({ status: 'paused', progress: 40 });
+  });
+
+  it('shares stealable work and the resulting ownership change', async () => {
+    expect(await claim()).toMatchObject({ success: true });
+    expect(await call('claims_mark-stealable', { issueId: '3178', reason: 'voluntary' }))
+      .toMatchObject({ success: true });
+    process.chdir(secondCwd);
+    expect(await call('claims_stealable')).toMatchObject({ count: 1 });
+    expect(await call('claims_steal', { issueId: '3178', stealer: 'agent:coder-2:coder' }))
+      .toMatchObject({ success: true });
+    process.chdir(firstCwd);
+    expect(await call('claims_load', { agentId: 'coder-2' })).toMatchObject({ totalClaims: 1 });
+    expect(readStore(project).claims['3178'].claimant.agentId).toBe('coder-2');
+    expect(await call('claims_stealable')).toMatchObject({ count: 0 });
+  });
+
+  it.each([undefined, '/', process.env.HOME])('preserves cwd fallback for CLAUDE_FLOW_CWD=%s', async value => {
+    vi.stubEnv('CLAUDE_FLOW_CWD', value);
+    expect(await claim()).toMatchObject({ success: true });
+    expect(readStore(firstCwd).claims['3178']).toMatchObject({ issueId: '3178' });
+    expect(existsSync(join(project, '.claude-flow'))).toBe(false);
+  });
+
+  it('does not share claims between different effective project roots', async () => {
+    expect(await claim()).toMatchObject({ success: true });
+    vi.stubEnv('CLAUDE_FLOW_CWD', secondCwd);
+    expect(await call('claims_list')).toMatchObject({ count: 0 });
+    expect(await claim('3178', 'agent:coder-2:coder')).toMatchObject({ success: true });
+    expect(readStore(project).claims['3178'].claimant.agentId).toBe('coder-1');
+    expect(readStore(secondCwd).claims['3178'].claimant.agentId).toBe('coder-2');
+  });
+});

--- a/v3/@claude-flow/cli/src/mcp-tools/claims-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/claims-tools.ts
@@ -7,7 +7,7 @@
  * @module @claude-flow/cli/mcp-tools/claims
  */
 
-import type { MCPTool } from './types.js';
+import { type MCPTool, getProjectCwd } from './types.js';
 import { validateIdentifier, validateText } from './validate-input.js';
 
 // Inline claim service since we can't import external modules
@@ -44,17 +44,17 @@ interface ClaimsStore {
 
 // File-based persistence
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 
 const CLAIMS_DIR = '.claude-flow/claims';
 const CLAIMS_FILE = 'claims.json';
 
 function getClaimsPath(): string {
-  return resolve(join(CLAIMS_DIR, CLAIMS_FILE));
+  return resolve(getProjectCwd(), CLAIMS_DIR, CLAIMS_FILE);
 }
 
 function ensureClaimsDir(): void {
-  const dir = resolve(CLAIMS_DIR);
+  const dir = resolve(getProjectCwd(), CLAIMS_DIR);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

Fixes #3178.

Claims persistence resolves its file and directory from the MCP process cwd, so a server launched in a subdirectory ignores `CLAUDE_FLOW_CWD`. Sessions configured with the same effective project root can consequently miss each other's claims.

Anchor both paths with the existing `getProjectCwd()` helper, matching the other file-backed tools. This preserves the helper's current fallback rules and keeps distinct effective project roots separate; it does not introduce cross-worktree root discovery or change claims ownership/expiry semantics (#3180).

## Validation

On macOS / Apple Silicon, Node 20.20.2 and Vitest 4.1.0, from `v3/@claude-flow/cli`:

```sh
npm test -- --pool=forks --maxWorkers=1 __tests__/claims-project-cwd-3178.test.ts __tests__/mcp-tools-deep.test.ts
```

- **114 tests passed** on the submitted commit. The seven new tests call the actual source handlers with a real temporary filesystem and real cwd changes: nested-cwd persistence, duplicate/release checks, handoff/status, steal/load, fallback, and root isolation.
- With the production file restored to main, **four new tests fail** and the other 110 tests pass. The existing Vite invalid-file-URL warning appears on both versions.
- Focused strict TypeScript check of the changed source and test, plus `git diff --check`: passed.

Used a toolchain-only local install and the declared `@claude-flow/cli-core@3.7.0-alpha.5` dependency. Full monorepo build/test and Windows/Linux CI were not run locally.
