### PR TITLE
fix(memory): stop reporting a gated native bridge as the active backend (#3228) + fast-uri CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "cors": "^2.8.5",
         "express": ">=4.22.2",
         "express-rate-limit": ">=8.4.1",
-        "fast-uri": "3.1.5",
+        "fast-uri": "^3.1.6",
         "fs-extra": "^11.2.0",
         "helmet": "^7.2.0",
         "inquirer": "^9.2.0",
@@ -7920,9 +7920,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.39.0",
+  "version": "3.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.39.0",
+      "version": "3.39.1",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/mcp",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "fs-extra": "^11.2.0",
     "express": ">=4.22.2",
     "express-rate-limit": ">=8.4.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "^3.1.6",
     "helmet": "^7.2.0",
     "inquirer": "^9.2.0",
     "semver": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.39.0",
+  "version": "3.39.1",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/mcp",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.39.0",
+  "version": "3.39.1",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/__tests__/issue-3228-gated-bridge-backend-honesty.test.ts
+++ b/v3/@claude-flow/cli/__tests__/issue-3228-gated-bridge-backend-honesty.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from 'vitest';
+
+// #3228: on Windows the native-bridge kill-switch added in 3.38.12 (#3024)
+// makes `getRegistry()` return null, so every memory read/write silently
+// falls back to the sql.js store (`memory.db`) instead of the AgentDB corpus
+// (`agentdb-memory.db`) the bridge would have opened. The reporter measured
+// the consequence: a canary store/retrieve round-trip SUCCEEDS (both halves
+// use the same unintended file), while an existing live-store key returns
+// `found: false` against 31,673 real rows.
+//
+// The status surface hid it. `getHNSWStatus()` gated its bridge branch on
+// whether the bridge MODULE was loaded — which it is, even when the registry
+// is gated off — so `describeBackend()` printed "sqlite (bridge, brute-force
+// cosine)" for a store the bridge never touched.
+//
+// These tests pin the discriminator. `CLAUDE_FLOW_DISABLE_BRIDGE=1` takes the
+// same `shouldDisableNativeBridge()` branch as the Windows default, so the
+// regression is reproducible on any platform.
+describe('#3228 a gated native bridge must not be reported as the active backend', () => {
+  const priorDisable = process.env.CLAUDE_FLOW_DISABLE_BRIDGE;
+
+  afterEach(() => {
+    if (priorDisable === undefined) delete process.env.CLAUDE_FLOW_DISABLE_BRIDGE;
+    else process.env.CLAUDE_FLOW_DISABLE_BRIDGE = priorDisable;
+  });
+
+  it('shouldDisableNativeBridge() is true for the Windows default and for the explicit kill-switch', async () => {
+    const { shouldDisableNativeBridge } = await import('../src/memory/memory-bridge.js');
+
+    // The Windows default (no opt-in) — the exact gate the issue reports.
+    expect(shouldDisableNativeBridge('win32', {})).toBe(true);
+    // Opt-in re-enables it.
+    expect(
+      shouldDisableNativeBridge('win32', { CLAUDE_FLOW_ENABLE_NATIVE_BRIDGE_ON_WINDOWS: '1' }),
+    ).toBe(false);
+    // Non-Windows is ungated by default...
+    expect(shouldDisableNativeBridge('linux', {})).toBe(false);
+    // ...but the explicit kill-switch gates every platform.
+    expect(shouldDisableNativeBridge('linux', { CLAUDE_FLOW_DISABLE_BRIDGE: '1' })).toBe(true);
+  });
+
+  it('getHNSWStatus() stops claiming the brute-force bridge path once the bridge is gated', async () => {
+    process.env.CLAUDE_FLOW_DISABLE_BRIDGE = '1';
+    const { getHNSWStatus } = await import('../src/memory/memory-initializer.js');
+
+    const status = getHNSWStatus();
+
+    // The pre-fix code reported `brute-force-cosine` here purely because the
+    // module object was resolvable, describing a path that cannot run. With
+    // the bridge gated, sql.js is what actually serves the request.
+    expect(status.algorithm).not.toBe('brute-force-cosine');
+  });
+
+  it('the backend label names the gate instead of implying the bridge is serving requests', async () => {
+    process.env.CLAUDE_FLOW_DISABLE_BRIDGE = '1';
+    const { shouldDisableNativeBridge, getBridgeFailureReason } = await import(
+      '../src/memory/memory-bridge.js'
+    );
+
+    // describeBackend() is module-private, so assert the two facts it composes:
+    // the gate is closed, and the reason is retrievable for the operator.
+    expect(shouldDisableNativeBridge()).toBe(true);
+    expect(typeof getBridgeFailureReason).toBe('function');
+
+    // A label built from these must not be a bare "sql.js + HNSW" — the point
+    // of #3228 is that an upgrade changed which FILE receives writes without
+    // saying so. Reconstruct the same composition describeBackend() performs.
+    const reason = getBridgeFailureReason();
+    const label = `sql.js + HNSW (native bridge disabled${reason ? `: ${reason}` : ''})`;
+    expect(label).toContain('native bridge disabled');
+  });
+});

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.39.0",
+  "version": "3.39.1",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/memory-tools.ts
@@ -255,7 +255,26 @@ async function describeBackend(): Promise<string> {
   try {
     const { getHNSWStatus } = await import('../memory/memory-initializer.js');
     const status = getHNSWStatus();
-    return status.algorithm === 'hnsw' ? 'sql.js + HNSW' : 'sqlite (bridge, brute-force cosine)';
+    if (status.algorithm !== 'hnsw') return 'sqlite (bridge, brute-force cosine)';
+
+    // #3228: with the native bridge gated off (the Windows default since
+    // 3.38.12), memory tools silently fall back to the sql.js store rather
+    // than the AgentDB corpus the bridge would have opened. A bare
+    // "sql.js + HNSW" hides that substitution — an upgrade can change which
+    // file receives writes while store/retrieve smoke tests still pass,
+    // because both operations use the same unintended file. Name the gate.
+    try {
+      const { shouldDisableNativeBridge, getBridgeFailureReason } = await import(
+        '../memory/memory-bridge.js'
+      );
+      if (shouldDisableNativeBridge()) {
+        const reason = getBridgeFailureReason();
+        return `sql.js + HNSW (native bridge disabled${reason ? `: ${reason}` : ''})`;
+      }
+    } catch {
+      // bridge module unavailable — the plain sql.js label is already accurate
+    }
+    return 'sql.js + HNSW';
   } catch {
     return 'sqlite';
   }

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -909,7 +909,17 @@ export function getHNSWStatus(): {
   // name promises — that's false while the bridge is the active path, so
   // this no longer claims otherwise. Vector search itself still works via
   // the bridge; `algorithm` tells callers it's brute-force, not HNSW.
-  if (_bridge && _bridge !== null) {
+  //
+  // #3228: this branch previously tested only that the bridge MODULE was
+  // loaded. On Windows the module imports fine but `getRegistry()` returns
+  // null behind the #3024 kill-switch, so every read/write actually goes to
+  // the sql.js store while this function still reported the bridge as the
+  // active path — `describeBackend()` then printed "sqlite (bridge, ...)"
+  // for a store the bridge never touched. Gate on whether the bridge is
+  // *permitted to be* the active path, not on whether the module resolved.
+  // `shouldDisableNativeBridge()` is sync and a pure function of platform +
+  // env, so it is a faithful discriminator here and needs no warm registry.
+  if (_bridge && _bridge !== null && !_bridge.shouldDisableNativeBridge()) {
     return {
       available: false,
       initialized: false,


### PR DESCRIPTION
## What

Two critical fixes, released as 3.39.1.

### 1. #3228 — a gated native bridge was reported as the active backend

On Windows the #3024 kill-switch makes `getRegistry()` return null, so every memory read/write silently falls back to the sql.js store (`memory.db`) instead of the AgentDB corpus (`agentdb-memory.db`) the bridge would have opened.

The reporter measured the consequence precisely: a canary store/retrieve round-trip **succeeds** — because both halves use the same unintended file — while an existing live-store key returns `found: false` against **31,673 real rows**. A normal smoke test cannot detect this.

The status surface hid it. `getHNSWStatus()` gated its bridge branch on whether the bridge **module was loaded** — which it is, even when the registry is gated off — so `describeBackend()` printed `sqlite (bridge, brute-force cosine)` for a store the bridge never touched.

**Fix:** gate on whether the bridge is *permitted to be* the active path, not on whether the module resolved. `shouldDisableNativeBridge()` is sync and a pure function of platform + env, so it is a faithful discriminator and needs no warm registry. `describeBackend()` now names the gate and its reason.

**Deliberately not fixed here:** the opt-in allocation abort (#2948, `0xC0000409` on a ~4.4 GB allocation) and rerouting the fallback to the AgentDB corpus. Both need Windows validation, which I do not have. This makes the *silent* case loud, which is what the report asks for first.

### 2. #3222 — fast-uri high-severity CVE

`fast-uri` was pinned at exactly `3.1.5`; the advisory range is `>=3.1.3 <3.1.6`. Bumped to `^3.1.6` (resolves 3.1.7).

- Clears **GHSA-5jgf-p345-68v8** (high, CVSS 7.5 — host confusion via skipped IDN canonicalization on scheme-relative references)
- Clears the `ajv` high that inherited it
- `npm audit` confirms both now CLEAR

Same change as #3222 by @aeonframework, applied here because CI was never authorized to run on that PR. Credit to them.

## Validation

- `tsc --noEmit` clean
- New regression test `__tests__/issue-3228-gated-bridge-backend-honesty.test.ts` (3 cases) — uses `CLAUDE_FLOW_DISABLE_BRIDGE=1`, which takes the same `shouldDisableNativeBridge()` branch as the Windows default, so the regression reproduces on any platform
- Existing `issue-2922-hnsw-status-honesty.test.ts` still passes (this change could have broken it)
- Full `__tests__` run: 3524 passed. The 64 failures are **pre-existing** — verified by A/B: stashed the fix, **rebuilt**, re-ran the two memory-path failures and got an identical 3 failed / 16 passed both halves. The rest are optional WASM/native deps (`ruvllm-wasm`, `agent-wasm`, `agenticow`) and the known helper-artifact-parity churn.
- `audit-umbrella-version-lockstep.mjs` — all three packages at 3.39.1 ✓

Refs #3228, #3222, #2948, #3024

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)