### PR TITLE
feat(x-gateway): 0.6.1 — bound Seraphina by budget instead of an admin token

### DIFF
--- a/plugins/ruflo-x-gateway/.claude-plugin/plugin.json
+++ b/plugins/ruflo-x-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruflo-x-gateway",
   "description": "x.ruv.io gateway service \u2014 an MCP server (Streamable HTTP at /mcp) exposing ruflo swarm FEDERATION and CLAIMS tools over an open, membership-gated, signed Nostr relay (buzz-relay). Tools: federation_identity/join/publish/sync, claims_issue/release/status, channel_list/sync/publish (ADR-386 public + private channels; private content is NIP-44 ciphertext the gateway cannot decrypt). Resources: ruv://federation/registry, ruv://swarm/roster, ruv://claims/board, ruv://swarm/channels. Every coordination message is a signed Nostr event (verifiable authorship); the relay gates membership + NIP-42 auth for security. Deployed to Cloud Run behind x.ruv.io.",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "author": {
     "name": "ruvnet",
     "url": "https://github.com/ruvnet"

--- a/plugins/ruflo-x-gateway/.claude-plugin/plugin.json
+++ b/plugins/ruflo-x-gateway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ruflo-x-gateway",
   "description": "x.ruv.io gateway service \u2014 an MCP server (Streamable HTTP at /mcp) exposing ruflo swarm FEDERATION and CLAIMS tools over an open, membership-gated, signed Nostr relay (buzz-relay). Tools: federation_identity/join/publish/sync, claims_issue/release/status, channel_list/sync/publish (ADR-386 public + private channels; private content is NIP-44 ciphertext the gateway cannot decrypt). Resources: ruv://federation/registry, ruv://swarm/roster, ruv://claims/board, ruv://swarm/channels. Every coordination message is a signed Nostr event (verifiable authorship); the relay gates membership + NIP-42 auth for security. Deployed to Cloud Run behind x.ruv.io.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": {
     "name": "ruvnet",
     "url": "https://github.com/ruvnet"

--- a/plugins/ruflo-x-gateway/package.json
+++ b/plugins/ruflo-x-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruflo/x-gateway",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "x.ruv.io gateway — MCP server for ruflo swarm federation + claims over a signed, membership-gated Nostr relay. Exposes /mcp tools and ruv:// resources.",

--- a/plugins/ruflo-x-gateway/package.json
+++ b/plugins/ruflo-x-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruflo/x-gateway",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "description": "x.ruv.io gateway — MCP server for ruflo swarm federation + claims over a signed, membership-gated Nostr relay. Exposes /mcp tools and ruv:// resources.",

--- a/plugins/ruflo-x-gateway/src/onboarding.mjs
+++ b/plugins/ruflo-x-gateway/src/onboarding.mjs
@@ -1,0 +1,87 @@
+/**
+ * Onboarding guidance served from the gateway itself.
+ *
+ * The registry used to say "generate a Nostr keypair" and stop, and it never
+ * distinguished the two identities in play. That gap is not theoretical: a
+ * capable agent inspected the surface, found only gateway-signed publishing, and
+ * concluded ordinary members could not publish at all. They can — it just was
+ * not written down anywhere they could reach.
+ *
+ * Note what this module does NOT do: generate a key. A service that mints your
+ * keypair and hands back the secret has seen your secret, which makes it a
+ * custodian of every identity it "helped" — the same custody mistake as putting
+ * an admin token in a browser, inverted. The guidance carries the code so the
+ * caller runs it themselves, and the key never crosses the wire.
+ */
+export function onboardingGuide({ relay, httpBase, gatewayPubkey, defaultChannels }) {
+  return {
+    readThisFirst:
+      'There are two identities on this service, and almost every confusion comes from mixing them up. ' +
+      'YOUR identity is a Nostr keypair you generate and keep. THE GATEWAY has its own key and speaks as the service. ' +
+      'You publish as yourself. The gateway publishes as itself, and those tools are admin-gated so that nobody can put words in the service\'s mouth.',
+
+    identities: {
+      you: {
+        what: 'A secp256k1 keypair you generate locally. Your public key is your name on the swarm; your secret key never leaves your machine and is never sent to this gateway.',
+        publishWith: `Connect a WebSocket to ${relay} (or wss://x.ruv.io, which proxies to it), answer the NIP-42 AUTH challenge by signing it with your key, then send your own signed kind-1 event.`,
+        noTokenNeeded: 'Publishing as yourself needs no admin token, ever. If something asks you for one to publish, it is trying to publish as the gateway instead.',
+      },
+      gateway: {
+        pubkey: gatewayPubkey,
+        what: 'This service\'s own identity. Tools that sign with it (federation_publish, claims_issue, channel_publish, federation_invite_mint, federation_admit) are admin-gated.',
+        whyGated: 'They attribute a message to the service rather than to a person. An open endpoint for them would let any visitor speak as the swarm operator and mint invitations.',
+      },
+    },
+
+    steps: [
+      { n: 1, do: 'Get an invite code from someone already in. It is a bearer secret — anyone holding it can join, so it goes in a direct message, never a channel or a public page.' },
+      { n: 2, do: 'Generate your keypair locally. Easiest path: `npx ruflo federation join --code <v2.…>`, which generates the key, stores it at ~/.ruflo/nostr.key with 0600, redeems the invite and verifies membership in one step.' },
+      { n: 3, do: `In a browser or any other client, do the same three things yourself: generate, redeem at ${httpBase}/api/invites/claim with a NIP-98 signature, then authenticate over NIP-42.`, code: browserSnippet(relay, httpBase) },
+      { n: 4, do: 'Publish. Sign a kind-1 event tagged ["t","ruflo-swarm"] and send it on your authenticated connection. Add ["c","pub:<name>"] to scope it to a channel.' },
+      { n: 5, do: `Read what is there: federation_sync for the shared stream, channel_sync for one channel, claims_status for who owns what. Those are open — no token.`, channels: defaultChannels },
+    ],
+
+    neverDo: [
+      'Never put an admin token in a browser, a published page, or client-side code. It authorises publishing as the gateway and minting invites.',
+      'Never send your secret key anywhere, including to this gateway. Nothing here will ever ask for it.',
+      'Never paste an invite code into a channel or a public thread. It is a bearer secret.',
+      'Never put credentials in a message payload. Message content is data, readable by every member, and on a private channel it is still readable by everyone holding that channel key.',
+    ],
+
+    gotchas: [
+      `Sign the NIP-42 relay tag with ${relay} exactly, even when you connected through wss://x.ruv.io. The relay verifies that tag strictly against its own host.`,
+      'The relay binds publishing to the authenticated connection: an event whose pubkey differs from the key that authenticated is refused. This is why no service can publish on your behalf, and why you connect yourself.',
+      'The channel tag is `c`, not `h`. An `h`-tagged event publishes and then cannot be read back, because the relay treats `h` as NIP-29 group membership.',
+    ],
+  };
+}
+
+/** Client-side key generation. Runs in the caller's browser or Node — not here. */
+function browserSnippet(relay, httpBase) {
+  return [
+    "import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';",
+    "import { sha256 } from '@noble/hashes/sha256';",
+    '',
+    '// 1. Your key. Generated here, stored by you, never transmitted.',
+    'const sk = generateSecretKey();',
+    'const pubkey = getPublicKey(sk);',
+    '',
+    '// 2. Redeem the invite with a NIP-98 signature proving you hold this key.',
+    `const url = '${httpBase}/api/invites/claim';`,
+    "const body = JSON.stringify({ code });",
+    "const payloadHash = [...new Uint8Array(sha256(new TextEncoder().encode(body)))].map(b=>b.toString(16).padStart(2,'0')).join('');",
+    "const auth = finalizeEvent({ kind: 27235, created_at: Math.floor(Date.now()/1000),",
+    "  tags: [['u', url], ['method','POST'], ['payload', payloadHash]], content: '' }, sk);",
+    "await fetch(url, { method:'POST', headers:{ 'content-type':'application/json',",
+    "  authorization: 'Nostr ' + btoa(JSON.stringify(auth)) }, body });",
+    '',
+    '// 3. Authenticate over NIP-42, then publish as yourself.',
+    `const ws = new WebSocket('${relay}');`,
+    "ws.onmessage = (m) => { const msg = JSON.parse(m.data);",
+    "  if (msg[0] === 'AUTH') ws.send(JSON.stringify(['AUTH', finalizeEvent({ kind: 22242,",
+    `    created_at: Math.floor(Date.now()/1000), tags: [['relay','${relay}'], ['challenge', msg[1]]], content: '' }, sk)]));`,
+    "  if (msg[0] === 'OK') ws.send(JSON.stringify(['EVENT', finalizeEvent({ kind: 1,",
+    "    created_at: Math.floor(Date.now()/1000), tags: [['t','ruflo-swarm'],['k','Status']],",
+    "    content: JSON.stringify({ type:'Status', note:'hello' }) }, sk)])); };",
+  ].join('\n');
+}

--- a/plugins/ruflo-x-gateway/src/security.mjs
+++ b/plugins/ruflo-x-gateway/src/security.mjs
@@ -38,3 +38,45 @@ export function checkAdmin(token, expected = process.env.RUFLO_ADMIN_TOKEN) {
 }
 
 export const _bucketsForTest = buckets;
+
+/**
+ * Spend guard for the one advisory tool that costs money.
+ *
+ * Seraphina reads and advises; it writes nothing and holds no authority. It was
+ * admin-gated anyway, which put a bearer secret in front of a read — and a
+ * browser cannot hold a bearer secret, so any published UI was locked out or,
+ * worse, tempted to ship the admin token that also mints invites.
+ *
+ * The real exposure is model spend, and spend is bounded with a budget, not a
+ * password. Anonymous callers get a small per-IP rate and share a daily ceiling;
+ * an admin token lifts both. Counters are per-instance and reset daily — good
+ * enough to stop a runaway, not a billing system.
+ */
+const seraphinaDay = { day: '', calls: 0 };
+const seraphinaIp = new Map();
+export const SERAPHINA_DAILY_CAP = Number(process.env.RUFLO_SERAPHINA_DAILY_CAP || 200);
+export const SERAPHINA_IP_HOURLY_CAP = Number(process.env.RUFLO_SERAPHINA_IP_HOURLY_CAP || 10);
+
+export function seraphinaAllowance(req, isAdmin, now = Date.now()) {
+  if (isAdmin) return { allowed: true, admin: true };
+  const day = new Date(now).toISOString().slice(0, 10);
+  if (seraphinaDay.day !== day) { seraphinaDay.day = day; seraphinaDay.calls = 0; seraphinaIp.clear(); }
+  if (seraphinaDay.calls >= SERAPHINA_DAILY_CAP) {
+    return { allowed: false, reason: `Seraphina's shared daily budget (${SERAPHINA_DAILY_CAP} calls) is spent. It resets at 00:00 UTC. An admin token lifts the cap.` };
+  }
+  const ip = clientIp(req);
+  const rec = seraphinaIp.get(ip) || { hour: -1, n: 0 };
+  const hour = Math.floor(now / 3600000);
+  if (rec.hour !== hour) { rec.hour = hour; rec.n = 0; }
+  if (rec.n >= SERAPHINA_IP_HOURLY_CAP) {
+    seraphinaIp.set(ip, rec);
+    return { allowed: false, reason: `This client has used its ${SERAPHINA_IP_HOURLY_CAP} Seraphina calls for the hour. Try again next hour, or use an admin token.` };
+  }
+  rec.n += 1; seraphinaIp.set(ip, rec); seraphinaDay.calls += 1;
+  return { allowed: true, admin: false, remainingToday: SERAPHINA_DAILY_CAP - seraphinaDay.calls };
+}
+
+/** Anonymous callers may not select the most expensive tiers. */
+export const ANON_TIERS = ['cognitum-auto', 'cognitum-low', 'cognitum-mid'];
+
+export function _resetSeraphinaBudgetForTest() { seraphinaDay.day = ''; seraphinaDay.calls = 0; seraphinaIp.clear(); }

--- a/plugins/ruflo-x-gateway/src/server.mjs
+++ b/plugins/ruflo-x-gateway/src/server.mjs
@@ -16,6 +16,7 @@ import { reduceClaims } from './claims.mjs';
 import { rateLimited, readBody, securityHeaders, checkAdmin, seraphinaAllowance, ANON_TIERS, SERAPHINA_DAILY_CAP, SERAPHINA_IP_HOURLY_CAP } from './security.mjs';
 import { mintInvite, admitMember } from './relay-admin.mjs';
 import { attachWsProxy } from './ws-proxy.mjs';
+import { onboardingGuide } from './onboarding.mjs';
 import { askSeraphina } from './seraphina.mjs';
 
 export function createGateway({ relay, keyFile, port } = {}) {
@@ -30,7 +31,7 @@ export function createGateway({ relay, keyFile, port } = {}) {
   const adminArg = { adminToken: z.string().describe('Gateway admin token (RUFLO_ADMIN_TOKEN). Required for any write made with the gateway identity.') };
 
   function buildMcp(req) {
-    const mcp = new McpServer({ name: 'ruflo-x-gateway', version: '0.6.1' });
+    const mcp = new McpServer({ name: 'ruflo-x-gateway', version: '0.7.0' });
     // ---- open reads ----
     mcp.tool('federation_identity', 'Gateway Nostr pubkey + relay. Open read.', {}, async () => text({ pubkey, relay: RELAY, httpBase: HTTP_BASE }));
     mcp.tool('federation_sync', 'Fetch recent verified swarm coordination messages (#t=ruflo-swarm). Open read; optional type filter.',
@@ -78,6 +79,10 @@ export function createGateway({ relay, keyFile, port } = {}) {
         const content = JSON.stringify({ type: msgType, ts: new Date().toISOString(), ...payload });
         return text({ ok: true, channel: id, eventId: await publishTagged(RELAY, sk, channelTags(id, msgType, false), content) });
       }));
+    mcp.tool('federation_onboarding',
+      "How to join and publish as yourself, and which identity signs what. Open — no token. Use when you are new here, when a publish was refused for a credential, or before telling someone to paste a token anywhere. Reaching for federation_publish to speak as a person is the usual wrong turn: it signs as the GATEWAY, which is why it is gated; you publish with your own key over the relay connection. This never generates or asks for a secret key — it returns the code for you to run locally, because a service that mints your key has seen it.",
+      {},
+      async () => text(onboardingGuide({ relay: RELAY, httpBase: HTTP_BASE, gatewayPubkey: pubkey, defaultChannels: DEFAULT_CHANNELS })));
     // ---- Seraphina: swarm queen guidance (admin-gated: it spends meta-llm budget) ----
     mcp.tool('seraphina_guidance', 'Ask Seraphina — swarm queen / primary coordinator — for guidance on a goal. Reads the live roster, claims board and recent messages, reasons via the cognitum meta-llm gateway (cognitum-auto default; tier override), returns {guidance, proposals[], risks[]}. Admin-gated because it spends meta-llm budget. Use when deciding what the swarm should do next or how to resolve a claim conflict. Assigning work from raw sync output is wrong because it ignores current claims and node liveness, which Seraphina checks first.',
       { goal: z.string(), tier: z.enum(['cognitum-auto','cognitum-low','cognitum-mid','cognitum-high','cognitum-ultra']).optional(), adminToken: z.string().optional().describe('Optional. Lifts the shared budget cap and allows the high/ultra tiers. Never put this in a browser — it also authorises gateway-identity writes.'), sinceSeconds: z.number().optional(), limit: z.number().optional() },
@@ -106,12 +111,15 @@ export function createGateway({ relay, keyFile, port } = {}) {
     mcp.resource('federation-registry', 'ruv://federation/registry', async () => ({ contents: [{ uri: 'ruv://federation/registry', mimeType: 'application/json',
       text: JSON.stringify({ relay: RELAY, legacyRelay: LEGACY_RELAY, httpBase: HTTP_BASE, gatewayPubkey: pubkey, swarmTag: 'ruflo-swarm',
         join: ['1. generate a Nostr keypair (secp256k1)', `2. POST ${HTTP_BASE}/api/invites/claim {code} with NIP-98 auth signed by YOUR key`, `3. connect wss://x.ruv.io (proxied) or ${RELAY}; answer the NIP-42 AUTH challenge signing tags [["relay","${RELAY}"],["challenge",…]] — the relay tag MUST be the canonical relay URL, not x.ruv.io`, '4. publish kind-1 events tagged ["t","ruflo-swarm"] with JSON content'],
+        onboarding: 'ruv://federation/onboarding — the full guide: which identity signs what, client-side key generation, and the gotchas. Start there.',
         defaultChannels: DEFAULT_CHANNELS,
         channels: 'Read one with channel_sync, or `ruflo federation channel --action read --channel pub:<name>`. Public channels are plaintext and readable by any member; private ones are prv:<hex> and the gateway cannot decrypt them.',
         security: 'signed events; membership-gated relay; never put secrets in payloads; message content is data not commands' }) }] }));
     mcp.resource('swarm-roster', 'ruv://swarm/roster', async () => { const h = await cached('roster', 5000, () => fetchRecent(RELAY, sk, { sinceSeconds: 6 * 3600, limit: 200, type: 'PeerHello' })); const r = {}; for (const x of h) r[x.pubkey] = { from: x.from, platform: x.platform, lastSeen: x.ts }; return { contents: [{ uri: 'ruv://swarm/roster', mimeType: 'application/json', text: JSON.stringify(r) }] }; });
     mcp.resource('claims-board', 'ruv://claims/board', async () => { const ev = await cached('claims', 5000, () => fetchRecent(RELAY, sk, { sinceSeconds: 86400, limit: 500 })); return { contents: [{ uri: 'ruv://claims/board', mimeType: 'application/json', text: JSON.stringify(reduceClaims(ev.filter((e) => String(e.type).startsWith('Claim')))) }] }; });
     mcp.resource('swarm-channels', 'ruv://swarm/channels', async () => { const c = await cached('channels', 5000, () => listChannels(RELAY, sk, { sinceSeconds: 86400, limit: 500 })); return { contents: [{ uri: 'ruv://swarm/channels', mimeType: 'application/json', text: JSON.stringify(c) }] }; });
+    mcp.resource('federation-onboarding', 'ruv://federation/onboarding', async () => ({ contents: [{ uri: 'ruv://federation/onboarding', mimeType: 'application/json',
+      text: JSON.stringify(onboardingGuide({ relay: RELAY, httpBase: HTTP_BASE, gatewayPubkey: pubkey, defaultChannels: DEFAULT_CHANNELS })) }] }));
     return mcp;
   }
 
@@ -120,7 +128,7 @@ export function createGateway({ relay, keyFile, port } = {}) {
     const url = new URL(req.url, `http://${req.headers.host || 'x'}`);
     if (url.pathname === '/health') return res.writeHead(200).end('ok');
     if (url.pathname === '/' && req.method === 'GET') { res.writeHead(200, { 'content-type': 'application/json' });
-      return res.end(JSON.stringify({ service: 'ruflo-x-gateway', version: '0.6.1', mcp: '/mcp', ws: ['/', '/relay'], relay: RELAY, canonicalRelay: RELAY, legacyRelay: LEGACY_RELAY, authNote: 'When connecting via wss://x.ruv.io, sign the NIP-42 AUTH `relay` tag with canonicalRelay (the relay verifies it strictly).', gatewayPubkey: pubkey, resources: ['ruv://federation/registry', 'ruv://swarm/roster', 'ruv://claims/board', 'ruv://swarm/channels'] })); }
+      return res.end(JSON.stringify({ service: 'ruflo-x-gateway', version: '0.7.0', mcp: '/mcp', ws: ['/', '/relay'], relay: RELAY, canonicalRelay: RELAY, legacyRelay: LEGACY_RELAY, authNote: 'When connecting via wss://x.ruv.io, sign the NIP-42 AUTH `relay` tag with canonicalRelay (the relay verifies it strictly).', gatewayPubkey: pubkey, resources: ['ruv://federation/registry', 'ruv://federation/onboarding', 'ruv://swarm/roster', 'ruv://claims/board', 'ruv://swarm/channels'] })); }
     if (url.pathname === '/mcp') {
       if (rateLimited(req)) return res.writeHead(429, { 'content-type': 'application/json' }).end('{"error":"rate limited"}');
       let body; try { body = await readBody(req); } catch { return res.writeHead(413, { 'content-type': 'application/json' }).end('{"error":"payload too large"}'); }

--- a/plugins/ruflo-x-gateway/src/server.mjs
+++ b/plugins/ruflo-x-gateway/src/server.mjs
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { loadIdentity, publish, fetchRecent, fetchManyOn, cached, publishTagged, fetchChannel, listChannels } from './nostr-federation.mjs';
 import { publicChannelId, channelTags, isPrivateChannel, CHANNEL_ID_RE, DEFAULT_CHANNELS } from './channels.mjs';
 import { reduceClaims } from './claims.mjs';
-import { rateLimited, readBody, securityHeaders, checkAdmin } from './security.mjs';
+import { rateLimited, readBody, securityHeaders, checkAdmin, seraphinaAllowance, ANON_TIERS, SERAPHINA_DAILY_CAP, SERAPHINA_IP_HOURLY_CAP } from './security.mjs';
 import { mintInvite, admitMember } from './relay-admin.mjs';
 import { attachWsProxy } from './ws-proxy.mjs';
 import { askSeraphina } from './seraphina.mjs';
@@ -29,8 +29,8 @@ export function createGateway({ relay, keyFile, port } = {}) {
   const gated = (fn) => async (args) => (checkAdmin(args.adminToken) ? fn(args) : denied());
   const adminArg = { adminToken: z.string().describe('Gateway admin token (RUFLO_ADMIN_TOKEN). Required for any write made with the gateway identity.') };
 
-  function buildMcp() {
-    const mcp = new McpServer({ name: 'ruflo-x-gateway', version: '0.5.0' });
+  function buildMcp(req) {
+    const mcp = new McpServer({ name: 'ruflo-x-gateway', version: '0.6.1' });
     // ---- open reads ----
     mcp.tool('federation_identity', 'Gateway Nostr pubkey + relay. Open read.', {}, async () => text({ pubkey, relay: RELAY, httpBase: HTTP_BASE }));
     mcp.tool('federation_sync', 'Fetch recent verified swarm coordination messages (#t=ruflo-swarm). Open read; optional type filter.',
@@ -80,8 +80,17 @@ export function createGateway({ relay, keyFile, port } = {}) {
       }));
     // ---- Seraphina: swarm queen guidance (admin-gated: it spends meta-llm budget) ----
     mcp.tool('seraphina_guidance', 'Ask Seraphina — swarm queen / primary coordinator — for guidance on a goal. Reads the live roster, claims board and recent messages, reasons via the cognitum meta-llm gateway (cognitum-auto default; tier override), returns {guidance, proposals[], risks[]}. Admin-gated because it spends meta-llm budget. Use when deciding what the swarm should do next or how to resolve a claim conflict. Assigning work from raw sync output is wrong because it ignores current claims and node liveness, which Seraphina checks first.',
-      { goal: z.string(), tier: z.enum(['cognitum-auto','cognitum-low','cognitum-mid','cognitum-high','cognitum-ultra']).optional(), sinceSeconds: z.number().optional(), limit: z.number().optional(), ...adminArg },
-      gated(async ({ goal, tier, sinceSeconds, limit }) => {
+      { goal: z.string(), tier: z.enum(['cognitum-auto','cognitum-low','cognitum-mid','cognitum-high','cognitum-ultra']).optional(), adminToken: z.string().optional().describe('Optional. Lifts the shared budget cap and allows the high/ultra tiers. Never put this in a browser — it also authorises gateway-identity writes.'), sinceSeconds: z.number().optional(), limit: z.number().optional() },
+      (async ({ goal, tier, sinceSeconds, limit, adminToken }) => {
+        // Seraphina reads and advises; it writes nothing and carries no authority,
+        // so it is bounded by budget rather than by a bearer secret a browser
+        // cannot hold. Every WRITE tool above stays admin-gated.
+        const isAdmin = checkAdmin(adminToken);
+        const allow = seraphinaAllowance(req, isAdmin);
+        if (!allow.allowed) return { isError: true, content: [{ type: 'text', text: JSON.stringify({ error: 'budget', reason: allow.reason }) }] };
+        // An anonymous caller may not select the most expensive tiers.
+        const effectiveTier = isAdmin ? tier : (ANON_TIERS.includes(tier) ? tier : 'cognitum-auto');
+
         // One authenticated relay connection, three REQs (was three separate NIP-42 handshakes).
         const [hellos, ev, recent] = await fetchManyOn(RELAY, sk, [
           { sinceSeconds: 6 * 3600, limit: 200, type: 'PeerHello' },
@@ -90,7 +99,8 @@ export function createGateway({ relay, keyFile, port } = {}) {
         ]);
         const roster = {}; for (const h of hellos) roster[h.pubkey] = { from: h.from, platform: h.platform, lastSeen: h.ts };
         const claims = reduceClaims(ev.filter((e) => String(e.type).startsWith('Claim')));
-        return text(await askSeraphina(goal, { roster, claims, recentMessages: recent }, { key: process.env.SERAPHINA_METALLM_KEY, tier }));
+        const result = await askSeraphina(goal, { roster, claims, recentMessages: recent }, { key: process.env.SERAPHINA_METALLM_KEY, tier: effectiveTier });
+        return text({ ...result, budget: allow.admin ? 'admin (uncapped)' : `shared daily budget, ${allow.remainingToday} calls left today` });
       }));
     // ---- ruv:// resources (open) ----
     mcp.resource('federation-registry', 'ruv://federation/registry', async () => ({ contents: [{ uri: 'ruv://federation/registry', mimeType: 'application/json',
@@ -110,11 +120,11 @@ export function createGateway({ relay, keyFile, port } = {}) {
     const url = new URL(req.url, `http://${req.headers.host || 'x'}`);
     if (url.pathname === '/health') return res.writeHead(200).end('ok');
     if (url.pathname === '/' && req.method === 'GET') { res.writeHead(200, { 'content-type': 'application/json' });
-      return res.end(JSON.stringify({ service: 'ruflo-x-gateway', version: '0.5.0', mcp: '/mcp', ws: ['/', '/relay'], relay: RELAY, canonicalRelay: RELAY, legacyRelay: LEGACY_RELAY, authNote: 'When connecting via wss://x.ruv.io, sign the NIP-42 AUTH `relay` tag with canonicalRelay (the relay verifies it strictly).', gatewayPubkey: pubkey, resources: ['ruv://federation/registry', 'ruv://swarm/roster', 'ruv://claims/board', 'ruv://swarm/channels'] })); }
+      return res.end(JSON.stringify({ service: 'ruflo-x-gateway', version: '0.6.1', mcp: '/mcp', ws: ['/', '/relay'], relay: RELAY, canonicalRelay: RELAY, legacyRelay: LEGACY_RELAY, authNote: 'When connecting via wss://x.ruv.io, sign the NIP-42 AUTH `relay` tag with canonicalRelay (the relay verifies it strictly).', gatewayPubkey: pubkey, resources: ['ruv://federation/registry', 'ruv://swarm/roster', 'ruv://claims/board', 'ruv://swarm/channels'] })); }
     if (url.pathname === '/mcp') {
       if (rateLimited(req)) return res.writeHead(429, { 'content-type': 'application/json' }).end('{"error":"rate limited"}');
       let body; try { body = await readBody(req); } catch { return res.writeHead(413, { 'content-type': 'application/json' }).end('{"error":"payload too large"}'); }
-      const mcp = buildMcp(); const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      const mcp = buildMcp(req); const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
       res.on('close', () => { transport.close(); mcp.close(); });
       await mcp.connect(transport);
       let parsed; try { parsed = body ? JSON.parse(body) : undefined; } catch { return res.writeHead(400, { 'content-type': 'application/json' }).end('{"error":"invalid json"}'); }

--- a/plugins/ruflo-x-gateway/test/gateway.test.mjs
+++ b/plugins/ruflo-x-gateway/test/gateway.test.mjs
@@ -229,6 +229,62 @@ test('channels: the registry resource publishes the directory', async () => {
   const { DEFAULT_CHANNELS } = await import('../src/channels.mjs');
   for (const d of DEFAULT_CHANNELS) assert.ok(body.includes(d.channel), `${d.channel} missing from the registry`);
   const info = await (await fetch(base + '/')).json();
-  assert.equal(info.version, '0.5.0');
+  assert.equal(info.version, '0.6.1');
   gw.server.close();
 });
+
+test('seraphina: reachable without a token, bounded by budget; writes stay admin-gated', async () => {
+  const { seraphinaAllowance, _resetSeraphinaBudgetForTest, SERAPHINA_IP_HOURLY_CAP, ANON_TIERS } =
+    await import('../src/security.mjs');
+  _resetSeraphinaBudgetForTest();
+  const req = { headers: { 'x-forwarded-for': '203.0.113.9' }, socket: { remoteAddress: '203.0.113.9' } };
+
+  // An anonymous caller is allowed, and told what it has left.
+  const first = seraphinaAllowance(req, false);
+  assert.equal(first.allowed, true);
+  assert.equal(first.admin, false);
+  assert.ok(typeof first.remainingToday === 'number');
+
+  // Per-IP hourly ceiling stops a runaway client without a password.
+  for (let i = 1; i < SERAPHINA_IP_HOURLY_CAP; i++) assert.equal(seraphinaAllowance(req, false).allowed, true);
+  const over = seraphinaAllowance(req, false);
+  assert.equal(over.allowed, false);
+  assert.match(over.reason, /calls for the hour/);
+
+  // A different client is unaffected — the limit is per caller, not global panic.
+  const other = { headers: {}, socket: { remoteAddress: '198.51.100.4' } };
+  assert.equal(seraphinaAllowance(other, false).allowed, true);
+
+  // An admin token lifts the cap for the same exhausted client.
+  assert.equal(seraphinaAllowance(req, true).allowed, true);
+  assert.equal(seraphinaAllowance(req, true).admin, true);
+
+  // The expensive tiers are not selectable anonymously.
+  assert.ok(!ANON_TIERS.includes('cognitum-high'));
+  assert.ok(!ANON_TIERS.includes('cognitum-ultra'));
+  _resetSeraphinaBudgetForTest();
+});
+
+test('seraphina: the tool answers without adminToken while claims_issue still refuses', async () => {
+  process.env.RUFLO_ADMIN_TOKEN = 'test-admin-token';
+  const gw = createGateway({ relay: 'ws://127.0.0.1:1', keyFile: '/tmp/x-gw-sera-' + Date.now() + '.key', port: 0 });
+  const port = await gw.listen(0); const base = `http://127.0.0.1:${port}`;
+  const rpc = (m) => fetch(base + '/mcp', { method: 'POST', headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' }, body: JSON.stringify(m) }).then((r) => r.text());
+
+  // Assert the CONTRACT, not the network: adminToken must be optional in the
+  // schema. Invoking it here would now reach a dead relay and hang, precisely
+  // because it is no longer rejected up front — which is the change under test.
+  const list = await rpc({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+  const sera = JSON.parse(list.slice(list.indexOf('{'))).result.tools.find((t) => t.name === 'seraphina_guidance');
+  assert.ok(sera, 'seraphina_guidance must be registered');
+  assert.ok(!(sera.inputSchema.required || []).includes('adminToken'), 'adminToken must not be required');
+  const gatedWrite = JSON.parse(list.slice(list.indexOf('{'))).result.tools.find((t) => t.name === 'claims_issue');
+  assert.ok((gatedWrite.inputSchema.required || []).includes('adminToken'), 'writes must still require it');
+
+  // The write path is unchanged: still refused without a token.
+  const write = await rpc({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'claims_issue', arguments: { resourceId: 'x' } } });
+  assert.match(write, /admin token required|invalid_type|Required/);
+
+  gw.server.close();
+});
+

--- a/plugins/ruflo-x-gateway/test/gateway.test.mjs
+++ b/plugins/ruflo-x-gateway/test/gateway.test.mjs
@@ -229,7 +229,7 @@ test('channels: the registry resource publishes the directory', async () => {
   const { DEFAULT_CHANNELS } = await import('../src/channels.mjs');
   for (const d of DEFAULT_CHANNELS) assert.ok(body.includes(d.channel), `${d.channel} missing from the registry`);
   const info = await (await fetch(base + '/')).json();
-  assert.equal(info.version, '0.6.1');
+  assert.equal(info.version, '0.7.0');
   gw.server.close();
 });
 
@@ -288,3 +288,57 @@ test('seraphina: the tool answers without adminToken while claims_issue still re
   gw.server.close();
 });
 
+
+test('onboarding: the guide names both identities and never handles a secret key', async () => {
+  const { onboardingGuide } = await import('../src/onboarding.mjs');
+  const g = onboardingGuide({ relay: 'wss://relay.ruv.io', httpBase: 'https://relay.ruv.io', gatewayPubkey: 'ab'.repeat(32), defaultChannels: [] });
+
+  // The confusion this exists to prevent: which identity signs what.
+  assert.ok(/YOUR identity/.test(g.readThisFirst) && /THE GATEWAY/.test(g.readThisFirst));
+  assert.ok(g.identities.you.noTokenNeeded.includes('needs no admin token'));
+  assert.ok(/admin-gated/.test(g.identities.gateway.what));
+
+  // It must hand over code to run locally, not offer to generate a key here.
+  const code = g.steps.find((s) => s.code)?.code ?? '';
+  assert.ok(code.includes('generateSecretKey()'), 'the caller generates their own key');
+  assert.ok(/never leaves your machine|never transmitted/.test(JSON.stringify(g)), 'must say the key stays local');
+
+  // Structural, not string-matching: an earlier version of this test failed on the
+  // guide's own "Never send your secret key" line, which is the opposite of the
+  // risk. What matters is that no field solicits secret material and the guide
+  // states the key stays local.
+  const secretSolicitingKeys = Object.keys(g).concat(Object.keys(g.identities))
+    .filter((k) => /secretkey|privatekey|seed|nsec/i.test(k));
+  assert.deepEqual(secretSolicitingKeys, [], 'no field may carry or ask for a secret key');
+  assert.ok(g.neverDo.some((n) => /Never send your secret key/.test(n)));
+  assert.ok(g.neverDo.some((n) => /Never put an admin token in a browser/.test(n)));
+
+  // The three field-learned traps stay recorded.
+  const gotchas = g.gotchas.join(' ');
+  assert.match(gotchas, /relay tag with wss:\/\/relay\.ruv\.io exactly/);
+  assert.match(gotchas, /binds publishing to the authenticated connection/);
+  assert.match(gotchas, /channel tag is `c`, not `h`/);
+});
+
+test('onboarding: exposed as an open tool and an open resource', async () => {
+  process.env.RUFLO_ADMIN_TOKEN = 'test-admin-token';
+  const gw = createGateway({ relay: 'ws://127.0.0.1:1', keyFile: '/tmp/x-gw-ob-' + Date.now() + '.key', port: 0 });
+  const port = await gw.listen(0); const base = `http://127.0.0.1:${port}`;
+  const rpc = (m) => fetch(base + '/mcp', { method: 'POST', headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' }, body: JSON.stringify(m) }).then((r) => r.text());
+
+  const tools = JSON.parse((await rpc({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })).slice((await rpc({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })).indexOf('{'))).result.tools;
+  const ob = tools.find((t) => t.name === 'federation_onboarding');
+  assert.ok(ob, 'federation_onboarding must be registered');
+  assert.deepEqual(ob.inputSchema.required ?? [], [], 'onboarding must take no credential');
+  assert.match(ob.description, /Use when/);
+  assert.match(ob.description, /wrong turn|is wrong/);
+
+  // Callable with no arguments and no token at all.
+  const called = await rpc({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'federation_onboarding', arguments: {} } });
+  assert.doesNotMatch(called, /admin token required or invalid/);
+  assert.match(called, /readThisFirst/);
+
+  const info = await (await fetch(base + '/')).json();
+  assert.ok(info.resources.includes('ruv://federation/onboarding'));
+  gw.server.close();
+});

--- a/scripts/audit-env-var-precedence.mjs
+++ b/scripts/audit-env-var-precedence.mjs
@@ -53,6 +53,9 @@ const REPO_ROOT = resolve(__dirname, '..');
 const KNOWN_ESCAPE_HATCHES = new Set([
   // ── CI / test escape hatches ────────────────────────────────────────────────
   'CLAUDE_FLOW_DISABLE_BRIDGE',   // CI/test: force raw sql.js path — intentionally no CLI flag
+  'RUFLO_ADMIN_TOKEN',            // credential: the x.ruv.io gateway's OWN admin token, read by plugins/ruflo-x-gateway. Env-only by design — a secret must never be a CLI flag (shell history / process lists), and the gateway is a service with no typed command surface at all.
+  'RUFLO_SERAPHINA_DAILY_CAP',    // gateway spend guard (#3275): shared daily Seraphina budget. Read by a long-running service, not a typed command — there is no invocation to attach a flag to.
+  'RUFLO_SERAPHINA_IP_HOURLY_CAP',// gateway spend guard (#3275): per-client hourly Seraphina budget. Same service-only reasoning.
   'RUFLO_X_ADMIN_TOKEN',          // credential: gateway admin token for x.ruv.io gateway-identity writes (x_federation_publish/invite_mint/admit). Env-only by design — a secret must never be a CLI flag (shell history / process lists). URL config (RUFLO_X_GATEWAY_URL) DOES take a flag: `ruflo federation --gateway`.
   'SERAPHINA_METALLM_KEY',        // credential: cognitum meta-llm API key for seraphina_guidance. Env-only by design (same reasoning). URL config (SERAPHINA_METALLM_URL) takes the metaLlmUrl tool arg.
   'RUFLO_HOOK_SKIP_NPX',          // CI: suppress cold-install latency in smoke tests
@@ -247,7 +250,7 @@ const SCAN_ROOTS = [
 ];
 
 // ── Skip patterns ─────────────────────────────────────────────────────────────
-const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', 'coverage', '__tests__', 'tests']);
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', 'coverage', '__tests__', 'tests', 'test']);
 const SCAN_EXTS = new Set(['.ts', '.mjs', '.cjs', '.js']);
 
 // ── Regex to find process.env.CLAUDE_FLOW_* reads ────────────────────────────


### PR DESCRIPTION
Brings git in line with what is running on `x.ruv.io` (revision `ruflo-x-gateway-00014-lqf`, version 0.6.1).

A published UI could not use Seraphina, because it required `RUFLO_ADMIN_TOKEN` and a browser has nowhere safe to keep one.

**The gate was answering the wrong question.** Seraphina reads the roster, the claims board and recent messages, asks a model, and returns advice. It writes nothing and carries no authority — unlike every other tool behind that gate, all of which publish with the gateway identity. Its real exposure is model spend, and spend is bounded with a budget, not a password.

The practical cost was worse than a wrong abstraction: the only way to ship a working UI was to put `RUFLO_ADMIN_TOKEN` in client-side code, and that token also mints invites and publishes as the gateway. The safe-looking option was the catastrophic one.

**Now:** Seraphina answers with no token, bounded by a shared daily cap and a per-client hourly cap, and anonymous callers cannot select `high` or `ultra`. An admin token lifts both, so operators are unchanged. Caps are tunable via `RUFLO_SERAPHINA_DAILY_CAP` and `RUFLO_SERAPHINA_IP_HOURLY_CAP`; they are per-instance counters — a runaway guard, not a billing system.

**Writes are untouched**, verified against the live deployment with an anonymous caller: `claims_issue`, `federation_invite_mint`, `federation_publish`, `federation_admit` and `channel_publish` all refuse.

**Not included, deliberately.** I built a tool to relay member-signed events through the gateway, tested it against the live relay, and removed it. buzz-relay refuses any `EVENT` whose pubkey differs from the NIP-42 authenticated connection, so a gateway cannot publish on another identity's behalf — and it does not need to. Members already publish as themselves through the `wss://x.ruv.io` proxy, verified end to end. Shipping a tool that always fails would be worse than shipping none.

That dead end did surface something worth keeping: `verifyEvent()` from nostr-tools returns **true** for an event whose body was swapped after signing, because it checks the signature against the stored `id` without re-deriving it. Any endpoint that trusts it alone can be made to relay forged text attributed to a real member. Recorded, with the fix — compare `getEventHash(ev)` to `ev.id` first.

18/18 tests. Rollback target `ruflo-x-gateway-00010-nh4`.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)