### PR TITLE
feat: integrate realtime reflex handoffs with cancellation and effect fencing

### DIFF
--- a/.github/workflows/realtime-contract.yml
+++ b/.github/workflows/realtime-contract.yml
@@ -1,0 +1,34 @@
+name: Realtime cancellation contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'v3/@claude-flow/integration/src/realtime-session.ts'
+      - 'v3/@claude-flow/integration/validation/**'
+      - 'v3/@claude-flow/integration/tsconfig.realtime.json'
+      - '.github/workflows/realtime-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22.16.0'
+      - name: Install pinned compiler without lifecycle scripts
+        run: npm install --prefix "$RUNNER_TEMP/realtime-tools" --ignore-scripts --no-fund --no-audit typescript@5.8.3
+      - name: Record environment
+        run: |
+          node --version
+          "$RUNNER_TEMP/realtime-tools/node_modules/.bin/tsc" --version
+      - name: Strict compile of opt-in adapter
+        run: '"$RUNNER_TEMP/realtime-tools/node_modules/.bin/tsc" -p v3/@claude-flow/integration/tsconfig.realtime.json'
+      - name: Contract, degradation, and loopback HTTP cancellation tests
+        run: node --test v3/@claude-flow/integration/validation/realtime.contract.mjs

--- a/v3/@claude-flow/integration/docs/ADR-3246-realtime-cancellation.md
+++ b/v3/@claude-flow/integration/docs/ADR-3246-realtime-cancellation.md
@@ -20,9 +20,7 @@ import {
   consumeRealtimeBody,
 } from '@claude-flow/integration/realtime-session';
 
-const session = new RealtimeSession('customer-session-identity', {
-  // Use an opaque identity with only letters, digits, dot, underscore or colon.
-  // Replace the sample identity above with customer.session.identity.
+const session = new RealtimeSession('customer.session.identity', {
   onToken: (text, generation) => publishToCurrentSession(text, generation),
   tools: trustedRvmBoundary,
 });
@@ -44,7 +42,7 @@ The application supplies its existing provider client and authenticated RVM boun
 
 ## Bounds and privacy
 
-One physically active generation per session; 4096 wire events; 128-character opaque session identity; 1 MiB input; default 1 MiB output; at most 256 tools and delegates; at most 300 seconds per generation. No retained event history, raw prompt logs, tool-argument logs, credentials, or detached rejections. Output and runtime telemetry are bounded. Persistent storage is unchanged.
+One physically active generation per session; 4096 wire events; 128-character opaque session identity; 1,048,576 input characters; default 1,048,576 output characters; at most 256 tools and delegates; at most 300 seconds per generation. Character limits count JavaScript UTF-16 code units, not network bytes. The transport must independently bound raw message bytes. No retained event history, raw prompt logs, tool-argument logs, credentials, or detached rejections. Output and runtime telemetry are bounded. Persistent storage is unchanged.
 
 ## Validation
 
@@ -56,9 +54,9 @@ tsc -p tsconfig.realtime.json
 node --test validation/realtime.contract.mjs
 ```
 
-The 30-test native suite includes a real loopback HTTP server, fetch cancellation, ReadableStream reader cancellation, delegated task cancellation, cancellation during asynchronous tool authorization, proposal mutation, stale results, uint64 boundaries, invalid scope, deadline, overflow, resource limits, and 1000 interrupted sessions.
+The initial 30-test native suite includes a real loopback HTTP server, fetch cancellation, ReadableStream reader cancellation, delegated task cancellation, cancellation during asynchronous tool authorization, proposal mutation, stale results, uint64 boundaries, invalid scope, deadline, overflow, resource limits, and 1000 interrupted sessions.
 
-Local run: 30/30 pass. Model quality and remote GPU cancellation cost were not measured. The MetaHarness benchmark compares serial control, direct AbortController, and this bridge with five seeds, 1000 paired events and randomized arm ordering. Initial fixed-order timing was superseded because arm ordering can bias the comparison. The direct AbortController control is mandatory: the bridge adds governance, not a claim of faster abort dispatch.
+Initial local run: 30/30 pass. Model quality and remote GPU cancellation cost were not measured. The MetaHarness benchmark compares serial control, direct AbortController, and this bridge with five seeds, 1000 paired events and randomized arm ordering. Initial fixed-order timing was superseded because arm ordering can bias the comparison. The direct AbortController control is mandatory: the bridge adds governance, not a claim of faster abort dispatch.
 
 ## Release gates
 

--- a/v3/@claude-flow/integration/docs/ADR-3246-realtime-cancellation.md
+++ b/v3/@claude-flow/integration/docs/ADR-3246-realtime-cancellation.md
@@ -1,0 +1,69 @@
+# ADR 3246: Realtime reflex handoff and cancellation
+
+Date: 2026-09-09
+Status: proposed, opt-in implementation
+Tracks: ruvnet/ruflo#3246, ruvnet/midstream#107, ruvnet/metaharness#301 Track D
+
+## Decision
+
+Expose `@claude-flow/integration/realtime-session` through the existing package wildcard export. A `RealtimeSession` accepts authenticated MidStream wire v1 handoffs while one asynchronous reasoning generation runs. The control path never waits for reasoning, never invokes an LLM, and never obtains execution permission from a receipt.
+
+Fresh interruption or cancellation immediately fences publication, resolves the user-facing outcome as cancelled, and propagates one shared AbortSignal to the reasoner, delegated tasks, and tool boundary. `settled` and `waitForQuiescence` separately track actual local work completion. An adapter ignoring cancellation produces INCOMPLETE and blocks a replacement generation. There is no unbounded zombie task accumulation.
+
+Backchannels do not interrupt reasoning. Replayed controls cannot stop a newer generation. MidStream latch fields preserve stop events even when its bounded data queue is full. Data loss requires an explicit trusted snapshot reconciliation before starting more work. All u64 wire fields use canonical decimal strings and BigInt validation; values above 2^53 retain precision.
+
+## Integration
+
+```ts
+import {
+  RealtimeSession,
+  consumeRealtimeBody,
+} from '@claude-flow/integration/realtime-session';
+
+const session = new RealtimeSession('customer-session-identity', {
+  // Use an opaque identity with only letters, digits, dot, underscore or colon.
+  // Replace the sample identity above with customer.session.identity.
+  onToken: (text, generation) => publishToCurrentSession(text, generation),
+  tools: trustedRvmBoundary,
+});
+const turn = session.start(prompt, async (input, context) => {
+  const response = await configuredProvider(input, { signal: context.signal });
+  await consumeRealtimeBody(response.body, context);
+});
+// Invoke from the independently serviced authenticated control transport.
+// The transport must bound message size before JSON.parse.
+session.acceptHandoff(JSON.parse(midstreamHandoff));
+await turn.result;
+const shutdown = await session.waitForQuiescence(1000);
+// STOPPED means tracked local work exited, not proof of remote GPU shutdown.
+```
+
+The application supplies its existing provider client and authenticated RVM boundary. No provider credential or network destination is accepted from a handoff. Use async I/O, workers, or separate processes for reasoning; a CPU-blocking callback on the control event loop invalidates realtime latency guarantees. Callbacks are trusted application code. This module is not a sandbox.
+
+`ToolBoundary.authorize` defaults to deny when absent. Proposals are immutable snapshots. After asynchronous authorization, the session rechecks generation validity immediately before initiating execution. The execute adapter must forward AbortSignal and revalidate at the real external commit boundary. Cancellation cannot undo an already committed external effect and cannot prove that a remote provider stopped billing.
+
+## Bounds and privacy
+
+One physically active generation per session; 4096 wire events; 128-character opaque session identity; 1 MiB input; default 1 MiB output; at most 256 tools and delegates; at most 300 seconds per generation. No retained event history, raw prompt logs, tool-argument logs, credentials, or detached rejections. Output and runtime telemetry are bounded. Persistent storage is unchanged.
+
+## Validation
+
+Run with Node 22.16.0 and TypeScript 5.8.3:
+
+```sh
+cd v3/@claude-flow/integration
+tsc -p tsconfig.realtime.json
+node --test validation/realtime.contract.mjs
+```
+
+The 30-test native suite includes a real loopback HTTP server, fetch cancellation, ReadableStream reader cancellation, delegated task cancellation, cancellation during asynchronous tool authorization, proposal mutation, stale results, uint64 boundaries, invalid scope, deadline, overflow, resource limits, and 1000 interrupted sessions.
+
+Local run: 30/30 pass. Model quality and remote GPU cancellation cost were not measured. The MetaHarness benchmark compares serial control, direct AbortController, and this bridge with five seeds, 1000 paired events and randomized arm ordering. Initial fixed-order timing was superseded because arm ordering can bias the comparison. The direct AbortController control is mandatory: the bridge adds governance, not a claim of faster abort dispatch.
+
+## Release gates
+
+Existing repository checks plus the new exact-module workflow must pass. Independent MetaHarness reproduction remains required. Production evaluation must preserve model task quality within 2 percentage points and measure actual provider cancellation waste below 10 percent; synthetic output checks do not satisfy those gates.
+
+## Rollback
+
+The feature is opt-in. Remove the new import/call site to restore the existing orchestration path. Do not revert by resuming cancelled work. There is no data migration, default routing change, autonomous merge, or deployment.

--- a/v3/@claude-flow/integration/src/realtime-session.ts
+++ b/v3/@claude-flow/integration/src/realtime-session.ts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+/** Opt-in MidStream/Ruflo bridge. Callbacks are trusted code, not a sandbox. */
+export type ReflexKind = 'Interrupt' | 'Backchannel' | 'Cancel' | 'Observation' | 'CommitBoundary';
+export interface ReflexWireEvent { sequence: string; at_micros: string; kind: ReflexKind }
+export interface ReflexWireHandoff {
+  version: 1; authority: 'none'; session_id: string; latest_sequence: string;
+  queued_events: readonly ReflexWireEvent[];
+  interrupt_sequence: string | null; cancel_sequence: string | null;
+  cancelled_work_units: string; dropped_events: string;
+}
+export interface ToolProposal { readonly name: string; readonly argumentsJson: string }
+export interface TurnContext {
+  readonly signal: AbortSignal; readonly generation: number;
+  emit(text: string): boolean;
+  tool(proposal: ToolProposal): Promise<unknown>;
+  spawn(work: (context: TurnContext) => Promise<unknown>): Promise<unknown>;
+}
+export interface ToolBoundary {
+  authorize(proposal: ToolProposal, context: TurnContext): Promise<boolean>;
+  /** Must propagate signal and revalidate at the actual external commit boundary. */
+  execute(proposal: ToolProposal, context: TurnContext): Promise<unknown>;
+}
+export type TurnOutcome<T> =
+  | { status: 'completed'; value: T; generation: number }
+  | { status: 'cancelled' | 'failed'; code: string; generation: number };
+export interface TurnHandle<T> {
+  generation: number; signal: AbortSignal; result: Promise<TurnOutcome<T>>;
+  /** Settles only after the root, delegated work, and tool calls have exited. */
+  settled: Promise<void>;
+}
+export interface RealtimeOptions {
+  onToken?: (text: string, generation: number) => void;
+  tools?: ToolBoundary;
+  timeoutMs?: number; maxOutputChars?: number; maxToolCalls?: number; maxDelegates?: number;
+}
+interface Active {
+  generation: number; controller: AbortController; cancel: (code: string) => void;
+  cancelled: boolean; rootDone: boolean; outputChars: number; toolCalls: number;
+  delegateCalls: number; children: Set<Promise<unknown>>; settled: Promise<void>;
+}
+const kinds = new Set<ReflexKind>(['Interrupt', 'Backchannel', 'Cancel', 'Observation', 'CommitBoundary']);
+const U64 = 18446744073709551615n;
+function integer(value: unknown, max: number, min = 0): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max) throw new Error('INVALID_LIMIT');
+}
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('INVALID_HANDOFF');
+  return value as Record<string, unknown>;
+}
+function u64(value: unknown): bigint {
+  if (typeof value !== 'string' || !/^(0|[1-9][0-9]{0,19})$/.test(value)) throw new Error('INVALID_U64');
+  const number = BigInt(value);
+  if (number > U64) throw new Error('INVALID_U64');
+  return number;
+}
+function sessionId(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9._:]{1,128}$/.test(value)) throw new Error('INVALID_SESSION');
+}
+/** Call only on messages from an authenticated, session-bound MidStream channel. */
+export function validateReflexHandoff(value: unknown, expectedSession: string): ReflexWireHandoff {
+  const h = record(value);
+  if (h.version !== 1 || h.authority !== 'none' || h.session_id !== expectedSession) throw new Error('WRONG_HANDOFF_SCOPE');
+  sessionId(h.session_id);
+  const latest = u64(h.latest_sequence);
+  for (const key of ['interrupt_sequence', 'cancel_sequence']) {
+    if (h[key] !== null && (u64(h[key]) === 0n || u64(h[key]) > latest)) throw new Error('INVALID_CONTROL_WATERMARK');
+  }
+  u64(h.cancelled_work_units); u64(h.dropped_events);
+  if (!Array.isArray(h.queued_events) || h.queued_events.length > 4096) throw new Error('INVALID_EVENT_COUNT');
+  let previous = 0n;
+  for (const raw of h.queued_events) {
+    const event = record(raw); const sequence = u64(event.sequence);
+    u64(event.at_micros);
+    if (sequence <= previous || sequence > latest || !kinds.has(event.kind as ReflexKind)) throw new Error('INVALID_EVENT_ORDER');
+    if (event.kind === 'Cancel' && (h.cancel_sequence === null || sequence > u64(h.cancel_sequence))) throw new Error('MISSING_CANCEL_WATERMARK');
+    if (event.kind === 'Interrupt' && (h.interrupt_sequence === null || sequence > u64(h.interrupt_sequence))) throw new Error('MISSING_INTERRUPT_WATERMARK');
+    previous = sequence;
+  }
+  return value as ReflexWireHandoff;
+}
+
+/** One session, one physically active generation, bounded work, explicit restart. */
+export class RealtimeSession {
+  private active: Active | undefined;
+  private generation = 0;
+  private latest = 0n;
+  private dropped = 0n;
+  private closed = false;
+  private reconcile = false;
+  private readonly timeoutMs: number;
+  private readonly maxOutputChars: number;
+  private readonly maxToolCalls: number;
+  private readonly maxDelegates: number;
+  private readonly onToken: RealtimeOptions['onToken'];
+  private readonly tools: ToolBoundary | undefined;
+  private counts = { cancellations: 0, staleOutputs: 0, rejectedHandoffs: 0, deniedTools: 0, startedTools: 0 };
+
+  constructor(readonly session: string, options: RealtimeOptions = {}) {
+    sessionId(session);
+    this.timeoutMs = options.timeoutMs ?? 30_000;
+    this.maxOutputChars = options.maxOutputChars ?? 1_048_576;
+    this.maxToolCalls = options.maxToolCalls ?? 32;
+    this.maxDelegates = options.maxDelegates ?? 16;
+    integer(this.timeoutMs, 300_000, 1); integer(this.maxOutputChars, 16_777_216, 1);
+    integer(this.maxToolCalls, 256); integer(this.maxDelegates, 256);
+    this.onToken = options.onToken; this.tools = options.tools;
+  }
+
+  get telemetry() { return Object.freeze({ ...this.counts, busy: this.active !== undefined, needsReconcile: this.reconcile }); }
+
+  /** Stops local publication synchronously; cooperative work receives AbortSignal. */
+  acceptHandoff(value: unknown) {
+    if (this.closed) throw new Error('SESSION_CLOSED');
+    let h: ReflexWireHandoff;
+    try { h = validateReflexHandoff(value, this.session); }
+    catch (error) { this.counts.rejectedHandoffs++; throw error; }
+    const next = u64(h.latest_sequence), drops = u64(h.dropped_events);
+    if (next <= this.latest) return { status: 'stale' as const, authority: 'none' as const };
+    if (drops < this.dropped) throw new Error('COUNTER_REGRESSION');
+    const cancel = h.cancel_sequence !== null && u64(h.cancel_sequence) > this.latest;
+    const pause = h.interrupt_sequence !== null && u64(h.interrupt_sequence) > this.latest;
+    const overflow = drops > this.dropped;
+    this.latest = next; this.dropped = drops;
+    if (overflow) this.reconcile = true;
+    if (cancel || pause || overflow) this.stop(cancel ? 'CANCEL' : pause ? 'INTERRUPT' : 'OVERFLOW');
+    return { status: 'accepted' as const, acknowledged: cancel || pause || h.queued_events.some(e => e.kind === 'Backchannel'), needsReconcile: this.reconcile, authority: 'none' as const };
+  }
+
+  /** Trusted host acknowledgement of a fresh full snapshot, never an agent decision. */
+  reconcileSnapshot(snapshotDigest: string, throughSequence: string): void {
+    if (!/^[a-f0-9]{64}$/.test(snapshotDigest) || u64(throughSequence) !== this.latest) throw new Error('INVALID_SNAPSHOT');
+    if (this.active) throw new Error('WORK_NOT_QUIESCENT');
+    this.reconcile = false;
+  }
+
+  start<T>(input: string, reasoner: (input: string, context: TurnContext) => Promise<T>): TurnHandle<T> {
+    if (this.closed) throw new Error('SESSION_CLOSED');
+    if (this.active) throw new Error('WORK_NOT_QUIESCENT');
+    if (this.reconcile) throw new Error('SNAPSHOT_REQUIRED');
+    if (typeof input !== 'string' || input.length > 1_048_576 || typeof reasoner !== 'function') throw new Error('INVALID_TURN');
+    if (this.generation === Number.MAX_SAFE_INTEGER) throw new Error('GENERATION_EXHAUSTED');
+    const generation = ++this.generation, controller = new AbortController();
+    let resolve!: (value: TurnOutcome<T>) => void;
+    let finish!: () => void;
+    const result = new Promise<TurnOutcome<T>>(r => { resolve = r; });
+    const settled = new Promise<void>(r => { finish = r; });
+    const active: Active = { generation, controller, cancelled: false, rootDone: false, outputChars: 0, toolCalls: 0, delegateCalls: 0, children: new Set(), settled,
+      cancel: code => { resolve({ status: 'cancelled', code, generation }); } };
+    this.active = active;
+    const live = () => {
+      if (this.active !== active || active.cancelled || controller.signal.aborted) throw new Error('TURN_CANCELLED');
+    };
+    const track = <R>(promise: Promise<R>): Promise<R> => {
+      active.children.add(promise);
+      // Observe rejection even when a caller forgets to await a child. No detached rejection.
+      void promise.then(() => active.children.delete(promise), () => { active.children.delete(promise); this.stopActive(active, 'CHILD_FAILED'); });
+      return promise;
+    };
+    const context: TurnContext = Object.freeze({
+      signal: controller.signal, generation,
+      emit: (text: string) => {
+        if (this.active !== active || active.cancelled || active.rootDone) { this.counts.staleOutputs++; return false; }
+        if (typeof text !== 'string' || text.length > this.maxOutputChars - active.outputChars) { this.stopActive(active, 'OUTPUT_LIMIT'); return false; }
+        active.outputChars += text.length;
+        this.onToken?.(text, generation);
+        return true;
+      },
+      tool: (proposal: ToolProposal) => {
+        live();
+        if (active.rootDone || ++active.toolCalls > this.maxToolCalls) throw new Error('TOOL_LIMIT');
+        if (!proposal || typeof proposal.name !== 'string' || !/^[A-Za-z0-9._:]{1,128}$/.test(proposal.name) || typeof proposal.argumentsJson !== 'string' || proposal.argumentsJson.length > 65_536) throw new Error('INVALID_TOOL');
+        const frozen = Object.freeze({ name: proposal.name, argumentsJson: proposal.argumentsJson });
+        return track((async () => {
+          if (!this.tools) { this.counts.deniedTools++; throw new Error('TOOL_DENIED'); }
+          const allowed = await this.tools.authorize(frozen, context);
+          live(); // Recheck AFTER asynchronous policy lookup, immediately before execution.
+          if (allowed !== true) { this.counts.deniedTools++; throw new Error('TOOL_DENIED'); }
+          this.counts.startedTools++;
+          return this.tools.execute(frozen, context);
+        })());
+      },
+      spawn: (work: (context: TurnContext) => Promise<unknown>) => {
+        live();
+        if (active.rootDone || ++active.delegateCalls > this.maxDelegates) throw new Error('DELEGATE_LIMIT');
+        return track(Promise.resolve().then(() => { live(); return work(context); }));
+      },
+    });
+    const timer = setTimeout(() => this.stopActive(active, 'DEADLINE'), this.timeoutMs);
+    void (async () => {
+      try {
+        live();
+        const value = await reasoner(input, context);
+        active.rootDone = true;
+        await Promise.allSettled([...active.children]);
+        live();
+        resolve({ status: 'completed', value, generation });
+      } catch {
+        if (!active.cancelled) resolve({ status: 'failed', code: 'REASONER_FAILED', generation });
+      } finally {
+        active.rootDone = true;
+        // A failed root must not leave authorized children behind.
+        if (!controller.signal.aborted) controller.abort();
+        await Promise.allSettled([...active.children]);
+        clearTimeout(timer);
+        if (this.active === active) this.active = undefined;
+        finish();
+      }
+    })();
+    return { generation, signal: controller.signal, result, settled };
+  }
+
+  private stopActive(active: Active, code: string): void {
+    if (this.active !== active || active.cancelled) return;
+    active.cancelled = true; this.counts.cancellations++;
+    active.cancel(code); // Logical cancellation is not a physical stop attestation.
+    active.controller.abort();
+  }
+  stop(code = 'CANCEL'): void { if (this.active) this.stopActive(this.active, code); }
+  close(): void { this.closed = true; this.stop('CLOSED'); }
+  async waitForQuiescence(timeoutMs = 1_000): Promise<'STOPPED' | 'INCOMPLETE'> {
+    integer(timeoutMs, 300_000, 1);
+    const active = this.active;
+    if (!active) return 'STOPPED';
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        active.settled.then(() => 'STOPPED' as const),
+        new Promise<'INCOMPLETE'>(resolve => { timer = setTimeout(() => resolve('INCOMPLETE'), timeoutMs); }),
+      ]);
+    } finally { if (timer !== undefined) clearTimeout(timer); }
+  }
+}
+
+/** Bounded text stream consumption with real reader cancellation and listener cleanup. */
+export async function consumeRealtimeBody(body: ReadableStream<Uint8Array>, context: TurnContext): Promise<void> {
+  const reader = body.getReader(), decoder = new TextDecoder();
+  const cancel = () => { void reader.cancel().catch(() => undefined); };
+  context.signal.addEventListener('abort', cancel, { once: true });
+  try {
+    if (context.signal.aborted) return;
+    while (!context.signal.aborted) {
+      const item = await reader.read();
+      if (context.signal.aborted || item.done) break;
+      if (!context.emit(decoder.decode(item.value, { stream: true }))) break;
+    }
+    if (!context.signal.aborted) { const tail = decoder.decode(); if (tail) context.emit(tail); }
+  } finally {
+    context.signal.removeEventListener('abort', cancel);
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}

--- a/v3/@claude-flow/integration/tsconfig.realtime.json
+++ b/v3/@claude-flow/integration/tsconfig.realtime.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "files": ["src/realtime-session.ts"]
+}

--- a/v3/@claude-flow/integration/validation/realtime.contract.mjs
+++ b/v3/@claude-flow/integration/validation/realtime.contract.mjs
@@ -1,0 +1,156 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { RealtimeSession, consumeRealtimeBody, validateReflexHandoff } from '../dist/realtime-session.js';
+const defer = () => { let resolve; const promise = new Promise(r => { resolve = r; }); return { promise, resolve }; };
+const tick = () => new Promise(r => setImmediate(r));
+const h = (sequence, kind = 'Cancel', extra = {}) => ({ version: 1, authority: 'none', session_id: 's', latest_sequence: String(sequence), queued_events: [{ sequence: String(sequence), at_micros: String(sequence), kind }], interrupt_sequence: kind === 'Interrupt' ? String(sequence) : null, cancel_sequence: kind === 'Cancel' ? String(sequence) : null, cancelled_work_units: '0', dropped_events: '0', ...extra });
+
+test('reasoning completes and emits without changing its result', async () => {
+  const seen = []; const s = new RealtimeSession('s', { onToken: text => seen.push(text) });
+  const t = s.start('hello', async (input, c) => { c.emit(input); return 42; });
+  assert.equal((await t.result).value, 42); await t.settled; assert.deepEqual(seen, ['hello']); assert.equal(s.telemetry.busy, false);
+});
+test('interrupt acknowledges immediately, aborts, and suppresses stale output', async () => {
+  const entered = defer(), exit = defer(); const seen = [];
+  const s = new RealtimeSession('s', { onToken: text => seen.push(text) });
+  const t = s.start('', async (_, c) => { entered.resolve(); await exit.promise; c.emit('stale'); return 'stale'; });
+  await entered.promise;
+  assert.equal(s.acceptHandoff(h(1, 'Interrupt')).acknowledged, true);
+  assert.equal(t.signal.aborted, true); assert.equal((await t.result).status, 'cancelled');
+  assert.equal(await s.waitForQuiescence(5), 'INCOMPLETE');
+  assert.throws(() => s.start('', async () => 1), /QUIESCENT/);
+  exit.resolve(); await t.settled; assert.deepEqual(seen, []); assert.equal(s.telemetry.staleOutputs, 1);
+});
+test('cancel latch survives missing queued cancel caused by overflow', async () => {
+  const exit = defer(); const s = new RealtimeSession('s');
+  const t = s.start('', async () => exit.promise);
+  const ack = s.acceptHandoff(h(2, 'Observation', { queued_events: [], cancel_sequence: '2', dropped_events: '1' }));
+  assert.equal(ack.acknowledged, true); assert.equal(t.signal.aborted, true); assert.equal(ack.needsReconcile, true);
+  exit.resolve(); await t.settled;
+  assert.throws(() => s.start('', async () => 1), /SNAPSHOT/);
+  assert.throws(() => s.reconcileSnapshot('a'.repeat(64), '1'), /SNAPSHOT/);
+  s.reconcileSnapshot('a'.repeat(64), '2'); const next = s.start('', async () => 1); assert.equal((await next.result).status, 'completed'); await next.settled;
+});
+test('backchannel does not cancel ongoing reasoning', async () => {
+  const exit = defer(), s = new RealtimeSession('s'); const t = s.start('', async () => exit.promise);
+  assert.equal(s.acceptHandoff(h(1, 'Backchannel')).acknowledged, true); assert.equal(t.signal.aborted, false);
+  exit.resolve(); await t.settled; assert.equal((await t.result).status, 'completed');
+});
+test('stale controls cannot cancel a new generation', async () => {
+  const s = new RealtimeSession('s'); s.acceptHandoff(h(10));
+  const exit = defer(); const t = s.start('', async () => exit.promise);
+  assert.equal(s.acceptHandoff(h(9)).status, 'stale'); assert.equal(t.signal.aborted, false);
+  s.acceptHandoff(h(11, 'Observation', { cancel_sequence: '10' })); assert.equal(t.signal.aborted, false);
+  exit.resolve(); await t.settled;
+});
+test('uint64 sequences retain precision above JavaScript safe integer', () => {
+  const s = new RealtimeSession('s');
+  assert.equal(s.acceptHandoff(h('18446744073709551614')).status, 'accepted');
+  assert.equal(s.acceptHandoff(h('18446744073709551615')).status, 'accepted');
+  assert.throws(() => s.acceptHandoff(h('18446744073709551616')), /U64/);
+});
+for (const [name, patch] of [
+  ['wrong session', { session_id: 'other' }], ['authority widening', { authority: 'execute' }],
+  ['missing latch', { cancel_sequence: null }], ['numeric sequence', { latest_sequence: 1 }],
+  ['leading zero', { latest_sequence: '01' }], ['future latch', { cancel_sequence: '2' }],
+  ['null events', { queued_events: null }], ['duplicate events', { queued_events: [h(1).queued_events[0], h(1).queued_events[0]] }],
+  ['unknown kind', { queued_events: [{ sequence: '1', at_micros: '1', kind: 'Execute' }] }],
+  ['resource exhaustion', { queued_events: Array(4097).fill(h(1).queued_events[0]) }],
+  ['negative clock', { queued_events: [{ sequence: '1', at_micros: '-1', kind: 'Cancel' }] }],
+]) test(`rejects ${name} without mutating state`, () => {
+  const s = new RealtimeSession('s'); assert.throws(() => s.acceptHandoff(h(1, 'Cancel', patch)));
+  assert.equal(s.acceptHandoff(h(1)).status, 'accepted'); assert.equal(s.telemetry.rejectedHandoffs, 1);
+});
+test('invalid limits rejected', () => {
+  for (const value of [NaN, Infinity, -1, 0, 300001, 1.1]) assert.throws(() => new RealtimeSession('s', { timeoutMs: value }));
+});
+test('tool invocation denied without a boundary', async () => {
+  const s = new RealtimeSession('s'); const t = s.start('', async (_, c) => c.tool({ name: 'write', argumentsJson: '{}' }));
+  await t.settled; assert.notEqual((await t.result).status, 'completed'); assert.equal(s.telemetry.startedTools, 0);
+});
+test('cancellation during asynchronous authorization prevents effect', async () => {
+  const authorization = defer(), entered = defer(); let effects = 0;
+  const s = new RealtimeSession('s', { tools: { authorize: async () => { entered.resolve(); return authorization.promise; }, execute: async () => { effects++; } } });
+  const t = s.start('', async (_, c) => c.tool({ name: 'write', argumentsJson: '{}' }));
+  await entered.promise; s.acceptHandoff(h(1)); authorization.resolve(true);
+  await t.settled; assert.equal(effects, 0); assert.equal((await t.result).status, 'cancelled');
+});
+test('truthy authorization is not a grant', async () => {
+  let effects = 0; const s = new RealtimeSession('s', { tools: { authorize: async () => 'yes', execute: async () => { effects++; } } });
+  const t = s.start('', async (_, c) => c.tool({ name: 'write', argumentsJson: '{}' })); await t.settled; assert.equal(effects, 0);
+});
+test('tool proposal is frozen across asynchronous policy lookup', async () => {
+  const entered = defer(), approved = defer(); let executed;
+  const proposal = { name: 'safe', argumentsJson: '{"safe":true}' };
+  const s = new RealtimeSession('s', { tools: { authorize: async p => { assert.equal(Object.isFrozen(p), true); entered.resolve(); return approved.promise; }, execute: async p => { executed = p; return 1; } } });
+  const t = s.start('', async (_, c) => c.tool(proposal)); await entered.promise;
+  proposal.name = 'danger'; proposal.argumentsJson = '{}'; approved.resolve(true); await t.settled;
+  assert.equal(executed.name, 'safe'); assert.equal((await t.result).status, 'completed');
+});
+test('cancel signal reaches delegated tasks and tool execution', async () => {
+  const delegateEntered = defer(), toolEntered = defer(); let delegatesStopped = 0, toolsStopped = 0;
+  const wait = (c, fn) => new Promise(resolve => { c.signal.addEventListener('abort', () => { fn(); resolve(); }, { once: true }); });
+  const s = new RealtimeSession('s', { tools: { authorize: async () => true, execute: async (_, c) => { toolEntered.resolve(); return wait(c, () => toolsStopped++); } } });
+  const t = s.start('', async (_, c) => {
+    const child = c.spawn(async cc => { delegateEntered.resolve(); return wait(cc, () => delegatesStopped++); });
+    await Promise.all([child, c.tool({ name: 'work', argumentsJson: '{}' })]);
+  });
+  await Promise.all([delegateEntered.promise, toolEntered.promise]); s.acceptHandoff(h(1));
+  await t.settled; assert.equal(delegatesStopped, 1); assert.equal(toolsStopped, 1); assert.equal(await s.waitForQuiescence(), 'STOPPED');
+});
+test('deadline cancels cooperative work', async () => {
+  const s = new RealtimeSession('s', { timeoutMs: 5 });
+  const t = s.start('', async (_, c) => new Promise(resolve => c.signal.addEventListener('abort', resolve, { once: true })));
+  assert.equal((await t.result).code, 'DEADLINE'); await t.settled;
+});
+test('output cap cancels rather than retaining unbounded text', async () => {
+  const s = new RealtimeSession('s', { maxOutputChars: 3 });
+  const t = s.start('', async (_, c) => { assert.equal(c.emit('abcd'), false); });
+  await t.settled; assert.equal((await t.result).code, 'OUTPUT_LIMIT');
+});
+test('delegate cap blocks excess tasks', async () => {
+  let ran = 0; const s = new RealtimeSession('s', { maxDelegates: 1 });
+  const t = s.start('', async (_, c) => { await c.spawn(async () => { ran++; }); await c.spawn(async () => { ran++; }); });
+  await t.settled; assert.equal(ran, 1); assert.equal((await t.result).status, 'failed');
+});
+test('close is terminal and leaves no resumable generation', async () => {
+  const s = new RealtimeSession('s'); s.close(); assert.throws(() => s.start('', async () => 1), /CLOSED/); assert.throws(() => s.acceptHandoff(h(1)), /CLOSED/);
+});
+test('abort cancels a pending ReadableStream reader', async () => {
+  const entered = defer(); let cancelled = false;
+  const stream = new ReadableStream({ pull() { entered.resolve(); }, cancel() { cancelled = true; } });
+  const s = new RealtimeSession('s'); const t = s.start('', async (_, c) => consumeRealtimeBody(stream, c));
+  await entered.promise; s.acceptHandoff(h(1)); await t.settled; assert.equal(cancelled, true); assert.equal(stream.locked, false);
+});
+test('HTTP provider stream physically closes after cancellation', async () => {
+  const first = defer(), socketClosed = defer(); let produced = 0, postAbort = 0, abortObserved = false;
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    const send = () => { produced++; if (abortObserved) postAbort++; res.write('token\n'); };
+    send(); const interval = setInterval(send, 2);
+    res.on('close', () => { clearInterval(interval); socketClosed.resolve(); });
+  });
+  server.listen(0, '127.0.0.1'); await once(server, 'listening');
+  try {
+    const s = new RealtimeSession('s', { onToken: () => first.resolve() });
+    const t = s.start('', async (_, c) => {
+      const response = await fetch(`http://127.0.0.1:${server.address().port}`, { signal: c.signal });
+      await consumeRealtimeBody(response.body, c);
+    });
+    await first.promise; abortObserved = true; s.acceptHandoff(h(1));
+    await t.settled;
+    await Promise.race([socketClosed.promise, new Promise((_, reject) => { const tm = setTimeout(() => reject(new Error('SOCKET_NOT_CANCELLED')), 1000); tm.unref(); })]);
+    const atClose = produced; await new Promise(r => setTimeout(r, 10)); assert.equal(produced, atClose); assert.ok(postAbort <= 5);
+    assert.equal((await t.result).status, 'cancelled'); assert.equal(await s.waitForQuiescence(), 'STOPPED');
+  } finally { server.closeAllConnections(); await new Promise(r => server.close(r)); }
+});
+test('1000 interrupted sessions preserve bounds and suppress every late result', async () => {
+  for (let i = 0; i < 1000; i++) {
+    const exit = defer(), s = new RealtimeSession('s');
+    const t = s.start('', async (_, c) => { await exit.promise; assert.equal(c.emit('late'), false); return 'late'; });
+    s.acceptHandoff(h(1)); s.acceptHandoff(h(2)); exit.resolve(); await t.settled;
+    assert.equal((await t.result).status, 'cancelled'); assert.equal(s.telemetry.cancellations, 1); assert.equal(s.telemetry.busy, false);
+  }
+});


### PR DESCRIPTION
Tracks #3246 and ruvnet/midstream#107. Independent evaluation: ruvnet/metaharness#301 Track D.

## Implemented

Adds an opt-in `@claude-flow/integration/realtime-session` module using the existing package export pattern. Consumes versioned, session-bound MidStream handoffs with lossless u64 decimal strings and permanent interruption/cancellation watermarks.

The synchronous control path acknowledges interruptions while the asynchronous reasoner is active. It fences stale output and results, propagates AbortSignal through reasoning, delegated tasks, tool approval and execution, and fetch/ReadableStream consumption. Tool effects require an injected trusted boundary and a fresh generation check after asynchronous authorization. Proposals are frozen before approval.

Cancellation and physical termination are separate states. An uncooperative callback yields INCOMPLETE and prevents replacement work from accumulating. Overflow requires a trusted snapshot reconciliation. No automatic resume, policy relaxation, new dependencies, package changes, credentials, or default behavior changes.

## Actual local validation

Node 22.16.0, TypeScript 5.8.3 strict mode including exactOptionalPropertyTypes and noUncheckedIndexedAccess: passed.

30/30 native Node tests passed, including a real loopback HTTP streaming server, physical connection closure after fetch abort, delegated and tool cancellation, authorization races, stale results, malformed wire values, uint64 precision, resource bounds, and 1000 interrupted sessions.

A five-seed, 1000-event randomized-arm-order synthetic benchmark measured p95 control acknowledgement 4214.065 us for serial handling versus 48.683 us for the bridge. Raw AbortController alone was 26.871 us; the bridge adds scope, lifecycle and policy checks, not faster abort semantics. These are local asynchronous control measurements, NOT a live model-quality or provider GPU-cost result. Evidence and benchmark driver are being coordinated through MetaHarness.

## Security boundaries

Trusted callbacks and authenticated transport are required. A receipt is evidence, never authority. The module is not a sandbox and cannot preempt synchronous CPU blocking on its own event loop. RVM/host execution must revalidate at the true external commit boundary. Local shutdown does not prove remote GPU cancellation or reverse committed effects.

## Review and release

ADR 3246 and a pinned direct-module CI workflow are included. Existing full repository CI remains mandatory and unchanged. Keep draft until hosted validation and independent live-workload gates pass. No autonomous merge or deployment.