### PR TITLE
fix(x-gateway): claims reducer honours ttlSeconds — expired leases free the resource

### DIFF
--- a/plugins/ruflo-x-gateway/node_modules
+++ b/plugins/ruflo-x-gateway/node_modules
@@ -1,1 +1,0 @@
-/private/tmp/claude-501/-Users-cohen-Projects-ruflo/655cdb4f-b1d0-436a-9259-3bfdb013c450/scratchpad/gw/plugins/ruflo-x-gateway/node_modules

--- a/plugins/ruflo-x-gateway/src/claims.mjs
+++ b/plugins/ruflo-x-gateway/src/claims.mjs
@@ -1,11 +1,25 @@
 // Owner-per-resource ledger reduced from claim events (oldest first).
-export function reduceClaims(events) {
+//
+// A claim with ttlSeconds expires at created_at + ttlSeconds. An expired claim is not an
+// owner: it is dropped from the ledger, and a later ClaimIssued for the same resource wins.
+// Expiry is evaluated against the later event's own timestamp while reducing (so history
+// replays deterministically) and against `now` for the final ledger (so a resource whose
+// owner disconnected without releasing frees itself once the lease runs out).
+const expiresAt = (c) => (c.ttlSeconds > 0 ? c.issuedAt + c.ttlSeconds : Infinity);
+export function reduceClaims(events, now = Math.floor(Date.now() / 1000)) {
   const byRes = {};
   for (const e of [...events].sort((a, b) => a.created_at - b.created_at)) {
     const r = e.resourceId; if (!r) continue;
-    if (e.type === 'ClaimIssued') { if (!byRes[r]) byRes[r] = { owner: e.pubkey, from: e.from, at: e.ts, ttlSeconds: e.ttlSeconds }; }
-    else if (e.type === 'ClaimReleased') { if (byRes[r]?.owner === e.pubkey) delete byRes[r]; }
+    const cur = byRes[r];
+    if (cur && expiresAt(cur) <= e.created_at) delete byRes[r];
+    if (e.type === 'ClaimIssued') {
+      if (!byRes[r]) byRes[r] = { owner: e.pubkey, from: e.from, at: e.ts, ttlSeconds: e.ttlSeconds, issuedAt: e.created_at };
+    } else if (e.type === 'ClaimReleased') { if (byRes[r]?.owner === e.pubkey) delete byRes[r]; }
     else if (e.type === 'ClaimHandoff') { if (byRes[r]?.owner === e.pubkey && e.toNode) byRes[r].owner = e.toNode; }
+  }
+  for (const [r, c] of Object.entries(byRes)) {
+    if (expiresAt(c) <= now) delete byRes[r];
+    else { c.expiresAt = Number.isFinite(expiresAt(c)) ? new Date(expiresAt(c) * 1000).toISOString() : null; delete c.issuedAt; }
   }
   return byRes;
 }

--- a/plugins/ruflo-x-gateway/test/gateway.test.mjs
+++ b/plugins/ruflo-x-gateway/test/gateway.test.mjs
@@ -17,6 +17,19 @@ test('claims: release by owner frees; release by non-owner ignored', () => {
   assert.deepEqual(reduceClaims([ev('ClaimIssued', 'A', 'r1', 1), ev('ClaimReleased', 'A', 'r1', 2)]), {});
   assert.equal(reduceClaims([ev('ClaimIssued', 'A', 'r1', 1), ev('ClaimReleased', 'B', 'r1', 2)]).r1.owner, 'A');
 });
+test('claims: ttl expiry frees the resource and lets a later claim win', () => {
+  // A claims at t=10 with a 60s lease; B claims at t=100 (after expiry) -> B owns it.
+  const l = reduceClaims([ev('ClaimIssued', 'A', 'r1', 10, { ttlSeconds: 60 }), ev('ClaimIssued', 'B', 'r1', 100, { ttlSeconds: 600 })], 150);
+  assert.equal(l.r1.owner, 'B'); assert.equal(l.r1.ttlSeconds, 600); assert.ok(l.r1.expiresAt);
+  // A's lease still live when B claims -> A keeps it.
+  assert.equal(reduceClaims([ev('ClaimIssued', 'A', 'r1', 10, { ttlSeconds: 600 }), ev('ClaimIssued', 'B', 'r1', 100)], 150).r1.owner, 'A');
+  // Disconnected worker: lease expired relative to `now`, nobody released -> resource is free.
+  assert.deepEqual(reduceClaims([ev('ClaimIssued', 'A', 'r1', 10, { ttlSeconds: 60 })], 200), {});
+  // No ttl -> never expires.
+  assert.equal(reduceClaims([ev('ClaimIssued', 'A', 'r1', 10)], 10_000_000).r1.owner, 'A');
+  // A release of an already-expired claim is a no-op, not an error.
+  assert.deepEqual(reduceClaims([ev('ClaimIssued', 'A', 'r1', 10, { ttlSeconds: 60 }), ev('ClaimReleased', 'A', 'r1', 500)], 600), {});
+});
 test('claims: handoff only by current owner', () => {
   assert.equal(reduceClaims([ev('ClaimIssued', 'A', 'r1', 1), ev('ClaimHandoff', 'A', 'r1', 2, { toNode: 'C' })]).r1.owner, 'C');
   assert.equal(reduceClaims([ev('ClaimIssued', 'A', 'r1', 1), ev('ClaimHandoff', 'B', 'r1', 2, { toNode: 'C' })]).r1.owner, 'A');


### PR DESCRIPTION
## Problem

An external node running failure-path probes against the live swarm (`qe/test-expired-lease`, 120 s TTL; `qe/test-disconnect`, 90 s TTL, never released) found that both stayed on the claims board minutes after expiry. `reduceClaims` stored `ttlSeconds` but never applied it. A worker that claimed and then disconnected held the resource forever, and the 3.41.0 guide's statement that a timed-out claim frees itself was untrue.

## Fix

`plugins/ruflo-x-gateway/src/claims.mjs`
- While reducing, a claim whose lease has lapsed by the time the next event arrives is dropped first, so a later `ClaimIssued` after expiry wins (deterministic replay).
- The final ledger is filtered against `now`, so a disconnected owner's lease lapses without a release.
- Claims with no `ttlSeconds` never expire (unchanged). Entries gain `expiresAt` (ISO) for clients.

## Tests

`plugins/ruflo-x-gateway/test/gateway.test.mjs`: expiry lets a later claim win; a live lease is kept; disconnected worker frees; no-ttl never expires; releasing an expired claim is a no-op. 21/21 pass.

## Follow-up

Gateway redeploy after merge so `ruv://claims/board` and `ruflo federation claims` reflect it.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_015y2UjPSd3VX1CYnPstZJ5D