### PR TITLE
fix(agentbbs-tools): detect the real CLI-only agentbbs package instead of a nonexistent JS import

### DIFF
--- a/v3/@claude-flow/cli/__tests__/agentbbs-tools.test.ts
+++ b/v3/@claude-flow/cli/__tests__/agentbbs-tools.test.ts
@@ -3,16 +3,17 @@
  *
  * Two surfaces under test:
  *   1. STRUCTURAL — exposure, schema, validation. Runs regardless of agentbbs presence.
- *   2. HAPPY PATH — gated on agentbbs being importable via it.skipIf(!havePkg).
+ *   2. HAPPY PATH — gated on the `agentbbs` CLI being resolvable, via it.skipIf(!havePkg).
  *
- * The degraded path is exercised structurally: when agentbbs is missing,
- * every handler returns `{degraded: true, reason: 'agentbbs-not-found'}`
+ * The degraded path is exercised structurally: when the agentbbs CLI is
+ * missing, every handler returns `{degraded: true, reason: 'agentbbs-not-found'}`
  * matching the metaharness / agenticow / testgen contract.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 import { agentbbsTools } from '../src/mcp-tools/agentbbs-tools.js';
 
@@ -23,8 +24,15 @@ function findTool(name: string) {
 }
 
 // Detect agentbbs availability at module scope so it.skipIf evaluates correctly.
+// The published `agentbbs` package is a CLI-only launcher with no importable
+// JS entry point, so presence is a subprocess probe, not a module import —
+// mirrors agentbbsCliAvailable() in the tools module under test.
 let havePkg = false;
-try { await import('agentbbs'); havePkg = true; } catch { havePkg = false; }
+try {
+  // shell: true — see agentbbsCliAvailable() in the module under test for why.
+  execFileSync(process.env.AGENTBBS_BIN || 'agentbbs', ['--version'], { stdio: 'ignore', timeout: 5000, shell: true });
+  havePkg = true;
+} catch { havePkg = false; }
 
 describe('agentbbs MCP tools — structural contract', () => {
   it('exposes exactly 4 tools (register / publish / watch / human_join)', () => {

--- a/v3/@claude-flow/cli/__tests__/agentbbs-tools.test.ts
+++ b/v3/@claude-flow/cli/__tests__/agentbbs-tools.test.ts
@@ -29,8 +29,13 @@ function findTool(name: string) {
 // mirrors agentbbsCliAvailable() in the tools module under test.
 let havePkg = false;
 try {
-  // shell: true — see agentbbsCliAvailable() in the module under test for why.
-  execFileSync(process.env.AGENTBBS_BIN || 'agentbbs', ['--version'], { stdio: 'ignore', timeout: 5000, shell: true });
+  // shell only on win32 — see agentbbsCliAvailable() in the module under test.
+  execFileSync(process.env.AGENTBBS_BIN || 'agentbbs', ['--version'], {
+    stdio: 'ignore',
+    timeout: 5000,
+    shell: process.platform === 'win32',
+    windowsHide: true,
+  });
   havePkg = true;
 } catch { havePkg = false; }
 

--- a/v3/@claude-flow/cli/src/mcp-tools/agentbbs-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agentbbs-tools.ts
@@ -52,11 +52,17 @@ function agentbbsCliAvailable(): boolean {
   if (_cliAvailable !== null) return _cliAvailable;
   const bin = process.env.AGENTBBS_BIN || CLI_NAME;
   try {
-    // shell: true is required on Windows — npm's global-install shim is
-    // `agentbbs.cmd`, and child_process does not consult PATHEXT unless the
-    // command is run through a shell. bin is either the fixed CLI_NAME or an
-    // operator-controlled AGENTBBS_BIN override, not untrusted input.
-    execFileSync(bin, ['--version'], { stdio: 'ignore', timeout: 5000, shell: true });
+    // On Windows npm's global-install shim is `agentbbs.cmd`, and
+    // child_process cannot spawn a .cmd without going through cmd.exe, which
+    // is what resolves the PATHEXT extension. POSIX keeps shell:false so the
+    // AGENTBBS_BIN override is never shell-interpreted — same convention as
+    // browser-tools.ts and commands/init.ts.
+    execFileSync(bin, ['--version'], {
+      stdio: 'ignore',
+      timeout: 5000,
+      shell: process.platform === 'win32',
+      windowsHide: true,
+    });
     _cliAvailable = true;
   } catch {
     _cliAvailable = false;

--- a/v3/@claude-flow/cli/src/mcp-tools/agentbbs-tools.ts
+++ b/v3/@claude-flow/cli/src/mcp-tools/agentbbs-tools.ts
@@ -21,36 +21,47 @@
  *     so callers see one contract regardless of install state
  *   - Phase 1: polling-based watch (streaming subscriptions are Phase 4)
  *
+ * Presence check: the published `agentbbs` package (as of 0.2.1) is a CLI-only
+ * launcher — a `bin` script with no importable JS entry point (no `main` /
+ * `exports` field) — that downloads/builds a Rust binary and shells out to it.
+ * `await import('agentbbs')` can therefore never resolve, even when the CLI is
+ * correctly installed and on PATH: there is no module for Node to find. This
+ * previously made every tool report `degraded: true` unconditionally,
+ * regardless of install state. Detect real availability instead by probing the
+ * CLI itself, matching how the rest of this codebase treats optional
+ * command-line tools (`shutil.which()`-style guards) rather than assuming a
+ * package shape the dependency doesn't have.
+ *
  * @module @claude-flow/cli/mcp-tools/agentbbs
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { resolve, isAbsolute, join } from 'node:path';
 import { randomBytes, createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import type { MCPTool } from './types.js';
 import { getProjectCwd } from './types.js';
 
-const PACKAGE_NAME = 'agentbbs';
+const CLI_NAME = 'agentbbs';
 
-// Cache: amortize dynamic-import cost across handler calls.
-// null = not yet attempted; false = unavailable; module = loaded.
-let _agentbbsMod: any = null;
-let _loadAttempted = false;
+// Cache: amortize the subprocess probe cost across handler calls within a
+// process. null = not yet probed; boolean = probe result.
+let _cliAvailable: boolean | null = null;
 
-async function loadAgentbbs(): Promise<any | null> {
-  if (_loadAttempted) return _agentbbsMod || null;
-  _loadAttempted = true;
+function agentbbsCliAvailable(): boolean {
+  if (_cliAvailable !== null) return _cliAvailable;
+  const bin = process.env.AGENTBBS_BIN || CLI_NAME;
   try {
-    _agentbbsMod = await import(PACKAGE_NAME);
-    return _agentbbsMod;
-  } catch (err: any) {
-    if (err && (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND' ||
-                /Cannot find (module|package)/i.test(String(err?.message)))) {
-      _agentbbsMod = false;
-      return null;
-    }
-    throw err;
+    // shell: true is required on Windows — npm's global-install shim is
+    // `agentbbs.cmd`, and child_process does not consult PATHEXT unless the
+    // command is run through a shell. bin is either the fixed CLI_NAME or an
+    // operator-controlled AGENTBBS_BIN override, not untrusted input.
+    execFileSync(bin, ['--version'], { stdio: 'ignore', timeout: 5000, shell: true });
+    _cliAvailable = true;
+  } catch {
+    _cliAvailable = false;
   }
+  return _cliAvailable;
 }
 
 function degradedResult(reason: string): { success: true; degraded: true; reason: string } {
@@ -140,11 +151,21 @@ function nextSeq(path: string): number {
  * agentbbs server's responsibility (nonce JTI tracking, per ADR-164 §3.2.4).
  * Phase 2+ will wire this to the existing federation Ed25519 keypair.
  */
+// Use @noble/ed25519 (already a hard dep of @claude-flow/cli for IPFS
+// signing). Memoized behind one loader — two separate dynamic `import()`
+// call sites for the same bare specifier in this module tripped up the
+// test runner's dependency pre-bundling (surfaced once federation_bbs_
+// human_join actually ran instead of always short-circuiting to degraded).
+let _edMod: any = null;
+async function loadEd25519(): Promise<any> {
+  if (!_edMod) _edMod = await import('@noble/ed25519');
+  return _edMod;
+}
+
 let _signingKey: { priv: Uint8Array; pub: Uint8Array } | null = null;
 async function getSigningKey(): Promise<{ priv: Uint8Array; pub: Uint8Array }> {
   if (_signingKey) return _signingKey;
-  // Use @noble/ed25519 (already a hard dep of @claude-flow/cli for IPFS signing).
-  const ed: any = await import('@noble/ed25519');
+  const ed = await loadEd25519();
   const priv = ed.utils.randomPrivateKey
     ? ed.utils.randomPrivateKey()
     : randomBytes(32);
@@ -191,8 +212,7 @@ export const agentbbsTools: MCPTool[] = [
       const roomLabel = validateRoomLabel(String(input.roomLabel));
       const basePath = resolveBasePath(input.basePath as string | undefined);
 
-      const api = await loadAgentbbs();
-      if (!api) return degradedResult('agentbbs-not-found');
+      if (!agentbbsCliAvailable()) return degradedResult('agentbbs-not-found');
 
       ensureDir(basePath);
 
@@ -280,8 +300,7 @@ export const agentbbsTools: MCPTool[] = [
         throw new Error('payload must be a JSON object');
       }
 
-      const api = await loadAgentbbs();
-      if (!api) return degradedResult('agentbbs-not-found');
+      if (!agentbbsCliAvailable()) return degradedResult('agentbbs-not-found');
 
       ensureDir(basePath);
       const logPath = roomLogPath(basePath, roomId);
@@ -336,8 +355,7 @@ export const agentbbsTools: MCPTool[] = [
       const basePath = resolveBasePath(input.basePath as string | undefined);
       const roomId = validateRoomId(String(input.roomId));
 
-      const api = await loadAgentbbs();
-      if (!api) return degradedResult('agentbbs-not-found');
+      if (!agentbbsCliAvailable()) return degradedResult('agentbbs-not-found');
 
       const limitRaw = typeof input.limit === 'number' ? input.limit : 50;
       const limit = Math.max(1, Math.min(500, Math.trunc(limitRaw)));
@@ -383,8 +401,7 @@ export const agentbbsTools: MCPTool[] = [
     handler: async (input) => {
       const roomId = validateRoomId(String(input.roomId));
 
-      const api = await loadAgentbbs();
-      if (!api) return degradedResult('agentbbs-not-found');
+      if (!agentbbsCliAvailable()) return degradedResult('agentbbs-not-found');
 
       const ttlRaw = typeof input.ttlSeconds === 'number' ? input.ttlSeconds : 300;
       const ttlSeconds = Math.max(30, Math.min(900, Math.trunc(ttlRaw)));
@@ -395,7 +412,7 @@ export const agentbbsTools: MCPTool[] = [
       const payload = { roomId, nonce, expiresAt };
       const canonical = JSON.stringify(payload);
 
-      const ed: any = await import('@noble/ed25519');
+      const ed = await loadEd25519();
       const { priv, pub } = await getSigningKey();
       const sigBytes: Uint8Array = await (ed.signAsync ?? ed.sign)(
         new TextEncoder().encode(canonical),

--- a/v3/@claude-flow/cli/vitest.config.ts
+++ b/v3/@claude-flow/cli/vitest.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
         if (source.startsWith('@ruvector/')) return { id: source, external: true };
         if (source.startsWith('@huggingface/transformers')) return { id: source, external: true };
         if (source.startsWith('@xenova/transformers')) return { id: source, external: true };
-        if (source.startsWith('@noble/ed25519')) return { id: source, external: true };
         return null;
       },
     },


### PR DESCRIPTION
## Summary
- `federation_bbs_register/publish/watch/human_join` all gate on `loadAgentbbs()`, which does `await import('agentbbs')`. The published `agentbbs` package (0.2.1) is a **CLI-only launcher** — a `bin` script with no `main`/`exports` JS entry point — that downloads/builds a Rust binary and shells out to it. That `import()` can therefore never resolve, so every tool reported `degraded: true` unconditionally, regardless of whether `agentbbs` was actually installed and working.
- Replaced it with a subprocess presence probe (`agentbbsCliAvailable()`, running `agentbbs --version`), matching how the rest of the codebase treats optional CLI tools (e.g. the `shutil.which()`-style guards mentioned elsewhere). `shell: true` is required on Windows since npm's global-install shim is `agentbbs.cmd` and `child_process` doesn't consult `PATHEXT` without a shell.
- Making the probe actually succeed surfaced two further pre-existing bugs in code that had never actually run before (always short-circuited to degraded):
  - `vitest.config.ts` externalized `@noble/ed25519` alongside genuinely-optional deps (`agentic-flow`, `agentdb`, ...) — but it's an always-installed hard dependency of this package (also used by `transfer/ipfs/client.ts` and `commands/verify.ts`), and externalizing it broke dynamic-import resolution under Vite's SSR transform.
  - `federation_bbs_human_join` dynamically imported `@noble/ed25519` a second time (`getSigningKey()` already does) — deduplicated behind one memoized `loadEd25519()`.
- Confirmed all 4 pre-existing failures in `proxy-verify.test.ts` / `harness-verify.test.ts` (Ed25519 signature verification mismatches) are unrelated to this change — reproduced identically with this branch's changes stashed out.

Scope note: this makes the Phase 1 local room/envelope surface actually functional when `agentbbs` is genuinely installed. It does not implement real cross-host federation (syncing two independent `.agentbbs` directories between machines) — that's still Phase 2+ per the module's own docs (`agentbbsBin` param, hop-count-always-0 comment).

## Test plan
- [x] `npx vitest run __tests__/agentbbs-tools.test.ts` — 12/12 pass (previously 8 passed, 4 always-skipped)
- [x] Confirmed via `git stash` that the 4 unrelated failures in `proxy-verify.test.ts`/`harness-verify.test.ts` pre-exist without this change
- [x] Verified on Windows that `agentbbs.cmd` (npm's global-install shim) is only found with `shell: true`