### PR TITLE
fix(flywheel): encode candidatePolicy fractions as decimal strings (ADR-322C rule 2, #3229)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/flywheel-receipt.test.ts
+++ b/v3/@claude-flow/cli/__tests__/flywheel-receipt.test.ts
@@ -5,6 +5,8 @@ import {
   RECEIPT_DOMAIN,
   canonicalizeJcs,
   createFlywheelReceipt,
+  assertReceiptNumberDomain,
+  encodePolicyFractions,
   policyCandidateId,
   sha256Ref,
   verifyFlywheelReceipt,
@@ -252,5 +254,102 @@ describe('flywheel receipt protocol', () => {
     });
     expect(receipt.payload.statistics.significant).toBe(true);
     expect(receipt.payload.decision).toBe('rejected');
+  });
+});
+
+describe('ADR-322C rule 2 — fractional values are decimal strings (#3229)', () => {
+  /**
+   * The exact candidatePolicy v3.38.21 wrote, from the issue. Fractions become
+   * scale-12 decimal strings; integers stay JSON numbers, which is what the
+   * contract's own example shows (`{"hnswEf": 128, "hybridWeight": "0.65"}`).
+   */
+  it('encodes the live RetrievalConfig shape from the bug report', () => {
+    const encoded = encodePolicyFractions({
+      alpha: 0.3,
+      subjectWeight: 1,
+      mmrLambda: 0.5,
+      bodyWeight: 1.5,
+      typePenaltyFactor: 0.5,
+    });
+    expect(encoded).toEqual({
+      alpha: '0.3',
+      subjectWeight: 1,
+      mmrLambda: '0.5',
+      bodyWeight: '1.5',
+      typePenaltyFactor: '0.5',
+    });
+  });
+
+  it('recurses through nested objects and arrays', () => {
+    expect(
+      encodePolicyFractions({ outer: { inner: 0.25 }, list: [1, 0.5, 'x'], flag: true }),
+    ).toEqual({ outer: { inner: '0.25' }, list: [1, '0.5', 'x'], flag: true });
+  });
+
+  /**
+   * Idempotence is load-bearing: `policyCandidateId` encodes at the hashing
+   * boundary, so a raw config and an already-encoded policy must hash the
+   * same or `verify` could never recompute the ID from the payload.
+   */
+  it('is idempotent, so a raw and an encoded policy share one candidate ID', () => {
+    const raw = { alpha: 0.3, hnswEf: 128 };
+    const once = encodePolicyFractions(raw);
+    expect(encodePolicyFractions(once)).toEqual(once);
+    expect(policyCandidateId(raw)).toBe(
+      policyCandidateId(once as Record<string, unknown>),
+    );
+  });
+
+  it('normalizes negative zero rather than emitting -0', () => {
+    expect(encodePolicyFractions({ z: -0 })).toEqual({ z: '0' });
+  });
+
+  it('refuses a non-finite policy value instead of writing null', () => {
+    expect(() => encodePolicyFractions({ a: Number.NaN })).toThrow(/must be finite/);
+    expect(() => encodePolicyFractions({ a: Number.POSITIVE_INFINITY })).toThrow(/must be finite/);
+  });
+
+  /** A produced receipt must satisfy the contract it claims. */
+  it('produces a receipt whose candidatePolicy carries no fractional floats', () => {
+    const { receipt } = acceptedReceipt();
+    const policy = receipt.payload.candidatePolicy as Record<string, unknown>;
+    expect(policy.alpha).toBe('0.3');
+    for (const [k, v] of Object.entries(policy)) {
+      if (typeof v === 'number') {
+        expect(Number.isInteger(v), `${k} must be an integer if it is a number`).toBe(true);
+      }
+    }
+  });
+
+  /**
+   * The enforcement half. Before this, `assertJsonValue` accepted any finite
+   * non-`-0` number, so ruflo verified its own non-conforming receipts while
+   * autogenous's stricter verifier rejected them. The error must NAME the
+   * path — the original bug needed a live fixture to find precisely because
+   * neither verifier said which field was wrong.
+   */
+  it('rejects a fractional JSON number anywhere in the payload, naming the path', () => {
+    const { receipt } = acceptedReceipt();
+    const tampered = JSON.parse(JSON.stringify(receipt));
+    tampered.payload.candidatePolicy.alpha = 0.3;
+    // Asserted at the RECEIPT boundary, not in the shared JCS canonicalizer —
+    // that is used by the proposer envelope and the ledger, which the contract
+    // does not govern.
+    const result = verifyFlywheelReceipt(tampered);
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(
+      /fractional number at \$\.candidatePolicy\.alpha must be a scale-12 decimal string/,
+    );
+  });
+
+  it('still accepts integers and scaled integers as JSON numbers', () => {
+    expect(() =>
+      assertReceiptNumberDomain({ micros: 1_500_000, iterations: 2000, depth: 24 }),
+    ).not.toThrow();
+  });
+
+  /** Regression guard: the rule must NOT live in the shared canonicalizer. */
+  it('leaves the shared JCS canonicalizer permissive for non-receipt structures', () => {
+    expect(() => canonicalizeJcs({ candidates: [{ policy: { alpha: 0.3 } }] })).not.toThrow();
   });
 });

--- a/v3/@claude-flow/cli/src/services/flywheel-receipt.ts
+++ b/v3/@claude-flow/cli/src/services/flywheel-receipt.ts
@@ -262,8 +262,50 @@ export function sha256Ref(value: string | Buffer): string {
   return `sha256:${createHash('sha256').update(value).digest('hex')}`;
 }
 
+/**
+ * Enforce ADR-322C rule 2 / conformance-checklist A3 over a receipt payload:
+ * "Every fractional value is a canonical decimal string, not a binary float."
+ *
+ * This lives at the RECEIPT boundary rather than inside `canonicalizeJcs`,
+ * which is shared with the proposer envelope (`flywheel-proposer.ts`) and the
+ * promotion ledger (`flywheel-transaction.ts`) — structures the contract does
+ * not govern. A first attempt put the check in the canonicalizer and broke
+ * those callers, which is the reason the scope is spelled out here.
+ *
+ * Integers and scaled integers stay JSON numbers (currency micros, durations,
+ * iteration counts). A fractional JSON number anywhere in the payload is a
+ * contract violation, and the error names the path — the original bug
+ * (ruvnet/ruflo#3229) needed a live fixture to find precisely because neither
+ * verifier said which field was wrong.
+ */
+export function assertReceiptNumberDomain(value: unknown, path = '$'): void {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error(
+        `fractional number at ${path} must be a scale-12 decimal string (ADR-322C rule 2)`,
+      );
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertReceiptNumberDomain(v, `${path}[${i}]`));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      assertReceiptNumberDomain(v, `${path}.${k}`);
+    }
+  }
+}
+
 export function policyCandidateId(policy: Record<string, unknown>): string {
-  return sha256Ref(canonicalizeJcs(policy));
+  // Encode at the hashing boundary so the content ID is always over the
+  // CANONICAL form, whether the caller passed a raw config or an
+  // already-encoded policy. `encodePolicyFractions` is idempotent — an
+  // encoded value is a string and passes through untouched — so
+  // policyCandidateId(raw) === policyCandidateId(encoded), which is what lets
+  // `verify` recompute the ID from the payload and still match.
+  return sha256Ref(canonicalizeJcs(encodePolicyFractions(policy)));
 }
 
 /** UUIDv7 with a 48-bit millisecond timestamp and RFC-4122 variant bits. */
@@ -282,6 +324,39 @@ const decimal = (value: number, scale = 12): string => {
   const normalized = value.toFixed(scale).replace(/\.?0+$/, '');
   return normalized === '-0' || normalized === '' ? '0' : normalized;
 };
+
+/**
+ * Encode an opaque policy object so every fractional value is a scale-12
+ * decimal string, per ADR-322C rule 2 and conformance-checklist A3.
+ *
+ * `candidatePolicy` is declared "Opaque to this contract; its shape is owned by
+ * policySchemaVersion. Must still satisfy the ADR-322C number rules" — a rule
+ * the JSON Schema cannot express for an opaque object, so nothing enforced it
+ * and the producer wrote binary floats (`{"alpha": 0.3, "mmrLambda": 0.5}`).
+ * Ruflo's own verifier accepted them because `assertJsonValue` only checked
+ * finite-and-not-negative-zero; autogenous's stricter verifier correctly
+ * rejected the receipt (ruvnet/ruflo#3229, ruvnet/autogenous#15).
+ *
+ * Integers stay JSON numbers and only non-integers are encoded, which is what
+ * the contract's own example shows: `{"hnswEf": 128, "hybridWeight": "0.65"}`.
+ * Recurses through nested objects and arrays, because "every fractional value"
+ * is not limited to the top level.
+ */
+export function encodePolicyFractions(value: unknown): unknown {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('policy value must be finite');
+    // Integers are exact in JSON and the contract permits scaled integers, so
+    // they are left alone; -0 is normalized away by `decimal`.
+    return Number.isInteger(value) && !Object.is(value, -0) ? value : decimal(value);
+  }
+  if (Array.isArray(value)) return value.map(encodePolicyFractions);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, encodePolicyFractions(v)]),
+    );
+  }
+  return value;
+}
 
 function seedFrom(parts: string[]): { seed: number; hex: string } {
   const digest = createHash('sha256').update(parts.join('')).digest();
@@ -385,6 +460,10 @@ function receiptIdentityPayload(payload: Omit<FlywheelReceiptPayload, 'receiptId
 }
 
 function signedBytes(payload: FlywheelReceiptPayload): Buffer {
+  // Assert at the signing boundary: a receipt must never be SIGNED unless it
+  // satisfies the number domain it claims. Covers both produce and verify,
+  // since both paths sign or re-derive these bytes.
+  assertReceiptNumberDomain(payload);
   return Buffer.concat([
     Buffer.from(RECEIPT_DOMAIN, 'utf8'),
     Buffer.from([0]),
@@ -396,7 +475,12 @@ export function createFlywheelReceipt(input: CreateReceiptInput): FlywheelEvalua
   const now = input.now ?? Date.now();
   const evaluationRunId = input.evaluationRunId ?? uuidV7(now);
   const lineageId = input.lineageId ?? uuidV7(now);
-  const candidateId = policyCandidateId(input.candidatePolicy);
+  // Encode ONCE and use the encoded object for both the candidate content ID
+  // and the payload, so `verify`'s recomputation of policyCandidateId still
+  // matches. Encoding after the ID were computed would make every receipt fail
+  // its own 'candidate content ID mismatch' check.
+  const candidatePolicy = encodePolicyFractions(input.candidatePolicy) as Record<string, unknown>;
+  const candidateId = policyCandidateId(candidatePolicy);
   // Verifiers recompute the statistics from the payload's scale-12 decimal
   // strings — the only values they ever have. The encoded values are therefore
   // the statistical inputs of record: compute the decision from them, not from
@@ -424,9 +508,23 @@ export function createFlywheelReceipt(input: CreateReceiptInput): FlywheelEvalua
     evaluationRunId,
     baselineRef: input.baselineRef,
     expectedLedgerHead: input.expectedLedgerHead ?? GENESIS_LEDGER_HEAD,
-    candidatePolicy: input.candidatePolicy,
+    candidatePolicy,
     gateVersion: input.gateVersion ?? statistics.ruleVersion,
-    policySchemaVersion: input.policySchemaVersion ?? 'ruflo.retrieval-policy/v1',
+    // v1 -> v2: the encoding of `candidatePolicy` changed (#3229). Fixing it
+    // changes the candidate content ID, so a pre-fix receipt can never match a
+    // post-fix champion reference. Bumping the schema version makes the
+    // promotion gate refuse those receipts with an ACCURATE reason —
+    // 'policy schema changed' (flywheel-transaction.ts:468) — instead of a
+    // confusing 'stale baseline' hash mismatch.
+    //
+    // Signed receipts are deliberately NOT migrated: re-encoding changes the
+    // content, which changes the ID, which invalidates the signature. A
+    // migration would mean re-signing, i.e. minting new receipts that claim to
+    // be old ones, which is what the receipt design exists to prevent. Existing
+    // receipts stay valid as history and unpromotable; the champion is
+    // re-established through the explicit reset path, which already requires
+    // confirmation and a recorded reason.
+    policySchemaVersion: input.policySchemaVersion ?? 'ruflo.retrieval-policy/v2',
     safetyEnvelopeRef: input.safetyEnvelopeRef,
     ...(input.anchorRef ? { anchorRef: input.anchorRef } : {}),
     requestedProposer: input.requestedProposer ?? 'local',
@@ -495,6 +593,16 @@ export interface ReceiptVerification {
 }
 
 export function verifyFlywheelReceipt(receipt: FlywheelEvaluationReceipt, trustedPublicKeys?: Set<string>): ReceiptVerification {
+  // The enforcement half of #3229. Before this, ruflo verified its own
+  // non-conforming receipts because the only number rule was
+  // finite-and-not-negative-zero, while autogenous's stricter verifier
+  // correctly rejected them. Reported as an error rather than thrown so the
+  // caller gets it alongside every other finding.
+  try {
+    assertReceiptNumberDomain(receipt.payload);
+  } catch (err) {
+    return { valid: false, signed: !!receipt.signature, errors: [(err as Error).message] };
+  }
   const errors: string[] = [];
   try {
     if (receipt.payload.schemaVersion !== RECEIPT_SCHEMA) errors.push('unsupported receipt schema');

--- a/v3/@claude-flow/cli/src/services/harness-flywheel.ts
+++ b/v3/@claude-flow/cli/src/services/harness-flywheel.ts
@@ -282,7 +282,12 @@ export async function evaluateFlywheelCandidate(projectRoot: string, deps: Flywh
       evaluationRunId: deps.evaluationRunId,
       baselineRef: refOf(baseline),
       expectedLedgerHead: txState.ledgerHead,
-      candidatePolicy: candidate as unknown as Record<string, unknown>,
+      // `as unknown as` erased RetrievalConfig's `number` fields and laundered
+      // binary floats into a receipt claiming ADR-322C conformance (#3229).
+      // createFlywheelReceipt now encodes fractional values to scale-12
+      // decimal strings, so a single structural cast is enough and the
+      // type-erasing double cast is gone.
+      candidatePolicy: { ...candidate } as Record<string, unknown>,
       safetyEnvelopeRef,
       anchorRef: deps.anchorRef,
       requestedProposer: deps.requestedProposer ?? 'local',


### PR DESCRIPTION
Fixes #3229. Reported by @ShortyLTD, reproduced against live v3.38.21 and confirmed still present in **published 3.38.23**.

## Confirmed in the published artifact, not just source

```
$ npm pack @claude-flow/cli@3.38.23
package/dist/src/services/harness-flywheel.js:219:   candidatePolicy: candidate,
```

Two releases shipped after the 3.38.21 report without fixing it.

## Root cause — two parts, and the second is why it survived

**1. Producer.** `candidatePolicy: candidate as unknown as Record<string, unknown>` — a **double** cast (a single one will not compile) that erased `RetrievalConfig`'s `number` fields and laundered binary floats into a receipt claiming conformance.

**2. Verifier.** `assertJsonValue` accepted any finite, non-`-0` number. That was its entire number rule, so ruflo verified its own non-conforming receipts while autogenous's stricter verifier correctly rejected them (ruvnet/autogenous#15).

The structural reason: ADR-322C states a **universal** rule — L22 *"Signed policy fractions use schema-quantized decimal strings"*, L231 *"Every fractional field is encoded by…"* — but the JSON Schema pins `decimalString` on **ten named fields** and cannot express it inside `candidatePolicy`, which it declares *"Opaque to this contract… Must still satisfy the ADR-322C number rules."* **The contract delegated a universal rule to prose exactly where the schema stops validating.** Fixing only the producer would leave the next writer free to drift, invisibly.

The spec's own example already shows the intended encoding: `{"hnswEf": 128, "hybridWeight": "0.65"}` — integers stay numbers, fractions become strings.

## What changed

| | |
|---|---|
| `encodePolicyFractions` | non-integers → scale-12 decimal strings; integers stay JSON numbers; recurses objects and arrays |
| `policyCandidateId` | encodes at the hashing boundary, so the content ID is always over the canonical form |
| `assertReceiptNumberDomain` | enforces the rule at the **receipt boundary** — on produce (pre-signing) and on verify |
| producer | type-erasing double cast removed |
| `policySchemaVersion` | `v1` → `v2` |

**Idempotence is load-bearing:** encoding an encoded policy is a no-op, so `policyCandidateId(raw) === policyCandidateId(encoded)` and `verify` can still recompute the ID from the payload.

## The compatibility decision

Fixing the encoding changes the candidate content ID, so a pre-fix receipt can never match a post-fix champion reference. Bumping `policySchemaVersion` makes the promotion gate refuse those receipts with an **accurate** reason — `policy schema changed` (`flywheel-transaction.ts:468`) — rather than a confusing `stale baseline` hash mismatch.

**Signed receipts are deliberately not migrated.** Re-encoding changes the content, hence the ID, hence invalidates the signature; a "migration" would mean re-signing — minting new receipts that claim to be old ones, which is what the receipt design exists to prevent. Existing receipts stay valid as history and unpromotable; the champion is re-established through the existing reset path, which already requires confirmation and a recorded reason.

## A scope mistake worth recording

My first attempt put the rule inside `canonicalizeJcs`. That broke the **proposer envelope** (`flywheel-proposer.ts`) and the **promotion ledger** (`flywheel-transaction.ts`), which share that canonicalizer and which the contract does not govern — 10 of 11 receipt tests plus four other files failed. The rule belongs at the receipt boundary. A test now pins that the shared canonicalizer stays permissive, so this cannot regress.

## Verification

**Mutation-verified, all three changes:**

| mutation | result |
|---|---|
| encoder returns the raw number (old producer) | **16 tests fail** |
| drop the fractional-number enforcement (old verifier) | **1 test fails** |
| `policyCandidateId` stops encoding (breaks idempotence) | **13 tests fail** |

**Measured A/B on one installed and built tree:**

| | baseline (`origin/main`) | with this fix |
|---|---|---|
| test files | 40 failed / 191 passed | **39 failed / 192 passed** |
| tests | 83 failed / 2801 passed | **82 failed / 2811 passed** |

Strictly better; nothing broken. The remaining failures are `@ruvector/ruvllm-wasm` and `@ruvector/rvagent-wasm` optional native deps absent on this host, present identically on `origin/main`.

## Still needed for @ShortyLTD's end-to-end validation

A fresh receipt from the corrected release, verified through autogenous. That needs this published, and **autogenous#15's CI unblocked** — its runs are `action_required`, GitHub's external-contributor workflow-approval gate, which is a maintainer click.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)
