### PR TITLE
fix(deps): bump fast-uri to patch 4 high-severity CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "cors": "^2.8.5",
         "express": ">=4.22.2",
         "express-rate-limit": ">=8.4.1",
-        "fast-uri": "3.1.5",
+        "fast-uri": "^3.1.6",
         "fs-extra": "^11.2.0",
         "helmet": "^7.2.0",
         "inquirer": "^9.2.0",
@@ -7920,9 +7920,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "cors": "^2.8.5",
-    "fs-extra": "^11.2.0",
     "express": ">=4.22.2",
     "express-rate-limit": ">=8.4.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "^3.1.6",
+    "fs-extra": "^11.2.0",
     "helmet": "^7.2.0",
     "inquirer": "^9.2.0",
     "semver": "7.7.3",
@@ -94,8 +94,8 @@
     "zod": "3.25.76"
   },
   "optionalDependencies": {
-    "@napi-rs/keyring": "1.3.0",
     "@claude-flow/plugin-gastown-bridge": "^0.1.3",
+    "@napi-rs/keyring": "1.3.0",
     "@ruvector/attention": "^0.1.3",
     "@ruvector/core": "^0.1.30",
     "@ruvector/router": "^0.1.30",


### PR DESCRIPTION
Automated dependency bump to address disclosed CVEs affecting the pinned `fast-uri` version.

- **CVEs:** CVE-2026-75931, CVE-2026-75975, CVE-2026-75899, CVE-2026-76172
- **Advisories:** [GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8), [GHSA-f65p-4m7j-42xc](https://github.com/advisories/GHSA-f65p-4m7j-42xc), [GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf), [GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp)
- **Severity:** high (CVSS 7.5 each)
- **Package:** `fast-uri` 3.1.5 → 3.1.6 (same-major, drop-in — `ajv`'s own declared range `^3.0.1` already accepts it)

Detected by [osv-scanner](https://google.github.io/osv-scanner/). Verified the target version (3.1.6) carries zero remaining advisories via a direct OSV API query. No code changes outside `package.json`/`package-lock.json` (npm alphabetized a couple of adjacent keys as a side effect of the lockfile-only regen — no dependency reordering intended).

**Not fully remediated by this PR — flagging rather than bundling untested bumps:**

A few other advisories surfaced by the same scan need a version bump that would exceed what a *transitive* dependent currently declares, so I didn't force them without a way to verify nothing breaks:

- `qs` 6.15.2 → needs 6.16.0 for [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) / [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) — your own `overrides.qs` (`>=6.15.2`) doesn't quite reach it, and a couple of vendored `express`/`body-parser` copies declare `~6.15.1`, which 6.16.0 would exceed.
- `adm-zip` (bundled via `onnxruntime-node`, pinned `^0.5.16`) needs 0.6.0 for [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85) (CVE-2026-39244) — outside that caret range.
- `sharp` (bundled via `@xenova/transformers`, pinned `^0.32.0`) needs 0.35.0 for [GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj) — same issue, outside the declared range.
- `toml` (direct dep, `^3.0.0`) needs a major bump to 4.2.0 for [GHSA-82x6-q7mm-w9cf](https://github.com/advisories/GHSA-82x6-q7mm-w9cf) / [GHSA-v5mp-jgw5-2x6j](https://github.com/advisories/GHSA-v5mp-jgw5-2x6j) — no 3.x fix exists.
- `agentic-flow`: your `optionalDependencies` entry already declares the fixed `^2.0.14` for [GHSA-vcv2-r9jh-99m5](https://github.com/advisories/GHSA-vcv2-r9jh-99m5) (CVE-2026-58195, high 8.8) — the committed lockfile just has a stale resolution (`2.0.12-fix.8`). A plain `npm install` refresh (no manifest change needed) should pick up the already-declared fix.

Happy to open follow-up PRs for any of these if you'd like the override ranges widened.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).