### PR TITLE
ci: control — does current main fail V3 install with no code change?

### DIFF
--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -3304,3 +3304,4 @@ export async function getMemoryBridgeStats(options: {
     return { totalEntries: 0, perNamespace: {}, source: 'memory-bridge (error)', reachable: false };
   }
 }
+


### PR DESCRIPTION
Diagnostic only, not for merge.

#3271 fails 28 V3 jobs with `Lockfile is up to date, resolution step is skipped` followed by `ENOENT … symlink tsx`, exit 254 — an install-link failure, on a PR whose only changes are TypeScript. Re-running reproduced it identically, so it is not transient.

This branch is an empty commit off the same `main`. If it fails the same way, the pipeline is broken at this commit and #3271 is clean. If it passes, the fault is mine and I will keep digging.

Will close either way once it answers the question.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)