### PR TITLE
fix(memory): honour an explicit database path, and stop counting one store as if it were all of them (#3196)

### DIFF
--- a/v3/@claude-flow/cli/__tests__/memory-registry-path-identity-3196.test.ts
+++ b/v3/@claude-flow/cli/__tests__/memory-registry-path-identity-3196.test.ts
@@ -1,0 +1,47 @@
+/**
+ * #3196 — an explicit database path must select that database.
+ *
+ * The bridge used to cache one registry globally: the first caller to touch it
+ * decided the file for the whole process, and every later caller's `dbPath` was
+ * accepted and then ignored. That is how a CLI write and an MCP write ended up
+ * in two files while both reported success.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { siblingAgentDbPath, _resetRegistryCacheForTest } from '../src/memory/memory-bridge.js';
+import { countSiblingStoreRows } from '../src/memory/sibling-store.js';
+
+describe('#3196 sibling store identity', () => {
+  beforeEach(() => _resetRegistryCacheForTest());
+
+  it('names the AgentDB store beside a given database, and never itself', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mem3196-'));
+    const primary = join(dir, 'memory.db');
+    expect(siblingAgentDbPath(primary)).toBe(join(dir, 'agentdb-memory.db'));
+    // A path that already IS the sibling has no sibling of its own — otherwise a
+    // disclosure would point a reader back at the file they just read.
+    expect(siblingAgentDbPath(join(dir, 'agentdb-memory.db'))).toBeNull();
+    expect(siblingAgentDbPath(':memory:')).toBeNull();
+    expect(siblingAgentDbPath('')).toBeNull();
+  });
+
+  it('resolves relative paths so one file cannot become two registries', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mem3196-'));
+    const a = siblingAgentDbPath(join(dir, 'memory.db'));
+    const b = siblingAgentDbPath(join(dir, '.', 'memory.db'));
+    expect(a).toBe(b);
+  });
+
+  it('stays silent when the sibling is absent or unreadable, rather than claiming zero', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mem3196-'));
+    // No sibling at all.
+    await expect(countSiblingStoreRows(join(dir, 'memory.db'))).resolves.toBeNull();
+    // Present but not a database: an unreadable store is not evidence of an
+    // empty one, so the caller must get null and print nothing.
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'agentdb-memory.db'), 'not a database');
+    await expect(countSiblingStoreRows(join(dir, 'memory.db'))).resolves.toBeNull();
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -9,6 +9,8 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { distillCommand } from './memory-distill.js';
 import { backupCommand } from './memory-backup.js';
+import { countSiblingStoreRows } from '../memory/sibling-store.js';
+import { resolveDbPath } from '../memory/memory-initializer.js';
 
 // Memory backends
 const BACKENDS = [
@@ -814,6 +816,18 @@ const listCommand: Command = {
 
       output.writeln();
       output.printInfo(`Showing ${entries.length} of ${listResult.total} entries`);
+
+      // #3196: AgentDB owns a sibling store next to this one. `total` counts only
+      // the file we read, so a bare count reads as "this is everything" while rows
+      // sit unreadable next door. Silence would be recoverable; a confident wrong
+      // total is not, because nothing prompts anyone to look further.
+      const unread = await countSiblingStoreRows(resolveDbPath(ctx.flags.path as string | undefined));
+      if (unread && unread.rows > 0) {
+        output.printWarning(
+          `${unread.rows} more entries are in ${unread.path} and were not read here. ` +
+          `That store is written by the MCP/AgentDB path; read it with --path ${unread.path}.`
+        );
+      }
 
       return { success: true, data: listResult.entries };
     } catch (error) {

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -21,10 +21,25 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import { createRequire } from 'node:module';
 
-// ===== Lazy singleton =====
+// ===== Lazy registry cache, keyed by database path =====
 
-let registryPromise: Promise<any> | null = null;
-let registryInstance: any = null;
+/**
+ * #3196: this cache is keyed by resolved database path, and that is the whole
+ * point of it.
+ *
+ * It used to be a single global instance. The first caller to touch the bridge
+ * decided which file the process would use, and every later caller's explicit
+ * `dbPath` was accepted and then silently ignored — `getRegistry()` returned the
+ * already-built instance without ever comparing paths. A `memory store --path A`
+ * following an MCP write therefore read and wrote B, reported success, and left
+ * two valid corpora that neither interface could see whole.
+ *
+ * Keying by path makes an explicit path mean what it says. Two paths in one
+ * process are two registries, which is the behaviour the CLI's `--path` flag and
+ * `CLAUDE_FLOW_DB_PATH` have always advertised.
+ */
+const registryPromises = new Map<string, Promise<any>>();
+const registryInstances = new Map<string, any>();
 let bridgeAvailable: boolean | null = null;
 // #2652/#2120: rows created before the status column existed receive NULL
 // during migration. They are live rows, not tombstones. Every user-facing
@@ -181,8 +196,15 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
   }
   if (bridgeAvailable === false) return null;
 
-  if (registryInstance) return registryInstance;
+  // Resolve first, then cache on the resolved value: `undefined`, a relative
+  // path and its absolute form must not become three different registries over
+  // the same file.
+  const resolvedPath = dbPath ? path.resolve(dbPath) : getAgentDbPath();
 
+  const cached = registryInstances.get(resolvedPath);
+  if (cached) return cached;
+
+  let registryPromise = registryPromises.get(resolvedPath);
   if (!registryPromise) {
     registryPromise = (async () => {
       try {
@@ -201,7 +223,7 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
         try {
           await (registry as any).initialize({
             // #2786: use agentdb-memory.db (plaintext) so native better-sqlite3 doesn't hit the encrypted memory.db.
-            dbPath: dbPath || getAgentDbPath(),
+            dbPath: resolvedPath,
             embeddingModel: 'Xenova/all-MiniLM-L6-v2',
             dimension: 384,
             vectorBackend: 'auto',
@@ -420,7 +442,7 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
           // Top-level catch — registry stays usable even if post-init wiring fails wholesale.
         }
 
-        registryInstance = registry;
+        registryInstances.set(resolvedPath, registry);
         bridgeAvailable = true;
         bridgeFailureReason = null;
         return registry;
@@ -430,13 +452,29 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
         // makes the resulting sql.js-fallback refusal undiagnosable.
         bridgeFailureReason = err instanceof Error ? err.message : String(err);
         bridgeAvailable = false;
-        registryPromise = null;
+        registryPromises.delete(resolvedPath);
         return null;
       }
     })();
+    registryPromises.set(resolvedPath, registryPromise);
   }
 
   return registryPromise;
+}
+
+/** Test seam: forget cached registries so a test can exercise a fresh open. */
+export function _resetRegistryCacheForTest(): void {
+  registryPromises.clear();
+  registryInstances.clear();
+  bridgeAvailable = null;
+  bridgeFailureReason = null;
+}
+
+/** #3196: the sibling store AgentDB owns next to a given sql.js database. */
+export function siblingAgentDbPath(dbPath: string): string | null {
+  if (!dbPath || dbPath === ':memory:') return null;
+  const sibling = path.join(path.dirname(path.resolve(dbPath)), 'agentdb-memory.db');
+  return path.resolve(dbPath) === sibling ? null : sibling;
 }
 
 // ===== Phase 2: BM25 hybrid scoring =====
@@ -1992,8 +2030,16 @@ export function getBridgeFailureReason(): string | null {
  * independent of package build order without changing production startup.
  */
 export function __setMemoryBridgeRegistryForTests(registry: any | null): void {
-  registryInstance = registry;
-  registryPromise = registry ? Promise.resolve(registry) : null;
+  registryPromises.clear();
+  registryInstances.clear();
+  if (registry) {
+    // Install under every key a caller can resolve to, so a test seam behaves
+    // the same whether the call site passes a path or leaves it default.
+    for (const key of new Set([getAgentDbPath(), path.resolve(getDbPath())])) {
+      registryInstances.set(key, registry);
+      registryPromises.set(key, Promise.resolve(registry));
+    }
+  }
   bridgeAvailable = registry ? true : null;
   bridgeFailureReason = null;
 }
@@ -2008,15 +2054,17 @@ export function __setMemoryBridgeRegistryForTests(registry: any | null): void {
  * therefore had no recovery path short of a restart.
  */
 export async function shutdownBridge(): Promise<void> {
-  if (registryInstance) {
+  // #3196: every cached registry owns an open database handle, so shutting down
+  // one of several would leave the rest holding files open.
+  for (const registry of registryInstances.values()) {
     try {
-      await registryInstance.shutdown();
+      await registry.shutdown();
     } catch {
       // Best-effort
     }
   }
-  registryInstance = null;
-  registryPromise = null;
+  registryInstances.clear();
+  registryPromises.clear();
   bridgeAvailable = null;
   bridgeFailureReason = null;
 }

--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -40,6 +40,15 @@ import { createRequire } from 'node:module';
  */
 const registryPromises = new Map<string, Promise<any>>();
 const registryInstances = new Map<string, any>();
+/**
+ * Test seam: when set, every path resolves to this registry.
+ *
+ * Kept separate from the path cache on purpose. A test installs a fake registry
+ * and then calls a bridge function with its own temp `dbPath`; keying the
+ * override by path would mean the seam only worked for callers that happened to
+ * pass the same path the seam guessed, which is how #2968's fixture broke.
+ */
+let testRegistryOverride: any = null;
 let bridgeAvailable: boolean | null = null;
 // #2652/#2120: rows created before the status column existed receive NULL
 // during migration. They are live rows, not tombstones. Every user-facing
@@ -194,6 +203,7 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
       : 'AgentDB native bridge disabled by CLAUDE_FLOW_DISABLE_BRIDGE=1';
     return null;
   }
+  if (testRegistryOverride) return testRegistryOverride;
   if (bridgeAvailable === false) return null;
 
   // Resolve first, then cache on the resolved value: `undefined`, a relative
@@ -466,6 +476,7 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
 export function _resetRegistryCacheForTest(): void {
   registryPromises.clear();
   registryInstances.clear();
+  testRegistryOverride = null;
   bridgeAvailable = null;
   bridgeFailureReason = null;
 }
@@ -2032,14 +2043,7 @@ export function getBridgeFailureReason(): string | null {
 export function __setMemoryBridgeRegistryForTests(registry: any | null): void {
   registryPromises.clear();
   registryInstances.clear();
-  if (registry) {
-    // Install under every key a caller can resolve to, so a test seam behaves
-    // the same whether the call site passes a path or leaves it default.
-    for (const key of new Set([getAgentDbPath(), path.resolve(getDbPath())])) {
-      registryInstances.set(key, registry);
-      registryPromises.set(key, Promise.resolve(registry));
-    }
-  }
+  testRegistryOverride = registry;
   bridgeAvailable = registry ? true : null;
   bridgeFailureReason = null;
 }
@@ -2065,6 +2069,7 @@ export async function shutdownBridge(): Promise<void> {
   }
   registryInstances.clear();
   registryPromises.clear();
+  testRegistryOverride = null;
   bridgeAvailable = null;
   bridgeFailureReason = null;
 }

--- a/v3/@claude-flow/cli/src/memory/sibling-store.ts
+++ b/v3/@claude-flow/cli/src/memory/sibling-store.ts
@@ -1,0 +1,51 @@
+/**
+ * #3196: report the store this interface is NOT reading.
+ *
+ * `memory.db` (sql.js, encrypted at rest when enabled) and `agentdb-memory.db`
+ * (native better-sqlite3, plaintext) are deliberately separate files — see
+ * #2786; pointing native at an encrypted file fails and silently disables the
+ * learning system. Both are legitimate stores, and a read of one is not a read
+ * of the other.
+ *
+ * The danger is not the split. It is a count that describes one file as though
+ * it described the memory. This module exists so the CLI can say what it did
+ * not read, without opening, migrating or modifying that file.
+ */
+import { existsSync } from 'node:fs';
+import { siblingAgentDbPath } from './memory-bridge.js';
+
+export interface SiblingStoreReport {
+  path: string;
+  rows: number;
+}
+
+/**
+ * Count rows in the sibling AgentDB store, read-only. Returns null when there
+ * is no sibling, it does not exist, or it cannot be read — an unreadable store
+ * is not evidence of an empty one, so we stay silent rather than claim zero.
+ */
+export async function countSiblingStoreRows(dbPath: string): Promise<SiblingStoreReport | null> {
+  const sibling = siblingAgentDbPath(dbPath);
+  if (!sibling || !existsSync(sibling)) return null;
+  try {
+    const require = (await import('node:module')).createRequire(import.meta.url);
+    // Optional native dependency: absence must degrade to silence, never throw.
+    const Database = require('better-sqlite3');
+    const db = new Database(sibling, { readonly: true, fileMustExist: true });
+    try {
+      const table = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries'")
+        .get();
+      if (!table) return null;
+      const row = db
+        .prepare("SELECT COUNT(*) AS n FROM memory_entries WHERE (status = 'active' OR status IS NULL)")
+        .get() as { n?: number } | undefined;
+      const rows = Number(row?.n ?? 0);
+      return rows > 0 ? { path: sibling, rows } : null;
+    } finally {
+      try { db.close(); } catch { /* best effort */ }
+    }
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes the routing half of #3196. Reported downstream by [pacphi/agentic-kit#213](https://github.com/pacphi/agentic-kit/issues/213), which is blocked on it.

**Reproduced on 3.41.0** in a clean directory, one process per write:

| file | CLI-written key | MCP-written key |
|---|---|---|
| `.swarm/memory.db` | 1 | 0 |
| `.swarm/agentdb-memory.db` | 0 | 1 |

**The cause is a cache, not a path calculation.** `getRegistry()` kept one global instance, so the first caller to touch the bridge decided the file for the entire process. Every later caller's `dbPath` was accepted and then silently ignored, because the function returned the existing instance without ever comparing paths. `--path` and `CLAUDE_FLOW_DB_PATH` have always advertised that they select a database; now they do. The cache is keyed by resolved path, so two paths in one process are two registries, and a relative path and its absolute form are one.

**The second half is worse than the split.** `memory list` printed `Showing 1 of 1 entries` — not a warning, not a partial result, a confident total describing one file as though it described the memory. The downstream reporter measured 51 rows in one store and 16,671 in its sibling, with 50 keys existing only in the smaller one. Silence would be recoverable; a wrong total is not, because nothing prompts anyone to look further. The CLI now names the store it did not read, and how to read it:

```
[INFO] Showing 1 of 1 entries
[WARN] 2 more entries are in …/.swarm/agentdb-memory.db and were not read here.
       That store is written by the MCP/AgentDB path; read it with --path …
```

**Deliberately not done: merging the two files.** #2786 gave AgentDB its own plaintext file so native better-sqlite3 does not open an encrypted `memory.db`, where it fails with *"file is not a database"* and silently disables the learning system. Unifying the path would re-break encryption at rest. Both corpora stay, and both stay readable — which also satisfies the downstream requirement that unique keys in either store survive.

The sibling count is read-only, opens the file read-only, and returns null when it is missing or unreadable. An unreadable store is not evidence of an empty one, so the CLI stays silent rather than claim zero.

**Verified** against the original reproduction, and three regression tests cover sibling identity, path resolution, and silence on an unreadable store.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)