### PR TITLE
docs: update stale contribution link and security contact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions! See the [docs/](docs/) directory for development guide
 
 ## Workflow
 
-1. Open an issue or discussion at [GitHub Issues](https://github.com/ruvnet/claude-flow/issues)
+1. Open an issue or discussion at [GitHub Issues](https://github.com/ruvnet/ruflo/issues)
 2. Fork and create a feature branch
 3. Run `npm test` to validate
 4. Submit a pull request with clear description

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,4 +50,4 @@ This project employs the following security measures at system boundaries:
 - **Path traversal prevention** via the `PathValidator` module
 - **Command injection protection** via the `SafeExecutor` module
 
-For questions about this policy, contact security@ruv.io.
+For questions about this policy, contact security@cognitum.one.


### PR DESCRIPTION
Fixes #3233

## Problem
`CONTRIBUTING.md` still pointed contributors at the legacy `ruvnet/claude-flow/issues` path while the project is now `ruvnet/ruflo`, and `SECURITY.md` gave two different contact domains (reporting: `security@cognitum.one`, policy questions: `security@ruv.io`), which can route contributors or security researchers to the wrong destination.

## Root cause
Stale copy from before the repo rename; the two security-contact lines were never unified.

## Changes
- `CONTRIBUTING.md:7` — contribution link `ruvnet/claude-flow/issues` → `ruvnet/ruflo/issues`
- `SECURITY.md:53` — policy-question contact `security@ruv.io` → `security@cognitum.one` (matches the reporting address on line 15)

Scope kept to the two files named in the issue; other historical `claude-flow` references (ADRs, changelogs, package metadata) are intentionally untouched.

## Test evidence
- Docs-only change; no test files reference `CONTRIBUTING.md` or `SECURITY.md` (verified via repo search).
- `git diff --stat`: 2 files changed, 2 insertions, 2 deletions.

## Checklist
- [x] Read `CONTRIBUTING.md` workflow and followed it (issue linked, feature branch, minimal diff, clear description)
- [x] Diffs minimal — one line per file
- [x] No code changes, no new dependencies
- [x] Branch is from upstream `main` HEAD (`e341ec8`)
