### PR TITLE
docs: canonicalize contribution and security links (#3233)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions! See the [docs/](docs/) directory for development guide
 
 ## Workflow
 
-1. Open an issue or discussion at [GitHub Issues](https://github.com/ruvnet/claude-flow/issues)
+1. Open an issue or discussion at [GitHub Issues](https://github.com/ruvnet/ruflo/issues)
 2. Fork and create a feature branch
 3. Run `npm test` to validate
 4. Submit a pull request with clear description

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,4 +50,4 @@ This project employs the following security measures at system boundaries:
 - **Path traversal prevention** via the `PathValidator` module
 - **Command injection protection** via the `SafeExecutor` module
 
-For questions about this policy, contact security@ruv.io.
+For questions about this policy, contact security@cognitum.one.


### PR DESCRIPTION
Closes #3233\n\n## Summary\n- point CONTRIBUTING.md at the current ruvnet/ruflo issue tracker\n- make SECURITY.md use the canonical security@cognitum.one mailbox consistently\n\n## Validation\n- git diff --check\n- rg verification of canonical URLs/mailbox\n\nThis is a docs-only correction; no runtime behavior changes.