### PR TITLE
fix(security): correct missing encryption key error message when flag is unset (#3212)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/encryption-vault.test.ts
+++ b/v3/@claude-flow/cli/__tests__/encryption-vault.test.ts
@@ -109,6 +109,35 @@ describe('vault (ADR-096 Phase 1)', () => {
       expect(() => getKey()).toThrow(/CLAUDE_FLOW_ENCRYPTION_KEY/);
     });
 
+    it('names the flag when encryption is enabled but the key is missing', () => {
+      process.env.CLAUDE_FLOW_ENCRYPT_AT_REST = '1';
+      delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+      expect(() => getKey()).toThrow(
+        /CLAUDE_FLOW_ENCRYPT_AT_REST is set but CLAUDE_FLOW_ENCRYPTION_KEY is not/,
+      );
+    });
+
+    it('does not claim the flag is set when it is unset (RFE1-on-disk case, #3212)', () => {
+      delete process.env.CLAUDE_FLOW_ENCRYPT_AT_REST;
+      delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+      expect(() => getKey()).toThrow(
+        /required to access encrypted storage/,
+      );
+      expect(() => getKey()).not.toThrow(/is set but/);
+    });
+
+    it.each(['0', 'false', 'no', 'off'])(
+      'does not claim the flag is set for disabled value "%s" (#3212)',
+      (v) => {
+        process.env.CLAUDE_FLOW_ENCRYPT_AT_REST = v;
+        delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+        expect(() => getKey()).not.toThrow(/is set but/);
+        expect(() => getKey()).toThrow(
+          /required to access encrypted storage/,
+        );
+      },
+    );
+
     it('returns a 32-byte buffer when the env var holds valid hex', () => {
       process.env.CLAUDE_FLOW_ENCRYPTION_KEY = 'c'.repeat(64);
       expect(getKey().length).toBe(32);

--- a/v3/@claude-flow/cli/src/encryption/vault.ts
+++ b/v3/@claude-flow/cli/src/encryption/vault.ts
@@ -80,8 +80,14 @@ export function isEncryptionEnabled(): boolean {
 export function getKey(): Buffer {
   const raw = process.env[ENV_KEY_VAR];
   if (!raw) {
+    // "0"/"false" are truthy strings but leave encryption disabled, so the
+    // canonical gate (not Boolean) decides which message is accurate (#3212).
+    const reason = isEncryptionEnabled()
+      ? `${ENV_ENABLE_FLAG} is set but ${ENV_KEY_VAR} is not.`
+      : `${ENV_KEY_VAR} is required to access encrypted storage, but is not set.`;
+
     throw new Error(
-      `${ENV_ENABLE_FLAG} is set but ${ENV_KEY_VAR} is not. ` +
+      `${reason} ` +
       `Provide a 32-byte key as 64-char hex or 44-char base64. ` +
       `See ADR-096 for keychain/passphrase support (coming in a follow-up).`,
     );


### PR DESCRIPTION
Fixes #3212

### Summary
`getKey()` had one error string hardcoding the enable-flag explanation, but it is reachable both when encryption was requested via the flag and when an RFE1 blob is read with the flag unset (e.g. DB restored from another machine).

Branch the message on `isEncryptionEnabled()` so falsey-but-truthy values like `"0"` / `"false"` no longer misdiagnose, and cover both branches plus the disabled-value regression in tests.

### Verification
- 5 encryption test suites pass (79/79 tests), including new unit tests covering unset, truthy, and falsey string flag states.
- Pre-existing clean main failures verified via stash; touched vault modules introduce zero regressions.