### PR TITLE
fix(witness): make WITNESS_ED25519_ROOT actually resolve @noble/ed25519 (#3200)

### DIFF
--- a/plugins/ruflo-core/scripts/witness/lib.mjs
+++ b/plugins/ruflo-core/scripts/witness/lib.mjs
@@ -60,7 +60,11 @@ function loadEd25519(probeRoots) {
   // pnpm's isolated layout (where transitive deps don't hoist to the
   // workspace root) still resolves @noble/ed25519. Callers don't need
   // to know about this — the function just probes more places.
+  // WITNESS_ED25519_ROOT is the escape hatch the thrown error below
+  // advertises — it must actually be probed, first, or the message lies.
+  const envRoot = process.env.WITNESS_ED25519_ROOT;
   const expanded = [
+    ...(envRoot ? [envRoot] : []),
     ...probeRoots,
     ...probeRoots.flatMap(r => [
       join(r, 'v3/@claude-flow/cli'),


### PR DESCRIPTION
## Summary

`loadEd25519()` in `plugins/ruflo-core/scripts/witness/lib.mjs` throws an
error when it can't locate `@noble/ed25519`, and that error text advertises
`WITNESS_ED25519_ROOT` as an escape hatch:

> Could not locate '@noble/ed25519'. Install it in your project
> (npm i @noble/ed25519) or pass a node_modules root via the
> WITNESS_ED25519_ROOT env var. Probed: ...

But the function never reads `process.env` anywhere — `grep -n
'process.env' plugins/ruflo-core/scripts/witness/lib.mjs` returned zero
matches before this change. Setting the env var had no effect; it just sent
users hunting for a workaround that doesn't exist.

- read `process.env.WITNESS_ED25519_ROOT` in `loadEd25519()`
- prepend it (when set) to the probe-root list, before the caller-supplied
  roots and the hardcoded workspace-subpath joins

No other behavior changes — probing still falls through to the existing
roots when the env var is unset.

## Validation

Reproduced the gap and verified the fix with a standalone probe (no
`@noble/ed25519` install required): a fake `node_modules/@noble/ed25519`
package placed only under a temp dir, with `probeRoots` deliberately
pointing elsewhere.

- Without `WITNESS_ED25519_ROOT` set: probing the (wrong) `probeRoots`
  fails, as expected.
- With `WITNESS_ED25519_ROOT` set to the temp dir: resolves successfully.

Fixes #3200