### PR TITLE
chore(release): 3.41.1 — memory path identity and Seraphina truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.41.0",
+  "version": "3.41.1",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/mcp",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.41.0",
+  "version": "3.41.1",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.41.0",
+  "version": "3.41.1",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Patch release. Two fixes, both found by someone hitting them rather than by us.

**#3196 — an explicit database path now selects that database.** The bridge cached one registry globally, so the first caller to touch it decided the file for the whole process and every later caller's `--path` or `CLAUDE_FLOW_DB_PATH` was accepted and then silently ignored. A CLI write and an MCP write landed in two files, both reporting success, and neither interface could see the other's rows. `memory list` also stopped printing a confident total for one store while rows sat unread in its sibling — it now names the store it did not read. Reported downstream by [pacphi/agentic-kit#213](https://github.com/pacphi/agentic-kit/issues/213), which is blocked on it.

**#3267 — Seraphina no longer passes a truncated reasoning dump off as guidance.** The routed model spent its whole token budget reasoning and never emitted its JSON, and the resulting empty proposal list read as *the swarm needs nothing* — the one conclusion a coordinator must never reach by accident.

Verified before cutting: umbrella lockstep audit passes with all three packages at 3.41.1, and `pnpm install --frozen-lockfile` is clean in `v3/` after the bump.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)