### PR TITLE
feat(mcp): isolate request authority and add MCP 2026 stateless adapter

### DIFF
--- a/scripts/__tests__/audit-mcp-era.test.mjs
+++ b/scripts/__tests__/audit-mcp-era.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  auditRepository,
+  MODERN_VERSION,
+  scanText,
+} from '../audit-mcp-era.mjs';
+
+test('scanText classifies legacy lifecycle and protocol version', () => {
+  const result = scanText(`
+    private readonly protocolVersion = '2025-11-25';
+    private async handleInitialize() {}
+    const id = req.headers['Mcp-Session-Id'];
+    this.getOrCreateSession();
+  `, 'server.ts');
+
+  assert.deepEqual(result.versions.map((item) => item.version), ['2025-11-25']);
+  assert.equal(result.lifecycle.find((item) => item.kind === 'initialize-handler')?.count, 1);
+  assert.equal(result.lifecycle.find((item) => item.kind === 'session-header')?.count, 1);
+  assert.equal(result.lifecycle.find((item) => item.kind === 'session-create')?.count, 1);
+});
+
+test('scanText classifies modern entrypoint and routing markers', () => {
+  const result = scanText(`
+    const protocolVersion = '${MODERN_VERSION}';
+    if (method === 'server/discover') return discover();
+    const routedMethod = headers['Mcp-Method'];
+    const routedName = headers['Mcp-Name'];
+    return { ttlMs: 1000, cacheScope: 'private', traceparent: meta.traceparent };
+  `, 'server.ts');
+
+  assert.deepEqual(result.versions.map((item) => item.version), [MODERN_VERSION]);
+  assert.deepEqual(
+    new Set(result.modern.map((item) => item.kind)),
+    new Set(['server-discover', 'mcp-method-header', 'mcp-name-header', 'cache-hint', 'trace-context'])
+  );
+});
+
+test('auditRepository distinguishes canonical modern readiness without dependencies', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ruflo-mcp-audit-'));
+  const server = path.join(temp, 'v3/@claude-flow/mcp/src/server.ts');
+  fs.mkdirSync(path.dirname(server), { recursive: true });
+  fs.writeFileSync(server, `
+    export const protocolVersion = '${MODERN_VERSION}';
+    export function route(method) {
+      if (method === 'server/discover') return { protocolVersion };
+      return null;
+    }
+  `);
+
+  const report = auditRepository(temp, ['v3/@claude-flow/mcp/src']);
+  assert.equal(report.summary.canonicalAdvertisesModern, true);
+  assert.equal(report.summary.canonicalHasDiscover, true);
+  assert.equal(report.summary.filesWithSignals, 1);
+});

--- a/scripts/__tests__/audit-mcp-session-isolation.test.mjs
+++ b/scripts/__tests__/audit-mcp-session-isolation.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { auditRepository, scanSources } from '../audit-mcp-session-isolation.mjs';
+
+const vulnerable = {
+  server: `
+    private currentSession?: MCPSession;
+    private handleInitialize() {
+      const session = this.sessionManager.createSession(this.config.transport);
+      this.currentSession = session;
+    }
+    private handleToolsCall() {
+      const context = { sessionId: this.currentSession?.id || 'unknown' };
+    }
+    private subscribe() {
+      const sessionId = this.currentSession?.id;
+    }
+  `,
+  types: `export type RequestHandler = (request: MCPRequest) => Promise<MCPResponse>;`,
+  http: `
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+    const response = await this.requestHandler(message as MCPRequest);
+    private validateAuth(req: Request): { valid: boolean; error?: string } { return { valid: true }; }
+  `,
+};
+
+const remediated = {
+  server: `
+    private handleToolsCall(request: MCPRequest, context: MCPRequestContext) {
+      const toolContext = { sessionId: context.legacySessionId || 'stateless', metadata: { principal: context.principal } };
+    }
+  `,
+  types: `export type RequestHandler = (request: MCPRequest, context?: MCPRequestContext) => Promise<MCPResponse>;`,
+  http: `
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID', 'MCP-Protocol-Version', 'Mcp-Method', 'Mcp-Name'],
+    const response = await this.requestHandler(message as MCPRequest, requestContext);
+    private validateAuth(req: Request): { valid: boolean; principal?: AuthenticatedPrincipal; error?: string } {
+      return { valid: true, principal: { subject: 'test' } };
+    }
+  `,
+};
+
+test('detects singleton session and dropped HTTP authority context', () => {
+  const report = scanSources(vulnerable);
+  assert.equal(report.summary.isolated, false);
+  assert.equal(report.summary.critical, 4);
+  assert.equal(report.summary.high, 2);
+  assert.equal(report.summary.medium, 1);
+  assert.equal(report.summary.activeFindings, 7);
+});
+
+test('passes when request-local transport and principal context are present', () => {
+  const report = scanSources(remediated);
+  assert.equal(report.summary.isolated, true);
+  assert.equal(report.summary.critical, 0);
+  assert.equal(report.summary.high, 0);
+  assert.equal(report.summary.activeFindings, 0);
+});
+
+test('repository audit reports missing canonical surfaces without throwing', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ruflo-session-audit-'));
+  const report = auditRepository(root);
+  assert.equal(report.missing.length, 3);
+  assert.equal(report.summary.isolated, true);
+});

--- a/scripts/audit-mcp-era.mjs
+++ b/scripts/audit-mcp-era.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const MODERN_VERSION = '2026-07-28';
+
+export const DEFAULT_RUNTIME_ROOTS = Object.freeze([
+  'v3/@claude-flow/mcp/src',
+  'v3/@claude-flow/shared/src/mcp',
+  'v3/mcp',
+  'v3/@claude-flow/cli/bin',
+  'ruflo/src/mcp-bridge',
+  'ruflo/src/ruvocal/src/lib/wasm',
+]);
+
+export const CANONICAL_SERVER = 'v3/@claude-flow/mcp/src/server.ts';
+
+const RUNTIME_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
+
+const PROTOCOL_LITERAL =
+  /(?:protocolVersion|MCP[-_ ]Protocol[-_ ]Version)[^'"`\n]{0,80}['"`](\d{4}-\d{2}-\d{2})['"`]/gi;
+
+const LIFECYCLE_MARKERS = Object.freeze([
+  ['session-header', /Mcp-Session-Id|MCP-Session-Id|MCP_SESSION_ID/g],
+  ['initialize-handler', /\bhandleInitialize\b/g],
+  ['session-create', /\bgetOrCreateSession\b|\binitializeSession\b/g],
+  ['initialized-notification', /['"`]initialized['"`]/g],
+]);
+
+const MODERN_MARKERS = Object.freeze([
+  ['server-discover', /server\/discover/g],
+  ['mcp-method-header', /Mcp-Method|MCP-Method/g],
+  ['mcp-name-header', /Mcp-Name|MCP-Name/g],
+  ['cache-hint', /\bttlMs\b|\bcacheScope\b/g],
+  ['trace-context', /\btraceparent\b|\btracestate\b/g],
+]);
+
+function normalizeRel(value) {
+  return value.split(path.sep).join('/');
+}
+
+function collectMatches(text, regex) {
+  regex.lastIndex = 0;
+  const matches = [];
+  for (const match of text.matchAll(regex)) {
+    matches.push({ value: match[0], index: match.index ?? -1 });
+  }
+  return matches;
+}
+
+export function scanText(text, file = '<memory>') {
+  const versions = [];
+  PROTOCOL_LITERAL.lastIndex = 0;
+  for (const match of text.matchAll(PROTOCOL_LITERAL)) {
+    versions.push({
+      version: match[1],
+      index: match.index ?? -1,
+    });
+  }
+
+  const lifecycle = [];
+  for (const [kind, regex] of LIFECYCLE_MARKERS) {
+    const matches = collectMatches(text, regex);
+    if (matches.length > 0) {
+      lifecycle.push({ kind, count: matches.length });
+    }
+  }
+
+  const modern = [];
+  for (const [kind, regex] of MODERN_MARKERS) {
+    const matches = collectMatches(text, regex);
+    if (matches.length > 0) {
+      modern.push({ kind, count: matches.length });
+    }
+  }
+
+  return {
+    file: normalizeRel(file),
+    versions,
+    lifecycle,
+    modern,
+  };
+}
+
+function walkFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const stat = fs.statSync(dir);
+  if (stat.isFile()) return RUNTIME_EXTENSIONS.has(path.extname(dir)) ? [dir] : [];
+
+  const out = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkFiles(full));
+    else if (entry.isFile() && RUNTIME_EXTENSIONS.has(path.extname(entry.name))) out.push(full);
+  }
+  return out;
+}
+
+export function auditRepository(repoRoot, runtimeRoots = DEFAULT_RUNTIME_ROOTS) {
+  const resolvedRoot = path.resolve(repoRoot);
+  const files = new Set();
+  for (const relativeRoot of runtimeRoots) {
+    const target = path.join(resolvedRoot, relativeRoot);
+    for (const file of walkFiles(target)) files.add(file);
+  }
+
+  const reports = [...files]
+    .sort()
+    .map((file) => scanText(fs.readFileSync(file, 'utf8'), path.relative(resolvedRoot, file)))
+    .filter((report) =>
+      report.versions.length > 0 ||
+      report.lifecycle.length > 0 ||
+      report.modern.length > 0
+    );
+
+  const versionCounts = {};
+  const lifecycleCounts = {};
+  const modernCounts = {};
+
+  for (const report of reports) {
+    for (const item of report.versions) {
+      versionCounts[item.version] = (versionCounts[item.version] ?? 0) + 1;
+    }
+    for (const item of report.lifecycle) {
+      lifecycleCounts[item.kind] = (lifecycleCounts[item.kind] ?? 0) + item.count;
+    }
+    for (const item of report.modern) {
+      modernCounts[item.kind] = (modernCounts[item.kind] ?? 0) + item.count;
+    }
+  }
+
+  const canonical = reports.find((report) => report.file === CANONICAL_SERVER);
+  const canonicalVersions = canonical?.versions.map((item) => item.version) ?? [];
+  const canonicalModern = new Set(canonical?.modern.map((item) => item.kind) ?? []);
+
+  return {
+    schema: 'ruflo.mcp-era-audit/v1',
+    modernVersion: MODERN_VERSION,
+    repoRoot: resolvedRoot,
+    runtimeRoots: [...runtimeRoots],
+    summary: {
+      filesWithSignals: reports.length,
+      versionCounts,
+      lifecycleCounts,
+      modernCounts,
+      canonicalServer: CANONICAL_SERVER,
+      canonicalAdvertisesModern: canonicalVersions.includes(MODERN_VERSION),
+      canonicalHasDiscover: canonicalModern.has('server-discover'),
+    },
+    files: reports,
+  };
+}
+
+export function formatHuman(report) {
+  const lines = [
+    'RuFlo MCP protocol era audit',
+    `Modern target: ${report.modernVersion}`,
+    `Runtime files with signals: ${report.summary.filesWithSignals}`,
+    `Protocol versions: ${JSON.stringify(report.summary.versionCounts)}`,
+    `Legacy lifecycle markers: ${JSON.stringify(report.summary.lifecycleCounts)}`,
+    `Modern markers: ${JSON.stringify(report.summary.modernCounts)}`,
+    `Canonical server: ${report.summary.canonicalServer}`,
+    `Canonical advertises modern: ${report.summary.canonicalAdvertisesModern}`,
+    `Canonical has server/discover: ${report.summary.canonicalHasDiscover}`,
+  ];
+
+  for (const file of report.files) {
+    lines.push(
+      '',
+      file.file,
+      `  versions: ${file.versions.map((item) => item.version).join(', ') || 'none'}`,
+      `  lifecycle: ${file.lifecycle.map((item) => `${item.kind}:${item.count}`).join(', ') || 'none'}`,
+      `  modern: ${file.modern.map((item) => `${item.kind}:${item.count}`).join(', ') || 'none'}`
+    );
+  }
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const options = {
+    root: process.cwd(),
+    json: false,
+    assertModernEntrypoint: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') options.json = true;
+    else if (arg === '--assert-modern-entrypoint') options.assertModernEntrypoint = true;
+    else if (arg === '--root') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--root requires a path');
+      options.root = value;
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/audit-mcp-era.mjs [--root PATH] [--json] [--assert-modern-entrypoint]',
+    '',
+    'Audits runtime MCP surfaces for protocol versions, legacy lifecycle markers,',
+    'and modern 2026-07-28 wire markers. It does not mutate the repository.',
+    '',
+    '--assert-modern-entrypoint exits nonzero until the canonical MCP server both',
+    'advertises 2026-07-28 and implements server/discover.',
+  ].join('\n');
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const report = auditRepository(options.root);
+  console.log(options.json ? JSON.stringify(report, null, 2) : formatHuman(report));
+
+  if (
+    options.assertModernEntrypoint &&
+    (!report.summary.canonicalAdvertisesModern || !report.summary.canonicalHasDiscover)
+  ) {
+    process.exitCode = 2;
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === modulePath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`audit-mcp-era: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/audit-mcp-session-isolation.mjs
+++ b/scripts/audit-mcp-session-isolation.mjs
@@ -17,7 +17,8 @@ const CHECKS = Object.freeze([
     file: 'server',
     severity: 'critical',
     unsafe: /\bcurrentSession\??\s*:\s*MCPSession|\bcurrentSession\s*=\s*session/g,
-    message: 'server owns mutable singleton currentSession state',
+    safe: /AsyncLocalStorage<MCPRequestContext>[\s\S]{0,1200}authoritySessions\s*=\s*new\s+Map<string,\s*string>/g,
+    message: 'server owns mutable singleton currentSession state without a request-local authority map',
   },
   {
     id: 'server.tool-context-from-singleton-session',

--- a/scripts/audit-mcp-session-isolation.mjs
+++ b/scripts/audit-mcp-session-isolation.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_FILES = Object.freeze({
+  server: 'v3/@claude-flow/mcp/src/server.ts',
+  types: 'v3/@claude-flow/mcp/src/types.ts',
+  http: 'v3/@claude-flow/mcp/src/transport/http.ts',
+});
+
+const CHECKS = Object.freeze([
+  {
+    id: 'server.singleton-current-session',
+    file: 'server',
+    severity: 'critical',
+    unsafe: /\bcurrentSession\??\s*:\s*MCPSession|\bcurrentSession\s*=\s*session/g,
+    message: 'server owns mutable singleton currentSession state',
+  },
+  {
+    id: 'server.tool-context-from-singleton-session',
+    file: 'server',
+    severity: 'critical',
+    unsafe: /sessionId:\s*this\.currentSession\?\.id/g,
+    message: 'tool or sampling authority context is derived from singleton currentSession',
+  },
+  {
+    id: 'server.subscription-from-singleton-session',
+    file: 'server',
+    severity: 'high',
+    unsafe: /const\s+sessionId\s*=\s*this\.currentSession\?\.id/g,
+    message: 'resource subscription ownership is derived from singleton currentSession',
+  },
+  {
+    id: 'types.request-handler-has-no-context',
+    file: 'types',
+    severity: 'critical',
+    unsafe: /type\s+RequestHandler\s*=\s*\(request:\s*MCPRequest\)\s*=>/g,
+    safe: /type\s+RequestHandler\s*=\s*\(\s*request:\s*MCPRequest\s*,\s*context\??:/g,
+    message: 'transport request handler cannot pass request-local protocol or principal context',
+  },
+  {
+    id: 'http.drops-request-context',
+    file: 'http',
+    severity: 'critical',
+    unsafe: /this\.requestHandler\(message\s+as\s+MCPRequest\)/g,
+    safe: /this\.requestHandler\(message\s+as\s+MCPRequest\s*,/g,
+    message: 'HTTP transport dispatches only the JSON body and drops request-local headers and principal context',
+  },
+  {
+    id: 'http.auth-has-no-principal',
+    file: 'http',
+    severity: 'high',
+    unsafe: /validateAuth\(req:\s*Request\):\s*\{\s*valid:\s*boolean;\s*error\?:\s*string\s*\}/g,
+    safe: /validateAuth\(req:\s*Request\):[^\n]*(principal|subject|identity)/gi,
+    message: 'authentication returns a boolean verdict without a request-local principal identity',
+  },
+  {
+    id: 'http.modern-routing-headers-not-cors-allowlisted',
+    file: 'http',
+    severity: 'medium',
+    unsafe: /allowedHeaders:\s*\[[^\]]*'Content-Type'[^\]]*'Authorization'[^\]]*'X-Request-ID'[^\]]*\]/g,
+    safe: /allowedHeaders:\s*\[[^\]]*['"]MCP-Protocol-Version['"][^\]]*['"]Mcp-Method['"][^\]]*['"]Mcp-Name['"][^\]]*\]/gis,
+    message: 'CORS allowlist does not expose the MCP 2026 routing/version headers',
+  },
+]);
+
+function count(text, regex) {
+  regex.lastIndex = 0;
+  return [...text.matchAll(regex)].length;
+}
+
+export function scanSources(sources) {
+  const findings = [];
+  for (const check of CHECKS) {
+    const text = sources[check.file] ?? '';
+    const unsafeCount = count(text, check.unsafe);
+    const safeCount = check.safe ? count(text, check.safe) : 0;
+    const active = unsafeCount > 0 && safeCount === 0;
+    findings.push({
+      id: check.id,
+      severity: check.severity,
+      active,
+      unsafeCount,
+      safeCount,
+      message: check.message,
+    });
+  }
+
+  const critical = findings.filter((item) => item.active && item.severity === 'critical').length;
+  const high = findings.filter((item) => item.active && item.severity === 'high').length;
+  const medium = findings.filter((item) => item.active && item.severity === 'medium').length;
+
+  return {
+    schema: 'ruflo.mcp-session-isolation-audit/v1',
+    summary: {
+      isolated: critical === 0 && high === 0,
+      activeFindings: findings.filter((item) => item.active).length,
+      critical,
+      high,
+      medium,
+    },
+    findings,
+  };
+}
+
+export function auditRepository(repoRoot, files = DEFAULT_FILES) {
+  const root = path.resolve(repoRoot);
+  const sources = {};
+  const missing = [];
+
+  for (const [key, rel] of Object.entries(files)) {
+    const absolute = path.join(root, rel);
+    if (!fs.existsSync(absolute)) {
+      missing.push(rel);
+      sources[key] = '';
+      continue;
+    }
+    sources[key] = fs.readFileSync(absolute, 'utf8');
+  }
+
+  return {
+    ...scanSources(sources),
+    repoRoot: root,
+    files,
+    missing,
+  };
+}
+
+export function formatHuman(report) {
+  const lines = [
+    'RuFlo MCP request-local isolation audit',
+    `Isolated: ${report.summary.isolated}`,
+    `Active findings: ${report.summary.activeFindings}`,
+    `Critical: ${report.summary.critical}`,
+    `High: ${report.summary.high}`,
+    `Medium: ${report.summary.medium}`,
+  ];
+
+  if (report.missing?.length) {
+    lines.push(`Missing files: ${report.missing.join(', ')}`);
+  }
+
+  for (const item of report.findings) {
+    lines.push(`${item.active ? 'FAIL' : 'PASS'} ${item.severity.toUpperCase()} ${item.id}: ${item.message}`);
+  }
+
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const options = { root: process.cwd(), json: false, assertIsolated: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') options.json = true;
+    else if (arg === '--assert-isolated') options.assertIsolated = true;
+    else if (arg === '--root') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--root requires a path');
+      options.root = value;
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/audit-mcp-session-isolation.mjs [--root PATH] [--json] [--assert-isolated]',
+    '',
+    'Audits the canonical MCP server, transport types, and HTTP transport for request-local',
+    'principal/protocol context and singleton-session aliasing. The audit is read-only.',
+    '',
+    '--assert-isolated exits nonzero while critical/high isolation findings remain.',
+  ].join('\n');
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMain) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(usage());
+      process.exit(0);
+    }
+    const report = auditRepository(options.root);
+    console.log(options.json ? JSON.stringify(report, null, 2) : formatHuman(report));
+    if (report.missing.length > 0) process.exitCode = 2;
+    else if (options.assertIsolated && !report.summary.isolated) process.exitCode = 1;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+  }
+}

--- a/v3/@claude-flow/mcp/src/__tests__/request-context.stress.test.ts
+++ b/v3/@claude-flow/mcp/src/__tests__/request-context.stress.test.ts
@@ -29,7 +29,7 @@ function init(id: number): MCPRequest {
 }
 
 describe('MCP request context stress', () => {
-  it('preserves principal and session identity across 10000 interleaved requests', async () => {
+  it('preserves session authority across 10000 interleaved requests', async () => {
     const server = createMCPServer({
       name: 'stress', version: '1.0.0', transport: 'in-process',
     }, logger);
@@ -40,12 +40,9 @@ describe('MCP request context stress', () => {
 
     server.registerTool({
       name: 'test/identity',
-      description: 'Return request-local identity',
+      description: 'Return request-local session identity',
       inputSchema: { type: 'object', properties: {} },
-      handler: async (_input, context) => ({
-        sessionId: context?.sessionId,
-        principal: context?.metadata?.principal,
-      }),
+      handler: async (_input, context) => ({ sessionId: context?.sessionId }),
     });
 
     const principalA = principalFromSecret('stress-token-a');
@@ -82,24 +79,49 @@ describe('MCP request context stress', () => {
           principal,
           legacySessionId: sessionId,
         }));
-        const result = response.result as { sessionId?: string; principal?: string } | undefined;
-        if (result?.sessionId !== sessionId || result?.principal !== principal.subject) aliases++;
+        const result = response.result as { sessionId?: string } | undefined;
+        if (result?.sessionId !== sessionId) aliases++;
       });
       await Promise.all(batch);
     }
 
+    const crossPrincipal = await (server as any).handleRequest({
+      jsonrpc: '2.0', id: 99_999, method: 'tools/list',
+    }, freezeRequestContext({
+      requestId: 'cross-principal-reuse',
+      transport: 'http',
+      principal: principalB,
+      legacySessionId: sessionA,
+    }));
+
     const elapsedMs = performance.now() - started;
     const throughput = total / (elapsedMs / 1000);
     console.info(JSON.stringify({
+      schema: 'ruflo.mcp-isolation-stress/v1',
       benchmark: 'mcp-request-context-isolation',
-      requests: total,
+      candidate: 'request-local-authority',
+      workload: 'two principals, two legacy sessions, alternating requests',
+      environment: {
+        node: process.version,
+        platform: process.platform,
+        arch: process.arch,
+      },
+      seed: 'deterministic-alternation-v1',
+      sampleSize: total,
       batchSize,
-      aliases,
-      elapsedMs: Number(elapsedMs.toFixed(2)),
-      throughputRps: Number(throughput.toFixed(2)),
-      node: process.version,
+      metrics: {
+        aliases,
+        crossPrincipalReuseAccepted: !crossPrincipal.error,
+        elapsedMs: Number(elapsedMs.toFixed(2)),
+        throughputRps: Number(throughput.toFixed(2)),
+      },
+      regressions: aliases > 0 || !crossPrincipal.error ? 1 : 0,
+      failures: aliases,
+      costEnergy: 'not measured in unit-test environment',
+      reproduction: 'pnpm vitest run src/__tests__/request-context.stress.test.ts',
     }));
 
     expect(aliases).toBe(0);
+    expect(crossPrincipal.error?.code).toBe(-32002);
   }, 30_000);
 });

--- a/v3/@claude-flow/mcp/src/__tests__/request-context.stress.test.ts
+++ b/v3/@claude-flow/mcp/src/__tests__/request-context.stress.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { performance } from 'node:perf_hooks';
+import { createMCPServer } from '../server.js';
+import type { ILogger, MCPRequest } from '../types.js';
+import {
+  freezeRequestContext,
+  getResponseTransportMetadata,
+  principalFromSecret,
+} from '../request-context.js';
+
+const logger: ILogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+function init(id: number): MCPRequest {
+  return {
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: `stress-${id}`, version: '1.0.0' },
+    },
+  };
+}
+
+describe('MCP request context stress', () => {
+  it('preserves principal and session identity across 10000 interleaved requests', async () => {
+    const server = createMCPServer({
+      name: 'stress', version: '1.0.0', transport: 'in-process',
+    }, logger);
+
+    const limiter = (server as any).rateLimiter;
+    limiter.check = () => ({ allowed: true });
+    limiter.consume = () => undefined;
+
+    server.registerTool({
+      name: 'test/identity',
+      description: 'Return request-local identity',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (_input, context) => ({
+        sessionId: context?.sessionId,
+        principal: context?.metadata?.principal,
+      }),
+    });
+
+    const principalA = principalFromSecret('stress-token-a');
+    const principalB = principalFromSecret('stress-token-b');
+    const initA = await (server as any).handleRequest(init(1), freezeRequestContext({
+      requestId: 'init-a', transport: 'http', principal: principalA,
+    }));
+    const initB = await (server as any).handleRequest(init(2), freezeRequestContext({
+      requestId: 'init-b', transport: 'http', principal: principalB,
+    }));
+    const sessionA = getResponseTransportMetadata(initA)?.legacySessionId;
+    const sessionB = getResponseTransportMetadata(initB)?.legacySessionId;
+    expect(sessionA).toBeTruthy();
+    expect(sessionB).toBeTruthy();
+    expect(sessionA).not.toBe(sessionB);
+
+    const started = performance.now();
+    let aliases = 0;
+    const batchSize = 250;
+    const total = 10_000;
+
+    for (let offset = 0; offset < total; offset += batchSize) {
+      const batch = Array.from({ length: Math.min(batchSize, total - offset) }, async (_, index) => {
+        const n = offset + index;
+        const useA = n % 2 === 0;
+        const principal = useA ? principalA : principalB;
+        const sessionId = useA ? sessionA : sessionB;
+        const response = await (server as any).handleRequest({
+          jsonrpc: '2.0', id: 10_000 + n, method: 'tools/call',
+          params: { name: 'test/identity', arguments: {} },
+        }, freezeRequestContext({
+          requestId: `stress-${n}`,
+          transport: 'http',
+          principal,
+          legacySessionId: sessionId,
+        }));
+        const result = response.result as { sessionId?: string; principal?: string } | undefined;
+        if (result?.sessionId !== sessionId || result?.principal !== principal.subject) aliases++;
+      });
+      await Promise.all(batch);
+    }
+
+    const elapsedMs = performance.now() - started;
+    const throughput = total / (elapsedMs / 1000);
+    console.info(JSON.stringify({
+      benchmark: 'mcp-request-context-isolation',
+      requests: total,
+      batchSize,
+      aliases,
+      elapsedMs: Number(elapsedMs.toFixed(2)),
+      throughputRps: Number(throughput.toFixed(2)),
+      node: process.version,
+    }));
+
+    expect(aliases).toBe(0);
+  }, 30_000);
+});

--- a/v3/@claude-flow/mcp/src/__tests__/request-context.test.ts
+++ b/v3/@claude-flow/mcp/src/__tests__/request-context.test.ts
@@ -32,9 +32,7 @@ function initialize(id: number): MCPRequest {
 describe('request local MCP authority', () => {
   it('keeps concurrent legacy principals bound to distinct sessions', async () => {
     const server = createMCPServer({
-      name: 'test',
-      version: '1.0.0',
-      transport: 'in-process',
+      name: 'test', version: '1.0.0', transport: 'in-process',
     }, logger);
 
     server.registerTool({
@@ -50,16 +48,13 @@ describe('request local MCP authority', () => {
 
     const principalA = principalFromSecret('token-a');
     const principalB = principalFromSecret('token-b');
-    const initContextA = freezeRequestContext({
-      requestId: 'init-a', transport: 'http', principal: principalA,
-    });
-    const initContextB = freezeRequestContext({
-      requestId: 'init-b', transport: 'http', principal: principalB,
-    });
-
     const [initA, initB] = await Promise.all([
-      (server as any).handleRequest(initialize(1), initContextA),
-      (server as any).handleRequest(initialize(2), initContextB),
+      (server as any).handleRequest(initialize(1), freezeRequestContext({
+        requestId: 'init-a', transport: 'http', principal: principalA,
+      })),
+      (server as any).handleRequest(initialize(2), freezeRequestContext({
+        requestId: 'init-b', transport: 'http', principal: principalB,
+      })),
     ]);
 
     const sessionA = getResponseTransportMetadata(initA)?.legacySessionId;
@@ -116,12 +111,11 @@ describe('request local MCP authority', () => {
     expect(response.error?.code).toBe(-32002);
   });
 
-  it('allows modern stateless requests without the legacy initialization lifecycle', async () => {
+  it('allows modern stateless discovery without legacy initialization', async () => {
     const server = createMCPServer({
       name: 'test', version: '1.0.0', transport: 'in-process',
     }, logger);
     const principal = principalFromSecret('modern-token');
-
     const response = await (server as any).handleRequest({
       jsonrpc: '2.0', id: 7, method: 'server/discover',
     }, freezeRequestContext({
@@ -130,6 +124,40 @@ describe('request local MCP authority', () => {
 
     expect((response.result as any).protocolVersion).toBe(MCP_2026_07_28);
     expect((response.result as any).transport.sessionsRequired).toBe(false);
+    expect((response.result as any).capabilities.resources.subscribe).toBe(false);
+  });
+
+  it('rejects initialize for the modern stateless protocol era', async () => {
+    const server = createMCPServer({
+      name: 'test', version: '1.0.0', transport: 'in-process',
+    }, logger);
+    const principal = principalFromSecret('modern-token');
+    const response = await (server as any).handleRequest(initialize(9), freezeRequestContext({
+      requestId: 'modern-init',
+      transport: 'http',
+      principal,
+      protocolVersion: MCP_2026_07_28,
+    }));
+
+    expect(response.error?.code).toBe(-32600);
+    expect(server.getSessions()).toHaveLength(0);
+  });
+
+  it('fails closed on modern resource subscriptions until delivery can be targeted', async () => {
+    const server = createMCPServer({
+      name: 'test', version: '1.0.0', transport: 'in-process',
+    }, logger);
+    const principal = principalFromSecret('modern-token');
+    const response = await (server as any).handleRequest({
+      jsonrpc: '2.0', id: 10, method: 'resources/subscribe', params: { uri: 'ruv://test' },
+    }, freezeRequestContext({
+      requestId: 'modern-subscribe',
+      transport: 'http',
+      principal,
+      protocolVersion: MCP_2026_07_28,
+    }));
+
+    expect(response.error?.code).toBe(-32601);
   });
 });
 

--- a/v3/@claude-flow/mcp/src/__tests__/request-context.test.ts
+++ b/v3/@claude-flow/mcp/src/__tests__/request-context.test.ts
@@ -3,9 +3,11 @@ import { createMCPServer } from '../server.js';
 import type { ILogger, MCPRequest } from '../types.js';
 import {
   MCP_2026_07_28,
+  MCP_HEADER_MISMATCH,
   freezeRequestContext,
   getResponseTransportMetadata,
   principalFromSecret,
+  validateModernEnvelope,
   validateRoutingHeaders,
 } from '../request-context.js';
 
@@ -29,6 +31,17 @@ function initialize(id: number): MCPRequest {
   };
 }
 
+function modernParams(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ...extra,
+    _meta: {
+      'io.modelcontextprotocol/protocolVersion': MCP_2026_07_28,
+      'io.modelcontextprotocol/clientCapabilities': {},
+      'io.modelcontextprotocol/clientInfo': { name: 'test-client', version: '1.0.0' },
+    },
+  };
+}
+
 describe('request local MCP authority', () => {
   it('keeps concurrent legacy principals bound to distinct sessions', async () => {
     const server = createMCPServer({
@@ -37,11 +50,10 @@ describe('request local MCP authority', () => {
 
     server.registerTool({
       name: 'test/whoami',
-      description: 'Return request scoped identity',
+      description: 'Return request scoped session identity',
       inputSchema: { type: 'object', properties: {} },
       handler: async (_input, context) => ({
         sessionId: context?.sessionId,
-        principal: context?.metadata?.principal,
         requestContextId: context?.metadata?.requestContextId,
       }),
     });
@@ -83,9 +95,7 @@ describe('request local MCP authority', () => {
 
     const results = await Promise.all(calls);
     for (const [a, b] of results) {
-      expect((a.result as any).principal).toBe(principalA.subject);
       expect((a.result as any).sessionId).toBe(sessionA);
-      expect((b.result as any).principal).toBe(principalB.subject);
       expect((b.result as any).sessionId).toBe(sessionB);
     }
   });
@@ -111,20 +121,24 @@ describe('request local MCP authority', () => {
     expect(response.error?.code).toBe(-32002);
   });
 
-  it('allows modern stateless discovery without legacy initialization', async () => {
+  it('returns final-era stateless discovery bookkeeping without a legacy session', async () => {
     const server = createMCPServer({
       name: 'test', version: '1.0.0', transport: 'in-process',
     }, logger);
     const principal = principalFromSecret('modern-token');
     const response = await (server as any).handleRequest({
-      jsonrpc: '2.0', id: 7, method: 'server/discover',
+      jsonrpc: '2.0', id: 7, method: 'server/discover', params: modernParams(),
     }, freezeRequestContext({
       requestId: 'modern', transport: 'http', principal, protocolVersion: MCP_2026_07_28,
     }));
 
-    expect((response.result as any).protocolVersion).toBe(MCP_2026_07_28);
-    expect((response.result as any).transport.sessionsRequired).toBe(false);
+    expect((response.result as any).supportedVersions).toContain(MCP_2026_07_28);
     expect((response.result as any).capabilities.resources.subscribe).toBe(false);
+    expect((response.result as any).resultType).toBe('complete');
+    expect((response.result as any).ttlMs).toBe(0);
+    expect((response.result as any).cacheScope).toBe('private');
+    expect((response.result as any)._meta['io.modelcontextprotocol/serverInfo'].name).toBeTruthy();
+    expect(server.getSessions()).toHaveLength(0);
   });
 
   it('rejects initialize for the modern stateless protocol era', async () => {
@@ -143,13 +157,13 @@ describe('request local MCP authority', () => {
     expect(server.getSessions()).toHaveLength(0);
   });
 
-  it('fails closed on modern resource subscriptions until delivery can be targeted', async () => {
+  it('fails closed on methods removed from the stateless era', async () => {
     const server = createMCPServer({
       name: 'test', version: '1.0.0', transport: 'in-process',
     }, logger);
     const principal = principalFromSecret('modern-token');
     const response = await (server as any).handleRequest({
-      jsonrpc: '2.0', id: 10, method: 'resources/subscribe', params: { uri: 'ruv://test' },
+      jsonrpc: '2.0', id: 10, method: 'resources/subscribe', params: modernParams({ uri: 'ruv://test' }),
     }, freezeRequestContext({
       requestId: 'modern-subscribe',
       transport: 'http',
@@ -159,12 +173,85 @@ describe('request local MCP authority', () => {
 
     expect(response.error?.code).toBe(-32601);
   });
+
+  it('validates x-mcp-header annotated tool arguments before execution', async () => {
+    const server = createMCPServer({
+      name: 'test', version: '1.0.0', transport: 'in-process',
+    }, logger);
+    let calls = 0;
+    server.registerTool({
+      name: 'test/tenant',
+      description: 'Header bound tool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tenant: { type: 'string', 'x-mcp-header': 'tenant' } as any,
+        },
+      },
+      handler: async () => {
+        calls++;
+        return { ok: true };
+      },
+    });
+
+    const principal = principalFromSecret('modern-token');
+    const base = {
+      requestId: 'modern-tool',
+      transport: 'http' as const,
+      principal,
+      protocolVersion: MCP_2026_07_28,
+    };
+    const request: MCPRequest = {
+      jsonrpc: '2.0', id: 20, method: 'tools/call',
+      params: modernParams({ name: 'test/tenant', arguments: { tenant: 'alpha' } }),
+    };
+
+    const rejected = await (server as any).handleRequest(request, freezeRequestContext({
+      ...base,
+      paramHeaders: { tenant: 'beta' },
+    }));
+    expect(rejected.error?.code).toBe(MCP_HEADER_MISMATCH);
+    expect(calls).toBe(0);
+
+    const accepted = await (server as any).handleRequest(request, freezeRequestContext({
+      ...base,
+      paramHeaders: { tenant: 'alpha' },
+    }));
+    expect(accepted.error).toBeUndefined();
+    expect(calls).toBe(1);
+  });
 });
 
-describe('MCP routing header validation', () => {
+describe('MCP 2026 envelope and routing validation', () => {
+  it('requires matching protocol version and client capabilities', () => {
+    const request: MCPRequest = {
+      jsonrpc: '2.0', id: 1, method: 'server/discover', params: modernParams(),
+    };
+    expect(validateModernEnvelope(request, MCP_2026_07_28).valid).toBe(true);
+
+    const missingCapabilities: MCPRequest = {
+      jsonrpc: '2.0', id: 2, method: 'server/discover',
+      params: {
+        _meta: { 'io.modelcontextprotocol/protocolVersion': MCP_2026_07_28 },
+      },
+    };
+    expect(validateModernEnvelope(missingCapabilities, MCP_2026_07_28).valid).toBe(false);
+    expect(validateModernEnvelope(request, '2099-01-01').code).toBe(MCP_HEADER_MISMATCH);
+  });
+
+  it('requires Mcp-Method on modern HTTP routing', () => {
+    const request: MCPRequest = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+    const result = validateRoutingHeaders(request, { protocolVersion: MCP_2026_07_28 });
+    expect(result.valid).toBe(false);
+    expect(result.code).toBe(MCP_HEADER_MISMATCH);
+  });
+
   it('rejects method disagreement before dispatch', () => {
     const request: MCPRequest = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
-    expect(validateRoutingHeaders(request, { routingMethod: 'tools/call' }).valid).toBe(false);
+    expect(validateRoutingHeaders(request, {
+      protocolVersion: MCP_2026_07_28,
+      routingMethod: 'tools/call',
+    }).valid).toBe(false);
   });
 
   it('rejects routed tool name disagreement before dispatch', () => {
@@ -172,16 +259,19 @@ describe('MCP routing header validation', () => {
       jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'safe-tool' },
     };
     expect(validateRoutingHeaders(request, {
+      protocolVersion: MCP_2026_07_28,
       routingMethod: 'tools/call', routingName: 'other-tool',
     }).valid).toBe(false);
   });
 
-  it('accepts matching routing metadata', () => {
+  it('accepts matching and base64 encoded routing metadata', () => {
     const request: MCPRequest = {
-      jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'safe-tool' },
+      jsonrpc: '2.0', id: 1, method: 'resources/read', params: { uri: 'ruv://alpha' },
     };
     expect(validateRoutingHeaders(request, {
-      routingMethod: 'tools/call', routingName: 'safe-tool',
+      protocolVersion: MCP_2026_07_28,
+      routingMethod: 'resources/read',
+      routingName: '=?base64?cnV2Oi8vYWxwaGE=?=',
     }).valid).toBe(true);
   });
 });

--- a/v3/@claude-flow/mcp/src/__tests__/request-context.test.ts
+++ b/v3/@claude-flow/mcp/src/__tests__/request-context.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { createMCPServer } from '../server.js';
+import type { ILogger, MCPRequest } from '../types.js';
+import {
+  MCP_2026_07_28,
+  freezeRequestContext,
+  getResponseTransportMetadata,
+  principalFromSecret,
+  validateRoutingHeaders,
+} from '../request-context.js';
+
+const logger: ILogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+function initialize(id: number): MCPRequest {
+  return {
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: `client-${id}`, version: '1.0.0' },
+    },
+  };
+}
+
+describe('request local MCP authority', () => {
+  it('keeps concurrent legacy principals bound to distinct sessions', async () => {
+    const server = createMCPServer({
+      name: 'test',
+      version: '1.0.0',
+      transport: 'in-process',
+    }, logger);
+
+    server.registerTool({
+      name: 'test/whoami',
+      description: 'Return request scoped identity',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (_input, context) => ({
+        sessionId: context?.sessionId,
+        principal: context?.metadata?.principal,
+        requestContextId: context?.metadata?.requestContextId,
+      }),
+    });
+
+    const principalA = principalFromSecret('token-a');
+    const principalB = principalFromSecret('token-b');
+    const initContextA = freezeRequestContext({
+      requestId: 'init-a', transport: 'http', principal: principalA,
+    });
+    const initContextB = freezeRequestContext({
+      requestId: 'init-b', transport: 'http', principal: principalB,
+    });
+
+    const [initA, initB] = await Promise.all([
+      (server as any).handleRequest(initialize(1), initContextA),
+      (server as any).handleRequest(initialize(2), initContextB),
+    ]);
+
+    const sessionA = getResponseTransportMetadata(initA)?.legacySessionId;
+    const sessionB = getResponseTransportMetadata(initB)?.legacySessionId;
+    expect(sessionA).toBeTruthy();
+    expect(sessionB).toBeTruthy();
+    expect(sessionA).not.toBe(sessionB);
+
+    const contextA = freezeRequestContext({
+      requestId: 'a', transport: 'http', principal: principalA, legacySessionId: sessionA,
+    });
+    const contextB = freezeRequestContext({
+      requestId: 'b', transport: 'http', principal: principalB, legacySessionId: sessionB,
+    });
+
+    const calls = Array.from({ length: 20 }, (_, index) => Promise.all([
+      (server as any).handleRequest({
+        jsonrpc: '2.0', id: 1000 + index, method: 'tools/call',
+        params: { name: 'test/whoami', arguments: {} },
+      }, contextA),
+      (server as any).handleRequest({
+        jsonrpc: '2.0', id: 2000 + index, method: 'tools/call',
+        params: { name: 'test/whoami', arguments: {} },
+      }, contextB),
+    ]));
+
+    const results = await Promise.all(calls);
+    for (const [a, b] of results) {
+      expect((a.result as any).principal).toBe(principalA.subject);
+      expect((a.result as any).sessionId).toBe(sessionA);
+      expect((b.result as any).principal).toBe(principalB.subject);
+      expect((b.result as any).sessionId).toBe(sessionB);
+    }
+  });
+
+  it('rejects cross principal reuse of a legacy session identifier', async () => {
+    const server = createMCPServer({
+      name: 'test', version: '1.0.0', transport: 'in-process',
+    }, logger);
+    const principalA = principalFromSecret('token-a');
+    const principalB = principalFromSecret('token-b');
+
+    const initA = await (server as any).handleRequest(initialize(1), freezeRequestContext({
+      requestId: 'init-a', transport: 'http', principal: principalA,
+    }));
+    const sessionA = getResponseTransportMetadata(initA)?.legacySessionId;
+
+    const response = await (server as any).handleRequest({
+      jsonrpc: '2.0', id: 3, method: 'tools/list',
+    }, freezeRequestContext({
+      requestId: 'reuse', transport: 'http', principal: principalB, legacySessionId: sessionA,
+    }));
+
+    expect(response.error?.code).toBe(-32002);
+  });
+
+  it('allows modern stateless requests without the legacy initialization lifecycle', async () => {
+    const server = createMCPServer({
+      name: 'test', version: '1.0.0', transport: 'in-process',
+    }, logger);
+    const principal = principalFromSecret('modern-token');
+
+    const response = await (server as any).handleRequest({
+      jsonrpc: '2.0', id: 7, method: 'server/discover',
+    }, freezeRequestContext({
+      requestId: 'modern', transport: 'http', principal, protocolVersion: MCP_2026_07_28,
+    }));
+
+    expect((response.result as any).protocolVersion).toBe(MCP_2026_07_28);
+    expect((response.result as any).transport.sessionsRequired).toBe(false);
+  });
+});
+
+describe('MCP routing header validation', () => {
+  it('rejects method disagreement before dispatch', () => {
+    const request: MCPRequest = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+    expect(validateRoutingHeaders(request, { routingMethod: 'tools/call' }).valid).toBe(false);
+  });
+
+  it('rejects routed tool name disagreement before dispatch', () => {
+    const request: MCPRequest = {
+      jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'safe-tool' },
+    };
+    expect(validateRoutingHeaders(request, {
+      routingMethod: 'tools/call', routingName: 'other-tool',
+    }).valid).toBe(false);
+  });
+
+  it('accepts matching routing metadata', () => {
+    const request: MCPRequest = {
+      jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'safe-tool' },
+    };
+    expect(validateRoutingHeaders(request, {
+      routingMethod: 'tools/call', routingName: 'safe-tool',
+    }).valid).toBe(true);
+  });
+});

--- a/v3/@claude-flow/mcp/src/request-context.ts
+++ b/v3/@claude-flow/mcp/src/request-context.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'crypto';
+import type { MCPRequest, MCPResponse, TransportType } from './types.js';
+
+export const MCP_2026_07_28 = '2026-07-28';
+
+export interface AuthenticatedPrincipal {
+  readonly subject: string;
+  readonly authMethod: 'token' | 'api-key' | 'oauth' | 'none';
+}
+
+export interface MCPRequestContext {
+  readonly requestId: string;
+  readonly transport: TransportType;
+  readonly principal: AuthenticatedPrincipal;
+  readonly protocolVersion?: string;
+  readonly legacySessionId?: string;
+  readonly routingMethod?: string;
+  readonly routingName?: string;
+  readonly traceparent?: string;
+  readonly tracestate?: string;
+  readonly remoteAddress?: string;
+}
+
+export interface MCPResponseTransportMetadata {
+  readonly legacySessionId?: string;
+}
+
+const responseMetadata = new WeakMap<MCPResponse, MCPResponseTransportMetadata>();
+
+export function principalFromSecret(
+  secret: string,
+  authMethod: AuthenticatedPrincipal['authMethod'] = 'token'
+): AuthenticatedPrincipal {
+  const digest = createHash('sha256').update(secret).digest('hex').slice(0, 24);
+  return Object.freeze({ subject: `${authMethod}:${digest}`, authMethod });
+}
+
+export function anonymousPrincipal(): AuthenticatedPrincipal {
+  return Object.freeze({ subject: 'anonymous', authMethod: 'none' });
+}
+
+export function freezeRequestContext(context: MCPRequestContext): MCPRequestContext {
+  return Object.freeze({ ...context, principal: Object.freeze({ ...context.principal }) });
+}
+
+export function attachResponseTransportMetadata(
+  response: MCPResponse,
+  metadata: MCPResponseTransportMetadata
+): MCPResponse {
+  responseMetadata.set(response, Object.freeze({ ...metadata }));
+  return response;
+}
+
+export function getResponseTransportMetadata(
+  response: MCPResponse
+): MCPResponseTransportMetadata | undefined {
+  return responseMetadata.get(response);
+}
+
+export interface RoutingValidationResult {
+  readonly valid: boolean;
+  readonly error?: string;
+}
+
+export function validateRoutingHeaders(
+  request: MCPRequest,
+  context: Pick<MCPRequestContext, 'routingMethod' | 'routingName'>
+): RoutingValidationResult {
+  if (context.routingMethod && context.routingMethod !== request.method) {
+    return {
+      valid: false,
+      error: `Mcp-Method mismatch: header=${context.routingMethod} body=${request.method}`,
+    };
+  }
+
+  if (!context.routingName) return { valid: true };
+
+  const params = request.params as { name?: unknown } | undefined;
+  const bodyName = typeof params?.name === 'string'
+    ? params.name
+    : request.method.includes('/') && !request.method.startsWith('tools/')
+      ? request.method
+      : undefined;
+
+  if (!bodyName || bodyName !== context.routingName) {
+    return {
+      valid: false,
+      error: `Mcp-Name mismatch: header=${context.routingName} body=${bodyName ?? '<none>'}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export function isModernStatelessContext(context?: MCPRequestContext): boolean {
+  return context?.protocolVersion === MCP_2026_07_28;
+}
+
+export function authorityKey(context?: MCPRequestContext): string | undefined {
+  if (!context) return undefined;
+  if (isModernStatelessContext(context)) return `stateless:${context.principal.subject}`;
+  if (!context.legacySessionId) return undefined;
+  return `${context.principal.subject}:${context.legacySessionId}`;
+}

--- a/v3/@claude-flow/mcp/src/request-context.ts
+++ b/v3/@claude-flow/mcp/src/request-context.ts
@@ -2,6 +2,11 @@ import { createHash } from 'crypto';
 import type { MCPRequest, MCPResponse, TransportType } from './types.js';
 
 export const MCP_2026_07_28 = '2026-07-28';
+export const MCP_HEADER_MISMATCH = -32020;
+export const MCP_UNSUPPORTED_PROTOCOL_VERSION = -32022;
+
+const BASE64_SENTINEL = /^=\?base64\?([A-Za-z0-9+/]+={0,2})\?=$/;
+const MODERN_NAMED_METHODS = new Set(['tools/call', 'resources/read', 'prompts/get']);
 
 export interface AuthenticatedPrincipal {
   readonly subject: string;
@@ -16,6 +21,7 @@ export interface MCPRequestContext {
   readonly legacySessionId?: string;
   readonly routingMethod?: string;
   readonly routingName?: string;
+  readonly paramHeaders?: Readonly<Record<string, string>>;
   readonly traceparent?: string;
   readonly tracestate?: string;
   readonly remoteAddress?: string;
@@ -31,7 +37,7 @@ export function principalFromSecret(
   secret: string,
   authMethod: AuthenticatedPrincipal['authMethod'] = 'token'
 ): AuthenticatedPrincipal {
-  const digest = createHash('sha256').update(secret).digest('hex').slice(0, 24);
+  const digest = createHash('sha256').update(secret).digest('hex');
   return Object.freeze({ subject: `${authMethod}:${digest}`, authMethod });
 }
 
@@ -40,7 +46,13 @@ export function anonymousPrincipal(): AuthenticatedPrincipal {
 }
 
 export function freezeRequestContext(context: MCPRequestContext): MCPRequestContext {
-  return Object.freeze({ ...context, principal: Object.freeze({ ...context.principal }) });
+  return Object.freeze({
+    ...context,
+    principal: Object.freeze({ ...context.principal }),
+    paramHeaders: context.paramHeaders
+      ? Object.freeze({ ...context.paramHeaders })
+      : undefined,
+  });
 }
 
 export function attachResponseTransportMetadata(
@@ -57,36 +69,145 @@ export function getResponseTransportMetadata(
   return responseMetadata.get(response);
 }
 
-export interface RoutingValidationResult {
+export interface ValidationResult {
   readonly valid: boolean;
   readonly error?: string;
+  readonly code?: number;
+}
+
+export function decodeMcpHeaderValue(value: string): string {
+  if (!value.startsWith('=?base64?')) return value;
+  const match = BASE64_SENTINEL.exec(value);
+  if (!match) throw new Error('Malformed MCP base64 header sentinel');
+  const decoded = Buffer.from(match[1], 'base64').toString('utf8');
+  if (!Buffer.from(decoded, 'utf8').equals(Buffer.from(match[1], 'base64'))) {
+    throw new Error('Invalid MCP base64 header encoding');
+  }
+  return decoded;
+}
+
+function expectedRoutingName(request: MCPRequest): string | undefined {
+  const params = request.params as { name?: unknown; uri?: unknown } | undefined;
+  if (request.method === 'resources/read') {
+    return typeof params?.uri === 'string' ? params.uri : undefined;
+  }
+  if (request.method === 'tools/call' || request.method === 'prompts/get') {
+    return typeof params?.name === 'string' ? params.name : undefined;
+  }
+  return undefined;
 }
 
 export function validateRoutingHeaders(
   request: MCPRequest,
-  context: Pick<MCPRequestContext, 'routingMethod' | 'routingName'>
-): RoutingValidationResult {
+  context: Pick<MCPRequestContext, 'routingMethod' | 'routingName' | 'protocolVersion'>,
+  requireModernHeaders = context.protocolVersion === MCP_2026_07_28
+): ValidationResult {
+  if (requireModernHeaders && !context.routingMethod) {
+    return {
+      valid: false,
+      code: MCP_HEADER_MISMATCH,
+      error: 'Mcp-Method is required for MCP 2026-07-28 HTTP requests',
+    };
+  }
+
   if (context.routingMethod && context.routingMethod !== request.method) {
     return {
       valid: false,
+      code: MCP_HEADER_MISMATCH,
       error: `Mcp-Method mismatch: header=${context.routingMethod} body=${request.method}`,
+    };
+  }
+
+  const requiresName = requireModernHeaders && MODERN_NAMED_METHODS.has(request.method);
+  if (requiresName && !context.routingName) {
+    return {
+      valid: false,
+      code: MCP_HEADER_MISMATCH,
+      error: `Mcp-Name is required for ${request.method}`,
     };
   }
 
   if (!context.routingName) return { valid: true };
 
-  const params = request.params as { name?: unknown } | undefined;
-  const bodyName = typeof params?.name === 'string'
-    ? params.name
-    : request.method.includes('/') && !request.method.startsWith('tools/')
-      ? request.method
-      : undefined;
-
-  if (!bodyName || bodyName !== context.routingName) {
+  const bodyName = expectedRoutingName(request);
+  if (!bodyName) {
     return {
       valid: false,
-      error: `Mcp-Name mismatch: header=${context.routingName} body=${bodyName ?? '<none>'}`,
+      code: MCP_HEADER_MISMATCH,
+      error: `Mcp-Name is not valid for method ${request.method}`,
     };
+  }
+
+  let decodedHeader: string;
+  try {
+    decodedHeader = decodeMcpHeaderValue(context.routingName);
+  } catch (error) {
+    return {
+      valid: false,
+      code: MCP_HEADER_MISMATCH,
+      error: error instanceof Error ? error.message : 'Invalid Mcp-Name encoding',
+    };
+  }
+
+  if (bodyName !== decodedHeader) {
+    return {
+      valid: false,
+      code: MCP_HEADER_MISMATCH,
+      error: `Mcp-Name mismatch: header=${decodedHeader} body=${bodyName}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export function bodyProtocolVersion(request: MCPRequest): string | undefined {
+  const meta = (request.params as { _meta?: Record<string, unknown> } | undefined)?._meta;
+  const version = meta?.['io.modelcontextprotocol/protocolVersion'];
+  return typeof version === 'string' ? version : undefined;
+}
+
+export function validateModernEnvelope(
+  request: MCPRequest,
+  headerVersion?: string
+): ValidationResult {
+  const params = request.params as { _meta?: Record<string, unknown> } | undefined;
+  const meta = params?._meta;
+  const bodyVersion = bodyProtocolVersion(request);
+
+  if (!headerVersion || !bodyVersion || headerVersion !== bodyVersion) {
+    return {
+      valid: false,
+      code: MCP_HEADER_MISMATCH,
+      error: `MCP protocol version mismatch: header=${headerVersion ?? '<missing>'} body=${bodyVersion ?? '<missing>'}`,
+    };
+  }
+
+  if (headerVersion !== MCP_2026_07_28) {
+    return {
+      valid: false,
+      code: MCP_UNSUPPORTED_PROTOCOL_VERSION,
+      error: `Unsupported MCP protocol version: ${headerVersion}`,
+    };
+  }
+
+  const clientCapabilities = meta?.['io.modelcontextprotocol/clientCapabilities'];
+  if (!clientCapabilities || typeof clientCapabilities !== 'object' || Array.isArray(clientCapabilities)) {
+    return {
+      valid: false,
+      code: -32602,
+      error: 'Modern MCP requests require _meta.io.modelcontextprotocol/clientCapabilities',
+    };
+  }
+
+  const clientInfo = meta?.['io.modelcontextprotocol/clientInfo'];
+  if (clientInfo !== undefined) {
+    if (!clientInfo || typeof clientInfo !== 'object' || Array.isArray(clientInfo)) {
+      return { valid: false, code: -32602, error: 'Invalid MCP clientInfo metadata' };
+    }
+    const info = clientInfo as Record<string, unknown>;
+    if (typeof info.name !== 'string' || typeof info.version !== 'string') {
+      return { valid: false, code: -32602, error: 'MCP clientInfo requires string name and version' };
+    }
   }
 
   return { valid: true };

--- a/v3/@claude-flow/mcp/src/server.ts
+++ b/v3/@claude-flow/mcp/src/server.ts
@@ -22,13 +22,16 @@ import type {
   ITransport,
   ILogger,
   ToolContext,
+  JSONSchema,
 } from './types.js';
 import { MCPServerError, ErrorCodes } from './types.js';
 import type { MCPRequestContext } from './request-context.js';
 import {
   MCP_2026_07_28,
+  MCP_HEADER_MISMATCH,
   attachResponseTransportMetadata,
   authorityKey,
+  decodeMcpHeaderValue,
   isModernStatelessContext,
 } from './request-context.js';
 import {
@@ -58,6 +61,23 @@ const DEFAULT_CONFIG: Partial<MCPServerConfig> = {
   requestTimeout: 30000,
   maxRequestSize: 10 * 1024 * 1024,
 };
+
+const MODERN_LEGACY_ONLY_METHODS = new Set([
+  'resources/subscribe',
+  'resources/unsubscribe',
+  'tasks/status',
+  'tasks/cancel',
+  'logging/setLevel',
+  'sampling/createMessage',
+]);
+
+const MODERN_CACHEABLE_METHODS = new Set([
+  'server/discover',
+  'tools/list',
+  'resources/list',
+  'resources/read',
+  'prompts/list',
+]);
 
 export interface IMCPServer {
   start(): Promise<void>;
@@ -195,7 +215,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   async start(): Promise<void> {
     if (this.running) throw new MCPServerError('Server already running');
 
-    const startTime = performance.now();
+    const startedAt = performance.now();
     this.startTime = new Date();
 
     this.logger.info('Starting MCP server', {
@@ -238,7 +258,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       await this.registerBuiltInTools();
 
       this.running = true;
-      this.startupDuration = performance.now() - startTime;
+      this.startupDuration = performance.now() - startedAt;
       this.logger.info('MCP server started', {
         startupTime: `${this.startupDuration.toFixed(2)}ms`,
         tools: this.toolRegistry.getToolCount(),
@@ -332,7 +352,10 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         metrics,
       };
     } catch (error) {
-      return { healthy: false, error: error instanceof Error ? error.message : 'Unknown error' };
+      return {
+        healthy: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
     }
   }
 
@@ -380,7 +403,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   }
 
   private async handleRequestScoped(request: MCPRequest): Promise<MCPResponse> {
-    const startTime = performance.now();
+    const startedAt = performance.now();
     this.requestStats.total++;
     const context = this.requestContext.getStore();
 
@@ -388,7 +411,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       id: request.id,
       method: request.method,
       requestContextId: context?.requestId,
-      principal: context?.principal.subject,
     });
 
     if (isModernStatelessContext(context) && request.method === 'initialize') {
@@ -433,8 +455,20 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         if (session) this.sessionManager.updateActivity(session.id);
       }
 
-      const response = await this.routeRequest(request);
-      const duration = performance.now() - startTime;
+      if (isModernStatelessContext(context) && MODERN_LEGACY_ONLY_METHODS.has(request.method)) {
+        return this.createErrorResponse(
+          request.id,
+          ErrorCodes.METHOD_NOT_FOUND,
+          `Method is not available in MCP 2026-07-28: ${request.method}`
+        );
+      }
+
+      let response = await this.routeRequest(request);
+      if (isModernStatelessContext(context)) {
+        response = this.finalizeModernResponse(request.method, response);
+      }
+
+      const duration = performance.now() - startedAt;
       this.requestStats.successful++;
       this.requestStats.totalResponseTime += duration;
       this.logger.debug('Request completed', {
@@ -445,7 +479,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       });
       return response;
     } catch (error) {
-      const duration = performance.now() - startTime;
+      const duration = performance.now() - startedAt;
       this.requestStats.failed++;
       this.requestStats.totalResponseTime += duration;
       this.logger.error('Request failed', {
@@ -478,11 +512,14 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     this.logger.debug('Handling notification', {
       method: notification.method,
       requestContextId: context?.requestId,
-      principal: context?.principal.subject,
     });
 
     switch (notification.method) {
       case 'initialized':
+        if (isModernStatelessContext(context)) {
+          this.logger.warn('Ignoring legacy initialized notification on modern stateless request');
+          return;
+        }
         this.logger.info('Client initialized notification received', {
           sessionId: this.resolveRequestSession()?.id,
         });
@@ -518,7 +555,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     this.logger.info('Session initialized', {
       sessionId: session.id,
       clientInfo: params.clientInfo,
-      principal: this.requestContext.getStore()?.principal.subject,
     });
 
     return attachResponseTransportMetadata({
@@ -545,42 +581,50 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       case 'logging/setLevel': return this.handleLoggingSetLevel(request);
       case 'sampling/createMessage': return this.handleSamplingCreateMessage(request);
       case 'ping':
-        return { jsonrpc: '2.0', id: request.id, result: { pong: true, timestamp: Date.now() } };
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: { pong: true, timestamp: Date.now() },
+        };
       default:
         if (this.toolRegistry.hasTool(request.method)) return this.handleToolExecution(request);
-        return this.createErrorResponse(request.id, ErrorCodes.METHOD_NOT_FOUND, `Method not found: ${request.method}`);
+        return this.createErrorResponse(
+          request.id,
+          ErrorCodes.METHOD_NOT_FOUND,
+          `Method not found: ${request.method}`
+        );
     }
   }
 
   private handleServerDiscover(request: MCPRequest): MCPResponse {
-    const modernCapabilities: MCPCapabilities = {
-      ...this.capabilities,
+    const capabilities: Record<string, unknown> = {
+      tools: this.capabilities.tools,
+      prompts: this.capabilities.prompts,
       resources: this.capabilities.resources
         ? { ...this.capabilities.resources, subscribe: false }
         : undefined,
     };
+
     return {
       jsonrpc: '2.0',
       id: request.id,
       result: {
-        protocolVersion: MCP_2026_07_28,
-        serverInfo: this.serverInfo,
-        capabilities: modernCapabilities,
-        transport: {
-          requestLocalAuthority: true,
-          sessionsRequired: false,
-          resourceSubscriptions: 'legacy-only-until-targeted-delivery',
-        },
+        supportedVersions: [MCP_2026_07_28],
+        capabilities,
+        instructions: 'Stateless request-local MCP endpoint. Legacy sessions remain available through the 2025-11-25 path.',
       },
     };
   }
 
   private handleToolsList(request: MCPRequest): MCPResponse {
-    const tools = this.toolRegistry.listTools().map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: this.toolRegistry.getTool(t.name)?.inputSchema,
-    }));
+    const tools = this.toolRegistry.listTools()
+      .map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: this.toolRegistry.getTool(t.name)?.inputSchema,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
     return { jsonrpc: '2.0', id: request.id, result: { tools } };
   }
 
@@ -589,6 +633,17 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     if (!params?.name) {
       return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Tool name is required');
     }
+
+    const tool = this.toolRegistry.getTool(params.name);
+    const headerError = this.validateToolParamHeaders(
+      tool?.inputSchema,
+      params.arguments || {},
+      this.requestContext.getStore()
+    );
+    if (headerError) {
+      return this.createErrorResponse(request.id, MCP_HEADER_MISMATCH, headerError);
+    }
+
     const result = await this.toolRegistry.execute(
       params.name,
       params.arguments || {},
@@ -598,9 +653,20 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   }
 
   private async handleToolExecution(request: MCPRequest): Promise<MCPResponse> {
+    const tool = this.toolRegistry.getTool(request.method);
+    const args = (request.params as Record<string, unknown>) || {};
+    const headerError = this.validateToolParamHeaders(
+      tool?.inputSchema,
+      args,
+      this.requestContext.getStore()
+    );
+    if (headerError) {
+      return this.createErrorResponse(request.id, MCP_HEADER_MISMATCH, headerError);
+    }
+
     const result = await this.toolRegistry.execute(
       request.method,
-      (request.params as Record<string, unknown>) || {},
+      args,
       this.createToolContext(request)
     );
     return { jsonrpc: '2.0', id: request.id, result };
@@ -608,7 +674,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesList(request: MCPRequest): MCPResponse {
     const params = request.params as { cursor?: string } | undefined;
-    return { jsonrpc: '2.0', id: request.id, result: this.resourceRegistry.list(params?.cursor) };
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: this.resourceRegistry.list(params?.cursor),
+    };
   }
 
   private async handleResourcesRead(request: MCPRequest): Promise<MCPResponse> {
@@ -617,7 +687,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Resource URI is required');
     }
     try {
-      return { jsonrpc: '2.0', id: request.id, result: await this.resourceRegistry.read(params.uri) };
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        result: await this.resourceRegistry.read(params.uri),
+      };
     } catch (error) {
       return this.createErrorResponse(
         request.id,
@@ -629,20 +703,16 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesSubscribe(request: MCPRequest): MCPResponse {
     const params = request.params as { uri: string } | undefined;
-    const requestContext = this.requestContext.getStore();
-    if (isModernStatelessContext(requestContext)) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.METHOD_NOT_FOUND,
-        'Stateless resource subscriptions are disabled until targeted notification delivery is available'
-      );
-    }
     const sessionId = this.resolveRequestScopeId();
     if (!params?.uri) {
       return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Resource URI is required');
     }
     if (!sessionId) {
-      return this.createErrorResponse(request.id, ErrorCodes.SERVER_NOT_INITIALIZED, 'No active request authority scope');
+      return this.createErrorResponse(
+        request.id,
+        ErrorCodes.SERVER_NOT_INITIALIZED,
+        'No active request authority scope'
+      );
     }
 
     try {
@@ -667,14 +737,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesUnsubscribe(request: MCPRequest): MCPResponse {
     const params = request.params as { uri: string } | undefined;
-    const requestContext = this.requestContext.getStore();
-    if (isModernStatelessContext(requestContext)) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.METHOD_NOT_FOUND,
-        'Stateless resource subscriptions are disabled until targeted notification delivery is available'
-      );
-    }
     const sessionId = this.resolveRequestScopeId();
     if (!params?.uri) {
       return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Resource URI is required');
@@ -685,7 +747,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handlePromptsList(request: MCPRequest): MCPResponse {
     const params = request.params as { cursor?: string } | undefined;
-    return { jsonrpc: '2.0', id: request.id, result: this.promptRegistry.list(params?.cursor) };
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: this.promptRegistry.list(params?.cursor),
+    };
   }
 
   private async handlePromptsGet(request: MCPRequest): Promise<MCPResponse> {
@@ -713,11 +779,19 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     if (params?.taskId) {
       const task = this.taskManager.getTask(params.taskId);
       if (!task) {
-        return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, `Task not found: ${params.taskId}`);
+        return this.createErrorResponse(
+          request.id,
+          ErrorCodes.INVALID_PARAMS,
+          `Task not found: ${params.taskId}`
+        );
       }
       return { jsonrpc: '2.0', id: request.id, result: task };
     }
-    return { jsonrpc: '2.0', id: request.id, result: { tasks: this.taskManager.getAllTasks() } };
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { tasks: this.taskManager.getAllTasks() },
+    };
   }
 
   private handleTasksCancel(request: MCPRequest): MCPResponse {
@@ -779,7 +853,9 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     if (!params?.level) {
       return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Log level is required');
     }
-    this.capabilities.logging = { level: params.level as 'debug' | 'info' | 'warn' | 'error' };
+    this.capabilities.logging = {
+      level: params.level as 'debug' | 'info' | 'warn' | 'error',
+    };
     this.logger.info('Log level updated', { level: params.level });
     return { jsonrpc: '2.0', id: request.id, result: { success: true } };
   }
@@ -801,10 +877,18 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       metadata?: Record<string, unknown>;
     } | undefined;
     if (!params?.messages || !params?.maxTokens) {
-      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'messages and maxTokens are required');
+      return this.createErrorResponse(
+        request.id,
+        ErrorCodes.INVALID_PARAMS,
+        'messages and maxTokens are required'
+      );
     }
     if (!(await this.samplingManager.isAvailable())) {
-      return this.createErrorResponse(request.id, ErrorCodes.INTERNAL_ERROR, 'No LLM provider available for sampling');
+      return this.createErrorResponse(
+        request.id,
+        ErrorCodes.INTERNAL_ERROR,
+        'No LLM provider available for sampling'
+      );
     }
 
     try {
@@ -835,6 +919,103 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         error instanceof Error ? error.message : 'Sampling failed'
       );
     }
+  }
+
+  private finalizeModernResponse(method: string, response: MCPResponse): MCPResponse {
+    if (response.error || !response.result || typeof response.result !== 'object' || Array.isArray(response.result)) {
+      return response;
+    }
+
+    const current = response.result as Record<string, unknown>;
+    const existingMeta = current._meta && typeof current._meta === 'object' && !Array.isArray(current._meta)
+      ? current._meta as Record<string, unknown>
+      : {};
+    const result: Record<string, unknown> = {
+      ...current,
+      _meta: {
+        ...existingMeta,
+        'io.modelcontextprotocol/serverInfo': this.serverInfo,
+      },
+      resultType: typeof current.resultType === 'string' ? current.resultType : 'complete',
+    };
+
+    if (MODERN_CACHEABLE_METHODS.has(method)) {
+      if (typeof result.ttlMs !== 'number') result.ttlMs = 0;
+      if (typeof result.cacheScope !== 'string') result.cacheScope = 'private';
+    }
+
+    return {
+      ...response,
+      result,
+    };
+  }
+
+  private validateToolParamHeaders(
+    schema: JSONSchema | undefined,
+    args: Record<string, unknown>,
+    context: MCPRequestContext | undefined
+  ): string | undefined {
+    if (!schema || !isModernStatelessContext(context) || context?.transport !== 'http') {
+      return undefined;
+    }
+
+    const declarations: Array<{ header: string; value: unknown; type: string }> = [];
+    const seen = new Set<string>();
+
+    const visit = (node: JSONSchema, value: unknown): string | undefined => {
+      const header = (node as JSONSchema & { 'x-mcp-header'?: unknown })['x-mcp-header'];
+      if (header !== undefined) {
+        if (typeof header !== 'string' || !/^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(header)) {
+          return 'Invalid x-mcp-header annotation';
+        }
+        if (!['string', 'integer', 'boolean'].includes(node.type)) {
+          return `x-mcp-header ${header} uses unsupported type ${node.type}`;
+        }
+        const key = header.toLowerCase();
+        if (seen.has(key)) return `Duplicate x-mcp-header annotation: ${header}`;
+        seen.add(key);
+        declarations.push({ header: key, value, type: node.type });
+      }
+
+      if (node.type === 'object' && node.properties && value && typeof value === 'object' && !Array.isArray(value)) {
+        const objectValue = value as Record<string, unknown>;
+        for (const [property, child] of Object.entries(node.properties)) {
+          const error = visit(child, objectValue[property]);
+          if (error) return error;
+        }
+      }
+      return undefined;
+    };
+
+    const schemaError = visit(schema, args);
+    if (schemaError) return schemaError;
+
+    const actualHeaders = context.paramHeaders || {};
+    for (const declaration of declarations) {
+      const actual = actualHeaders[declaration.header];
+      if (declaration.value === undefined) {
+        if (actual !== undefined) {
+          return `Mcp-Param-${declaration.header} is present but the body argument is missing`;
+        }
+        continue;
+      }
+      if (actual === undefined) {
+        return `Mcp-Param-${declaration.header} is required for the annotated body argument`;
+      }
+
+      let decoded: string;
+      try {
+        decoded = decodeMcpHeaderValue(actual);
+      } catch (error) {
+        return error instanceof Error ? error.message : 'Invalid MCP parameter header encoding';
+      }
+      const expected = String(declaration.value);
+      if (decoded !== expected) {
+        return `Mcp-Param-${declaration.header} mismatch`;
+      }
+    }
+
+    return undefined;
   }
 
   private async sendNotification(method: string, params?: Record<string, unknown>): Promise<void> {
@@ -883,7 +1064,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       orchestrator: this.orchestrator,
       swarmCoordinator: this.swarmCoordinator,
       metadata: requestContext ? {
-        principal: requestContext.principal.subject,
         protocolVersion: requestContext.protocolVersion,
         requestContextId: requestContext.requestId,
         traceparent: requestContext.traceparent,
@@ -891,7 +1071,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     };
   }
 
-  private createErrorResponse(id: string | number | null, code: number, message: string): MCPResponse {
+  private createErrorResponse(
+    id: string | number | null,
+    code: number,
+    message: string
+  ): MCPResponse {
     return { jsonrpc: '2.0', id, error: { code, message } };
   }
 
@@ -933,11 +1117,15 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       description: 'List all registered tools with details',
       inputSchema: {
         type: 'object',
-        properties: { category: { type: 'string', description: 'Filter by category' } },
+        properties: {
+          category: { type: 'string', description: 'Filter by category' },
+        },
       },
       handler: async (input: unknown) => {
         const params = input as { category?: string };
-        return params.category ? this.toolRegistry.getByCategory(params.category) : this.toolRegistry.listTools();
+        return params.category
+          ? this.toolRegistry.getByCategory(params.category)
+          : this.toolRegistry.listTools();
       },
       category: 'system',
     });

--- a/v3/@claude-flow/mcp/src/server.ts
+++ b/v3/@claude-flow/mcp/src/server.ts
@@ -20,7 +20,6 @@ import type {
   MCPProtocolVersion,
   MCPServerMetrics,
   ITransport,
-  TransportType,
   ILogger,
   ToolContext,
 } from './types.js';
@@ -43,8 +42,8 @@ import { ResourceRegistry, createResourceRegistry } from './resource-registry.js
 import { PromptRegistry, createPromptRegistry } from './prompt-registry.js';
 import { TaskManager, createTaskManager } from './task-manager.js';
 import { createTransport, TransportManager, createTransportManager } from './transport/index.js';
-import { RateLimiter, createRateLimiter, type RateLimitConfig } from './rate-limiter.js';
-import { SamplingManager, createSamplingManager, type SamplingConfig, type LLMProvider } from './sampling.js';
+import { RateLimiter, createRateLimiter } from './rate-limiter.js';
+import { SamplingManager, createSamplingManager, type LLMProvider } from './sampling.js';
 
 const DEFAULT_CONFIG: Partial<MCPServerConfig> = {
   name: 'Claude-Flow MCP Server V3',
@@ -94,6 +93,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   private running = false;
   private startTime?: Date;
   private startupDuration?: number;
+  /** Contextless fallback retained only for transports that cannot supply request context. */
   private currentSession?: MCPSession;
   private resourceSubscriptions: Map<string, Set<string>> = new Map();
 
@@ -102,6 +102,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     version: '3.0.0',
   };
 
+  /** Legacy initialization response version. Modern clients use server/discover. */
   private readonly protocolVersion: MCPProtocolVersion = '2025-11-25';
 
   private capabilities: MCPCapabilities = {
@@ -192,9 +193,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   }
 
   async start(): Promise<void> {
-    if (this.running) {
-      throw new MCPServerError('Server already running');
-    }
+    if (this.running) throw new MCPServerError('Server already running');
 
     const startTime = performance.now();
     this.startTime = new Date();
@@ -221,10 +220,8 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       } as any));
 
       for (const transport of transports) {
-        transport.onRequest(async (request, context?: MCPRequestContext) => await this.handleRequest(request, context));
-        transport.onNotification(async (notification) => {
-          await this.handleNotification(notification);
-        });
+        transport.onRequest(async (request, context?: MCPRequestContext) => this.handleRequest(request, context));
+        transport.onNotification(async (notification, context?: MCPRequestContext) => this.handleNotification(notification, context));
       }
 
       const started: ITransport[] = [];
@@ -242,17 +239,14 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
       this.running = true;
       this.startupDuration = performance.now() - startTime;
-
       this.logger.info('MCP server started', {
         startupTime: `${this.startupDuration.toFixed(2)}ms`,
         tools: this.toolRegistry.getToolCount(),
       });
-
       this.emit('server:started', {
         startupTime: this.startupDuration,
         tools: this.toolRegistry.getToolCount(),
       });
-
     } catch (error) {
       this.logger.error('Failed to start MCP server', { error });
       throw new MCPServerError('Failed to start server', ErrorCodes.INTERNAL_ERROR, { error });
@@ -260,12 +254,9 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   }
 
   async stop(): Promise<void> {
-    if (!this.running) {
-      return;
-    }
+    if (!this.running) return;
 
     this.logger.info('Stopping MCP server');
-
     try {
       if (this.transports.length > 0) {
         const transports = this.transports;
@@ -279,16 +270,12 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       this.authoritySessions.clear();
       this.rateLimiter.destroy();
 
-      if (this.connectionPool) {
-        await this.connectionPool.clear();
-      }
+      if (this.connectionPool) await this.connectionPool.clear();
 
       this.running = false;
       this.currentSession = undefined;
-
       this.logger.info('MCP server stopped');
       this.emit('server:stopped');
-
     } catch (error) {
       this.logger.error('Error stopping MCP server', { error });
       throw error;
@@ -323,10 +310,8 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       const transportHealth = this.transports.length > 0
         ? await Promise.all(this.transports.map((transport) => transport.getHealthStatus()))
         : [{ healthy: false, error: 'Transport not initialized' }];
-
       const sessionMetrics = this.sessionManager.getSessionMetrics();
       const poolStats = this.connectionPool?.getStats();
-
       const metrics: Record<string, number> = {
         registeredTools: this.toolRegistry.getToolCount(),
         totalRequests: this.requestStats.total,
@@ -336,31 +321,24 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         activeSessions: sessionMetrics.active,
         ...Object.assign({}, ...transportHealth.map((health) => health.metrics || {})),
       };
-
       if (poolStats) {
         metrics.poolConnections = poolStats.totalConnections;
         metrics.poolIdleConnections = poolStats.idleConnections;
         metrics.poolBusyConnections = poolStats.busyConnections;
       }
-
       return {
         healthy: this.running && transportHealth.every((health) => health.healthy),
         error: transportHealth.map((health) => health.error).filter(Boolean).join('; ') || undefined,
         metrics,
       };
-
     } catch (error) {
-      return {
-        healthy: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      };
+      return { healthy: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
   }
 
   getMetrics(): MCPServerMetrics {
     const sessionMetrics = this.sessionManager.getSessionMetrics();
     const registryStats = this.toolRegistry.getStats();
-
     return {
       totalRequests: this.requestStats.total,
       successfulRequests: this.requestStats.successful,
@@ -369,9 +347,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         ? this.requestStats.totalResponseTime / this.requestStats.total
         : 0,
       activeSessions: sessionMetrics.active,
-      toolInvocations: Object.fromEntries(
-        registryStats.topTools.map((t) => [t.name, t.calls])
-      ),
+      toolInvocations: Object.fromEntries(registryStats.topTools.map((t) => [t.name, t.calls])),
       errors: {},
       lastReset: this.startTime || new Date(),
       startupTime: this.startupDuration,
@@ -389,23 +365,18 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   terminateSession(sessionId: string): boolean {
     const result = this.sessionManager.closeSession(sessionId, 'Terminated by server');
-    if (this.currentSession?.id === sessionId) {
-      this.currentSession = undefined;
-    }
+    if (this.currentSession?.id === sessionId) this.currentSession = undefined;
     for (const [key, boundSessionId] of this.authoritySessions) {
       if (boundSessionId === sessionId) this.authoritySessions.delete(key);
     }
     return result;
   }
 
-  private async handleRequest(
-    request: MCPRequest,
-    context?: MCPRequestContext
-  ): Promise<MCPResponse> {
+  private async handleRequest(request: MCPRequest, context?: MCPRequestContext): Promise<MCPResponse> {
     if (context) {
-      return await this.requestContext.run(context, async () => await this.handleRequestScoped(request));
+      return this.requestContext.run(context, async () => this.handleRequestScoped(request));
     }
-    return await this.handleRequestScoped(request);
+    return this.handleRequestScoped(request);
   }
 
   private async handleRequestScoped(request: MCPRequest): Promise<MCPResponse> {
@@ -419,6 +390,15 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       requestContextId: context?.requestId,
       principal: context?.principal.subject,
     });
+
+    if (isModernStatelessContext(context) && request.method === 'initialize') {
+      this.requestStats.failed++;
+      return this.createErrorResponse(
+        request.id,
+        ErrorCodes.INVALID_REQUEST,
+        'initialize is not valid for MCP 2026-07-28 stateless requests; use server/discover'
+      );
+    }
 
     if (request.method !== 'initialize') {
       const scopeId = this.resolveRequestScopeId();
@@ -439,9 +419,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
 
     try {
-      if (request.method === 'initialize') {
-        return await this.handleInitialize(request);
-      }
+      if (request.method === 'initialize') return this.handleInitialize(request);
 
       if (!isModernStatelessContext(context)) {
         const session = this.resolveRequestSession();
@@ -456,32 +434,26 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       }
 
       const response = await this.routeRequest(request);
-
       const duration = performance.now() - startTime;
       this.requestStats.successful++;
       this.requestStats.totalResponseTime += duration;
-
       this.logger.debug('Request completed', {
         id: request.id,
         method: request.method,
         duration: `${duration.toFixed(2)}ms`,
         requestContextId: context?.requestId,
       });
-
       return response;
-
     } catch (error) {
       const duration = performance.now() - startTime;
       this.requestStats.failed++;
       this.requestStats.totalResponseTime += duration;
-
       this.logger.error('Request failed', {
         id: request.id,
         method: request.method,
         error,
         requestContextId: context?.requestId,
       });
-
       return this.createErrorResponse(
         request.id,
         ErrorCodes.INTERNAL_ERROR,
@@ -490,18 +462,37 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
   }
 
-  private async handleNotification(notification: MCPNotification): Promise<void> {
-    this.logger.debug('Handling notification', { method: notification.method });
+  private async handleNotification(
+    notification: MCPNotification,
+    context?: MCPRequestContext
+  ): Promise<void> {
+    if (context) {
+      await this.requestContext.run(context, async () => this.handleNotificationScoped(notification));
+      return;
+    }
+    await this.handleNotificationScoped(notification);
+  }
+
+  private async handleNotificationScoped(notification: MCPNotification): Promise<void> {
+    const context = this.requestContext.getStore();
+    this.logger.debug('Handling notification', {
+      method: notification.method,
+      requestContextId: context?.requestId,
+      principal: context?.principal.subject,
+    });
 
     switch (notification.method) {
       case 'initialized':
-        this.logger.info('Client initialized notification received');
+        this.logger.info('Client initialized notification received', {
+          sessionId: this.resolveRequestSession()?.id,
+        });
         break;
-
       case 'notifications/cancelled':
-        this.logger.debug('Request cancelled', notification.params);
+        this.logger.debug('Request cancelled', {
+          ...notification.params,
+          authorityScope: this.resolveRequestScopeId(),
+        });
         break;
-
       default:
         this.logger.debug('Unknown notification', { method: notification.method });
     }
@@ -509,13 +500,8 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private async handleInitialize(request: MCPRequest): Promise<MCPResponse> {
     const params = request.params as unknown as MCPInitializeParams | undefined;
-
     if (!params) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Invalid params'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Invalid params');
     }
 
     const session = this.sessionManager.createSession(this.config.transport);
@@ -535,75 +521,55 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       principal: this.requestContext.getStore()?.principal.subject,
     });
 
-    const response: MCPResponse = {
+    return attachResponseTransportMetadata({
       jsonrpc: '2.0',
       id: request.id,
       result,
-    };
-
-    return attachResponseTransportMetadata(response, { legacySessionId: session.id });
+    }, { legacySessionId: session.id });
   }
 
   private async routeRequest(request: MCPRequest): Promise<MCPResponse> {
     switch (request.method) {
-      case 'server/discover':
-        return this.handleServerDiscover(request);
-      case 'tools/list':
-        return this.handleToolsList(request);
-      case 'tools/call':
-        return this.handleToolsCall(request);
-      case 'resources/list':
-        return this.handleResourcesList(request);
-      case 'resources/read':
-        return this.handleResourcesRead(request);
-      case 'resources/subscribe':
-        return this.handleResourcesSubscribe(request);
-      case 'resources/unsubscribe':
-        return this.handleResourcesUnsubscribe(request);
-      case 'prompts/list':
-        return this.handlePromptsList(request);
-      case 'prompts/get':
-        return this.handlePromptsGet(request);
-      case 'tasks/status':
-        return this.handleTasksStatus(request);
-      case 'tasks/cancel':
-        return this.handleTasksCancel(request);
-      case 'completion/complete':
-        return this.handleCompletion(request);
-      case 'logging/setLevel':
-        return this.handleLoggingSetLevel(request);
-      case 'sampling/createMessage':
-        return this.handleSamplingCreateMessage(request);
+      case 'server/discover': return this.handleServerDiscover(request);
+      case 'tools/list': return this.handleToolsList(request);
+      case 'tools/call': return this.handleToolsCall(request);
+      case 'resources/list': return this.handleResourcesList(request);
+      case 'resources/read': return this.handleResourcesRead(request);
+      case 'resources/subscribe': return this.handleResourcesSubscribe(request);
+      case 'resources/unsubscribe': return this.handleResourcesUnsubscribe(request);
+      case 'prompts/list': return this.handlePromptsList(request);
+      case 'prompts/get': return this.handlePromptsGet(request);
+      case 'tasks/status': return this.handleTasksStatus(request);
+      case 'tasks/cancel': return this.handleTasksCancel(request);
+      case 'completion/complete': return this.handleCompletion(request);
+      case 'logging/setLevel': return this.handleLoggingSetLevel(request);
+      case 'sampling/createMessage': return this.handleSamplingCreateMessage(request);
       case 'ping':
-        return {
-          jsonrpc: '2.0',
-          id: request.id,
-          result: { pong: true, timestamp: Date.now() },
-        };
+        return { jsonrpc: '2.0', id: request.id, result: { pong: true, timestamp: Date.now() } };
       default:
-        if (this.toolRegistry.hasTool(request.method)) {
-          return this.handleToolExecution(request);
-        }
-
-        return this.createErrorResponse(
-          request.id,
-          ErrorCodes.METHOD_NOT_FOUND,
-          `Method not found: ${request.method}`
-        );
+        if (this.toolRegistry.hasTool(request.method)) return this.handleToolExecution(request);
+        return this.createErrorResponse(request.id, ErrorCodes.METHOD_NOT_FOUND, `Method not found: ${request.method}`);
     }
   }
 
   private handleServerDiscover(request: MCPRequest): MCPResponse {
+    const modernCapabilities: MCPCapabilities = {
+      ...this.capabilities,
+      resources: this.capabilities.resources
+        ? { ...this.capabilities.resources, subscribe: false }
+        : undefined,
+    };
     return {
       jsonrpc: '2.0',
       id: request.id,
       result: {
         protocolVersion: MCP_2026_07_28,
         serverInfo: this.serverInfo,
-        capabilities: this.capabilities,
+        capabilities: modernCapabilities,
         transport: {
           requestLocalAuthority: true,
           sessionsRequired: false,
+          resourceSubscriptions: 'legacy-only-until-targeted-delivery',
         },
       },
     };
@@ -615,85 +581,43 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       description: t.description,
       inputSchema: this.toolRegistry.getTool(t.name)?.inputSchema,
     }));
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result: { tools },
-    };
+    return { jsonrpc: '2.0', id: request.id, result: { tools } };
   }
 
   private async handleToolsCall(request: MCPRequest): Promise<MCPResponse> {
     const params = request.params as { name: string; arguments?: Record<string, unknown> };
-
     if (!params?.name) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Tool name is required'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Tool name is required');
     }
-
-    const context: ToolContext = this.createToolContext(request);
-
     const result = await this.toolRegistry.execute(
       params.name,
       params.arguments || {},
-      context
+      this.createToolContext(request)
     );
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result,
-    };
+    return { jsonrpc: '2.0', id: request.id, result };
   }
 
   private async handleToolExecution(request: MCPRequest): Promise<MCPResponse> {
-    const context: ToolContext = this.createToolContext(request);
-
     const result = await this.toolRegistry.execute(
       request.method,
       (request.params as Record<string, unknown>) || {},
-      context
+      this.createToolContext(request)
     );
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result,
-    };
+    return { jsonrpc: '2.0', id: request.id, result };
   }
 
   private handleResourcesList(request: MCPRequest): MCPResponse {
     const params = request.params as { cursor?: string } | undefined;
-    const result = this.resourceRegistry.list(params?.cursor);
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result,
-    };
+    return { jsonrpc: '2.0', id: request.id, result: this.resourceRegistry.list(params?.cursor) };
   }
 
   private async handleResourcesRead(request: MCPRequest): Promise<MCPResponse> {
     const params = request.params as { uri: string } | undefined;
-
     if (!params?.uri) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Resource URI is required'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Resource URI is required');
     }
-
     try {
-      const result = await this.resourceRegistry.read(params.uri);
-      return {
-        jsonrpc: '2.0',
-        id: request.id,
-        result,
-      };
+      return { jsonrpc: '2.0', id: request.id, result: await this.resourceRegistry.read(params.uri) };
     } catch (error) {
       return this.createErrorResponse(
         request.id,
@@ -705,22 +629,20 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesSubscribe(request: MCPRequest): MCPResponse {
     const params = request.params as { uri: string } | undefined;
-    const sessionId = this.resolveRequestScopeId();
-
-    if (!params?.uri) {
+    const requestContext = this.requestContext.getStore();
+    if (isModernStatelessContext(requestContext)) {
       return this.createErrorResponse(
         request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Resource URI is required'
+        ErrorCodes.METHOD_NOT_FOUND,
+        'Stateless resource subscriptions are disabled until targeted notification delivery is available'
       );
     }
-
+    const sessionId = this.resolveRequestScopeId();
+    if (!params?.uri) {
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Resource URI is required');
+    }
     if (!sessionId) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.SERVER_NOT_INITIALIZED,
-        'No active request authority scope'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.SERVER_NOT_INITIALIZED, 'No active request authority scope');
     }
 
     try {
@@ -729,18 +651,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         sessionSubs = new Set();
         this.resourceSubscriptions.set(sessionId, sessionSubs);
       }
-
-      const subscriptionId = this.resourceRegistry.subscribe(params.uri, (uri, content) => {
+      const subscriptionId = this.resourceRegistry.subscribe(params.uri, (uri) => {
         this.sendNotification('notifications/resources/updated', { uri });
       });
-
       sessionSubs.add(params.uri);
-
-      return {
-        jsonrpc: '2.0',
-        id: request.id,
-        result: { subscriptionId },
-      };
+      return { jsonrpc: '2.0', id: request.id, result: { subscriptionId } };
     } catch (error) {
       return this.createErrorResponse(
         request.id,
@@ -752,58 +667,37 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesUnsubscribe(request: MCPRequest): MCPResponse {
     const params = request.params as { uri: string } | undefined;
-    const sessionId = this.resolveRequestScopeId();
-
-    if (!params?.uri) {
+    const requestContext = this.requestContext.getStore();
+    if (isModernStatelessContext(requestContext)) {
       return this.createErrorResponse(
         request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Resource URI is required'
+        ErrorCodes.METHOD_NOT_FOUND,
+        'Stateless resource subscriptions are disabled until targeted notification delivery is available'
       );
     }
-
-    if (sessionId) {
-      const sessionSubs = this.resourceSubscriptions.get(sessionId);
-      if (sessionSubs) {
-        sessionSubs.delete(params.uri);
-      }
+    const sessionId = this.resolveRequestScopeId();
+    if (!params?.uri) {
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Resource URI is required');
     }
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result: { success: true },
-    };
+    if (sessionId) this.resourceSubscriptions.get(sessionId)?.delete(params.uri);
+    return { jsonrpc: '2.0', id: request.id, result: { success: true } };
   }
 
   private handlePromptsList(request: MCPRequest): MCPResponse {
     const params = request.params as { cursor?: string } | undefined;
-    const result = this.promptRegistry.list(params?.cursor);
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result,
-    };
+    return { jsonrpc: '2.0', id: request.id, result: this.promptRegistry.list(params?.cursor) };
   }
 
   private async handlePromptsGet(request: MCPRequest): Promise<MCPResponse> {
     const params = request.params as { name: string; arguments?: Record<string, string> } | undefined;
-
     if (!params?.name) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Prompt name is required'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Prompt name is required');
     }
-
     try {
-      const result = await this.promptRegistry.get(params.name, params.arguments);
       return {
         jsonrpc: '2.0',
         id: request.id,
-        result,
+        result: await this.promptRegistry.get(params.name, params.arguments),
       };
     } catch (error) {
       return this.createErrorResponse(
@@ -816,47 +710,25 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleTasksStatus(request: MCPRequest): MCPResponse {
     const params = request.params as { taskId?: string } | undefined;
-
     if (params?.taskId) {
       const task = this.taskManager.getTask(params.taskId);
       if (!task) {
-        return this.createErrorResponse(
-          request.id,
-          ErrorCodes.INVALID_PARAMS,
-          `Task not found: ${params.taskId}`
-        );
+        return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, `Task not found: ${params.taskId}`);
       }
-      return {
-        jsonrpc: '2.0',
-        id: request.id,
-        result: task,
-      };
+      return { jsonrpc: '2.0', id: request.id, result: task };
     }
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result: { tasks: this.taskManager.getAllTasks() },
-    };
+    return { jsonrpc: '2.0', id: request.id, result: { tasks: this.taskManager.getAllTasks() } };
   }
 
   private handleTasksCancel(request: MCPRequest): MCPResponse {
     const params = request.params as { taskId: string; reason?: string } | undefined;
-
     if (!params?.taskId) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Task ID is required'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Task ID is required');
     }
-
-    const success = this.taskManager.cancelTask(params.taskId, params.reason);
-
     return {
       jsonrpc: '2.0',
       id: request.id,
-      result: { success },
+      result: { success: this.taskManager.cancelTask(params.taskId, params.reason) },
     };
   }
 
@@ -865,7 +737,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       ref: { type: string; name?: string; uri?: string };
       argument: { name: string; value: string };
     } | undefined;
-
     if (!params?.ref || !params?.argument) {
       return this.createErrorResponse(
         request.id,
@@ -875,7 +746,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
 
     const completions: string[] = [];
-
     if (params.ref.type === 'ref/prompt') {
       const prompt = this.promptRegistry.getPrompt(params.ref.name || '');
       if (prompt?.arguments) {
@@ -888,12 +758,9 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     } else if (params.ref.type === 'ref/resource') {
       const { resources } = this.resourceRegistry.list();
       for (const resource of resources) {
-        if (resource.uri.startsWith(params.argument.value)) {
-          completions.push(resource.uri);
-        }
+        if (resource.uri.startsWith(params.argument.value)) completions.push(resource.uri);
       }
     }
-
     return {
       jsonrpc: '2.0',
       id: request.id,
@@ -909,23 +776,12 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleLoggingSetLevel(request: MCPRequest): MCPResponse {
     const params = request.params as { level: string } | undefined;
-
     if (!params?.level) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'Log level is required'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'Log level is required');
     }
-
     this.capabilities.logging = { level: params.level as 'debug' | 'info' | 'warn' | 'error' };
     this.logger.info('Log level updated', { level: params.level });
-
-    return {
-      jsonrpc: '2.0',
-      id: request.id,
-      result: { success: true },
-    };
+    return { jsonrpc: '2.0', id: request.id, result: { success: true } };
   }
 
   private async handleSamplingCreateMessage(request: MCPRequest): Promise<MCPResponse> {
@@ -933,28 +789,22 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       messages: Array<{ role: string; content: { type: string; text?: string } }>;
       maxTokens: number;
       systemPrompt?: string;
-      modelPreferences?: { hints?: Array<{ name?: string }>; intelligencePriority?: number; speedPriority?: number; costPriority?: number };
+      modelPreferences?: {
+        hints?: Array<{ name?: string }>;
+        intelligencePriority?: number;
+        speedPriority?: number;
+        costPriority?: number;
+      };
       includeContext?: string;
       temperature?: number;
       stopSequences?: string[];
       metadata?: Record<string, unknown>;
     } | undefined;
-
     if (!params?.messages || !params?.maxTokens) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INVALID_PARAMS,
-        'messages and maxTokens are required'
-      );
+      return this.createErrorResponse(request.id, ErrorCodes.INVALID_PARAMS, 'messages and maxTokens are required');
     }
-
-    const available = await this.samplingManager.isAvailable();
-    if (!available) {
-      return this.createErrorResponse(
-        request.id,
-        ErrorCodes.INTERNAL_ERROR,
-        'No LLM provider available for sampling'
-      );
+    if (!(await this.samplingManager.isAvailable())) {
+      return this.createErrorResponse(request.id, ErrorCodes.INTERNAL_ERROR, 'No LLM provider available for sampling');
     }
 
     try {
@@ -977,12 +827,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
           serverId: this.serverInfo.name,
         }
       );
-
-      return {
-        jsonrpc: '2.0',
-        id: request.id,
-        result,
-      };
+      return { jsonrpc: '2.0', id: request.id, result };
     } catch (error) {
       return this.createErrorResponse(
         request.id,
@@ -1006,7 +851,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       this.currentSession = session;
       return;
     }
-
     const incomingKey = authorityKey(context);
     if (incomingKey) this.authoritySessions.set(incomingKey, session.id);
     this.authoritySessions.set(`${context.principal.subject}:${session.id}`, session.id);
@@ -1016,7 +860,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     const context = this.requestContext.getStore();
     if (!context) return this.currentSession;
     if (isModernStatelessContext(context)) return undefined;
-
     const key = authorityKey(context);
     if (!key) return undefined;
     const sessionId = this.authoritySessions.get(key);
@@ -1048,16 +891,8 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     };
   }
 
-  private createErrorResponse(
-    id: string | number | null,
-    code: number,
-    message: string
-  ): MCPResponse {
-    return {
-      jsonrpc: '2.0',
-      id,
-      error: { code, message },
-    };
+  private createErrorResponse(id: string | number | null, code: number, message: string): MCPResponse {
+    return { jsonrpc: '2.0', id, error: { code, message } };
   }
 
   private async registerBuiltInTools(): Promise<void> {
@@ -1075,17 +910,15 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       }),
       category: 'system',
     });
-
     this.registerTool({
       name: 'system/health',
       description: 'Get system health status',
       inputSchema: { type: 'object', properties: {} },
-      handler: async () => await this.getHealthStatus(),
+      handler: async () => this.getHealthStatus(),
       category: 'system',
       cacheable: true,
       cacheTTL: 2000,
     });
-
     this.registerTool({
       name: 'system/metrics',
       description: 'Get server metrics',
@@ -1095,59 +928,30 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       cacheable: true,
       cacheTTL: 1000,
     });
-
     this.registerTool({
       name: 'tools/list-detailed',
       description: 'List all registered tools with details',
       inputSchema: {
         type: 'object',
-        properties: {
-          category: { type: 'string', description: 'Filter by category' },
-        },
+        properties: { category: { type: 'string', description: 'Filter by category' } },
       },
       handler: async (input: unknown) => {
         const params = input as { category?: string };
-        if (params.category) {
-          return this.toolRegistry.getByCategory(params.category);
-        }
-        return this.toolRegistry.listTools();
+        return params.category ? this.toolRegistry.getByCategory(params.category) : this.toolRegistry.listTools();
       },
       category: 'system',
     });
-
-    this.logger.info('Built-in tools registered', {
-      count: 4,
-    });
+    this.logger.info('Built-in tools registered', { count: 4 });
   }
 
   private setupEventHandlers(): void {
-    this.toolRegistry.on('tool:registered', (name) => {
-      this.emit('tool:registered', name);
-    });
-
-    this.toolRegistry.on('tool:called', (data) => {
-      this.emit('tool:called', data);
-    });
-
-    this.toolRegistry.on('tool:completed', (data) => {
-      this.emit('tool:completed', data);
-    });
-
-    this.toolRegistry.on('tool:error', (data) => {
-      this.emit('tool:error', data);
-    });
-
-    this.sessionManager.on('session:created', (session) => {
-      this.emit('session:created', session);
-    });
-
-    this.sessionManager.on('session:closed', (data) => {
-      this.emit('session:closed', data);
-    });
-
-    this.sessionManager.on('session:expired', (session) => {
-      this.emit('session:expired', session);
-    });
+    this.toolRegistry.on('tool:registered', (name) => this.emit('tool:registered', name));
+    this.toolRegistry.on('tool:called', (data) => this.emit('tool:called', data));
+    this.toolRegistry.on('tool:completed', (data) => this.emit('tool:completed', data));
+    this.toolRegistry.on('tool:error', (data) => this.emit('tool:error', data));
+    this.sessionManager.on('session:created', (session) => this.emit('session:created', session));
+    this.sessionManager.on('session:closed', (data) => this.emit('session:closed', data));
+    this.sessionManager.on('session:expired', (session) => this.emit('session:expired', session));
   }
 }
 

--- a/v3/@claude-flow/mcp/src/server.ts
+++ b/v3/@claude-flow/mcp/src/server.ts
@@ -4,6 +4,7 @@
  * High-performance MCP server implementation
  */
 
+import { AsyncLocalStorage } from 'async_hooks';
 import { EventEmitter } from 'events';
 import { platform, arch } from 'os';
 import type {
@@ -24,6 +25,13 @@ import type {
   ToolContext,
 } from './types.js';
 import { MCPServerError, ErrorCodes } from './types.js';
+import type { MCPRequestContext } from './request-context.js';
+import {
+  MCP_2026_07_28,
+  attachResponseTransportMetadata,
+  authorityKey,
+  isModernStatelessContext,
+} from './request-context.js';
 import {
   ToolRegistry,
   createToolRegistry,
@@ -80,23 +88,22 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   private readonly transportManager: TransportManager;
   private readonly rateLimiter: RateLimiter;
   private readonly samplingManager: SamplingManager;
+  private readonly requestContext = new AsyncLocalStorage<MCPRequestContext>();
+  private readonly authoritySessions = new Map<string, string>();
   private transports: ITransport[] = [];
   private running = false;
   private startTime?: Date;
   private startupDuration?: number;
   private currentSession?: MCPSession;
-  private resourceSubscriptions: Map<string, Set<string>> = new Map(); // sessionId -> subscribed URIs
+  private resourceSubscriptions: Map<string, Set<string>> = new Map();
 
   private readonly serverInfo = {
     name: 'Claude-Flow MCP Server V3',
     version: '3.0.0',
   };
 
-  // MCP protocol version — spec-required YYYY-MM-DD date string (#1874).
-  // Claude Code's Zod validator rejects any other shape.
   private readonly protocolVersion: MCPProtocolVersion = '2025-11-25';
 
-  // Full MCP 2025-11-25 capabilities
   private capabilities: MCPCapabilities = {
     logging: { level: 'info' },
     tools: { listChanged: true },
@@ -160,44 +167,26 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     this.setupEventHandlers();
   }
 
-  /**
-   * Get resource registry for external registration
-   */
   getResourceRegistry(): ResourceRegistry {
     return this.resourceRegistry;
   }
 
-  /**
-   * Get prompt registry for external registration
-   */
   getPromptRegistry(): PromptRegistry {
     return this.promptRegistry;
   }
 
-  /**
-   * Get task manager for async operations
-   */
   getTaskManager(): TaskManager {
     return this.taskManager;
   }
 
-  /**
-   * Get rate limiter for configuration
-   */
   getRateLimiter(): RateLimiter {
     return this.rateLimiter;
   }
 
-  /**
-   * Get sampling manager for LLM provider registration
-   */
   getSamplingManager(): SamplingManager {
     return this.samplingManager;
   }
 
-  /**
-   * Register an LLM provider for sampling
-   */
   registerLLMProvider(provider: LLMProvider, isDefault: boolean = false): void {
     this.samplingManager.registerProvider(provider, isDefault);
   }
@@ -232,7 +221,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       } as any));
 
       for (const transport of transports) {
-        transport.onRequest(async (request) => await this.handleRequest(request));
+        transport.onRequest(async (request, context?: MCPRequestContext) => await this.handleRequest(request, context));
         transport.onNotification(async (notification) => {
           await this.handleNotification(notification);
         });
@@ -287,6 +276,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       this.sessionManager.clearAll();
       this.taskManager.destroy();
       this.resourceSubscriptions.clear();
+      this.authoritySessions.clear();
       this.rateLimiter.destroy();
 
       if (this.connectionPool) {
@@ -402,22 +392,37 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     if (this.currentSession?.id === sessionId) {
       this.currentSession = undefined;
     }
+    for (const [key, boundSessionId] of this.authoritySessions) {
+      if (boundSessionId === sessionId) this.authoritySessions.delete(key);
+    }
     return result;
   }
 
-  private async handleRequest(request: MCPRequest): Promise<MCPResponse> {
+  private async handleRequest(
+    request: MCPRequest,
+    context?: MCPRequestContext
+  ): Promise<MCPResponse> {
+    if (context) {
+      return await this.requestContext.run(context, async () => await this.handleRequestScoped(request));
+    }
+    return await this.handleRequestScoped(request);
+  }
+
+  private async handleRequestScoped(request: MCPRequest): Promise<MCPResponse> {
     const startTime = performance.now();
     this.requestStats.total++;
+    const context = this.requestContext.getStore();
 
     this.logger.debug('Handling request', {
       id: request.id,
       method: request.method,
+      requestContextId: context?.requestId,
+      principal: context?.principal.subject,
     });
 
-    // Rate limiting check (skip for initialize)
     if (request.method !== 'initialize') {
-      const sessionId = this.currentSession?.id;
-      const rateLimitResult = this.rateLimiter.check(sessionId);
+      const scopeId = this.resolveRequestScopeId();
+      const rateLimitResult = this.rateLimiter.check(scopeId);
       if (!rateLimitResult.allowed) {
         this.requestStats.failed++;
         return {
@@ -430,7 +435,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
           },
         };
       }
-      this.rateLimiter.consume(sessionId);
+      this.rateLimiter.consume(scopeId);
     }
 
     try {
@@ -438,17 +443,17 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         return await this.handleInitialize(request);
       }
 
-      const session = this.getOrCreateSession();
-
-      if (!session.isInitialized && request.method !== 'initialized') {
-        return this.createErrorResponse(
-          request.id,
-          ErrorCodes.SERVER_NOT_INITIALIZED,
-          'Server not initialized'
-        );
+      if (!isModernStatelessContext(context)) {
+        const session = this.resolveRequestSession();
+        if (!session?.isInitialized && request.method !== 'initialized') {
+          return this.createErrorResponse(
+            request.id,
+            ErrorCodes.SERVER_NOT_INITIALIZED,
+            'Server not initialized for this request authority context'
+          );
+        }
+        if (session) this.sessionManager.updateActivity(session.id);
       }
-
-      this.sessionManager.updateActivity(session.id);
 
       const response = await this.routeRequest(request);
 
@@ -460,6 +465,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         id: request.id,
         method: request.method,
         duration: `${duration.toFixed(2)}ms`,
+        requestContextId: context?.requestId,
       });
 
       return response;
@@ -473,6 +479,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         id: request.id,
         method: request.method,
         error,
+        requestContextId: context?.requestId,
       });
 
       return this.createErrorResponse(
@@ -513,7 +520,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
     const session = this.sessionManager.createSession(this.config.transport);
     this.sessionManager.initializeSession(session.id, params);
-    this.currentSession = session;
+    this.bindSessionToRequestAuthority(session);
 
     const result: MCPInitializeResult = {
       protocolVersion: this.protocolVersion,
@@ -525,24 +532,26 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     this.logger.info('Session initialized', {
       sessionId: session.id,
       clientInfo: params.clientInfo,
+      principal: this.requestContext.getStore()?.principal.subject,
     });
 
-    return {
+    const response: MCPResponse = {
       jsonrpc: '2.0',
       id: request.id,
       result,
     };
+
+    return attachResponseTransportMetadata(response, { legacySessionId: session.id });
   }
 
   private async routeRequest(request: MCPRequest): Promise<MCPResponse> {
     switch (request.method) {
-      // Tool methods
+      case 'server/discover':
+        return this.handleServerDiscover(request);
       case 'tools/list':
         return this.handleToolsList(request);
       case 'tools/call':
         return this.handleToolsCall(request);
-
-      // Resource methods (MCP 2025-11-25)
       case 'resources/list':
         return this.handleResourcesList(request);
       case 'resources/read':
@@ -551,41 +560,27 @@ export class MCPServer extends EventEmitter implements IMCPServer {
         return this.handleResourcesSubscribe(request);
       case 'resources/unsubscribe':
         return this.handleResourcesUnsubscribe(request);
-
-      // Prompt methods (MCP 2025-11-25)
       case 'prompts/list':
         return this.handlePromptsList(request);
       case 'prompts/get':
         return this.handlePromptsGet(request);
-
-      // Task methods (MCP 2025-11-25)
       case 'tasks/status':
         return this.handleTasksStatus(request);
       case 'tasks/cancel':
         return this.handleTasksCancel(request);
-
-      // Completion (MCP 2025-11-25)
       case 'completion/complete':
         return this.handleCompletion(request);
-
-      // Logging (MCP 2025-11-25)
       case 'logging/setLevel':
         return this.handleLoggingSetLevel(request);
-
-      // Sampling (MCP 2025-11-25)
       case 'sampling/createMessage':
         return this.handleSamplingCreateMessage(request);
-
-      // Utility
       case 'ping':
         return {
           jsonrpc: '2.0',
           id: request.id,
           result: { pong: true, timestamp: Date.now() },
         };
-
       default:
-        // Check if it's a direct tool call
         if (this.toolRegistry.hasTool(request.method)) {
           return this.handleToolExecution(request);
         }
@@ -596,6 +591,22 @@ export class MCPServer extends EventEmitter implements IMCPServer {
           `Method not found: ${request.method}`
         );
     }
+  }
+
+  private handleServerDiscover(request: MCPRequest): MCPResponse {
+    return {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        protocolVersion: MCP_2026_07_28,
+        serverInfo: this.serverInfo,
+        capabilities: this.capabilities,
+        transport: {
+          requestLocalAuthority: true,
+          sessionsRequired: false,
+        },
+      },
+    };
   }
 
   private handleToolsList(request: MCPRequest): MCPResponse {
@@ -623,12 +634,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       );
     }
 
-    const context: ToolContext = {
-      sessionId: this.currentSession?.id || 'unknown',
-      requestId: request.id,
-      orchestrator: this.orchestrator,
-      swarmCoordinator: this.swarmCoordinator,
-    };
+    const context: ToolContext = this.createToolContext(request);
 
     const result = await this.toolRegistry.execute(
       params.name,
@@ -644,12 +650,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
   }
 
   private async handleToolExecution(request: MCPRequest): Promise<MCPResponse> {
-    const context: ToolContext = {
-      sessionId: this.currentSession?.id || 'unknown',
-      requestId: request.id,
-      orchestrator: this.orchestrator,
-      swarmCoordinator: this.swarmCoordinator,
-    };
+    const context: ToolContext = this.createToolContext(request);
 
     const result = await this.toolRegistry.execute(
       request.method,
@@ -663,10 +664,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       result,
     };
   }
-
-  // ============================================================================
-  // Resource Handlers (MCP 2025-11-25)
-  // ============================================================================
 
   private handleResourcesList(request: MCPRequest): MCPResponse {
     const params = request.params as { cursor?: string } | undefined;
@@ -708,7 +705,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesSubscribe(request: MCPRequest): MCPResponse {
     const params = request.params as { uri: string } | undefined;
-    const sessionId = this.currentSession?.id;
+    const sessionId = this.resolveRequestScopeId();
 
     if (!params?.uri) {
       return this.createErrorResponse(
@@ -722,12 +719,11 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       return this.createErrorResponse(
         request.id,
         ErrorCodes.SERVER_NOT_INITIALIZED,
-        'No active session'
+        'No active request authority scope'
       );
     }
 
     try {
-      // Track subscription for this session
       let sessionSubs = this.resourceSubscriptions.get(sessionId);
       if (!sessionSubs) {
         sessionSubs = new Set();
@@ -735,7 +731,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       }
 
       const subscriptionId = this.resourceRegistry.subscribe(params.uri, (uri, content) => {
-        // Send notification when resource updates
         this.sendNotification('notifications/resources/updated', { uri });
       });
 
@@ -757,7 +752,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
 
   private handleResourcesUnsubscribe(request: MCPRequest): MCPResponse {
     const params = request.params as { uri: string } | undefined;
-    const sessionId = this.currentSession?.id;
+    const sessionId = this.resolveRequestScopeId();
 
     if (!params?.uri) {
       return this.createErrorResponse(
@@ -780,10 +775,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       result: { success: true },
     };
   }
-
-  // ============================================================================
-  // Prompt Handlers (MCP 2025-11-25)
-  // ============================================================================
 
   private handlePromptsList(request: MCPRequest): MCPResponse {
     const params = request.params as { cursor?: string } | undefined;
@@ -823,10 +814,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
   }
 
-  // ============================================================================
-  // Task Handlers (MCP 2025-11-25)
-  // ============================================================================
-
   private handleTasksStatus(request: MCPRequest): MCPResponse {
     const params = request.params as { taskId?: string } | undefined;
 
@@ -846,7 +833,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       };
     }
 
-    // Return all tasks
     return {
       jsonrpc: '2.0',
       id: request.id,
@@ -874,10 +860,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     };
   }
 
-  // ============================================================================
-  // Completion Handler (MCP 2025-11-25)
-  // ============================================================================
-
   private handleCompletion(request: MCPRequest): MCPResponse {
     const params = request.params as {
       ref: { type: string; name?: string; uri?: string };
@@ -892,21 +874,18 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       );
     }
 
-    // Basic completion implementation - can be extended
     const completions: string[] = [];
 
     if (params.ref.type === 'ref/prompt') {
-      // Get prompt argument completions
       const prompt = this.promptRegistry.getPrompt(params.ref.name || '');
       if (prompt?.arguments) {
         for (const arg of prompt.arguments) {
           if (arg.name === params.argument.name) {
-            // Could add domain-specific completions here
+            // Domain-specific completions can be added here.
           }
         }
       }
     } else if (params.ref.type === 'ref/resource') {
-      // Get resource URI completions
       const { resources } = this.resourceRegistry.list();
       for (const resource of resources) {
         if (resource.uri.startsWith(params.argument.value)) {
@@ -928,10 +907,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     };
   }
 
-  // ============================================================================
-  // Logging Handler (MCP 2025-11-25)
-  // ============================================================================
-
   private handleLoggingSetLevel(request: MCPRequest): MCPResponse {
     const params = request.params as { level: string } | undefined;
 
@@ -943,9 +918,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       );
     }
 
-    // Update capabilities
     this.capabilities.logging = { level: params.level as 'debug' | 'info' | 'warn' | 'error' };
-
     this.logger.info('Log level updated', { level: params.level });
 
     return {
@@ -954,10 +927,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       result: { success: true },
     };
   }
-
-  // ============================================================================
-  // Sampling Handler (MCP 2025-11-25)
-  // ============================================================================
 
   private async handleSamplingCreateMessage(request: MCPRequest): Promise<MCPResponse> {
     const params = request.params as {
@@ -979,7 +948,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
       );
     }
 
-    // Check if sampling is available
     const available = await this.samplingManager.isAvailable();
     if (!available) {
       return this.createErrorResponse(
@@ -1005,7 +973,7 @@ export class MCPServer extends EventEmitter implements IMCPServer {
           metadata: params.metadata,
         },
         {
-          sessionId: this.currentSession?.id || 'unknown',
+          sessionId: this.resolveRequestScopeId() || 'unknown',
           serverId: this.serverInfo.name,
         }
       );
@@ -1024,10 +992,6 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }
   }
 
-  // ============================================================================
-  // Notification Sender
-  // ============================================================================
-
   private async sendNotification(method: string, params?: Record<string, unknown>): Promise<void> {
     await Promise.all(this.transports.map(async (transport) => {
       if (transport.sendNotification) {
@@ -1036,14 +1000,52 @@ export class MCPServer extends EventEmitter implements IMCPServer {
     }));
   }
 
-  private getOrCreateSession(): MCPSession {
-    if (this.currentSession) {
-      return this.currentSession;
+  private bindSessionToRequestAuthority(session: MCPSession): void {
+    const context = this.requestContext.getStore();
+    if (!context) {
+      this.currentSession = session;
+      return;
     }
 
-    const session = this.sessionManager.createSession(this.config.transport);
-    this.currentSession = session;
-    return session;
+    const incomingKey = authorityKey(context);
+    if (incomingKey) this.authoritySessions.set(incomingKey, session.id);
+    this.authoritySessions.set(`${context.principal.subject}:${session.id}`, session.id);
+  }
+
+  private resolveRequestSession(): MCPSession | undefined {
+    const context = this.requestContext.getStore();
+    if (!context) return this.currentSession;
+    if (isModernStatelessContext(context)) return undefined;
+
+    const key = authorityKey(context);
+    if (!key) return undefined;
+    const sessionId = this.authoritySessions.get(key);
+    return sessionId ? this.sessionManager.getSession(sessionId) : undefined;
+  }
+
+  private resolveRequestScopeId(): string | undefined {
+    const context = this.requestContext.getStore();
+    if (context) {
+      if (isModernStatelessContext(context)) return `stateless:${context.principal.subject}`;
+      return this.resolveRequestSession()?.id ?? authorityKey(context);
+    }
+    return this.currentSession?.id;
+  }
+
+  private createToolContext(request: MCPRequest): ToolContext {
+    const requestContext = this.requestContext.getStore();
+    return {
+      sessionId: this.resolveRequestScopeId() || 'unknown',
+      requestId: request.id,
+      orchestrator: this.orchestrator,
+      swarmCoordinator: this.swarmCoordinator,
+      metadata: requestContext ? {
+        principal: requestContext.principal.subject,
+        protocolVersion: requestContext.protocolVersion,
+        requestContextId: requestContext.requestId,
+        traceparent: requestContext.traceparent,
+      } : undefined,
+    };
   }
 
   private createErrorResponse(

--- a/v3/@claude-flow/mcp/src/transport/http.ts
+++ b/v3/@claude-flow/mcp/src/transport/http.ts
@@ -11,7 +11,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import cors from 'cors';
 import helmet from 'helmet';
 import { rateLimit } from 'express-rate-limit';
-import { randomUUID } from 'crypto';
+import { randomUUID, timingSafeEqual } from 'crypto';
 import type {
   ITransport,
   TransportType,
@@ -26,6 +26,7 @@ import type {
 } from '../types.js';
 import type { AuthenticatedPrincipal, MCPRequestContext } from '../request-context.js';
 import {
+  MCP_2026_07_28,
   anonymousPrincipal,
   freezeRequestContext,
   getResponseTransportMetadata,
@@ -78,6 +79,8 @@ export class HttpTransport extends EventEmitter implements ITransport {
   private activeConnections = new Set<WebSocket>();
   private sseClients = new Map<string, Response>();
   private wsPrincipals = new WeakMap<WebSocket, AuthenticatedPrincipal>();
+  private wsSessions = new WeakMap<WebSocket, string>();
+  private wsProtocolVersions = new WeakMap<WebSocket, string>();
 
   private messagesReceived = 0;
   private messagesSent = 0;
@@ -106,18 +109,11 @@ export class HttpTransport extends EventEmitter implements ITransport {
     });
 
     this.server = createServer(this.app);
-
-    this.wss = new WebSocketServer({
-      server: this.server,
-      path: '/ws',
-    });
-
+    this.wss = new WebSocketServer({ server: this.server, path: '/ws' });
     this.setupWebSocketHandlers();
 
     await new Promise<void>((resolve, reject) => {
-      this.server!.listen(this.config.port, this.config.host, () => {
-        resolve();
-      });
+      this.server!.listen(this.config.port, this.config.host, () => resolve());
       this.server!.on('error', reject);
     });
 
@@ -128,9 +124,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
   }
 
   async stop(): Promise<void> {
-    if (!this.running) {
-      return;
-    }
+    if (!this.running) return;
 
     this.logger.info('Stopping HTTP transport');
     this.running = false;
@@ -139,14 +133,12 @@ export class HttpTransport extends EventEmitter implements ITransport {
       try {
         ws.close(1000, 'Server shutting down');
       } catch {
-        // Ignore errors
+        // Ignore close races.
       }
     }
     this.activeConnections.clear();
 
-    for (const response of this.sseClients.values()) {
-      response.end();
-    }
+    for (const response of this.sseClients.values()) response.end();
     this.sseClients.clear();
 
     if (this.wss) {
@@ -155,9 +147,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
     }
 
     if (this.server) {
-      await new Promise<void>((resolve) => {
-        this.server!.close(() => resolve());
-      });
+      await new Promise<void>((resolve) => this.server!.close(() => resolve()));
       this.server = undefined;
     }
 
@@ -208,24 +198,17 @@ export class HttpTransport extends EventEmitter implements ITransport {
   }
 
   private setupMiddleware(): void {
-    this.app.use(helmet({
-      contentSecurityPolicy: false,
-    }));
+    this.app.use(helmet({ contentSecurityPolicy: false }));
 
     if (this.config.corsEnabled !== false) {
       const allowedOrigins = this.config.corsOrigins;
-
       if (!allowedOrigins || allowedOrigins.length === 0) {
         this.logger.warn('CORS: No origins configured, restricting to same-origin only');
       }
 
       this.app.use(cors({
         origin: (origin, callback) => {
-          if (!origin) {
-            callback(null, true);
-            return;
-          }
-
+          if (!origin) return callback(null, true);
           if (allowedOrigins && allowedOrigins.length > 0) {
             if (allowedOrigins.includes(origin) || allowedOrigins.includes('*')) {
               callback(null, true);
@@ -240,23 +223,14 @@ export class HttpTransport extends EventEmitter implements ITransport {
         maxAge: 86400,
         methods: ['GET', 'POST', 'OPTIONS'],
         allowedHeaders: [
-          'Content-Type',
-          'Authorization',
-          'X-Request-ID',
-          'MCP-Protocol-Version',
-          'Mcp-Method',
-          'Mcp-Name',
-          'Mcp-Session-Id',
-          'traceparent',
-          'tracestate',
+          'Content-Type', 'Authorization', 'X-Request-ID', 'MCP-Protocol-Version',
+          'Mcp-Method', 'Mcp-Name', 'Mcp-Session-Id', 'traceparent', 'tracestate',
         ],
         exposedHeaders: ['Mcp-Session-Id'],
       }));
     }
 
-    this.app.use(express.json({
-      limit: this.config.maxRequestSize || '10mb',
-    }));
+    this.app.use(express.json({ limit: this.config.maxRequestSize || '10mb' }));
 
     this.app.use(['/rpc', '/mcp'], rateLimit({
       windowMs: this.config.rateLimit?.windowMs ?? 60_000,
@@ -264,8 +238,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
       standardHeaders: 'draft-7',
       legacyHeaders: false,
       message: {
-        jsonrpc: '2.0',
-        id: null,
+        jsonrpc: '2.0', id: null,
         error: { code: -32000, message: 'Rate limit exceeded' },
       },
     }));
@@ -274,8 +247,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
       this.app.use((req, res, next) => {
         res.setTimeout(this.config.requestTimeout!, () => {
           res.status(408).json({
-            jsonrpc: '2.0',
-            id: null,
+            jsonrpc: '2.0', id: null,
             error: { code: -32000, message: 'Request timeout' },
           });
         });
@@ -286,12 +258,11 @@ export class HttpTransport extends EventEmitter implements ITransport {
     this.app.use((req, res, next) => {
       const startTime = performance.now();
       res.on('finish', () => {
-        const duration = performance.now() - startTime;
         this.logger.debug('HTTP request', {
           method: req.method,
           path: req.path,
           status: res.statusCode,
-          duration: `${duration.toFixed(2)}ms`,
+          duration: `${(performance.now() - startTime).toFixed(2)}ms`,
         });
       });
       next();
@@ -299,17 +270,11 @@ export class HttpTransport extends EventEmitter implements ITransport {
   }
 
   private setupRoutes(): void {
-    this.app.get('/health', (req, res) => {
-      res.json({
-        status: 'ok',
-        timestamp: new Date().toISOString(),
-        connections: this.activeConnections.size,
-      });
+    this.app.get('/health', (_req, res) => {
+      res.json({ status: 'ok', timestamp: new Date().toISOString(), connections: this.activeConnections.size });
     });
 
-    this.app.post('/rpc', async (req, res) => {
-      await this.handleHttpRequest(req, res);
-    });
+    this.app.post('/rpc', async (req, res) => this.handleHttpRequest(req, res));
 
     this.app.get('/mcp', (req, res) => {
       if (this.config.auth?.enabled) {
@@ -328,44 +293,29 @@ export class HttpTransport extends EventEmitter implements ITransport {
       res.flushHeaders();
       this.sseClients.set(sessionId, res);
       res.write(`event: endpoint\ndata: /mcp?sessionId=${encodeURIComponent(sessionId)}\n\n`);
-
       res.on('close', () => {
-        if (this.sseClients.get(sessionId) === res) {
-          this.sseClients.delete(sessionId);
-        }
+        if (this.sseClients.get(sessionId) === res) this.sseClients.delete(sessionId);
       });
     });
 
-    this.app.post('/mcp', async (req, res) => {
-      await this.handleHttpRequest(req, res);
-    });
+    this.app.post('/mcp', async (req, res) => this.handleHttpRequest(req, res));
 
-    this.app.get('/info', (req, res) => {
+    this.app.get('/info', (_req, res) => {
       res.json({
         name: 'Claude-Flow MCP Server V3',
         version: '3.0.0',
         transport: 'http',
-        capabilities: {
-          jsonrpc: true,
-          websocket: true,
-          requestLocalAuthority: true,
-        },
+        capabilities: { jsonrpc: true, websocket: true, requestLocalAuthority: true },
       });
     });
 
-    this.app.use((req, res) => {
-      res.status(404).json({
-        error: 'Not found',
-        path: req.path,
-      });
-    });
+    this.app.use((req, res) => res.status(404).json({ error: 'Not found', path: req.path }));
 
-    this.app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    this.app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
       this.logger.error('Express error', { error: err });
       this.errors++;
       res.status(500).json({
-        jsonrpc: '2.0',
-        id: null,
+        jsonrpc: '2.0', id: null,
         error: { code: -32603, message: 'Internal error' },
       });
     });
@@ -376,29 +326,22 @@ export class HttpTransport extends EventEmitter implements ITransport {
 
     this.wss.on('connection', (ws, req) => {
       let principal = anonymousPrincipal();
+      const protocolVersionHeader = req.headers['mcp-protocol-version'];
+      if (typeof protocolVersionHeader === 'string') {
+        this.wsProtocolVersions.set(ws, protocolVersionHeader);
+      }
 
       if (this.config.auth?.enabled) {
         const url = new URL(req.url || '', `http://${req.headers.host}`);
         const token = url.searchParams.get('token') || req.headers['authorization']?.replace(/^Bearer\s+/i, '');
-
         if (!token) {
           this.logger.warn('WebSocket connection rejected: no authentication token');
           ws.close(4001, 'Authentication required');
           return;
         }
 
-        let valid = false;
-        if (this.config.auth.tokens?.length) {
-          for (const validToken of this.config.auth.tokens) {
-            if (this.timingSafeCompare(token, validToken)) {
-              valid = true;
-              break;
-            }
-          }
-        } else {
-          valid = true;
-        }
-
+        const valid = !this.config.auth.tokens?.length ||
+          this.config.auth.tokens.some((candidate) => this.timingSafeCompare(token, candidate));
         if (!valid) {
           this.logger.warn('WebSocket connection rejected: invalid token');
           ws.close(4003, 'Invalid token');
@@ -414,17 +357,11 @@ export class HttpTransport extends EventEmitter implements ITransport {
         authenticated: !!this.config.auth?.enabled,
       });
 
-      ws.on('message', async (data) => {
-        await this.handleWebSocketMessage(ws, data.toString());
-      });
-
+      ws.on('message', async (data) => this.handleWebSocketMessage(ws, data.toString()));
       ws.on('close', () => {
         this.activeConnections.delete(ws);
-        this.logger.info('WebSocket client disconnected', {
-          total: this.activeConnections.size,
-        });
+        this.logger.info('WebSocket client disconnected', { total: this.activeConnections.size });
       });
-
       ws.on('error', (error) => {
         this.logger.error('WebSocket error', { error });
         this.errors++;
@@ -443,16 +380,8 @@ export class HttpTransport extends EventEmitter implements ITransport {
     if (requiresAuth && this.config.auth) {
       const authResult = this.validateAuth(req);
       if (!authResult.valid || !authResult.principal) {
-        this.logger.warn('Authentication failed', {
-          ip: req.ip,
-          path: req.path,
-          error: authResult.error,
-        });
-        res.status(401).json({
-          jsonrpc: '2.0',
-          id: null,
-          error: { code: -32001, message: 'Unauthorized' },
-        });
+        this.logger.warn('Authentication failed', { ip: req.ip, path: req.path, error: authResult.error });
+        res.status(401).json({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Unauthorized' } });
         return;
       }
       principal = authResult.principal;
@@ -461,80 +390,69 @@ export class HttpTransport extends EventEmitter implements ITransport {
     }
 
     const message = req.body;
-
     if (message.jsonrpc !== '2.0') {
-      res.status(400).json({
-        jsonrpc: '2.0',
-        id: message.id || null,
-        error: { code: -32600, message: 'Invalid JSON-RPC version' },
-      });
+      res.status(400).json({ jsonrpc: '2.0', id: message.id || null, error: { code: -32600, message: 'Invalid JSON-RPC version' } });
       return;
     }
-
     if (!message.method) {
-      res.status(400).json({
-        jsonrpc: '2.0',
-        id: message.id || null,
-        error: { code: -32600, message: 'Missing method' },
-      });
+      res.status(400).json({ jsonrpc: '2.0', id: message.id || null, error: { code: -32600, message: 'Missing method' } });
       return;
     }
 
     const sseSessionId = typeof req.query.sessionId === 'string' ? req.query.sessionId : undefined;
     const sseResponse = sseSessionId ? this.sseClients.get(sseSessionId) : undefined;
     const context = this.createHttpContext(req, principal, sseSessionId);
-    const routing = validateRoutingHeaders(message as MCPRequest, context);
 
+    if (context.protocolVersion === MCP_2026_07_28 && context.legacySessionId) {
+      this.errors++;
+      res.status(400).json({
+        jsonrpc: '2.0', id: message.id ?? null,
+        error: { code: -32600, message: 'Mcp-Session-Id is invalid for MCP 2026-07-28 stateless requests' },
+      });
+      return;
+    }
+
+    const routing = validateRoutingHeaders(message as MCPRequest, context);
     if (!routing.valid) {
       this.errors++;
       res.status(400).json({
-        jsonrpc: '2.0',
-        id: message.id ?? null,
+        jsonrpc: '2.0', id: message.id ?? null,
         error: { code: -32600, message: routing.error || 'Routing header mismatch' },
       });
       return;
     }
 
     if (message.id === undefined) {
-      if (this.notificationHandler) {
-        await this.notificationHandler(message as MCPNotification, context);
-      }
+      if (this.notificationHandler) await this.notificationHandler(message as MCPNotification, context);
       res.status(sseResponse ? 202 : 204).end();
-    } else {
-      if (!this.requestHandler) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          id: message.id,
-          error: { code: -32603, message: 'No request handler' },
-        });
-        return;
+      return;
+    }
+
+    if (!this.requestHandler) {
+      res.status(500).json({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: 'No request handler' } });
+      return;
+    }
+
+    try {
+      const response = await this.requestHandler(message as MCPRequest, context);
+      const transportMetadata = getResponseTransportMetadata(response);
+      if (transportMetadata?.legacySessionId && context.protocolVersion !== MCP_2026_07_28) {
+        res.setHeader('Mcp-Session-Id', transportMetadata.legacySessionId);
       }
 
-      try {
-        const response = await this.requestHandler(message as MCPRequest, context);
-        const transportMetadata = getResponseTransportMetadata(response);
-        if (transportMetadata?.legacySessionId) {
-          res.setHeader('Mcp-Session-Id', transportMetadata.legacySessionId);
-        }
-
-        if (sseResponse) {
-          sseResponse.write(`event: message\ndata: ${JSON.stringify(response)}\n\n`);
-          res.status(202).end();
-        } else {
-          res.json(response);
-        }
-        this.messagesSent++;
-      } catch (error) {
-        this.errors++;
-        res.status(500).json({
-          jsonrpc: '2.0',
-          id: message.id,
-          error: {
-            code: -32603,
-            message: error instanceof Error ? error.message : 'Internal error',
-          },
-        });
+      if (sseResponse) {
+        sseResponse.write(`event: message\ndata: ${JSON.stringify(response)}\n\n`);
+        res.status(202).end();
+      } else {
+        res.json(response);
       }
+      this.messagesSent++;
+    } catch (error) {
+      this.errors++;
+      res.status(500).json({
+        jsonrpc: '2.0', id: message.id,
+        error: { code: -32603, message: error instanceof Error ? error.message : 'Internal error' },
+      });
     }
   }
 
@@ -544,66 +462,53 @@ export class HttpTransport extends EventEmitter implements ITransport {
 
     try {
       const message = JSON.parse(data);
-
       if (message.jsonrpc !== '2.0') {
-        ws.send(JSON.stringify({
-          jsonrpc: '2.0',
-          id: message.id || null,
-          error: { code: -32600, message: 'Invalid JSON-RPC version' },
-        }));
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id: message.id || null, error: { code: -32600, message: 'Invalid JSON-RPC version' } }));
         return;
       }
 
+      const protocolVersion = this.wsProtocolVersions.get(ws);
+      const legacySessionId = this.wsSessions.get(ws);
+      if (protocolVersion === MCP_2026_07_28 && legacySessionId) {
+        this.wsSessions.delete(ws);
+      }
       const context = freezeRequestContext({
         requestId: randomUUID(),
         transport: 'websocket',
         principal: this.wsPrincipals.get(ws) ?? anonymousPrincipal(),
+        protocolVersion,
+        legacySessionId: protocolVersion === MCP_2026_07_28 ? undefined : legacySessionId,
       });
 
       if (message.id === undefined) {
-        if (this.notificationHandler) {
-          await this.notificationHandler(message as MCPNotification, context);
-        }
-      } else {
-        if (!this.requestHandler) {
-          ws.send(JSON.stringify({
-            jsonrpc: '2.0',
-            id: message.id,
-            error: { code: -32603, message: 'No request handler' },
-          }));
-          return;
-        }
-
-        const response = await this.requestHandler(message as MCPRequest, context);
-        ws.send(JSON.stringify(response));
-        this.messagesSent++;
+        if (this.notificationHandler) await this.notificationHandler(message as MCPNotification, context);
+        return;
       }
+      if (!this.requestHandler) {
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: 'No request handler' } }));
+        return;
+      }
+
+      const response = await this.requestHandler(message as MCPRequest, context);
+      const metadata = getResponseTransportMetadata(response);
+      if (metadata?.legacySessionId && protocolVersion !== MCP_2026_07_28) {
+        this.wsSessions.set(ws, metadata.legacySessionId);
+      }
+      ws.send(JSON.stringify(response));
+      this.messagesSent++;
     } catch (error) {
       this.errors++;
       this.logger.error('WebSocket message error', { error });
-
       try {
         const parsed = JSON.parse(data);
-        ws.send(JSON.stringify({
-          jsonrpc: '2.0',
-          id: parsed.id || null,
-          error: { code: -32700, message: 'Parse error' },
-        }));
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id: parsed.id || null, error: { code: -32700, message: 'Parse error' } }));
       } catch {
-        ws.send(JSON.stringify({
-          jsonrpc: '2.0',
-          id: null,
-          error: { code: -32700, message: 'Parse error' },
-        }));
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }));
       }
     }
   }
 
-  private createHttpContext(
-    req: Request,
-    principal: AuthenticatedPrincipal,
-    sseSessionId?: string
-  ): MCPRequestContext {
+  private createHttpContext(req: Request, principal: AuthenticatedPrincipal, sseSessionId?: string): MCPRequestContext {
     return freezeRequestContext({
       requestId: this.singleHeader(req, 'x-request-id') ?? randomUUID(),
       transport: 'http',
@@ -624,52 +529,32 @@ export class HttpTransport extends EventEmitter implements ITransport {
   }
 
   private timingSafeCompare(a: string, b: string): boolean {
-    const crypto = require('crypto');
     const bufA = Buffer.from(a, 'utf-8');
     const bufB = Buffer.from(b, 'utf-8');
-
     if (bufA.length !== bufB.length) {
-      crypto.timingSafeEqual(bufA, bufA);
+      timingSafeEqual(bufA, bufA);
       return false;
     }
-
-    return crypto.timingSafeEqual(bufA, bufB);
+    return timingSafeEqual(bufA, bufB);
   }
 
   private validateAuth(req: Request): AuthValidationResult {
     const auth = req.headers.authorization;
-
-    if (!auth) {
-      return { valid: false, error: 'Authorization header required' };
-    }
+    if (!auth) return { valid: false, error: 'Authorization header required' };
 
     const tokenMatch = auth.match(/^Bearer\s+(.+)$/i);
-    if (!tokenMatch) {
-      return { valid: false, error: 'Invalid authorization format' };
-    }
-
+    if (!tokenMatch) return { valid: false, error: 'Invalid authorization format' };
     const token = tokenMatch[1];
 
-    if (this.config.auth?.tokens?.length) {
-      let valid = false;
-      for (const validToken of this.config.auth.tokens) {
-        if (this.timingSafeCompare(token, validToken)) {
-          valid = true;
-          break;
-        }
-      }
-      if (!valid) {
-        return { valid: false, error: 'Invalid token' };
-      }
+    if (this.config.auth?.tokens?.length &&
+        !this.config.auth.tokens.some((candidate) => this.timingSafeCompare(token, candidate))) {
+      return { valid: false, error: 'Invalid token' };
     }
 
     return { valid: true, principal: principalFromSecret(token, 'token') };
   }
 }
 
-export function createHttpTransport(
-  logger: ILogger,
-  config: HttpTransportConfig
-): HttpTransport {
+export function createHttpTransport(logger: ILogger, config: HttpTransportConfig): HttpTransport {
   return new HttpTransport(logger, config);
 }

--- a/v3/@claude-flow/mcp/src/transport/http.ts
+++ b/v3/@claude-flow/mcp/src/transport/http.ts
@@ -1,7 +1,7 @@
 /**
  * @claude-flow/mcp - HTTP Transport
  *
- * HTTP/REST transport with WebSocket support
+ * HTTP/REST transport with legacy SSE/WebSocket compatibility.
  */
 
 import { EventEmitter } from 'events';
@@ -27,10 +27,14 @@ import type {
 import type { AuthenticatedPrincipal, MCPRequestContext } from '../request-context.js';
 import {
   MCP_2026_07_28,
+  MCP_HEADER_MISMATCH,
+  MCP_UNSUPPORTED_PROTOCOL_VERSION,
   anonymousPrincipal,
+  bodyProtocolVersion,
   freezeRequestContext,
   getResponseTransportMetadata,
   principalFromSecret,
+  validateModernEnvelope,
   validateRoutingHeaders,
 } from '../request-context.js';
 
@@ -80,7 +84,6 @@ export class HttpTransport extends EventEmitter implements ITransport {
   private sseClients = new Map<string, Response>();
   private wsPrincipals = new WeakMap<WebSocket, AuthenticatedPrincipal>();
   private wsSessions = new WeakMap<WebSocket, string>();
-  private wsProtocolVersions = new WeakMap<WebSocket, string>();
 
   private messagesReceived = 0;
   private messagesSent = 0;
@@ -99,9 +102,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
   }
 
   async start(): Promise<void> {
-    if (this.running) {
-      throw new Error('HTTP transport already running');
-    }
+    if (this.running) throw new Error('HTTP transport already running');
 
     this.logger.info('Starting HTTP transport', {
       host: this.config.host,
@@ -223,8 +224,15 @@ export class HttpTransport extends EventEmitter implements ITransport {
         maxAge: 86400,
         methods: ['GET', 'POST', 'OPTIONS'],
         allowedHeaders: [
-          'Content-Type', 'Authorization', 'X-Request-ID', 'MCP-Protocol-Version',
-          'Mcp-Method', 'Mcp-Name', 'Mcp-Session-Id', 'traceparent', 'tracestate',
+          'Content-Type',
+          'Authorization',
+          'X-Request-ID',
+          'MCP-Protocol-Version',
+          'Mcp-Method',
+          'Mcp-Name',
+          'Mcp-Session-Id',
+          'traceparent',
+          'tracestate',
         ],
         exposedHeaders: ['Mcp-Session-Id'],
       }));
@@ -238,7 +246,8 @@ export class HttpTransport extends EventEmitter implements ITransport {
       standardHeaders: 'draft-7',
       legacyHeaders: false,
       message: {
-        jsonrpc: '2.0', id: null,
+        jsonrpc: '2.0',
+        id: null,
         error: { code: -32000, message: 'Rate limit exceeded' },
       },
     }));
@@ -247,7 +256,8 @@ export class HttpTransport extends EventEmitter implements ITransport {
       this.app.use((req, res, next) => {
         res.setTimeout(this.config.requestTimeout!, () => {
           res.status(408).json({
-            jsonrpc: '2.0', id: null,
+            jsonrpc: '2.0',
+            id: null,
             error: { code: -32000, message: 'Request timeout' },
           });
         });
@@ -256,13 +266,13 @@ export class HttpTransport extends EventEmitter implements ITransport {
     }
 
     this.app.use((req, res, next) => {
-      const startTime = performance.now();
+      const started = performance.now();
       res.on('finish', () => {
         this.logger.debug('HTTP request', {
           method: req.method,
           path: req.path,
           status: res.statusCode,
-          duration: `${(performance.now() - startTime).toFixed(2)}ms`,
+          duration: `${(performance.now() - started).toFixed(2)}ms`,
         });
       });
       next();
@@ -271,12 +281,28 @@ export class HttpTransport extends EventEmitter implements ITransport {
 
   private setupRoutes(): void {
     this.app.get('/health', (_req, res) => {
-      res.json({ status: 'ok', timestamp: new Date().toISOString(), connections: this.activeConnections.size });
+      res.json({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+        connections: this.activeConnections.size,
+      });
     });
 
     this.app.post('/rpc', async (req, res) => this.handleHttpRequest(req, res));
 
     this.app.get('/mcp', (req, res) => {
+      if (this.singleHeader(req, 'mcp-protocol-version') === MCP_2026_07_28) {
+        res.status(405).json({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32600,
+            message: 'MCP 2026-07-28 uses stateless HTTP POST; legacy SSE GET is not available',
+          },
+        });
+        return;
+      }
+
       if (this.config.auth?.enabled) {
         const authResult = this.validateAuth(req);
         if (!authResult.valid) {
@@ -305,17 +331,24 @@ export class HttpTransport extends EventEmitter implements ITransport {
         name: 'Claude-Flow MCP Server V3',
         version: '3.0.0',
         transport: 'http',
-        capabilities: { jsonrpc: true, websocket: true, requestLocalAuthority: true },
+        capabilities: {
+          jsonrpc: true,
+          websocket: true,
+          requestLocalAuthority: true,
+        },
       });
     });
 
-    this.app.use((req, res) => res.status(404).json({ error: 'Not found', path: req.path }));
+    this.app.use((req, res) => {
+      res.status(404).json({ error: 'Not found', path: req.path });
+    });
 
     this.app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
       this.logger.error('Express error', { error: err });
       this.errors++;
       res.status(500).json({
-        jsonrpc: '2.0', id: null,
+        jsonrpc: '2.0',
+        id: null,
         error: { code: -32603, message: 'Internal error' },
       });
     });
@@ -325,15 +358,16 @@ export class HttpTransport extends EventEmitter implements ITransport {
     if (!this.wss) return;
 
     this.wss.on('connection', (ws, req) => {
-      let principal = anonymousPrincipal();
-      const protocolVersionHeader = req.headers['mcp-protocol-version'];
-      if (typeof protocolVersionHeader === 'string') {
-        this.wsProtocolVersions.set(ws, protocolVersionHeader);
+      if (req.headers['mcp-protocol-version'] === MCP_2026_07_28) {
+        ws.close(4002, 'MCP 2026-07-28 requires stateless HTTP POST');
+        return;
       }
 
+      let principal = anonymousPrincipal();
       if (this.config.auth?.enabled) {
         const url = new URL(req.url || '', `http://${req.headers.host}`);
-        const token = url.searchParams.get('token') || req.headers['authorization']?.replace(/^Bearer\s+/i, '');
+        const token = url.searchParams.get('token') ||
+          req.headers['authorization']?.replace(/^Bearer\s+/i, '');
         if (!token) {
           this.logger.warn('WebSocket connection rejected: no authentication token');
           ws.close(4001, 'Authentication required');
@@ -360,7 +394,9 @@ export class HttpTransport extends EventEmitter implements ITransport {
       ws.on('message', async (data) => this.handleWebSocketMessage(ws, data.toString()));
       ws.on('close', () => {
         this.activeConnections.delete(ws);
-        this.logger.info('WebSocket client disconnected', { total: this.activeConnections.size });
+        this.logger.info('WebSocket client disconnected', {
+          total: this.activeConnections.size,
+        });
       });
       ws.on('error', (error) => {
         this.logger.error('WebSocket error', { error });
@@ -380,8 +416,16 @@ export class HttpTransport extends EventEmitter implements ITransport {
     if (requiresAuth && this.config.auth) {
       const authResult = this.validateAuth(req);
       if (!authResult.valid || !authResult.principal) {
-        this.logger.warn('Authentication failed', { ip: req.ip, path: req.path, error: authResult.error });
-        res.status(401).json({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Unauthorized' } });
+        this.logger.warn('Authentication failed', {
+          ip: req.ip,
+          path: req.path,
+          error: authResult.error,
+        });
+        res.status(401).json({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32001, message: 'Unauthorized' },
+        });
         return;
       }
       principal = authResult.principal;
@@ -389,69 +433,141 @@ export class HttpTransport extends EventEmitter implements ITransport {
       this.logger.warn('No authentication configured - running in development mode');
     }
 
-    const message = req.body;
+    const message = req.body as MCPRequest;
     if (message.jsonrpc !== '2.0') {
-      res.status(400).json({ jsonrpc: '2.0', id: message.id || null, error: { code: -32600, message: 'Invalid JSON-RPC version' } });
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: { code: -32600, message: 'Invalid JSON-RPC version' },
+      });
       return;
     }
     if (!message.method) {
-      res.status(400).json({ jsonrpc: '2.0', id: message.id || null, error: { code: -32600, message: 'Missing method' } });
-      return;
-    }
-
-    const sseSessionId = typeof req.query.sessionId === 'string' ? req.query.sessionId : undefined;
-    const sseResponse = sseSessionId ? this.sseClients.get(sseSessionId) : undefined;
-    const context = this.createHttpContext(req, principal, sseSessionId);
-
-    if (context.protocolVersion === MCP_2026_07_28 && context.legacySessionId) {
-      this.errors++;
       res.status(400).json({
-        jsonrpc: '2.0', id: message.id ?? null,
-        error: { code: -32600, message: 'Mcp-Session-Id is invalid for MCP 2026-07-28 stateless requests' },
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: { code: -32600, message: 'Missing method' },
       });
       return;
     }
 
-    const routing = validateRoutingHeaders(message as MCPRequest, context);
+    const headerVersion = this.singleHeader(req, 'mcp-protocol-version');
+    const bodyVersion = bodyProtocolVersion(message);
+    const modernRequested = headerVersion === MCP_2026_07_28 || bodyVersion === MCP_2026_07_28;
+
+    if (modernRequested) {
+      const envelope = validateModernEnvelope(message, headerVersion);
+      if (!envelope.valid) {
+        this.errors++;
+        res.status(400).json({
+          jsonrpc: '2.0',
+          id: message.id ?? null,
+          error: {
+            code: envelope.code ?? MCP_HEADER_MISMATCH,
+            message: envelope.error || 'Invalid MCP 2026-07-28 envelope',
+            ...(envelope.code === MCP_UNSUPPORTED_PROTOCOL_VERSION
+              ? { data: { supportedVersions: [MCP_2026_07_28] } }
+              : {}),
+          },
+        });
+        return;
+      }
+    } else if (
+      (headerVersion && headerVersion !== '2025-11-25') ||
+      (bodyVersion && bodyVersion !== MCP_2026_07_28)
+    ) {
+      this.errors++;
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: {
+          code: MCP_UNSUPPORTED_PROTOCOL_VERSION,
+          message: `Unsupported MCP protocol version: ${headerVersion ?? bodyVersion}`,
+          data: { supportedVersions: ['2025-11-25', MCP_2026_07_28] },
+        },
+      });
+      return;
+    }
+
+    const sseSessionId = typeof req.query.sessionId === 'string'
+      ? req.query.sessionId
+      : undefined;
+    const sseResponse = sseSessionId ? this.sseClients.get(sseSessionId) : undefined;
+    const context = this.createHttpContext(req, principal, sseSessionId);
+
+    if (modernRequested && context.legacySessionId) {
+      this.errors++;
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: {
+          code: MCP_HEADER_MISMATCH,
+          message: 'Mcp-Session-Id is invalid for MCP 2026-07-28 stateless requests',
+        },
+      });
+      return;
+    }
+
+    const routing = validateRoutingHeaders(message, context, modernRequested);
     if (!routing.valid) {
       this.errors++;
       res.status(400).json({
-        jsonrpc: '2.0', id: message.id ?? null,
-        error: { code: -32600, message: routing.error || 'Routing header mismatch' },
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: {
+          code: routing.code ?? MCP_HEADER_MISMATCH,
+          message: routing.error || 'Routing header mismatch',
+        },
       });
       return;
     }
 
     if (message.id === undefined) {
-      if (this.notificationHandler) await this.notificationHandler(message as MCPNotification, context);
+      if (this.notificationHandler) {
+        await this.notificationHandler(message as MCPNotification, context);
+      }
       res.status(sseResponse ? 202 : 204).end();
       return;
     }
 
     if (!this.requestHandler) {
-      res.status(500).json({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: 'No request handler' } });
+      res.status(500).json({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32603, message: 'No request handler' },
+      });
       return;
     }
 
     try {
-      const response = await this.requestHandler(message as MCPRequest, context);
+      const response = await this.requestHandler(message, context);
       const transportMetadata = getResponseTransportMetadata(response);
-      if (transportMetadata?.legacySessionId && context.protocolVersion !== MCP_2026_07_28) {
+      if (transportMetadata?.legacySessionId && !modernRequested) {
         res.setHeader('Mcp-Session-Id', transportMetadata.legacySessionId);
       }
 
-      if (sseResponse) {
+      if (sseResponse && !modernRequested) {
         sseResponse.write(`event: message\ndata: ${JSON.stringify(response)}\n\n`);
         res.status(202).end();
       } else {
-        res.json(response);
+        const status = response.error?.code === -32601
+          ? 404
+          : response.error?.code === MCP_HEADER_MISMATCH ||
+              response.error?.code === MCP_UNSUPPORTED_PROTOCOL_VERSION
+            ? 400
+            : 200;
+        res.status(status).json(response);
       }
       this.messagesSent++;
     } catch (error) {
       this.errors++;
       res.status(500).json({
-        jsonrpc: '2.0', id: message.id,
-        error: { code: -32603, message: error instanceof Error ? error.message : 'Internal error' },
+        jsonrpc: '2.0',
+        id: message.id,
+        error: {
+          code: -32603,
+          message: error instanceof Error ? error.message : 'Internal error',
+        },
       });
     }
   }
@@ -463,37 +579,39 @@ export class HttpTransport extends EventEmitter implements ITransport {
     try {
       const message = JSON.parse(data);
       if (message.jsonrpc !== '2.0') {
-        ws.send(JSON.stringify({ jsonrpc: '2.0', id: message.id || null, error: { code: -32600, message: 'Invalid JSON-RPC version' } }));
+        ws.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id ?? null,
+          error: { code: -32600, message: 'Invalid JSON-RPC version' },
+        }));
         return;
       }
 
-      const protocolVersion = this.wsProtocolVersions.get(ws);
-      const legacySessionId = this.wsSessions.get(ws);
-      if (protocolVersion === MCP_2026_07_28 && legacySessionId) {
-        this.wsSessions.delete(ws);
-      }
       const context = freezeRequestContext({
         requestId: randomUUID(),
         transport: 'websocket',
         principal: this.wsPrincipals.get(ws) ?? anonymousPrincipal(),
-        protocolVersion,
-        legacySessionId: protocolVersion === MCP_2026_07_28 ? undefined : legacySessionId,
+        legacySessionId: this.wsSessions.get(ws),
       });
 
       if (message.id === undefined) {
-        if (this.notificationHandler) await this.notificationHandler(message as MCPNotification, context);
+        if (this.notificationHandler) {
+          await this.notificationHandler(message as MCPNotification, context);
+        }
         return;
       }
       if (!this.requestHandler) {
-        ws.send(JSON.stringify({ jsonrpc: '2.0', id: message.id, error: { code: -32603, message: 'No request handler' } }));
+        ws.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32603, message: 'No request handler' },
+        }));
         return;
       }
 
       const response = await this.requestHandler(message as MCPRequest, context);
       const metadata = getResponseTransportMetadata(response);
-      if (metadata?.legacySessionId && protocolVersion !== MCP_2026_07_28) {
-        this.wsSessions.set(ws, metadata.legacySessionId);
-      }
+      if (metadata?.legacySessionId) this.wsSessions.set(ws, metadata.legacySessionId);
       ws.send(JSON.stringify(response));
       this.messagesSent++;
     } catch (error) {
@@ -501,14 +619,26 @@ export class HttpTransport extends EventEmitter implements ITransport {
       this.logger.error('WebSocket message error', { error });
       try {
         const parsed = JSON.parse(data);
-        ws.send(JSON.stringify({ jsonrpc: '2.0', id: parsed.id || null, error: { code: -32700, message: 'Parse error' } }));
+        ws.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: parsed.id ?? null,
+          error: { code: -32700, message: 'Parse error' },
+        }));
       } catch {
-        ws.send(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }));
+        ws.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32700, message: 'Parse error' },
+        }));
       }
     }
   }
 
-  private createHttpContext(req: Request, principal: AuthenticatedPrincipal, sseSessionId?: string): MCPRequestContext {
+  private createHttpContext(
+    req: Request,
+    principal: AuthenticatedPrincipal,
+    sseSessionId?: string
+  ): MCPRequestContext {
     return freezeRequestContext({
       requestId: this.singleHeader(req, 'x-request-id') ?? randomUUID(),
       transport: 'http',
@@ -517,10 +647,20 @@ export class HttpTransport extends EventEmitter implements ITransport {
       legacySessionId: this.singleHeader(req, 'mcp-session-id') ?? sseSessionId,
       routingMethod: this.singleHeader(req, 'mcp-method'),
       routingName: this.singleHeader(req, 'mcp-name'),
+      paramHeaders: this.mcpParamHeaders(req),
       traceparent: this.singleHeader(req, 'traceparent'),
       tracestate: this.singleHeader(req, 'tracestate'),
       remoteAddress: req.ip,
     });
+  }
+
+  private mcpParamHeaders(req: Request): Record<string, string> {
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!key.startsWith('mcp-param-') || typeof value !== 'string') continue;
+      headers[key.slice('mcp-param-'.length).toLowerCase()] = value;
+    }
+    return headers;
   }
 
   private singleHeader(req: Request, name: string): string | undefined {
@@ -546,15 +686,23 @@ export class HttpTransport extends EventEmitter implements ITransport {
     if (!tokenMatch) return { valid: false, error: 'Invalid authorization format' };
     const token = tokenMatch[1];
 
-    if (this.config.auth?.tokens?.length &&
-        !this.config.auth.tokens.some((candidate) => this.timingSafeCompare(token, candidate))) {
+    if (
+      this.config.auth?.tokens?.length &&
+      !this.config.auth.tokens.some((candidate) => this.timingSafeCompare(token, candidate))
+    ) {
       return { valid: false, error: 'Invalid token' };
     }
 
-    return { valid: true, principal: principalFromSecret(token, 'token') };
+    return {
+      valid: true,
+      principal: principalFromSecret(token, 'token'),
+    };
   }
 }
 
-export function createHttpTransport(logger: ILogger, config: HttpTransportConfig): HttpTransport {
+export function createHttpTransport(
+  logger: ILogger,
+  config: HttpTransportConfig
+): HttpTransport {
   return new HttpTransport(logger, config);
 }

--- a/v3/@claude-flow/mcp/src/transport/http.ts
+++ b/v3/@claude-flow/mcp/src/transport/http.ts
@@ -24,6 +24,14 @@ import type {
   ILogger,
   AuthConfig,
 } from '../types.js';
+import type { AuthenticatedPrincipal, MCPRequestContext } from '../request-context.js';
+import {
+  anonymousPrincipal,
+  freezeRequestContext,
+  getResponseTransportMetadata,
+  principalFromSecret,
+  validateRoutingHeaders,
+} from '../request-context.js';
 
 export interface HttpTransportConfig {
   host: string;
@@ -42,17 +50,34 @@ export interface HttpTransportConfig {
   };
 }
 
+type ContextualRequestHandler = (
+  request: MCPRequest,
+  context?: MCPRequestContext
+) => Promise<MCPResponse>;
+
+type ContextualNotificationHandler = (
+  notification: MCPNotification,
+  context?: MCPRequestContext
+) => Promise<void>;
+
+interface AuthValidationResult {
+  valid: boolean;
+  principal?: AuthenticatedPrincipal;
+  error?: string;
+}
+
 export class HttpTransport extends EventEmitter implements ITransport {
   public readonly type: TransportType = 'http';
 
-  private requestHandler?: RequestHandler;
-  private notificationHandler?: NotificationHandler;
+  private requestHandler?: ContextualRequestHandler;
+  private notificationHandler?: ContextualNotificationHandler;
   private app: Express;
   private server?: Server;
   private wss?: WebSocketServer;
   private running = false;
   private activeConnections = new Set<WebSocket>();
   private sseClients = new Map<string, Response>();
+  private wsPrincipals = new WeakMap<WebSocket, AuthenticatedPrincipal>();
 
   private messagesReceived = 0;
   private messagesSent = 0;
@@ -140,11 +165,11 @@ export class HttpTransport extends EventEmitter implements ITransport {
   }
 
   onRequest(handler: RequestHandler): void {
-    this.requestHandler = handler;
+    this.requestHandler = handler as ContextualRequestHandler;
   }
 
   onNotification(handler: NotificationHandler): void {
-    this.notificationHandler = handler;
+    this.notificationHandler = handler as ContextualNotificationHandler;
   }
 
   async getHealthStatus(): Promise<TransportHealthStatus> {
@@ -214,7 +239,18 @@ export class HttpTransport extends EventEmitter implements ITransport {
         credentials: true,
         maxAge: 86400,
         methods: ['GET', 'POST', 'OPTIONS'],
-        allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+        allowedHeaders: [
+          'Content-Type',
+          'Authorization',
+          'X-Request-ID',
+          'MCP-Protocol-Version',
+          'Mcp-Method',
+          'Mcp-Name',
+          'Mcp-Session-Id',
+          'traceparent',
+          'tracestate',
+        ],
+        exposedHeaders: ['Mcp-Session-Id'],
       }));
     }
 
@@ -222,8 +258,6 @@ export class HttpTransport extends EventEmitter implements ITransport {
       limit: this.config.maxRequestSize || '10mb',
     }));
 
-    // Bound authenticated and unauthenticated RPC traffic before route-level
-    // authorization or request dispatch can consume significant resources.
     this.app.use(['/rpc', '/mcp'], rateLimit({
       windowMs: this.config.rateLimit?.windowMs ?? 60_000,
       limit: this.config.rateLimit?.limit ?? 120,
@@ -277,9 +311,6 @@ export class HttpTransport extends EventEmitter implements ITransport {
       await this.handleHttpRequest(req, res);
     });
 
-    // Legacy MCP clients fall back to the HTTP+SSE transport when
-    // Streamable HTTP negotiation fails. Advertise this same POST endpoint
-    // and route its responses back over the established event stream.
     this.app.get('/mcp', (req, res) => {
       if (this.config.auth?.enabled) {
         const authResult = this.validateAuth(req);
@@ -317,6 +348,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
         capabilities: {
           jsonrpc: true,
           websocket: true,
+          requestLocalAuthority: true,
         },
       });
     });
@@ -342,9 +374,9 @@ export class HttpTransport extends EventEmitter implements ITransport {
   private setupWebSocketHandlers(): void {
     if (!this.wss) return;
 
-    // SECURITY: Handle WebSocket authentication via upgrade request
     this.wss.on('connection', (ws, req) => {
-      // Validate authentication if enabled
+      let principal = anonymousPrincipal();
+
       if (this.config.auth?.enabled) {
         const url = new URL(req.url || '', `http://${req.headers.host}`);
         const token = url.searchParams.get('token') || req.headers['authorization']?.replace(/^Bearer\s+/i, '');
@@ -355,7 +387,6 @@ export class HttpTransport extends EventEmitter implements ITransport {
           return;
         }
 
-        // SECURITY: Timing-safe token validation
         let valid = false;
         if (this.config.auth.tokens?.length) {
           for (const validToken of this.config.auth.tokens) {
@@ -364,6 +395,8 @@ export class HttpTransport extends EventEmitter implements ITransport {
               break;
             }
           }
+        } else {
+          valid = true;
         }
 
         if (!valid) {
@@ -371,8 +404,10 @@ export class HttpTransport extends EventEmitter implements ITransport {
           ws.close(4003, 'Invalid token');
           return;
         }
+        principal = principalFromSecret(token, 'token');
       }
 
+      this.wsPrincipals.set(ws, principal);
       this.activeConnections.add(ws);
       this.logger.info('WebSocket client connected', {
         total: this.activeConnections.size,
@@ -403,10 +438,11 @@ export class HttpTransport extends EventEmitter implements ITransport {
     this.messagesReceived++;
 
     const requiresAuth = this.config.auth?.enabled !== false;
+    let principal = anonymousPrincipal();
 
     if (requiresAuth && this.config.auth) {
       const authResult = this.validateAuth(req);
-      if (!authResult.valid) {
+      if (!authResult.valid || !authResult.principal) {
         this.logger.warn('Authentication failed', {
           ip: req.ip,
           path: req.path,
@@ -419,6 +455,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
         });
         return;
       }
+      principal = authResult.principal;
     } else if (requiresAuth && !this.config.auth) {
       this.logger.warn('No authentication configured - running in development mode');
     }
@@ -445,10 +482,22 @@ export class HttpTransport extends EventEmitter implements ITransport {
 
     const sseSessionId = typeof req.query.sessionId === 'string' ? req.query.sessionId : undefined;
     const sseResponse = sseSessionId ? this.sseClients.get(sseSessionId) : undefined;
+    const context = this.createHttpContext(req, principal, sseSessionId);
+    const routing = validateRoutingHeaders(message as MCPRequest, context);
+
+    if (!routing.valid) {
+      this.errors++;
+      res.status(400).json({
+        jsonrpc: '2.0',
+        id: message.id ?? null,
+        error: { code: -32600, message: routing.error || 'Routing header mismatch' },
+      });
+      return;
+    }
 
     if (message.id === undefined) {
       if (this.notificationHandler) {
-        await this.notificationHandler(message as MCPNotification);
+        await this.notificationHandler(message as MCPNotification, context);
       }
       res.status(sseResponse ? 202 : 204).end();
     } else {
@@ -462,7 +511,12 @@ export class HttpTransport extends EventEmitter implements ITransport {
       }
 
       try {
-        const response = await this.requestHandler(message as MCPRequest);
+        const response = await this.requestHandler(message as MCPRequest, context);
+        const transportMetadata = getResponseTransportMetadata(response);
+        if (transportMetadata?.legacySessionId) {
+          res.setHeader('Mcp-Session-Id', transportMetadata.legacySessionId);
+        }
+
         if (sseResponse) {
           sseResponse.write(`event: message\ndata: ${JSON.stringify(response)}\n\n`);
           res.status(202).end();
@@ -500,9 +554,15 @@ export class HttpTransport extends EventEmitter implements ITransport {
         return;
       }
 
+      const context = freezeRequestContext({
+        requestId: randomUUID(),
+        transport: 'websocket',
+        principal: this.wsPrincipals.get(ws) ?? anonymousPrincipal(),
+      });
+
       if (message.id === undefined) {
         if (this.notificationHandler) {
-          await this.notificationHandler(message as MCPNotification);
+          await this.notificationHandler(message as MCPNotification, context);
         }
       } else {
         if (!this.requestHandler) {
@@ -514,7 +574,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
           return;
         }
 
-        const response = await this.requestHandler(message as MCPRequest);
+        const response = await this.requestHandler(message as MCPRequest, context);
         ws.send(JSON.stringify(response));
         this.messagesSent++;
       }
@@ -539,19 +599,36 @@ export class HttpTransport extends EventEmitter implements ITransport {
     }
   }
 
-  /**
-   * SECURITY: Timing-safe token comparison to prevent timing attacks
-   */
+  private createHttpContext(
+    req: Request,
+    principal: AuthenticatedPrincipal,
+    sseSessionId?: string
+  ): MCPRequestContext {
+    return freezeRequestContext({
+      requestId: this.singleHeader(req, 'x-request-id') ?? randomUUID(),
+      transport: 'http',
+      principal,
+      protocolVersion: this.singleHeader(req, 'mcp-protocol-version'),
+      legacySessionId: this.singleHeader(req, 'mcp-session-id') ?? sseSessionId,
+      routingMethod: this.singleHeader(req, 'mcp-method'),
+      routingName: this.singleHeader(req, 'mcp-name'),
+      traceparent: this.singleHeader(req, 'traceparent'),
+      tracestate: this.singleHeader(req, 'tracestate'),
+      remoteAddress: req.ip,
+    });
+  }
+
+  private singleHeader(req: Request, name: string): string | undefined {
+    const value = req.headers[name.toLowerCase()];
+    return typeof value === 'string' ? value : undefined;
+  }
+
   private timingSafeCompare(a: string, b: string): boolean {
     const crypto = require('crypto');
-
-    // Ensure both strings are the same length for timing-safe comparison
     const bufA = Buffer.from(a, 'utf-8');
     const bufB = Buffer.from(b, 'utf-8');
 
-    // If lengths differ, still do a comparison to prevent length-based timing
     if (bufA.length !== bufB.length) {
-      // Compare against itself to maintain constant time
       crypto.timingSafeEqual(bufA, bufA);
       return false;
     }
@@ -559,7 +636,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
     return crypto.timingSafeEqual(bufA, bufB);
   }
 
-  private validateAuth(req: Request): { valid: boolean; error?: string } {
+  private validateAuth(req: Request): AuthValidationResult {
     const auth = req.headers.authorization;
 
     if (!auth) {
@@ -574,7 +651,6 @@ export class HttpTransport extends EventEmitter implements ITransport {
     const token = tokenMatch[1];
 
     if (this.config.auth?.tokens?.length) {
-      // SECURITY: Use timing-safe comparison to prevent timing attacks
       let valid = false;
       for (const validToken of this.config.auth.tokens) {
         if (this.timingSafeCompare(token, validToken)) {
@@ -587,7 +663,7 @@ export class HttpTransport extends EventEmitter implements ITransport {
       }
     }
 
-    return { valid: true };
+    return { valid: true, principal: principalFromSecret(token, 'token') };
   }
 }
 

--- a/v3/@claude-flow/mcp/src/types.ts
+++ b/v3/@claude-flow/mcp/src/types.ts
@@ -5,6 +5,8 @@
  * Zero external @claude-flow dependencies
  */
 
+import type { MCPRequestContext } from './request-context.js';
+
 // ============================================================================
 // Core Protocol Types
 // ============================================================================
@@ -267,7 +269,7 @@ export interface ResourceContent {
   uri: string;
   mimeType?: string;
   text?: string;
-  blob?: string; // base64 encoded
+  blob?: string;
 }
 
 export interface ResourceTemplate {
@@ -320,14 +322,14 @@ export interface TextContent {
 
 export interface ImageContent {
   type: 'image';
-  data: string; // base64
+  data: string;
   mimeType: string;
   annotations?: ContentAnnotations;
 }
 
 export interface AudioContent {
   type: 'audio';
-  data: string; // base64
+  data: string;
   mimeType: string;
   annotations?: ContentAnnotations;
 }
@@ -499,9 +501,15 @@ export interface CompletionResult {
 // Transport Types
 // ============================================================================
 
-export type RequestHandler = (request: MCPRequest) => Promise<MCPResponse>;
+export type RequestHandler = (
+  request: MCPRequest,
+  context?: MCPRequestContext
+) => Promise<MCPResponse>;
 
-export type NotificationHandler = (notification: MCPNotification) => Promise<void>;
+export type NotificationHandler = (
+  notification: MCPNotification,
+  context?: MCPRequestContext
+) => Promise<void>;
 
 export interface TransportHealthStatus {
   healthy: boolean;

--- a/v3/docs/adr/ADR-387-mcp-2026-07-28-stateless-era-adapter.md
+++ b/v3/docs/adr/ADR-387-mcp-2026-07-28-stateless-era-adapter.md
@@ -1,0 +1,202 @@
+# ADR 387: MCP 2026 07 28 stateless era adapter
+
+Status: Proposed, benchmark and independent reproduction required before runtime promotion
+
+Date: 2026 09 10
+
+Related: issue 2542, ADR 112, ADR 125, ADR 144, ADR 325, ADR 329, ADR 386
+
+## Decision
+
+RuFlo will support MCP 2026 07 28 through an explicit protocol era adapter instead of replacing the existing handshake path in place.
+
+The modern era is stateless. It has no initialize or initialized exchange and no MCP session identifier. Each request carries its protocol version, client identity, and client capabilities. Streamable HTTP requests carry MCP Method and, where applicable, MCP Name headers. A new server discover method exposes supported versions and capabilities. List and resource responses may carry bounded cache hints. W3C trace context propagates through reserved metadata.
+
+The existing 2025 11 25 and earlier handshake era remains a compatibility path during the transition. Modern requests must never create, consult, or mutate legacy session state. Legacy behavior remains the rollback target until the compatibility matrix is proven.
+
+Primary specification: https://blog.modelcontextprotocol.io/posts/2026-07-28/
+
+Current roadmap: https://blog.modelcontextprotocol.io/posts/mcp-roadmap/
+
+## Why now
+
+The 2026 07 28 MCP release is final and the official roadmap identifies removal of protocol sessions and initialization as a major scalability change. RuFlo currently contains multiple protocol eras at once:
+
+* v3/@claude-flow/mcp/src/server.ts advertises 2025 11 25 and still creates a SessionManager, requires initialize for ordinary requests, and exposes session scoped behavior.
+* v3/@claude-flow/shared/src/mcp/server.ts advertises 2024 11 05.
+* ruflo/src/mcp-bridge/mcp-stdio-kernel.js advertises 2024 11 05.
+* v3/@claude-flow/cli/bin/mcp-server.js advertises 2024 11 05.
+* v3/@claude-flow/cli/bin/cli.js advertises 2024 11 05.
+* ruflo/src/ruvocal/src/lib/wasm/wasm.worker.ts advertises 2024 11 05.
+* v3/mcp/server.ts contains an older incompatible protocol version representation and an initialize based lifecycle.
+
+This is not only version string drift. The lifecycle semantics differ. Advertising a modern version without separating the modern request path would be incorrect and can create authorization, cache, routing, and cross tenant state leakage hazards.
+
+## Opportunity score
+
+Weighted Opportunity Score: 4.590 of 5.
+
+| Dimension | Score |
+| --- | ---: |
+| applicability | 5.0 |
+| performance impact | 4.0 |
+| implementation speed | 4.0 |
+| cross stack leverage | 5.0 |
+| commercial value | 5.0 |
+| strategic differentiation | 3.5 |
+| security improvement | 5.0 |
+| open source leadership | 4.5 |
+| evidence confidence | 5.0 |
+| long horizon option value | 5.0 |
+| experiment reversibility | 5.0 |
+
+Weights are the RuV SOTA research weights frozen before implementation.
+
+## Required architecture
+
+### 1. Era detection
+
+Introduce a single parser that classifies each request as modern 2026 07 28 or legacy handshake era. The parser is transport aware but policy neutral.
+
+Modern HTTP uses MCP Protocol Version and the reserved request metadata. Modern stdio uses the reserved request metadata. No process global or mutable current session value may determine the identity or authorization context of a modern request.
+
+Unknown protocol versions fail closed with a structured unsupported version response and the supported set.
+
+### 2. Stateless modern request context
+
+Construct a request local context from authenticated transport identity plus request metadata. Request metadata is descriptive and must not grant authority. Authorization derives from the authenticated principal and RuFlo or RVM policy, never from a claimed client name or capability field.
+
+Modern requests do not call getOrCreateSession, update session activity, or inherit state from a previous request.
+
+### 3. server/discover
+
+Implement server/discover with deterministic ordering and explicit cache semantics. The discover result exposes supported protocol versions, capabilities, and enabled extensions. It must not expose secrets, tenant private tool names, or capabilities that the authenticated principal cannot observe.
+
+Default cache policy is private with zero TTL unless a surface has an explicit public stability policy.
+
+### 4. HTTP routing integrity
+
+For 2026 07 28 Streamable HTTP, validate MCP Method against the JSON RPC body method and MCP Name against the body tool or resource name when defined. A mismatch is rejected before dispatch and before any side effect.
+
+Gateways may use these headers for routing and rate limiting, but header values never substitute for body validation or authorization.
+
+### 5. Trace context
+
+Propagate W3C traceparent, tracestate, and baggage through the standardized MCP metadata keys. Treat baggage as untrusted input. Enforce size and allowlist rules before downstream propagation.
+
+### 6. Cache hints
+
+Add ttlMs and cacheScope to modern list and resource read responses. Private is the default. Public caching is opt in and requires proof that output is principal invariant. Authorization sensitive tool lists must never be marked public.
+
+### 7. Extensions and long running work
+
+Keep RuFlo specific behavior out of the base protocol. Use the MCP extensions framework for optional surfaces. Evaluate the Tasks extension against the existing TaskManager rather than creating a second task lifecycle.
+
+Sampling, Roots, and Logging remain legacy compatibility surfaces while deprecated. Do not expand dependence on them. Modern server initiated interaction must use the modern multi round trip mechanism when supported or explicitly fall back to a compatible legacy era.
+
+## Compatibility strategy
+
+Phase 0 is inventory and conformance fixtures.
+
+Phase 1 introduces era detection and server discover with no change to legacy dispatch.
+
+Phase 2 adds the stateless modern request path and header consistency checks.
+
+Phase 3 adds cache hints and trace context.
+
+Phase 4 maps the existing TaskManager to the Tasks extension if independent tests show semantic compatibility.
+
+Phase 5 removes legacy paths only after the MCP deprecation window, measured client telemetry, and an explicit human approved migration ADR.
+
+## Security invariants
+
+1. Client metadata is never authority.
+2. A modern request cannot inherit identity, authorization, budget, tool visibility, trace baggage, or tenant state from another request.
+3. Header and body mismatches are rejected before dispatch.
+4. cacheScope public is forbidden for principal dependent results.
+5. Unsupported or malformed protocol metadata fails closed.
+6. Legacy and modern request contexts cannot alias mutable authorization state.
+7. Discovery does not make a tool invokable and does not widen capability.
+8. Task continuation tokens are opaque, integrity protected, bounded, and cannot escalate authority.
+9. No candidate may modify the evaluator, security policy, promotion threshold, or release gate.
+10. No autonomous merge, deployment, credential escalation, or irreversible migration.
+
+## MetaHarness evaluation
+
+Use independent roles for research, baseline capture, implementation, adversarial review, security, testing, reproducibility, and release review. The implementation role cannot approve its own result.
+
+Freeze the following matrix before candidate execution:
+
+* transports: stdio and Streamable HTTP
+* eras: 2024 11 05, 2025 03 26, 2025 06 18, 2025 11 25, 2026 07 28
+* clients: official TypeScript SDK plus one independent official SDK
+* authorization contexts: anonymous where allowed, one principal, two isolated tenants
+* workloads: tools list, tool call, resources list, resource read, prompt list, server discover, one long running Task extension case
+* fault cases: missing version, unknown version, malformed metadata, header body mismatch, replayed continuation, cross tenant cache probe, oversized baggage, cancellation, worker restart, load balanced instance change
+
+## Benchmark contract
+
+Report baseline and candidate using the exact same workload and pinned environment.
+
+Required fields: repository commit, dependency lock hash, runtime versions, operating system, CPU, memory, transport, SDK versions, seeds, sample size, concurrency, request payload sizes, absolute latency, relative latency, throughput, error rate, variance, process RSS, bytes transferred, cache hit rate, authorization failures, cross tenant leakage attempts, restart recovery, cost and energy when measurable.
+
+Minimum run:
+
+* 10 warmup iterations per cell
+* at least 1,000 measured requests per cheap request cell
+* at least 100 measured executions per tool call cell
+* at least 3 independent process restarts
+* concurrency 1, 8, 32, and 100 where the host supports it
+
+Acceptance thresholds:
+
+* 100 percent expected modern conformance fixtures pass
+* 100 percent retained legacy compatibility fixtures pass unless an exception is explicitly approved
+* zero cross tenant state or cache leakage in the adversarial corpus
+* zero header body mismatch dispatches
+* zero authority expansion from request metadata
+* p95 modern request latency no worse than 5 percent versus the equivalent legacy request after excluding handshake cost
+* at concurrency 32, modern throughput at least 15 percent higher or process resident memory at least 20 percent lower than the current stateful path. If neither threshold is met, retain the implementation only for interoperability, not performance claims
+* restart and round robin instance change succeed without shared session storage for modern requests
+
+## Contradiction tests
+
+The expected performance benefit can be false if current in process sessions are already cheap and the workload does not require horizontal scale. Therefore interoperability and isolation are independent acceptance dimensions. A candidate can be accepted for protocol correctness without claiming a speedup.
+
+The new cache hints can make latency worse or leak data if cache boundaries are wrong. Public caching must be separately proven principal invariant.
+
+Tasks can duplicate RuFlo lifecycle semantics. Reuse TaskManager only if cancellation, idempotency, approval, budget, and receipt semantics can be mapped without authority loss. Otherwise expose a thin adapter.
+
+## Dependencies and licensing
+
+Prefer the official MCP SDK for wire conformance where practical. Do not vendor draft server card or unrelated discovery schemas into the core protocol. No new dependency is accepted without license review, lockfile update, advisory scan, and a simpler implementation comparison.
+
+## Rollback
+
+The legacy handshake path remains untouched until the modern path passes independent reproduction. Era routing is additive and controlled by a feature gate during initial rollout. Rollback disables the modern path and restores the previous protocol advertisement without data migration.
+
+No persistent session schema migration is required by this ADR.
+
+## Cross stack mapping
+
+RuFlo: modern stateless dispatch, Tasks adapter, federation gateway compatibility.
+
+MetaHarness: conformance, isolation, restart, load balance, and adversarial evaluation.
+
+RVM: authoritative per action effect boundary remains unchanged; modern request metadata never becomes authority.
+
+Core Memory and RuVector: cache and retrieval results remain tenant scoped; cache hints cannot widen visibility.
+
+RVF and RVForge: attach protocol era and trace provenance to evidence receipts without treating it as authorization.
+
+Cognitum: horizontal MCP gateway scaling without sticky sessions or a shared session store.
+
+RuVector WASM and browser runtimes: simpler stateless MCP calls and deterministic capability discovery.
+
+Autogenous, MidStream, RuView, RuField, WorldGraph, Dream Machine, and LatentMesh: all gain a common modern tool transport boundary while retaining domain specific policy.
+
+## Promotion decision
+
+Do not merge runtime changes from this ADR until the independent MetaHarness matrix is attached to the exact candidate commit. Documentation and conformance fixtures may land first.
+
+The first implementation target is the canonical v3/@claude-flow/mcp package. Legacy mirrors and generated CLI bridges are migrated only after the canonical path passes the frozen matrix.

--- a/v3/docs/adr/ADR-388-mcp-request-local-authority-context.md
+++ b/v3/docs/adr/ADR-388-mcp-request-local-authority-context.md
@@ -1,0 +1,167 @@
+# ADR 388: MCP request local authority context
+
+Status: Proposed
+
+Date: 2026-09-11
+
+Related: #2542, #3294, ADR 387, ruvnet/metaharness#305
+
+## Context
+
+The canonical MCP package currently carries one mutable `currentSession` on `MCPServer`. Legacy `initialize` replaces that value. Tool calls, sampling, and resource subscription paths subsequently derive session context from it.
+
+The transport interface compounds the problem. `RequestHandler` receives only an `MCPRequest`. The HTTP transport validates authorization and then passes only the JSON body to the server. The exact authenticated principal, protocol version header, routing headers, connection identity, and legacy session identifier therefore do not survive the transport boundary as one immutable request scoped object.
+
+This architecture is ambiguous for multiple concurrent legacy HTTP clients and is incompatible with the trust boundary required by MCP 2026 07 28. The modern protocol removes protocol sessions and initialization, makes every request self describing, and requires Streamable HTTP routing metadata to describe the exact request being dispatched.
+
+A session identifier is not an authority grant. Client supplied metadata is not an authority grant. A successful authentication check is not sufficient unless the resulting principal is bound to the exact request that reaches policy enforcement.
+
+## Decision
+
+Introduce an immutable transport neutral `MCPRequestContext` and make it the only source of transport level caller context after parsing and authentication.
+
+The request context is created by the transport immediately before request dispatch. It is passed together with the JSON RPC request to the MCP server and then projected into `ToolContext`, subscription ownership, task ownership, trace evidence, and any policy decision that needs caller identity.
+
+The server must not use mutable process global state to determine the calling principal or logical client.
+
+## Request context
+
+The initial shape should contain these fields or equivalent strongly typed fields:
+
+```ts
+export interface MCPRequestContext {
+  readonly transport: TransportType;
+  readonly protocolVersion?: MCPProtocolVersion;
+  readonly requestId?: string;
+  readonly traceId?: string;
+  readonly connectionId?: string;
+  readonly legacySessionId?: string;
+  readonly routing?: {
+    readonly method?: string;
+    readonly name?: string;
+  };
+  readonly principal?: {
+    readonly subject?: string;
+    readonly issuer?: string;
+    readonly authMethod?: AuthMethod;
+    readonly credentialFingerprint?: string;
+  };
+}
+```
+
+Raw bearer tokens, API keys, authorization headers, client secrets, or other reusable credentials must never be copied into this structure.
+
+## Legacy protocol behavior
+
+Protocol versions through 2025 11 25 keep their handshake semantics during the compatibility window.
+
+Legacy session lookup is request local. An HTTP request carrying a session identifier is resolved to one legacy session and, when authentication is enabled, that session is bound to the authenticated principal that created it. A session identifier presented by another principal fails closed.
+
+Stdio may retain one connection scoped legacy session because the process stream itself is the connection boundary. WebSocket may retain one session per authenticated socket. Neither case permits a server global mutable session to determine another connection's identity.
+
+## Modern protocol behavior
+
+Protocol version 2026 07 28 does not create a protocol session and does not depend on `initialize`, `initialized`, or `Mcp-Session-Id`.
+
+The transport validates `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` before server dispatch. A routing header that disagrees with the JSON body fails closed before tool lookup or policy evaluation.
+
+Client information and capabilities from request metadata are descriptive inputs. They may influence compatibility or feature negotiation but must never widen policy authority.
+
+`server/discover` reports server features without creating authority or hidden state.
+
+## Principal binding
+
+Authentication produces a principal reference, not merely a boolean. The exact principal is attached to the request context after credential validation.
+
+For static bearer token deployments, a migration implementation may use a non secret SHA 256 credential fingerprint as an internal subject key when no explicit subject exists. The raw token is discarded after validation. Production deployments should prefer issuer and subject claims from a validated identity protocol when available.
+
+A credential fingerprint is an implementation identity key only. It is not proof of user intent or permission for a particular tool invocation.
+
+## Tool authorization
+
+`ToolAuthorizer` continues to decide whether a specific tool call may execute. The request context gives the authorizer correct caller evidence but does not change the decision model.
+
+The migration should extend `ToolContext.metadata` first to preserve source compatibility, then consider first class principal fields only after downstream packages are audited.
+
+RVM remains the privileged effect boundary for consequential operations. MCP transport identity, KYA signals, agent identity, signatures, attestation, discovery, and trace metadata remain evidence inputs to that boundary rather than substitutes for it.
+
+## Resource subscriptions and server initiated interaction
+
+Legacy resource subscriptions must be owned by the exact legacy session and authenticated principal that created them. Unsubscribe operations must prove the same ownership.
+
+Modern MCP should migrate change notification behavior to the current subscription model rather than recreating hidden transport sessions.
+
+Deprecated legacy sampling, roots, logging, and HTTP SSE support remain compatibility surfaces only. New functionality must not depend on them.
+
+## Failure behavior
+
+The server fails closed when:
+
+1. a modern routing header disagrees with the body
+2. a required protocol version is malformed or unsupported
+3. a legacy session identifier is unknown, expired, or bound to another principal
+4. authenticated principal context is required but unavailable
+5. request metadata attempts to assert authority that policy has not granted
+6. a request context cannot be constructed without retaining a raw credential
+
+Errors must not echo secrets or security sensitive internal state.
+
+## Migration
+
+Phase 1 adds the typed request context and transport plumbing with no behavior change for a single legacy client.
+
+Phase 2 removes server global session lookup from tool, sampling, subscription, and task paths. Legacy sessions are selected from request local context.
+
+Phase 3 adds modern MCP request classification, routing header validation, and `server/discover`.
+
+Phase 4 moves modern list and resource caching, subscriptions, Tasks extension behavior, and tracing onto the modern path.
+
+Phase 5 removes deprecated compatibility code only after retained clients have an explicit migration window and rollback is no longer required.
+
+Each phase is independently revertible.
+
+## Verification
+
+The frozen MetaHarness suite must cover at least two concurrent authenticated clients and two concurrent modern clients across in process, stdio, HTTP, WebSocket, and retained HTTP SSE behavior.
+
+Required schedules include A initialize, B initialize, A call; simultaneous A and B calls; reconnect; process restart; and modern requests alternating across two server instances without shared session storage.
+
+Adversarial cases include stolen or replayed legacy session identifiers, mismatched principal and session, routing header and body disagreement, malformed metadata, cancellation races, oversized headers, partial requests, and connection loss during subscription activity.
+
+Promotion requires:
+
+1. zero cross principal or cross session authority aliases across at least 10000 interleaved cheap requests
+2. zero successful use of one principal's session identifier by another principal
+3. zero tool dispatch on routing header and body mismatch
+4. zero authority expansion from request metadata
+5. 100 percent retained legacy fixtures passing
+6. 100 percent modern 2026 07 28 fixtures passing
+7. p95 request context overhead no greater than 5 percent against the frozen baseline
+8. no reusable secret in logs, traces, cache keys, receipts, or error bodies
+9. modern restart and round robin tests passing without shared session storage
+
+## Benchmark record
+
+Every run records exact commit, Node and package manager versions, MCP SDK versions, operating system, CPU, memory, workload, seed, sample size, concurrency, request mix, absolute and relative throughput, p50 p95 p99 latency, variance, RSS, network bytes, failures, regressions, auth failures, and reproduction commands.
+
+A correctness improvement may be accepted without a throughput improvement. Performance claims require measured evidence.
+
+## Rollback
+
+Legacy behavior remains behind an explicit compatibility path until the migration is promoted. Each implementation phase is a separate commit or reviewable unit. No database migration, credential format migration, deployment, or irreversible state conversion is required by this ADR.
+
+If request local context introduces a compatibility regression, disable the modern path and revert the affected phase while preserving the new regression tests and audit evidence.
+
+## Consequences
+
+The additional request object adds a small allocation and parsing cost per request. The expected overhead is low single digit percent and must be measured rather than assumed.
+
+The design removes hidden authority state from the server core, makes multi tenant reasoning testable, enables correct MCP 2026 routing and stateless scaling, and creates a reusable authority context for RuFlo, MetaHarness, RVM, RVF, Cognitum gateways, and future agent identity or commerce trust adapters.
+
+## Non goals
+
+This ADR does not define a new identity protocol, payment protocol, attestation format, agent certification scheme, or authorization policy language.
+
+It does not treat KYA, AICP, AADP, MCP metadata, signatures, hashes, attestation, or federation membership as execution authority.
+
+It does not authorize autonomous merge, deployment, credential escalation, or irreversible migration.


### PR DESCRIPTION
## Scope

Implements the request-local authority prerequisite for the MCP 2026-07-28 migration while retaining the legacy 2025-11-25 initialization path as rollback.

This PR now contains runtime code, architecture, audits, tests, and a stress gate. It remains draft until the frozen MetaHarness Track A acceptance matrix completes on the exact head.

## Runtime implementation

* immutable `MCPRequestContext` propagated from transport to server
* SHA-256 credential fingerprints used as non-secret principal references; raw bearer secrets are not placed in request context
* `AsyncLocalStorage` request scoping in `MCPServer`
* explicit principal plus legacy-session binding instead of HTTP authority derived from singleton `currentSession`
* cross-principal legacy session reuse fails closed
* HTTP propagation of `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, `Mcp-Session-Id`, trace context, request ID, transport and remote address
* strict routing-header/body agreement before dispatch
* modern `server/discover` entry point for protocol `2026-07-28`
* modern requests do not require legacy initialization and modern `initialize` is rejected
* modern HTTP requests carrying `Mcp-Session-Id` are rejected
* WebSocket principal identity and legacy session state are connection scoped with `WeakMap` storage
* notification dispatch receives request-local context
* modern resource subscriptions advertise `subscribe: false` and fail closed until notification delivery can target one authority scope; this prevents the existing broadcast notification path from becoming cross-tenant leakage
* CORS allowlist includes the modern MCP routing/version headers
* response-only legacy session metadata is kept out of JSON serialization through a `WeakMap`
* zero new runtime dependencies

## Security invariants

1. No mutable server-global variable determines the authenticated principal for HTTP or WebSocket requests.
2. A legacy session identifier is usable only with the principal to which it was bound.
3. Modern MCP requests never require a protocol session and cannot create one through `initialize`.
4. `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` disagreement fails before dispatch.
5. Request metadata, trace data, discovery data, signatures, caches and benchmark evidence never expand authority.
6. Raw credentials never enter `ToolContext`, request context, logs, receipts or cache keys through the new path.
7. Legacy rollback remains available while modern conformance is being validated.

RVM remains the privileged effect boundary. This transport work does not create a second authorization plane.

## Tests and falsification

Added focused Vitest coverage for:

* concurrent legacy principal isolation
* cross-principal legacy session reuse rejection
* modern stateless discovery without initialization
* rejection of modern `initialize`
* modern resource-subscription fail-closed behavior
* routing method mismatch rejection
* routed tool-name mismatch rejection
* matching routing metadata acceptance

Added a 10,000-request interleaved isolation stress test. It alternates two authenticated principals and two legacy sessions, executes in bounded concurrent batches, and fails on any principal or session alias. The stress test bypasses only the rate limiter so it measures request-context isolation independently of throttling policy. It records exact Node version, request count, elapsed time and throughput.

Existing dependency-free audits remain in place:

* `scripts/audit-mcp-era.mjs`
* `scripts/audit-mcp-session-isolation.mjs`

## ADRs

* ADR-387: MCP 2026-07-28 stateless era adapter
* ADR-388: MCP request-local authority context

## Governance and coordination

Tracks:

* ruvnet/ruflo#2542
* ruvnet/ruflo#3294
* ruvnet/metaharness#305 Track A
* ruvnet/core-memory#77 federation record

Self-improvement may optimize request-context overhead only after baseline freeze. It may not alter identity semantics, authority boundaries, compatibility fixtures, acceptance thresholds, provenance, rollback, or negative-result recording.

No autonomous merge, deployment, credential escalation, compatibility waiver, or irreversible migration.

## Current validation state

Exact candidate head when this body was updated: `e6918468c66a631d9774cd70d05d7b274883c6c7`.

Triggered hosted gates on that exact head:

* V3 CI/CD Pipeline
* CI/CD Pipeline
* Verification Pipeline
* Cross-Agent Integration Tests
* CodeQL Advanced
* no-metaharness-smoke
* CVE Audit Gate

The PR stays draft until those exact-head checks complete and the remaining dedicated promotion evidence is attached:

* 100% retained legacy client fixtures
* 100% modern 2026-07-28 fixtures
* zero aliases across the 10,000-request stress gate
* zero successful cross-principal session reuse
* zero dispatch on routing-header/body mismatch
* p95 request-context overhead <= 5% on a pinned benchmark environment
* process restart and round-robin instance-change tests for modern requests with no shared session store
* no raw secret leakage in logs, traces, caches, receipts or errors

A correctness-only result may be accepted without a performance claim. Any performance claim still requires the stronger MetaHarness gate at concurrency 32: at least 15% more throughput or at least 20% lower RSS.