### PR TITLE
fix: persist hive-mind init's hiveId so status reports the same id (#655)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts
+++ b/v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts
@@ -727,6 +727,15 @@ describe('MCP Tools Deep Test Suite', () => {
       expect(result).toBeDefined();
     });
 
+    it('hive-mind_status reports the same hiveId that hive-mind_init returned (#655)', async () => {
+      const initTool = hiveMindTools.find(t => t.name === 'hive-mind_init')!;
+      const statusTool = hiveMindTools.find(t => t.name === 'hive-mind_status')!;
+      const initResult: any = await initTool.handler({ topology: 'mesh' });
+      const statusResult: any = await statusTool.handler({});
+      expect(statusResult.hiveId).toBe(initResult.hiveId);
+      expect(statusResult.id).toBe(initResult.hiveId);
+    });
+
     it('hive-mind_consensus with list action returns data', async () => {
       const tool = hiveMindTools.find(t => t.name === 'hive-mind_consensus')!;
       const result: any = await tool.handler({ action: 'list' });

--- a/v3/@claude-flow/cli/src/mcp-tools/hive-mind-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/hive-mind-tools.ts
@@ -23,6 +23,10 @@ type ConsensusStrategyName = 'raft' | 'byzantine' | 'gossip' | 'crdt' | 'quorum'
 
 interface HiveState {
   initialized: boolean;
+  // #655 — persist the hiveId generated at init time so every subsequent
+  // hive-mind_status call reports the SAME id the user saw at init/spawn,
+  // instead of re-deriving a differently-formatted id from createdAt.
+  hiveId?: string;
   topology: 'mesh' | 'hierarchical' | 'ring' | 'star';
   consensusStrategy?: ConsensusStrategyName;
   queen?: {
@@ -322,6 +326,9 @@ export const hiveMindTools: MCPTool[] = [
 
       const requestedConsensus = (input.consensus as ConsensusStrategyName) || 'raft';
       state.initialized = true;
+      // #655 — persist the id we're about to return so status/spawn read it
+      // back verbatim instead of recomputing a different-looking id.
+      state.hiveId = hiveId;
       state.topology = (input.topology as HiveState['topology']) || 'mesh';
       state.consensusStrategy = requestedConsensus;
       state.createdAt = new Date().toISOString();
@@ -388,9 +395,14 @@ export const hiveMindTools: MCPTool[] = [
       const workerCount = Math.max(1, state.workers.length);
       const realLoad = activeTaskCount / workerCount;
 
+      // #655 — fall back to the old derived-from-createdAt format only for
+      // state files persisted before this field existed; a freshly
+      // initialized hive always has state.hiveId set by hive-mind_init.
+      const hiveId = state.hiveId ?? `hive-${state.createdAt ? new Date(state.createdAt).getTime() : Date.now()}`;
+
       const status = {
         // CLI expected fields
-        hiveId: `hive-${state.createdAt ? new Date(state.createdAt).getTime() : Date.now()}`,
+        hiveId,
         status: state.initialized ? 'active' : 'offline',
         topology: state.topology,
         // ADR-093 F3: surface the persisted strategy instead of a hardcoded "byzantine".
@@ -431,7 +443,7 @@ export const hiveMindTools: MCPTool[] = [
           memory: 'healthy',
         },
         // Additional fields
-        id: `hive-${state.createdAt ? new Date(state.createdAt).getTime() : Date.now()}`,
+        id: hiveId,
         initialized: state.initialized,
         workerCount: state.workers.length,
         pendingConsensus: state.consensus.pending.length,


### PR DESCRIPTION
Fixes #655.

`hive-mind_init` generated a `hiveId` with a random suffix (`hive-<ts>-<rand>`) and returned it to the caller, but never persisted it to `HiveState`. `hive-mind_status` independently re-derived a *differently-formatted* id (`hive-<ts>`, no random suffix) from `state.createdAt` on every call. So the id a user saw at `init`/`spawn` time never matched what a later `hive-mind status` call reported — this is (part of) the ID-mismatch symptom reported in #655 ("the Swarm ID printed by `spawn` never shows up in `hive-mind status`").

This PR persists the generated `hiveId` on `HiveState` at init time and has `hive-mind_status` read it back verbatim (both the `hiveId` and `id` fields it returns), falling back to the old derived format only for pre-existing state files written before this field existed.

Note on scope: #655 also describes hive-mind tasks/workers never actually progressing past `idle`/`0 tasks`. That symptom is a separate, larger, already-tracked gap in the task-dispatch bridge between the enqueue layer and the worker runtime (see the `#1791.1` comment in `v3/@claude-flow/cli/src/commands/hive-mind.ts` around the `task` command, and the issue's own April 2026 follow-up comment referencing this). This PR only fixes the id-mismatch half; the dispatch-bridge half needs a design decision and is out of scope for an automated nightly-triage fix.

Added a regression test (`hive-mind_status reports the same hiveId that hive-mind_init returned (#655)`) in `v3/@claude-flow/cli/__tests__/mcp-tools-deep.test.ts` that fails on the pre-fix code (asserts `hive-1788931174852` !== `hive-1788931174852-sqtkce`) and passes after the fix. Ran the full `mcp-tools-deep.test.ts` suite (108 tests) — all pass.

Opened by the nightly triage routine — human review required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1AZKuNW6xE4R74cUQg5t1)_