### PR TITLE
fix(memory): replace the drive colon when deriving the auto memory key

### DIFF
--- a/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.test.ts
@@ -105,6 +105,18 @@ describe('resolveAutoMemoryDir', () => {
     expect(result).not.toContain('RX_ERP');
   });
 
+  it('should normalize a colon to a dash, as a Windows drive letter needs (issue #3303)', () => {
+    // Claude Code replaces the colon too: a git root of D:\projects\elearning\v3_26
+    // maps to D--projects-elearning-v3-26. A colon is not legal inside a Windows path
+    // segment, so leaving it there made ensureMemoryDir() throw ENOENT and doSync()
+    // swallow it as "Sync failed (non-critical)" — the sync never ran on Windows.
+    //
+    // Driven with an absolute path that no repository sits above, so findGitRoot
+    // returns null on every platform and the key comes from the input alone.
+    const result = resolveAutoMemoryDir('/3303-not-a-repo/drive:d/v3_26');
+    expect(path.basename(path.dirname(result))).toBe('-3303-not-a-repo-drive-d-v3-26');
+  });
+
   it('should produce consistent paths for same input', () => {
     const a = resolveAutoMemoryDir('/workspaces/my-project');
     const b = resolveAutoMemoryDir('/workspaces/my-project');

--- a/v3/@claude-flow/memory/src/auto-memory-bridge.ts
+++ b/v3/@claude-flow/memory/src/auto-memory-bridge.ts
@@ -797,11 +797,15 @@ export function resolveAutoMemoryDir(workingDir: string): string {
   const gitRoot = findGitRoot(workingDir);
   const basePath = gitRoot || workingDir;
 
-  // Claude Code normalizes to forward slashes then replaces both `/` and `_`
+  // Claude Code normalizes to forward slashes then replaces `/`, `_` and `:`
   // with dashes (e.g. /workspaces/RX_ERP -> -workspaces-RX-ERP). The leading
-  // dash IS preserved.
+  // dash IS preserved. The colon matters on Windows: a drive letter survived as
+  // `D:-projects-...`, which is not a legal path segment there, so
+  // ensureMemoryDir() failed with ENOENT and doSync() swallowed it as
+  // "Sync failed (non-critical)" — the sync had never run on Windows. Claude
+  // Code writes `D--projects-...`, both characters replaced (#3303).
   const normalized = basePath.split(path.sep).join('/');
-  const projectKey = normalized.replace(/[\/_]/g, '-');
+  const projectKey = normalized.replace(/[\/_:]/g, '-');
 
   return path.join(
     process.env.HOME || process.env.USERPROFILE || '~',


### PR DESCRIPTION
Fixes #3303.

`resolveAutoMemoryDir` mirrors Claude Code's project key, and its comment says so, but it replaced only `/` and `_`:

```js
const normalized = basePath.split(path.sep).join('/');
const projectKey = normalized.replace(/[\/_]/g, '-');
```

Claude Code replaces the colon as well. So for a Windows git root of `D:\projects\elearning\v3_26` this produced `D:-projects-elearning-v3-26` where Claude Code writes `D--projects-elearning-v3-26`. Two consequences, and the reporter caught both:

- a colon is not legal inside a Windows path segment, so `ensureMemoryDir()` failed with `ENOENT` and `doSync()` swallowed it as `Sync failed (non-critical)`. The auto memory sync had never run on Windows, while reporting success.
- even if the directory had been creatable, it is not the key Claude Code reads, so nothing written there would ever be seen.

The change is the character class. POSIX paths carry no colon, so nothing moves there, and the underscore behaviour from #2282 is untouched.

## Test

`src/auto-memory-bridge.test.ts`, next to the `#2282` underscore case:

```ts
const result = resolveAutoMemoryDir('/3303-not-a-repo/drive:d/v3_26');
expect(path.basename(path.dirname(result))).toBe('-3303-not-a-repo-drive-d-v3-26');
```

It is driven with an absolute path that no repository sits above, so `findGitRoot` returns null on every platform and the key comes from the input alone. That keeps it deterministic without mocking `node:fs`, which vitest cannot spy on for an ESM namespace. Reverting the colon fails it.

```
npx vitest run src/auto-memory-bridge.test.ts   79 passed
```

Verified with pnpm and the workspace's own vitest, in `v3/@claude-flow/memory`.
