### PR TITLE
fix(metaharness): bump the darwin pin to 0.10.2 (unblocks pin-drift + clean-install on main)

### DIFF
--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -130,7 +130,7 @@
   "optionalDependencies": {
     "@agntcy/slim-bindings": "2.0.0-alpha.5",
     "@claude-flow/memory": "^3.0.0-alpha.23",
-    "@metaharness/darwin": "~0.9.0",
+    "@metaharness/darwin": "~0.10.2",
     "@metaharness/flywheel": "~0.1.10",
     "@metaharness/radio": "~0.1.0",
     "@metaharness/turn-credit": "~0.1.0",

--- a/v3/@claude-flow/cli/src/services/distill-oracle.ts
+++ b/v3/@claude-flow/cli/src/services/distill-oracle.ts
@@ -52,7 +52,7 @@ import {
 // scripts/check-metaharness-pins.mjs watch this constant for drift. Kept in
 // lock-step with the optionalDependencies pin in package.json and the plugin
 // darwin cache (versioned by the plugin's own `~0.8.0` pin in _darwin.mjs).
-export const MH_DARWIN_PIN = '0.9.0';
+export const MH_DARWIN_PIN = '0.10.2';
 
 // ── Provenance ─────────────────────────────────────────────────────────────
 

--- a/v3/pnpm-lock.yaml
+++ b/v3/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^3.0.0-alpha.23
         version: link:../memory
       '@metaharness/darwin':
-        specifier: ~0.9.0
-        version: 0.9.0
+        specifier: ~0.10.2
+        version: 0.10.2
       '@metaharness/flywheel':
         specifier: ~0.1.10
         version: 0.1.10
@@ -1767,19 +1767,19 @@ packages:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: false
 
-  /@metaharness/darwin@0.2.8:
-    resolution: {integrity: sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-    dev: false
-
-  /@metaharness/darwin@0.9.0:
-    resolution: {integrity: sha512-X/u0sI4QNFi/YUhcQwZ2hcmthgc3H3n4PdPoKMbAE/y+rUWOQCS9oc1wqCcUysBN5K0jHV7U+3QApdMFvwKvRQ==}
+  /@metaharness/darwin@0.10.2:
+    resolution: {integrity: sha512-Glczy9YJDLf5x4HlfVuQVbZuPuue45K+8ohfLixZPJ18oc0Q8RR+BcsopHUQsL4hBkvs3YPXUyZ16piDJQp4gw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     requiresBuild: true
     dev: false
     optional: true
+
+  /@metaharness/darwin@0.2.8:
+    resolution: {integrity: sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    dev: false
 
   /@metaharness/flywheel@0.1.10:
     resolution: {integrity: sha512-yrLXDXNdf4jKqHlW6QZw3Cy5T0eMMjjaPqn1XB717/Xx/y0Iv9R03W0OhMEiR/kfqMNebRBW1fi6D7inStEyqA==}


### PR DESCRIPTION
`main` is red on two required gates right now — `pin-drift` and `clean-install` — because `@metaharness/darwin` is declared `~0.9.0` and npm latest is `0.10.2`.

The drift predates #3256, which merged with these gates already failing. It is on `main` now either way.

**Checked, not assumed.** Unpacked both tarballs and compared surfaces:

| | 0.9.0 | 0.10.2 |
|---|---|---|
| `bin` | `metaharness-darwin` | same |
| `exports` | `.`, `./gepa` | same |
| gepa symbols this repo imports | `loadCand6Genome`, `CAND6_GENOME_PATH` | same |

Nothing we call was removed.

`MH_DARWIN_PIN` moves with the declaration, since the Tier-1 mechanical oracle shells out to `npx @metaharness/darwin@<pin>` and an out-of-range constant is its own drift failure. The pnpm lockfile is regenerated in the same commit — `v3/` is a separate pnpm workspace, and a stale lockfile takes the frozen-lockfile jobs down.

**Verified:** `node scripts/check-metaharness-pins.mjs` exits 0 with every pin reported current.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)