### PR TITLE
fix(doctor): resolve MetaHarness version from the installed package (#3187)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/doctor.ts
+++ b/v3/@claude-flow/cli/src/commands/doctor.ts
@@ -2059,20 +2059,40 @@ async function checkMetaharnessDeclaredPackages(): Promise<HealthCheck> {
 
 async function checkMetaharness(): Promise<HealthCheck> {
   try {
-    const version = await runCommand('npx -y metaharness@latest --version 2>&1', 15000);
-    // metaharness emits multi-line stdout; parse a version-shaped line.
-    const versionMatch = version.match(/(\d+\.\d+\.\d+)/);
-    if (!versionMatch) {
+    // `metaharness` has no --version flag (it falls through to the usage
+    // banner, which never matches a version regex) and shelling out via
+    // `npx metaharness@latest` ignores the installed version and hits the
+    // network every run. Resolve the version from the installed package's
+    // own package.json instead. `import.meta.resolve` is the reliable route:
+    // `require('metaharness/package.json')` is blocked by the package's
+    // `exports` map, and `createRequire().resolve()` fails on its ESM-only
+    // entry point.
+    const resolved = import.meta.resolve('metaharness');
+    let dir = dirname(fileURLToPath(resolved));
+    let version: string | null = null;
+    for (let i = 0; i < 8; i++) {
+      const pj = join(dir, 'package.json');
+      if (existsSync(pj)) {
+        try {
+          const j = JSON.parse(readFileSync(pj, 'utf-8')) as { name?: string; version?: string };
+          if (j.name === 'metaharness') { version = j.version ?? null; break; }
+        } catch { /* keep walking */ }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    if (!version) {
       return {
         name: 'MetaHarness (ADR-150)',
         status: 'warn',
-        message: 'Installed but version-string not parseable; integration may still work',
+        message: 'Installed but its package.json was not found while walking up from the resolved module; integration may still work',
       };
     }
     return {
       name: 'MetaHarness (ADR-150)',
       status: 'pass',
-      message: `v${versionMatch[1]} — run \`npx ruflo metaharness score\` for the full scorecard`,
+      message: `v${version} — run \`npx ruflo metaharness score\` for the full scorecard`,
     };
   } catch {
     return {


### PR DESCRIPTION
## Summary

`doctor`'s MetaHarness check (`checkMetaharness()` in
`v3/@claude-flow/cli/src/commands/doctor.ts`) permanently reported:

> ⚠ MetaHarness (ADR-150): Installed but version-string not parseable;
> integration may still work

even with a working `metaharness` install, because:

1. **`metaharness` has no `--version` flag.** The old check shelled out to
   `npx -y metaharness@latest --version`, which falls through to the usage
   banner — a string with no `x.y.z`-shaped token — so the version regex
   could never match, regardless of what's installed.
2. **It ignored the installed package.** `npx -y metaharness@latest`
   reports on whatever npm serves, not the version actually resolvable in
   the project.
3. **It hit the network on every `doctor` run** (~15s timeout budget),
   which also breaks/hangs `doctor` on an offline or air-gapped machine.

Fix: resolve the version from the installed package's own `package.json`
via `import.meta.resolve('metaharness')`, walking up from the resolved
module path to find the owning `package.json`. Two alternatives were
ruled out:
- `require('metaharness/package.json')` — blocked by the package's
  `exports` map (`ERR_PACKAGE_PATH_NOT_EXPORTED`)
- `createRequire().resolve('metaharness')` — fails on the package's
  ESM-only entry point

`import.meta.resolve` is synchronous and unflagged since Node 20.6, within
this repo's supported Node 20+ range.

## Validation

- Confirmed `import.meta.resolve('metaharness')` type-checks as `string`
  under this project's `tsconfig` (`target: ES2022`, `module: ESNext`,
  `moduleResolution: bundler`) with `@types/node` — isolated `tsc --noEmit`
  check passes.
- Reviewed the diff against `checkMetaharnessDeclaredPackages()` just above
  it in the same file, which already uses the same "walk up from a resolved
  module path to find package.json" pattern for `@claude-flow/cli`'s own
  root — this fix follows the same, already-established approach.
- The check drops from a ~15s network round trip (or timeout) to an
  in-process file read.

Fixes #3187