### PR TITLE
fix(security): make the fast-uri CVE fix actually reach shipped packages (#3222) — 3.39.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "3.39.1",
+  "version": "3.39.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "3.39.1",
+      "version": "3.39.2",
       "bundleDependencies": [
         "@claude-flow/codex",
         "@claude-flow/mcp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.39.1",
+  "version": "3.39.2",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/mcp",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.39.1",
+  "version": "3.39.2",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",
@@ -74,7 +74,8 @@
     "@opentelemetry/otlp-transformer": ">=0.220.0",
     "agentdb": ">=3.0.0-alpha.17",
     "agentic-flow": ">=2.0.14",
-    "@ruvector/ruvllm": ">=2.6.0"
+    "@ruvector/ruvllm": ">=2.6.0",
+    "fast-uri": ">=3.1.6"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.39.1",
+  "version": "3.39.2",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
@@ -115,7 +115,7 @@
     "cors": "^2.8.5",
     "express": ">=4.22.2",
     "express-rate-limit": ">=8.4.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "^3.1.6",
     "fs-extra": "^11.2.0",
     "helmet": "^7.2.0",
     "inquirer": "^9.2.0",

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: '>=8.4.1'
         version: 8.6.2(express@5.2.1)
       fast-uri:
-        specifier: 3.1.5
-        version: 3.1.5
+        specifier: ^3.1.6
+        version: 3.1.7
       fs-extra:
         specifier: ^11.2.0
         version: 11.3.3
@@ -7610,7 +7610,7 @@ packages:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     dev: false
@@ -7619,7 +7619,7 @@ packages:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8976,8 +8976,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  /fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   /fastmcp@3.26.7:
     resolution: {integrity: sha512-6bXv8+8TBBvNlPBvASkzx8VYBWJk3TlojZoa20/2Gv43+LBA32c35gz0DM6Kov1XuDOheo5IAHtfEfgI5MqTww==}


### PR DESCRIPTION
## Post-publish validation caught an incomplete fix

3.39.1 bumped `fast-uri` **only in the root `package.json`**. A fresh `npm install ruflo@3.39.1` from the registry still resolved **`fast-uri@3.1.5`** — squarely inside the advisory range for **GHSA-5jgf-p345-68v8** (high, CVSS 7.5, `>=3.1.3 <3.1.6`). The CVE was never actually fixed for users.

**Root cause:** `v3/@claude-flow/cli/package.json` carried its own hard pin `"fast-uri": "3.1.5"` in `dependencies` — and that is the package that actually ships. The root bump did not override it. This is the #2112 lesson recorded in CLAUDE.md ("root overrides do NOT propagate to the published `ruflo` wrapper"), which applies to the CLI package too.

```
ruflo@3.39.1
└─┬ @claude-flow/cli@3.39.1
  ├─┬ ajv@8.20.0
  │ └── fast-uri@3.1.5 deduped
  └── fast-uri@3.1.5      ← the hard pin, direct dependency
```

## Fix

- `v3/@claude-flow/cli`: `fast-uri` `3.1.5` → `^3.1.6` — the dependency that actually ships
- `ruflo`: add `"fast-uri": ">=3.1.6"` override so the wrapper cannot regress independently of the CLI

## Validation

- Build clean, `#3228` + `#2922` regression tests still pass (5/5)
- Lockstep audit: all three packages at 3.39.2 ✓
- Will be re-verified after publish by **fresh-installing the published tarball**, not by reading the lockfile — reading the lockfile is exactly what missed this the first time

## Note

Expect the 2 pre-existing `pin-drift` / `clean-install` failures — `@metaharness/darwin` pinned `~0.9.0` vs npm latest `0.10.2`, tracked in #3219. Unrelated to this change; deliberately not bundled into a security patch since 0.9→0.10 on a 0.x package is semver-breaking.

Refs #3222, #2112, #3219

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)