### PR TITLE
fix(gateway): GET /mcp serves discovery, after four client failures

### DIFF
--- a/plugins/ruflo-x-gateway/src/server.mjs
+++ b/plugins/ruflo-x-gateway/src/server.mjs
@@ -244,16 +244,124 @@ export function createGateway({ relay, keyFile, port } = {}) {
         authorization: { type: 'oauth2', issuer: OAUTH_ISSUER, clientId: OAUTH_CLIENT_ID || null,
           scopes: [SCOPE_READ, SCOPE_PUBLISH], protectedResourceMetadata: prmUrl('/mcp'),
           note: 'Additive: reads stay open and adminToken still works; an access token with swarm:publish is an alternative write credential.' } })); }
+    // ---- MCP Server Registry (modelcontextprotocol/registry) ----
+    // Several clients treat a URL you hand them as a REGISTRY — a directory of
+    // servers — before they treat it as a server. Lovable does: every failure it
+    // reported named "registry", and once the body finally parsed it said
+    // `This registry currently advertises no servers.`
+    //
+    // So this gateway publishes itself as a one-entry registry. The shape is the
+    // official one, taken from a live response of
+    // registry.modelcontextprotocol.io/v0/servers rather than from prose: a
+    // `servers` array whose items wrap the entry under `server`, with `_meta`
+    // alongside, and a sibling `metadata` for the page.
+    //
+    // It lists THIS gateway only. Listing api.cognitum.one here would be this
+    // service asserting the shape and availability of another one, which is not
+    // its to claim.
+    const registryEntry = () => ({
+      server: {
+        $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+        name: 'io.ruv.x/mcp',
+        title: 'Ruflo Federation Gateway',
+        description: 'Swarm federation coordination over Nostr: read the roster, claims board and '
+          + 'channels, and publish signed coordination messages. Anonymous reads are open; writes '
+          + 'take an OAuth token carrying ' + SCOPE_PUBLISH + '.',
+        version: '0.7.0',
+        remotes: [{ type: 'streamable-http', url: `${PUBLIC_URL}/mcp` }],
+      },
+      _meta: {
+        'io.modelcontextprotocol.registry/official': { status: 'active', isLatest: true },
+      },
+    });
+    const registryDoc = () => ({ servers: [registryEntry()], metadata: { count: 1 } });
+
+    // The conventional registry paths, so a client pointed at the ORIGIN finds
+    // the listing where the spec says it lives. v0 is what the live registry
+    // serves today; v0.1 is its stated successor, and answering both costs one
+    // line rather than a future outage.
+    if (req.method === 'GET' && /^\/v0(\.1)?\/servers\/?$/.test(url.pathname)) {
+      res.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+      return res.end(JSON.stringify(registryDoc()));
+    }
+
     if (url.pathname === '/mcp' && req.method === 'GET') {
-      // Streamable HTTP allows a GET to open a server->client SSE stream, but
-      // this transport is STATELESS (sessionIdGenerator: undefined) so there is
-      // no session to attach one to: the SDK holds the socket open and Cloud Run
-      // eventually severs it at 300s with "Truncated response body". A client
-      // probing GET then waits five minutes instead of failing in milliseconds.
-      // 405 is the spec's answer for a server that does not offer the GET stream.
-      res.writeHead(405, { 'content-type': 'application/json', allow: 'POST, OPTIONS' });
-      return res.end(JSON.stringify({ error: 'method_not_allowed',
-        error_description: 'this MCP endpoint is stateless; use POST' }));
+      // Streamable HTTP's GET opens a server->client SSE stream. This one
+      // response has now failed five clients five ways. The whole sequence is
+      // recorded because each attempt DISPROVED the previous theory, and the
+      // final shape only makes sense as the answer to all five:
+      //
+      //   1. Unbounded open stream -> Cloud Run severed it at 300s with
+      //      "Truncated response body"; a probe waited five minutes.
+      //   2. Bare 405 (spec-correct for a server offering no GET stream) -> it
+      //      carries no WWW-Authenticate, so a probing client cannot discover
+      //      this resource speaks OAuth: `registry returned 405`.
+      //   3. 401 + challenge -> `registry returned 401`. The probe wants 2xx and
+      //      never reads a challenge.
+      //   4. Bounded long-lived stream -> `context deadline exceeded ... while
+      //      reading body`. The client reads to COMPLETION, so ANY open stream is
+      //      a timeout however well bounded — and it never arrived through the
+      //      load balancer at all, because a proxy flushes when a response ENDS.
+      //   5. Immediate open-and-close SSE -> `parsing registry response: invalid
+      //      character ':' looking for beginning of value`. That ':' is the SSE
+      //      comment leader: the client parses this body as JSON.
+      //
+      // (5) is not conformant — the MCP spec says GET opens an event stream —
+      // but it is real, and the two demands are not in conflict, because they
+      // are distinguishable by Accept. So: honour the spec for a client that
+      // ASKS for an event stream, and serve a finite JSON descriptor to
+      // everything else. Both end immediately, which is what (1) and (4) require.
+      //
+      // Nothing regresses: GET /mcp answered 405 until today, so no working
+      // client depends on a long-lived stream. Anonymous reads were always over
+      // POST and are untouched.
+      const accept = String(req.headers.accept || '');
+      const wantsStream = accept.includes('text/event-stream');
+      if (wantsStream) {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache, no-transform',
+          'x-accel-buffering': 'no',
+        });
+        return res.end(
+          `: ruflo-x-gateway ${new Date().toISOString()}\n` +
+          ': stateless Streamable HTTP; no server-initiated messages. POST JSON-RPC to this URL.\n\n',
+        );
+      }
+      // A finite JSON descriptor. Deliberately NOT a JSON-RPC envelope: this is
+      // not a response to any request, and dressing it as one would invite a
+      // client to treat it as the result of a call it never made. Tool names are
+      // not listed here — they would drift from the real registry — so it points
+      // at `tools/list`, which is always current.
+      res.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+      return res.end(JSON.stringify({
+        // `servers` FIRST and at the top level, because a client that probes this
+        // URL as a registry looks for exactly that and reports "advertises no
+        // servers" when it is absent. The descriptive fields below are additive:
+        // a registry client reads the array, a human reading the response gets
+        // told what this endpoint is and how to call it.
+        ...registryDoc(),
+        service: 'ruflo-x-gateway',
+        version: '0.7.0',
+        protocol: 'mcp',
+        transport: 'streamable-http',
+        endpoint: `${PUBLIC_URL}/mcp`,
+        methods: ['POST'],
+        note: 'Stateless Streamable HTTP. Send JSON-RPC over POST to this same URL; '
+            + 'call tools/list for the current tool set. A GET returns this descriptor, '
+            + 'or an immediately-closed event stream if you ask for text/event-stream.',
+        gatewayPubkey: pubkey,
+        relay: RELAY,
+        authorization: {
+          type: 'oauth2',
+          issuer: OAUTH_ISSUER,
+          clientId: OAUTH_CLIENT_ID || null,
+          scopes: [SCOPE_READ, SCOPE_PUBLISH],
+          protectedResourceMetadata: prmUrl('/mcp'),
+          note: 'Additive: anonymous reads stay open over POST; an access token carrying '
+              + `${SCOPE_PUBLISH} authorises writes.`,
+        },
+      }));
     }
     if (url.pathname === '/mcp') {
       if (rateLimited(req)) return res.writeHead(429, { 'content-type': 'application/json' }).end('{"error":"rate limited"}');

--- a/plugins/ruflo-x-gateway/test/oauth.test.mjs
+++ b/plugins/ruflo-x-gateway/test/oauth.test.mjs
@@ -250,17 +250,120 @@ test('a dynamically registered client\'s token is accepted; a stranger\'s is not
   } finally { as.close(); }
 });
 
-test('GET /mcp is refused immediately instead of hanging a stateless stream', async () => {
-  // It used to hold the socket until Cloud Run severed it at 300s, so a client
-  // probing GET waited five minutes instead of failing in milliseconds.
+test('GET /mcp serves JSON by default and SSE only when asked — both finite and fast', async () => {
+  // Five clients, five failures, all on this one response. Each disproved the
+  // previous theory, so the sequence is the justification for the final shape:
+  //
+  //   1. Unbounded stream -> Cloud Run severed at 300s; probe waited 5 min.
+  //   2. Bare 405 -> no WWW-Authenticate, so OAuth was undiscoverable:
+  //      `registry returned 405`.
+  //   3. 401 + challenge -> `registry returned 401`; the probe wants 2xx.
+  //   4. Bounded long-lived stream -> `context deadline exceeded ... while
+  //      reading body`; the client reads to COMPLETION, and a proxy only flushes
+  //      when a response ENDS.
+  //   5. Immediate open-and-close SSE -> `parsing registry response: invalid
+  //      character ':'`; the client parses the body as JSON.
+  //
+  // (4) and (5) are the two that pin this test: the body must COMPLETE, and the
+  // default content type must PARSE AS JSON.
   const as = await fakeAuthServer();
   try {
     await withGateway(as, async (port) => {
+      // Default: JSON, because that is what a client that does not ask for a
+      // stream turned out to expect.
       const t0 = Date.now();
-      const r = await fetch(`http://127.0.0.1:${port}/mcp`, { headers: { accept: 'text/event-stream' } });
-      assert.equal(r.status, 405);
-      assert.match(r.headers.get('allow') || '', /POST/);
-      assert.ok(Date.now() - t0 < 2000, 'must answer immediately, not hold the stream open');
+      const r = await fetch(`http://127.0.0.1:${port}/mcp`);
+      assert.equal(r.status, 200, 'a reachability probe must get 2xx');
+      assert.match(r.headers.get('content-type') || '', /application\/json/);
+      const body = await Promise.race([
+        r.text(),
+        new Promise((_, rej) => setTimeout(() => rej(new Error('body did not complete within 3s')), 3000)),
+      ]);
+      assert.ok(Date.now() - t0 < 3000, 'must complete immediately, not hold the connection');
+      // The exact failure from (5), asserted directly: this must PARSE.
+      const doc = JSON.parse(body);
+      assert.equal(doc.transport, 'streamable-http');
+      assert.deepEqual(doc.methods, ['POST'], 'point the caller at the transport that works');
+      assert.ok(doc.authorization.protectedResourceMetadata.includes('oauth-protected-resource'),
+        'keep OAuth discovery reachable from the descriptor');
+      assert.ok(!('jsonrpc' in doc),
+        'this is not a response to any request; dressing it as JSON-RPC would invite a client to treat it as one');
+
+      // Asking for a stream still gets the spec-conformant answer — closed
+      // immediately, per (1) and (4).
+      const t1 = Date.now();
+      const sse = await fetch(`http://127.0.0.1:${port}/mcp`, { headers: { accept: 'text/event-stream' } });
+      assert.equal(sse.status, 200);
+      assert.match(sse.headers.get('content-type') || '', /text\/event-stream/);
+      const stream = await Promise.race([
+        sse.text(),
+        new Promise((_, rej) => setTimeout(() => rej(new Error('stream did not complete within 3s')), 3000)),
+      ]);
+      assert.ok(Date.now() - t1 < 3000, 'the event stream must end, not stay open');
+      assert.match(stream, /^: /, 'an SSE body is comments/events, never JSON');
+    });
+  } finally { as.close(); }
+});
+
+test('the gateway publishes itself as an MCP registry, in the official shape', async () => {
+  // Several clients probe a URL as a REGISTRY before treating it as a server.
+  // Every failure Lovable reported named "registry", and once the body finally
+  // parsed it said `This registry currently advertises no servers.`
+  //
+  // The shape asserted here was taken from a live response of
+  // registry.modelcontextprotocol.io/v0/servers, not from prose: items in
+  // `servers` wrap the entry under `server`, with `_meta` alongside.
+  const as = await fakeAuthServer();
+  try {
+    await withGateway(as, async (port) => {
+      for (const path of ['/v0/servers', '/v0.1/servers', '/mcp']) {
+        const r = await fetch(`http://127.0.0.1:${port}${path}`);
+        assert.equal(r.status, 200, path);
+        const doc = await r.json();
+        assert.ok(Array.isArray(doc.servers), `${path}: a registry client looks for a servers array`);
+        assert.equal(doc.servers.length, 1, `${path}: must advertise this gateway`);
+
+        const entry = doc.servers[0];
+        assert.ok(entry.server, `${path}: the entry is wrapped under "server"`);
+        assert.match(entry.server.$schema, /server\.schema\.json$/);
+        assert.equal(entry.server.name, 'io.ruv.x/mcp');
+        assert.ok(entry.server.version, `${path}: a registry entry needs a version`);
+        assert.ok(entry.server.description, `${path}: a registry entry needs a description`);
+
+        // The point of the entry: it must send a client to the transport that
+        // actually works, which is POST to /mcp.
+        const remote = entry.server.remotes[0];
+        assert.equal(remote.type, 'streamable-http');
+        assert.match(remote.url, /\/mcp$/);
+      }
+    });
+  } finally { as.close(); }
+});
+
+test('the registry entry points at an endpoint that really answers', async () => {
+  // A registry that advertises a URL nothing serves is worse than an empty one:
+  // it fails later, in a client, instead of here.
+  const as = await fakeAuthServer();
+  try {
+    await withGateway(as, async (port) => {
+      const doc = await (await fetch(`http://127.0.0.1:${port}/v0/servers`)).json();
+      const advertised = new URL(doc.servers[0].server.remotes[0].url);
+      // PUBLIC_URL is the deployed host in the entry; exercise the same PATH here.
+      const r = await call(port, 'federation_identity', {});
+      assert.equal(r.status, 200, `${advertised.pathname} must answer a JSON-RPC POST`);
+    });
+  } finally { as.close(); }
+});
+
+test('anonymous POST reads stay open — the GET change is a probe change only', async () => {
+  // The gateway's whole design is that reads are open. If tightening the GET
+  // probe had also closed anonymous reads, that would be a regression dressed up
+  // as a fix.
+  const as = await fakeAuthServer();
+  try {
+    await withGateway(as, async (port) => {
+      const r = await call(port, 'federation_identity', {});
+      assert.equal(r.status, 200, 'an anonymous read must still succeed over POST');
     });
   } finally { as.close(); }
 });


### PR DESCRIPTION
Stacked on #3285 — one commit on top of it.

> **x.ruv.io is already running this code.** Revisions 00023–00027 were deployed from a working tree while iterating against a real client. **Committing it late is the bug here**: production and git disagreed for the length of the debugging session, and a redeploy from `main` would have silently reverted all of it. Opening this the moment I noticed.

## Four attempts, each disproved by the next client error

`GET /mcp` used to answer 405. Every correction came from a real error message, not from reasoning:

| # | response | client said |
|---|---|---|
| 1 | unbounded SSE stream | Cloud Run severed it at 300s — `Truncated response body`; a probe waited five minutes |
| 2 | bare `405` | `could not reach registry: registry returned 405` — no `WWW-Authenticate`, so OAuth was undiscoverable |
| 3 | `401` + challenge | `registry returned 401` — the probe wants 2xx and never reads a challenge |
| 4 | bounded stream, self-closing at 240s | `context deadline exceeded … while reading body` — the client reads to **completion** |
| 5 | immediate open-and-close SSE | `parsing registry response: invalid character ':'` — it parses the body as **JSON** |

(2) and (3) were both attempts to make a *refusal* informative. (5) measured that as the wrong shape entirely.

**(4) also never arrived at all through the load balancer** — a proxy flushes when a response **ends**. Measured: 0.25s to first byte direct to Cloud Run, nothing in 15s via the LB. Ending the response fixed the buffering with no infrastructure change.

## The answer

Content-negotiated. `Accept: text/event-stream` → a spec-shaped stream that **ends immediately**; everything else → a finite JSON descriptor. Both complete in one response, which is what (1) and (4) require.

The descriptor is also a **one-entry MCP registry**, served at `/mcp`, `/v0/servers` and `/v0.1/servers`. Several clients treat a URL as a *directory of servers* before treating it as a server; without the `servers` array the same client reported *"this registry currently advertises no servers"*. The shape came from a live response of `registry.modelcontextprotocol.io/v0/servers`, not from prose.

## What did not change

**Anonymous POST reads**, verified live before and after and pinned by its own test — tightening a GET probe that also closed the open read surface would be a regression dressed as a fix.

```
41 tests pass
```

The test records all five failures so the next person doesn't re-derive them, and reproduces the two that actually bit — the body must **complete**, and the default must **parse as JSON** — in-process rather than in a bug report.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_013u4pmL9ZUAXb6usVQgNo67