### PR TITLE
chore(release): 3.41.2 — memory index protection, daemon consent, sibling disclosure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-flow",
-  "version": "3.41.1",
+  "version": "3.41.2",
   "workspaces": [
     "v3/@claude-flow/codex",
     "v3/@claude-flow/mcp",

--- a/ruflo/package.json
+++ b/ruflo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruflo",
-  "version": "3.41.1",
+  "version": "3.41.2",
   "description": "Ruflo - Enterprise AI agent orchestration platform. Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
   "main": "bin/ruflo.js",
   "type": "module",

--- a/v3/@claude-flow/cli/package.json
+++ b/v3/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-flow/cli",
-  "version": "3.41.1",
+  "version": "3.41.2",
   "type": "module",
   "description": "Ruflo CLI - Enterprise AI agent orchestration with 60+ specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Patch release. Three fixes from the current issue backlog, each confirmed in source and each with a test that fails without it.

**#3224 — silent user data loss.** The bridge rebuilt `MEMORY.md` from its own topic files and overwrote whatever was there. The `#1556` guard only skipped the write when *nothing* matched, but the bridge writes the first topic file itself, so after the first insight a hand-maintained index was replaced with a stub — 75 lines and 49 links down to 6 in the report. A curate may now grow or reorder the index and never shrink it; a smaller generated view goes beside the file and the bridge says it declined.

**#3278 — `autoStart: false` was ignored.** The disable check read `claude-flow.config.json` → `daemon.autostart`; `init` generates `.claude/settings.json` → `claudeFlow.daemon.autoStart`. Different file, different capital S, so the setting a fresh project actually ships was never consulted — under a comment saying it exists to prevent unintended token consumption.

**#3228, the half that was ours.** 3.41.1 shipped the sibling-store disclosure in `memory list` alone. `retrieve`, `search` and an empty list kept returning a confident negative while the rows sat in the file they do not read.

**Verified before cutting:** umbrella lockstep passes with all three packages at 3.41.2, and `pnpm install --frozen-lockfile` is clean in `v3/`.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)