### PR TITLE
docs: add Windows installation guide (#672)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ npx ruflo@latest init wizard
 npm install -g ruflo@latest
 ```
 
-> 💡 **Windows users:** the `curl ... | bash` form needs a POSIX shell (Git-Bash, WSL, MSYS). The `npx ruflo@latest init wizard` line works natively in PowerShell and cmd. If you hit an `'bash' is not recognized` error, use the `npx` line instead — both end up running the same init flow.
+> 💡 **Windows users:** the `curl ... | bash` form needs a POSIX shell (Git-Bash, WSL, MSYS). The `npx ruflo@latest init wizard` line works natively in PowerShell and cmd. If you hit an `'bash' is not recognized` error, use the `npx` line instead — both end up running the same init flow. See the [Windows Installation Guide](docs/windows-installation.md) for prerequisites, config file locations, and troubleshooting.
 
 ### MCP Server
 

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -7415,6 +7415,7 @@ $env:CLAUDE_FLOW_MEMORY_PATH = "./data"
 # Or use absolute path
 $env:CLAUDE_FLOW_MEMORY_PATH = "C:/Users/name/ruflo/data"
 ```
+See the [Windows Installation Guide](windows-installation.md) for full setup and troubleshooting steps.
 
 **Permission denied errors**
 ```bash

--- a/docs/windows-installation.md
+++ b/docs/windows-installation.md
@@ -1,0 +1,86 @@
+# Windows Installation Guide
+
+Ruflo runs natively on Windows — PowerShell and `cmd.exe` both work — as well
+as under WSL and Git-Bash. This guide covers the install path, config file
+locations, and the handful of quirks that only show up on native Windows.
+
+## Prerequisites
+
+- Node.js 20 or newer (`node --version`)
+- npm 9 or newer (`npm --version`)
+- Git for Windows (optional, needed only for Git-Bash / the POSIX install
+  script below)
+
+## Installing
+
+**Recommended — works identically on PowerShell, cmd.exe, WSL, and macOS/Linux:**
+
+```powershell
+npx ruflo@latest init wizard
+```
+
+This runs the interactive setup wizard with no shell-specific steps. For a
+quick non-interactive setup, use `npx ruflo@latest init` instead, or install
+the CLI globally:
+
+```powershell
+npm install -g ruflo@latest
+```
+
+**POSIX one-line installer (`curl | bash`) — Git-Bash, WSL, or MSYS only:**
+
+```bash
+curl -fsSL https://cdn.jsdelivr.net/gh/ruvnet/ruflo@main/scripts/install.sh | bash
+```
+
+This script requires a POSIX shell and will not run in plain PowerShell or
+`cmd.exe` — if you see `'bash' is not recognized as an internal or external
+command`, you're in a non-POSIX shell; switch to one of the `npx`/`npm`
+commands above instead. Both paths end up running the same init flow.
+
+## MCP server registration
+
+```powershell
+claude mcp add claude-flow -- npx ruflo@latest mcp start
+```
+
+Claude Desktop's config file on Windows lives at:
+
+```text
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+## Verifying your setup
+
+```powershell
+npx ruflo@latest doctor --fix
+```
+
+`doctor` checks Node/npm versions, git, config file validity, and MCP server
+registration, and will attempt to auto-fix common problems.
+
+## Common Windows-specific issues
+
+**Path escaping in environment variables** — PowerShell backslash paths can
+trip up tools that expect POSIX-style paths. Use forward slashes, or an
+absolute path with forward slashes:
+
+```powershell
+$env:CLAUDE_FLOW_MEMORY_PATH = "./data"
+# or
+$env:CLAUDE_FLOW_MEMORY_PATH = "C:/Users/name/ruflo/data"
+```
+
+**`'bash' is not recognized`** — you're running the POSIX one-line installer
+in PowerShell or `cmd.exe`. Use `npx ruflo@latest init wizard` instead (see
+above).
+
+**Permission errors on global install** — if `npm install -g ruflo@latest`
+fails with an EACCES/permission error, run your terminal as Administrator,
+or use a Node version manager (e.g. `nvm-windows`) so npm's global prefix is
+writable by your user account.
+
+If you hit something not covered here, please open an issue with the exact
+command you ran, `npx ruflo@latest doctor` output, and your Windows/terminal
+version (PowerShell vs. `cmd.exe`, Windows 10 vs. 11) — that detail is what
+lets a Windows-specific bug get diagnosed and fixed.


### PR DESCRIPTION
Fixes #672. Also addresses the same underlying gap reported independently in #738 and #869 (all three report the same missing/dead Windows installation guide referenced from the README).

**What changed**
- Added `docs/windows-installation.md`: prerequisites, install methods (the `npx` wizard vs. the POSIX `curl | bash` one-liner and why the latter needs Git-Bash/WSL/MSYS), MCP config file location on Windows, `doctor --fix` verification, and the path-escaping / `'bash' is not recognized` issues already scattered across README/USERGUIDE troubleshooting sections, consolidated in one place.
- Linked the new guide from `README.md`'s existing Windows callout and from `docs/USERGUIDE.md`'s "Windows path issues" troubleshooting entry.

**Why**
`README.md` promises a Windows guide but none existed in `docs/`, and the previously-linked `docs/windows-installation.md` / wiki `Windows-Installation` page 404'd (as reported in #672, #738, #869). The dead reference itself was since removed from the README, but the actual gap — no dedicated Windows setup doc — remained.

**Scope**
Docs-only change (3 files: 1 new, 2 edited links). No code, CI, or release tooling touched.

Opened by the nightly triage routine — human review required before merge.

---
🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01RbPUbXvCMyUaHKaxstR4Yu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbPUbXvCMyUaHKaxstR4Yu)_