### PR TITLE
fix(cost-tracker): log Stop hook write failures instead of discarding them silently

### DIFF
--- a/plugins/ruflo-cost-tracker/scripts/ruflo-hook.cjs
+++ b/plugins/ruflo-cost-tracker/scripts/ruflo-hook.cjs
@@ -16,6 +16,9 @@
  *   2. Spawns track.mjs with TRACK_QUIET=1 and swallows all output.
  *   3. Always exits 0 — telemetry is best-effort, must NEVER block a turn.
  *   4. Times out at 30s so a hung track.mjs can't stall session shutdown.
+ *   5. Records spawn/track failures as one line in <pluginRoot>/logs/
+ *      hook-errors.log plus a one-line stderr warning (#3227) — reporting
+ *      a failure is independent of blocking on it, so exit 0 is kept.
  *
  * Usage: node ruflo-hook.cjs [hook-args ignored]
  */
@@ -42,15 +45,49 @@ const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT
   || path.resolve(__dirname, '..');
 const trackScript = path.join(pluginRoot, 'scripts', 'track.mjs');
 
+/**
+ * Record a hook failure without ever blocking session end (#3227).
+ * Best-effort: logging itself must not throw. Exit code stays 0.
+ */
+function logFailure(reason) {
+  try {
+    const logDir = path.join(pluginRoot, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.appendFileSync(
+      path.join(logDir, 'hook-errors.log'),
+      `${new Date().toISOString()} ruflo-hook: cost-track failed: ${reason}\n`,
+    );
+  } catch {
+    /* ignore — logging must never break the hook contract */
+  }
+  try {
+    console.warn(
+      `[ruflo-cost-tracker] cost-track failed (best-effort, session end continues): ${reason}`,
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
 if (!fs.existsSync(trackScript)) {
-  // Plugin layout drifted — exit clean, never block the turn
+  // Plugin layout drifted — record it, exit clean, never block the turn
+  logFailure(`track script not found: ${trackScript}`);
   done();
 }
 
-spawnSync(process.execPath, [trackScript], {
+const result = spawnSync(process.execPath, [trackScript], {
   env: { ...process.env, TRACK_QUIET: '1' },
   stdio: 'ignore',
   timeout: 30_000,
 });
+
+if (result.error || result.status !== 0) {
+  const reason = result.error
+    ? `spawn error: ${result.error.message}`
+    : result.signal
+      ? `killed by ${result.signal} (30s timeout)`
+      : `track.mjs exited with status ${result.status}`;
+  logFailure(reason);
+}
 
 done();


### PR DESCRIPTION
Fixes #3227

## Problem
The cost-tracker's Stop hook (`scripts/ruflo-hook.cjs`) discarded every `track.mjs` write failure with no log, no stderr warning, and no counter — a bare fire-and-forget spawn with `stdio: 'ignore'` and an unchecked result. On machines where `memory store` fails (e.g. the Windows WAL refusal), session records were lost for days with nothing anywhere recording it.

## Root cause
"Best-effort, must never block a turn" was implemented as "never report either": the `spawnSync` return value was ignored and the missing-script early exit was equally silent. Not blocking and not reporting are independent choices — this change separates them.

## Changes
- `plugins/ruflo-cost-tracker/scripts/ruflo-hook.cjs` — capture the `spawnSync` result; on spawn error, timeout kill, or non-zero exit, append one timestamped line to `<pluginRoot>/logs/hook-errors.log` and emit a one-line `console.warn` to stderr. The missing-`track.mjs` early exit is logged the same way. `process.exit(0)` is kept on every path, and the logging itself is wrapped so it can never throw.
- Kept the exact strings the plugin's `smoke.sh` step 28b asserts (`track.mjs`, `TRACK_QUIET`, `function done`) and the `node -e` bootstrap in `hooks/hooks.json` is untouched.

## Test evidence
- `node --check` on the shim: passes.
- `smoke.sh` step-28b grep assertions re-checked locally (`track.mjs` / `TRACK_QUIET` / `function done` all present).
- Functional run against a fake `CLAUDE_PLUGIN_ROOT`:
  - failing `track.mjs` (exit 1) → shim exits **0**, log line `… cost-track failed: track.mjs exited with status 1` written, one-line stderr warning emitted;
  - missing `track.mjs` → shim exits **0**, log line `… track script not found: …` written;
  - succeeding `track.mjs` (exit 0) → shim exits **0**, no log file, no stderr output (silent as before).
- Full `smoke.sh` could not run locally (requires bash); CI will cover it — saying so honestly.

## Checklist
- [x] Read `CONTRIBUTING.md` workflow and followed it (issue linked, feature branch, minimal diff, clear description)
- [x] Diffs minimal — one file, contract unchanged (always exit 0, `TRACK_QUIET=1` preserved)
- [x] No matching unit-test file exists for this shim (only `smoke.sh` assertions, which still hold); verified behavior with direct runs instead
- [x] Branch is from upstream `main` HEAD (`e341ec8`)
