### PR TITLE
fix(cli): report actual flag state when decrypting an encrypted store without a key

### DIFF
--- a/v3/@claude-flow/cli/__tests__/encryption-vault.test.ts
+++ b/v3/@claude-flow/cli/__tests__/encryption-vault.test.ts
@@ -113,6 +113,34 @@ describe('vault (ADR-096 Phase 1)', () => {
       process.env.CLAUDE_FLOW_ENCRYPTION_KEY = 'c'.repeat(64);
       expect(getKey().length).toBe(32);
     });
+
+    it('keeps the original message on the default (encrypt) path', () => {
+      process.env.CLAUDE_FLOW_ENCRYPT_AT_REST = '1';
+      delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+      expect(() => getKey()).toThrow(/is set but/);
+    });
+
+    it('does not claim the flag is set on the decrypt path (#3212)', () => {
+      delete process.env.CLAUDE_FLOW_ENCRYPT_AT_REST;
+      delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+      expect(() => getKey('decrypt')).not.toThrow(/is set but/);
+      expect(() => getKey('decrypt')).toThrow(/is required but not set/);
+    });
+
+    it('echoes the flag actual value and on-disk state on the decrypt path', () => {
+      delete process.env.CLAUDE_FLOW_ENCRYPT_AT_REST;
+      delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+      expect(() => getKey('decrypt')).toThrow(
+        /CLAUDE_FLOW_ENCRYPT_AT_REST=unset.*RFE1-encrypted/,
+      );
+      process.env.CLAUDE_FLOW_ENCRYPT_AT_REST = '0';
+      expect(() => getKey('decrypt')).toThrow(/CLAUDE_FLOW_ENCRYPT_AT_REST=0/);
+    });
+
+    it('warns a new key will not decrypt the existing store', () => {
+      delete process.env.CLAUDE_FLOW_ENCRYPTION_KEY;
+      expect(() => getKey('decrypt')).toThrow(/will not decrypt it/);
+    });
   });
 
   describe('encrypt / decrypt round-trip', () => {

--- a/v3/@claude-flow/cli/src/encryption/vault.ts
+++ b/v3/@claude-flow/cli/src/encryption/vault.ts
@@ -69,6 +69,15 @@ export function isEncryptionEnabled(): boolean {
  * encryption is enabled but no key resolves, this throws with a clear
  * message rather than silently falling back to plaintext (fail-closed).
  *
+ * The optional `context` selects which missing-key message to throw:
+ *   - `'encrypt'` (default): the caller is about to encrypt because
+ *     `CLAUDE_FLOW_ENCRYPT_AT_REST` is set, so the original message is
+ *     accurate.
+ *   - `'decrypt'`: the caller hit an RFE1-encrypted blob on read (e.g. a
+ *     store restored from another machine) while the enable flag may be
+ *     unset (issue #3212). The message echoes the flag's actual value and
+ *     the on-disk state instead of asserting the flag is set.
+ *
  * Accepted encodings (auto-detected by length):
  *   - 64-char hex (32 bytes)
  *   - 44-char base64 (32 bytes + padding)
@@ -77,9 +86,18 @@ export function isEncryptionEnabled(): boolean {
  * Anything else is rejected — we'd rather fail loudly than encrypt with a
  * truncated key.
  */
-export function getKey(): Buffer {
+export function getKey(context: 'encrypt' | 'decrypt' = 'encrypt'): Buffer {
   const raw = process.env[ENV_KEY_VAR];
   if (!raw) {
+    if (context === 'decrypt') {
+      const flag = process.env[ENV_ENABLE_FLAG] ?? 'unset';
+      throw new Error(
+        `${ENV_KEY_VAR} is required but not set ` +
+        `(${ENV_ENABLE_FLAG}=${flag}; the store on disk is RFE1-encrypted). ` +
+        `Supply the key this store was encrypted with — a newly generated key will not decrypt it. ` +
+        `Provide a 32-byte key as 64-char hex or 44-char base64.`,
+      );
+    }
     throw new Error(
       `${ENV_ENABLE_FLAG} is set but ${ENV_KEY_VAR} is not. ` +
       `Provide a 32-byte key as 64-char hex or 44-char base64. ` +

--- a/v3/@claude-flow/cli/src/fs-secure.ts
+++ b/v3/@claude-flow/cli/src/fs-secure.ts
@@ -193,7 +193,9 @@ export function readFileMaybeEncrypted(
   const raw = readFileSync(path);
   let plain: Buffer;
   if (isEncryptedBlob(raw)) {
-    plain = decryptBuffer(raw, getKey());
+    // 'decrypt': the blob on disk is RFE1-encrypted but the enable flag may
+    // be unset (e.g. store restored from another machine) — see #3212.
+    plain = decryptBuffer(raw, getKey('decrypt'));
   } else {
     plain = raw;
   }


### PR DESCRIPTION
Fixes #3212

## Problem
When a `memory.db` on disk is an RFE1-encrypted blob but no `CLAUDE_FLOW_ENCRYPTION_KEY` is present, every `ruflo memory` operation fails with "`CLAUDE_FLOW_ENCRYPT_AT_REST` is set but `CLAUDE_FLOW_ENCRYPTION_KEY` is not" — even when the flag is genuinely unset. Users hunt for a variable that does not exist instead of seeing the real cause (the on-disk state of the database).

## Root cause
`getKey()` (`v3/@claude-flow/cli/src/encryption/vault.ts:80`) had exactly one error string, hardcoding the enable-flag explanation. But it is reachable from two situations:
1. **Encryption requested** via the flag (write path, `fs-secure.ts:156`) — message accurate.
2. **An encrypted blob encountered on read** regardless of the flag (`readFileMaybeEncrypted` → `fs-secure.ts:196`, hit by `memory-initializer.ts` on every `memory` command) — message wrong and misleading.

## Changes
- `v3/@claude-flow/cli/src/encryption/vault.ts:80` — `getKey()` takes an optional `'encrypt' | 'decrypt'` context (default `'encrypt'`, so existing callers are unaffected). The `'decrypt'` message echoes the flag's actual value (`unset`, `0`, …) and the on-disk state, and warns that a newly generated key will not decrypt the existing store.
- `v3/@claude-flow/cli/src/fs-secure.ts:196` — the `isEncryptedBlob` read path passes `'decrypt'`.
- `v3/@claude-flow/cli/__tests__/encryption-vault.test.ts` — 4 new tests: default message unchanged, decrypt path never claims the flag is set, flag value + RFE1 state echoed, new-key warning present.

New decrypt-path message:
`CLAUDE_FLOW_ENCRYPTION_KEY is required but not set (CLAUDE_FLOW_ENCRYPT_AT_REST=unset; the store on disk is RFE1-encrypted). Supply the key this store was encrypted with — a newly generated key will not decrypt it. …`

## Test evidence
- `vitest run __tests__/encryption-vault.test.ts`: **49/49 passed** (45 existing + 4 new).
- Related suites touching the same code: `memory-db-encryption`, `session-encryption`, `terminal-encryption`, `doctor-encryption` — **28/28 passed**.
- `tsc --noEmit`: no errors in touched files; only pre-existing errors from uninstalled workspace deps (`@claude-flow/security` module resolution, project-reference `TS6305`s, `auth/client.ts` `unknown` catches), all in unrelated files.

## Checklist
- [x] Read `CONTRIBUTING.md` workflow and followed it (issue linked, feature branch, minimal diff, clear description)
- [x] Diffs minimal — behavior change limited to the previously-wrong error string; default call signature unchanged
- [x] Added/updated tests in the matching test file (`encryption-vault.test.ts`)
- [x] Branch is from upstream `main` HEAD (`e341ec8`)
