### PR TITLE
fix(memory): never overwrite a MEMORY.md this bridge did not author

### DIFF
--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -754,6 +754,52 @@ Already in DB
       expect(skipEvent).toBeDefined();
       expect(skipEvent.reason).toBe('no-matching-topic-files');
     });
+
+    // #3224: the #1556 guard above only holds while zero topic files exist.
+    // The bridge creates its own first topic file (e.g. patterns.md) the
+    // moment an insight is recorded, which used to make the guard stop
+    // applying and silently destroy a hand-maintained MEMORY.md on that
+    // very next curate.
+    it('should not overwrite a hand-maintained MEMORY.md once a matching topic file exists (#3224)', async () => {
+      const indexPath = path.join(testDir, 'MEMORY.md');
+      const handCurated = '# My Hand-Curated Memory\n\n## Section 1\nImportant notes, 49 links elsewhere\n';
+      fsSync.writeFileSync(indexPath, handCurated, 'utf-8');
+
+      // patterns.md IS in DEFAULT_TOPIC_MAPPING (project-patterns), so the
+      // #1556 guard does not apply here — sections will be non-empty.
+      fsSync.writeFileSync(
+        path.join(testDir, 'patterns.md'),
+        '# Project Patterns\n\n- Some new insight\n',
+        'utf-8',
+      );
+
+      let skipEvent: any;
+      bridge.on('index:skipped', (e) => { skipEvent = e; });
+
+      await bridge.curateIndex();
+
+      // MEMORY.md must be byte-identical to what the user wrote.
+      expect(fsSync.readFileSync(indexPath, 'utf-8')).toBe(handCurated);
+      expect(skipEvent).toBeDefined();
+      expect(skipEvent.reason).toBe('foreign-index');
+    });
+
+    it('should curate normally once it owns the index (marker present from a prior curate)', async () => {
+      const indexPath = path.join(testDir, 'MEMORY.md');
+      fsSync.writeFileSync(path.join(testDir, 'patterns.md'), '# Project Patterns\n\n- First insight\n', 'utf-8');
+
+      // First curate creates the index and stamps it with the ownership marker.
+      await bridge.curateIndex();
+      const firstWrite = fsSync.readFileSync(indexPath, 'utf-8');
+      expect(firstWrite).toContain('First insight');
+
+      // A later curate on a file this bridge owns must still update normally.
+      fsSync.writeFileSync(path.join(testDir, 'patterns.md'), '# Project Patterns\n\n- Second insight\n', 'utf-8');
+      await bridge.curateIndex();
+
+      const secondWrite = fsSync.readFileSync(indexPath, 'utf-8');
+      expect(secondWrite).toContain('Second insight');
+    });
   });
 
   describe('getStatus', () => {

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -800,6 +800,28 @@ Already in DB
       const secondWrite = fsSync.readFileSync(indexPath, 'utf-8');
       expect(secondWrite).toContain('Second insight');
     });
+
+    // Review feedback on #3224's fix: treating every unmarked MEMORY.md as
+    // foreign would also catch every index this bridge wrote *before* the
+    // marker existed, silently freezing it on upgrade. A pre-marker
+    // bridge-authored file is recognized by its exact legacy title line
+    // and continues to curate (and gets the marker going forward).
+    it('should recognize and continue curating a pre-marker (legacy) bridge-authored MEMORY.md', async () => {
+      const indexPath = path.join(testDir, 'MEMORY.md');
+      const legacyOutput = '# Claude Flow V3 Project Memory\n\n## Debugging\n- Old insight\n- See `debugging.md` for details\n';
+      fsSync.writeFileSync(indexPath, legacyOutput, 'utf-8');
+      fsSync.writeFileSync(path.join(testDir, 'debugging.md'), '# Debugging\n\n- New insight\n', 'utf-8');
+
+      let skipEvent: any;
+      bridge.on('index:skipped', (e) => { skipEvent = e; });
+
+      await bridge.curateIndex();
+
+      expect(skipEvent).toBeUndefined();
+      const after = fsSync.readFileSync(indexPath, 'utf-8');
+      expect(after).toContain('New insight');
+      expect(after).not.toBe(legacyOutput);
+    });
   });
 
   describe('getStatus', () => {

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -158,6 +158,13 @@ const DEFAULT_TOPIC_MAPPING: Record<InsightCategory, string> = {
 // output apart from a hand-maintained index it must never overwrite (#3224).
 const INDEX_OWNERSHIP_MARKER = '<!-- claude-flow:auto-memory-index -->';
 
+// The exact title line buildIndexLines() has always produced. Every
+// MEMORY.md this bridge wrote before INDEX_OWNERSHIP_MARKER existed has
+// exactly this as its first line and nothing else — used to recognize
+// pre-marker bridge output so upgrading doesn't silently freeze existing
+// installs (see isBridgeOwnedIndex below).
+const INDEX_TITLE_LINE = '# Claude Flow V3 Project Memory';
+
 const CATEGORY_LABELS: Record<string, string> = {
   'project-patterns': 'Project Patterns',
   'debugging': 'Debugging',
@@ -495,7 +502,7 @@ export class AutoMemoryBridge extends EventEmitter {
     const indexPath = this.getIndexPath();
     if (existsSync(indexPath)) {
       const existingIndex = await fs.readFile(indexPath, 'utf-8');
-      if (!existingIndex.includes(INDEX_OWNERSHIP_MARKER)) {
+      if (!isBridgeOwnedIndex(existingIndex)) {
         this.emit('index:skipped', { reason: 'foreign-index' });
         return;
       }
@@ -995,6 +1002,26 @@ function pruneSectionsToFit(
 }
 
 /**
+ * Whether an existing MEMORY.md was authored by this bridge and is
+ * therefore safe to overwrite on the next curate.
+ *
+ * True for current-format output (carries INDEX_OWNERSHIP_MARKER) and for
+ * legacy pre-marker output (first line is exactly INDEX_TITLE_LINE, which
+ * is all buildIndexLines() ever produced before the marker existed) — the
+ * legacy check exists so upgrading to the marker-based guard doesn't
+ * silently stop curating every MEMORY.md this bridge already owned.
+ * Anything else (no marker, different or extra first-line content) is
+ * presumed foreign and left untouched.
+ */
+function isBridgeOwnedIndex(content: string): boolean {
+  if (content.includes(INDEX_OWNERSHIP_MARKER)) {
+    return true;
+  }
+  const firstLine = content.split('\n', 1)[0];
+  return firstLine === INDEX_TITLE_LINE;
+}
+
+/**
  * Build MEMORY.md index lines from curated sections.
  */
 function buildIndexLines(
@@ -1002,7 +1029,7 @@ function buildIndexLines(
   topicMapping: Record<string, string>,
   sectionOrder?: string[],
 ): string[] {
-  const lines: string[] = ['# Claude Flow V3 Project Memory', ''];
+  const lines: string[] = [INDEX_TITLE_LINE, ''];
 
   // Use provided order, then append any remaining sections
   const orderedCategories = sectionOrder

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -154,6 +154,10 @@ const DEFAULT_TOPIC_MAPPING: Record<InsightCategory, string> = {
   'swarm-results': 'swarm-results.md',
 };
 
+// Marks a MEMORY.md this bridge wrote, so curateIndex() can tell its own
+// output apart from a hand-maintained index it must never overwrite (#3224).
+const INDEX_OWNERSHIP_MARKER = '<!-- claude-flow:auto-memory-index -->';
+
 const CATEGORY_LABELS: Record<string, string> = {
   'project-patterns': 'Project Patterns',
   'debugging': 'Debugging',
@@ -481,6 +485,22 @@ export class AutoMemoryBridge extends EventEmitter {
       return;
     }
 
+    // Fix for #3224: the guard above only protects the *no-topic-files-yet*
+    // case. As soon as this bridge writes its first topic file, sections is
+    // non-empty and the code below used to overwrite MEMORY.md unconditionally
+    // — destroying a hand-maintained index (e.g. Claude Code's own auto
+    // memory) the very first time a real insight was recorded. Never rebuild
+    // an index this bridge did not author: a pre-existing MEMORY.md that
+    // lacks our ownership marker is presumed foreign and left untouched.
+    const indexPath = this.getIndexPath();
+    if (existsSync(indexPath)) {
+      const existingIndex = await fs.readFile(indexPath, 'utf-8');
+      if (!existingIndex.includes(INDEX_OWNERSHIP_MARKER)) {
+        this.emit('index:skipped', { reason: 'foreign-index' });
+        return;
+      }
+    }
+
     // ADR-049: Use graph PageRank to prioritize sections
     let sectionOrder: string[] | undefined;
     if (this.memoryGraph) {
@@ -506,8 +526,12 @@ export class AutoMemoryBridge extends EventEmitter {
       this.config.topicMapping as Record<string, string>,
       sectionOrder,
     );
+    // Embed the marker on the title line rather than as its own line, so it
+    // doesn't perturb maxIndexLines budgeting (pruneSectionsToFit sizes for
+    // the title as exactly 1 line).
+    lines[0] = `${lines[0]} ${INDEX_OWNERSHIP_MARKER}`;
 
-    await fs.writeFile(this.getIndexPath(), lines.join('\n'), 'utf-8');
+    await fs.writeFile(indexPath, lines.join('\n'), 'utf-8');
     this.emit('index:curated', { lines: lines.length });
   }
 


### PR DESCRIPTION
Fixes #3224

## Problem
`AutoMemoryBridge.curateIndex()` rebuilds `MEMORY.md` from whichever `DEFAULT_TOPIC_MAPPING` topic files exist, and writes it unconditionally. When the configured `memoryDir` is Claude Code's own `~/.claude/projects/<key>/memory` — which is what `resolveAutoMemoryDir()` targets by design — that file is the user's hand-maintained memory index, and it gets silently replaced the first time the bridge writes a topic file.

Measured on a copy of a real memory directory (reproduced in this PR's new test as well):
```
MEMORY.md before: 75 lines (hand-curated, 49 links to topic files)
MEMORY.md after :  6 lines
```
There is no backup and no prompt.

## Root cause
The `#1556` guard (`if (Object.keys(sections).length === 0) { ...skip... }`) only protects the case where **zero** topic files match `DEFAULT_TOPIC_MAPPING`. The bridge creates its own first topic file (e.g. `patterns.md`) the moment an insight is recorded — at that point `sections` is non-empty, the guard no longer applies, and every subsequent curate overwrites `MEMORY.md`, whether or not the bridge is the one that created it.

## Changes
`v3/@claude-flow/memory/src/auto-memory-bridge.ts`:
- Add `INDEX_OWNERSHIP_MARKER`, a small HTML comment stamped onto the title line of any `MEMORY.md` this bridge writes (kept on the title line, not its own line, so it doesn't add to `maxIndexLines` budgeting — `pruneSectionsToFit` sizes for the title as exactly 1 line).
- Before writing, if `MEMORY.md` already exists and does **not** contain the marker, treat it as foreign (hand-maintained or written by something else) and skip the write, emitting `index:skipped` with `{ reason: 'foreign-index' }` — mirroring the existing `#1556` event shape. A file the bridge already owns (marker present) continues to be curated normally on every subsequent call.

This is suggested fix #1 from the issue (marker + refuse-to-overwrite). I scoped this PR to that option specifically since it's the smallest, lowest-risk change that fully closes the hole; the issue's alternative "curate only inside a delimited block" option is a larger change (needs to parse and preserve arbitrary surrounding content) that felt like a separate PR if there's appetite for it later.

`v3/@claude-flow/memory/src/auto-memory-bridge.test.ts`:
- New test reproducing the exact repro from the issue: a hand-curated `MEMORY.md` plus a `patterns.md` (which *does* match `DEFAULT_TOPIC_MAPPING`, so the `#1556` guard doesn't apply) — asserts the file is byte-identical after `curateIndex()` and that `index:skipped`/`foreign-index` fires.
- New test asserting a bridge-owned index (marker present) still curates normally across repeated calls.

## Test evidence
`vitest` could not be run in my environment — a pre-existing, unrelated `ERR_PACKAGE_IMPORT_NOT_DEFINED: "#module-evaluator"` failure inside the installed `vitest@4.1.8` (duplicate `@vitest/utils` version hoisting) reproduces on a clean `pnpm install` at `v3/` before touching any of my files. I validated with `tsx` running the real `AutoMemoryBridge` class directly from standalone scripts instead (not part of this diff):
- **Without the fix**: reproduced the bug exactly as described — a hand-curated `MEMORY.md` was replaced with a 4-line stub after `patterns.md` was written.
- **With the fix**: the same sequence leaves `MEMORY.md` byte-identical and emits `index:skipped`/`foreign-index`.
- Regression-checked four existing behaviors are unaffected: the original `#1556` no-matching-topic-files skip, normal index generation (title + content present, now with the marker on the title line), the `maxIndexLines` budget test (`<= 20` lines, confirming the inlined marker doesn't change line count), and that an owned index keeps updating across repeated `curateIndex()` calls.

## Checklist
- [x] Read `CONTRIBUTING.md` workflow and followed it (issue linked, feature branch, minimal diff, clear description)
- [x] Diffs minimal — one source file + one test file
- [x] Added tests for the new behavior; verified via direct script execution since the local `vitest` toolchain is broken independent of this change (see Test evidence)
- [x] Branch is from upstream `main` HEAD (`e341ec8`)